### PR TITLE
[setup][tf] remove emulambda dep and add tfvar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ colorama==0.3.3
 coverage==4.3.4
 decorator==4.0.11
 docutils==0.13.1
--e git://github.com/fugue/emulambda.git@8a1b3ae7718750e8ee25e1dd9ec4a76b265ebd3b#egg=emulambda
 futures==3.0.5
 hurry.filesize==0.9
 Jinja2==2.9.5

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,3 +37,8 @@ variable "lambda_settings" {
   type    = "map"
   default = {}
 }
+
+variable "flow_log_settings" {
+  type    = "map"
+  default = {}
+}

--- a/variables.json
+++ b/variables.json
@@ -24,6 +24,7 @@
     "lambda_source_bucket_name": "ADD-ORG-NAME-HERE.streamalert.source",
     "lambda_source_current_hash": "auto",
     "lambda_source_key": "auto",
+    "flow_log_settings": {},
     "output_lambda_current_hash": "auto",
     "output_lambda_source_key": "auto",
     "prefix": "ADD-ORG-NAME-HERE",


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 

* add `flow_log_settings` variable in `variables.json` and `variables.tf` to enable the usage of the new vpc flow log module.
* remove old `emulambda` dependency.