### PR TITLE
[testing] import loaded rules from main.py

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -19,11 +19,9 @@ import json
 import logging
 import os
 
-from main import StreamAlert
-from rules import (
-    sample_rules,
-    sample_matchers
-)
+from stream_alert.handler import StreamAlert
+# import all rules loaded from the main handler
+import main
 
 LOGGER_SA = logging.getLogger('StreamAlert')
 LOGGER_CLI = logging.getLogger('StreamAlertCLI')


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 

* to avoid loading rules in two places (one for testing, one for the AWS Lambda function), import the entire `main` package to get the rule imports.