### PR TITLE
[docs] fix formatting

### DIFF
--- a/docs/source/account.rst
+++ b/docs/source/account.rst
@@ -40,6 +40,7 @@ Steps:
 * Click: Next
 * Select: Attach existing policies directly
 * Attach the following policies:
+
   * AmazonKinesisFirehoseFullAccess
   * AmazonKinesisFullAccess
   * AmazonS3FullAccess


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: tiny

markdown formatting was busted for the account setup page