### PR TITLE
[testing] updating cli testing to include s3 as a service

### DIFF
--- a/conf/sources.json
+++ b/conf/sources.json
@@ -16,9 +16,13 @@
 		}
 	},
 	"s3": {
-		"my-s3-bucket-id": {
+		"example_s3_bucket": {
 			"logs": [
-				"syslog_log"
+				"json_log",
+				"syslog_log",
+				"kv_log",
+				"csv_log",
+				"osquery"
 			]
 		}
 	}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Jinja2==2.9.5
 jmespath==0.9.1
 jsonpath-rw==1.4.0
 MarkupSafe==0.23
+moto==0.4.31
 netaddr==0.7.18
 nose==1.3.7
 numpy==1.12.0

--- a/stream_alert/classifier.py
+++ b/stream_alert/classifier.py
@@ -205,6 +205,8 @@ class StreamClassifier(object):
                 payload.records]):
             payload.valid = True
 
+        logger.debug('payload: %s', payload)
+
     def _parse(self, payload, data):
         """Parse a record into a declared type.
 
@@ -264,7 +266,6 @@ class StreamClassifier(object):
                     payload.log_source = log_name
                     payload.type = parser_name
                     payload.records = typed_data
-                    logger.debug('valid data detected')
                     return True
         return False
 

--- a/stream_alert/parsers.py
+++ b/stream_alert/parsers.py
@@ -221,19 +221,13 @@ class CSVParser(ParserBase):
         service = self.options['service']
         delimiter = self.options['delimiter'] or self.__default_delimiter
 
-        if service == 's3':
-            try:
-                csv_data = StringIO.StringIO(data)
-                reader = csv.DictReader(csv_data, delimiter=delimiter)
-            except ValueError, csv.Error:
-                return False
-
-        elif service == 'kinesis':
-            try:
-                csv_data = StringIO.StringIO(data)
-                reader = csv.reader(csv_data, delimiter=delimiter)
-            except ValueError, csv.Error:
-                return False
+        # TODO(ryandeivert): either subclass a current parser or add a new
+        # parser to support parsing CSV data that contains a header line
+        try:
+            csv_data = StringIO.StringIO(data)
+            reader = csv.reader(csv_data, delimiter=delimiter)
+        except ValueError, csv.Error:
+            return False
 
         return reader
 

--- a/stream_alert/pre_parsers.py
+++ b/stream_alert/pre_parsers.py
@@ -91,13 +91,13 @@ class StreamPreParsers(object):
             raise S3ObjectSizeError('S3 object to download is above 128MB')
 
         logger.debug('/tmp directory contents:%s ', os.listdir('/tmp'))
-        logger.debug(os.system('df -h /tmp | tail -1'))
+        logger.debug(os.popen('df -h /tmp | tail -1').read().strip())
 
         if size_mb:
             display_size = '{}MB'.format(size_mb)
         else:
             display_size = '{}KB'.format(size_kb)
-        logger.info('Starting download from S3 - %s/%s [%s]',
+        logger.debug('Starting download from S3 - %s/%s [%s]',
                     bucket, key, display_size)
 
         suffix = key.replace('/', '-')
@@ -107,7 +107,7 @@ class StreamPreParsers(object):
             client.download_fileobj(bucket, key, data)
 
         end_time = time.time() - start_time
-        logger.info('Completed download in %s seconds', round(end_time, 2))
+        logger.debug('Completed download in %s seconds', round(end_time, 2))
 
         return downloaded_s3_object
 
@@ -144,6 +144,6 @@ class StreamPreParsers(object):
         # remove file path
         os.remove(downloaded_s3_object)
         if not os.path.exists(downloaded_s3_object):
-            logger.info('Removed temp file - %s', downloaded_s3_object)
+            logger.debug('Removed temp file - %s', downloaded_s3_object)
 
         return lines

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -18,9 +18,12 @@ import base64
 import json
 import logging
 import os
+import random
 import re
 import time
 
+import boto3
+from moto import mock_s3
 from stream_alert.handler import StreamAlert
 # import all rules loaded from the main handler
 import main
@@ -28,6 +31,8 @@ import main
 LOGGER_SA = logging.getLogger('StreamAlert')
 LOGGER_CLI = logging.getLogger('StreamAlertCLI')
 LOGGER_CLI.setLevel(logging.INFO)
+
+BOTO_MOCKER = mock_s3()
 
 DIR_RULES = 'test/integration/rules'
 DIR_TEMPLATES = 'test/integration/templates'
@@ -41,7 +46,7 @@ def report_output(cols, force_exit):
         cols: A list of columns to print (test description, pass|fail)
         force_exit: Boolean to break exectuion of integration testing
     """
-    print '\ttest: {: <40} {: >25}'.format(*cols)
+    print '\t{}\ttest ({}): {}'.format(*cols)
     if force_exit:
         os._exit(1)
 
@@ -55,26 +60,24 @@ def test_rule(rule_name, test_file_contents):
     print '\n{}'.format(rule_name)
 
     for record in test_file_contents['records']:
-        context = None
-        event = {'Records': []}
-        event['Records'].append(record['kinesis_data'])
-        if record['trigger']:
-            expected_alerts = 1
-        else:
-            expected_alerts = 0
+        service = record['service']
+        service_record_key = '{}_record'.format(service)
+        event = {'Records': [record[service_record_key]]}
 
-        alerts = StreamAlert(return_alerts=True).run(event, context)
+        expected_alert_count = (0, 1)[record['trigger']]
+
+        alerts = StreamAlert(return_alerts=True).run(event, None)
         # we only want alerts for the specific rule passed in
-        matched_alerts = [x for x in alerts if x['rule_name'] == rule_name]
+        matched_alert_count = len([x for x in alerts if x['rule_name'] == rule_name])
 
-        if len(matched_alerts) == expected_alerts:
+        if matched_alert_count == expected_alert_count:
             result = '{}[Pass]{}'.format(COLOR_GREEN, COLOR_RESET)
             force_exit = False
         else:
             result = '{}[Fail]{}'.format(COLOR_RED, COLOR_RESET)
             force_exit = True
 
-        report_output([record['description'], result], force_exit)
+        report_output([result, service, record['description']], force_exit)
 
 def format_record(test_record):
     """Create a properly formatted Kinesis, S3, or SNS record.
@@ -90,7 +93,7 @@ def format_record(test_record):
             service - which aws service originated the data
 
     Returns:
-        populated dict in the format of the specific service.
+        dict in the format of the specific service
     """
     service = test_record['service']
     source = test_record['source']
@@ -104,27 +107,33 @@ def format_record(test_record):
         LOGGER_CLI.info('Invalid data type: %s', type(test_record['data']))
         return
 
+    # Get the template file for this particular service
+    template_path = os.path.join(DIR_TEMPLATES, '{}.json'.format(service))
+    with open(template_path, 'r') as service_template:
+        try:
+            template = json.load(service_template)
+        except ValueError as err:
+            LOGGER_CLI.error('Error loading %s.json: %s', service, err)
+            return
     if service == 's3':
-        pass
+        # Set the S3 object key to a random value for testing
+        test_record['key'] = ('{:032X}'.format(random.randrange(16**32)))
+        template['s3']['object']['key'] = test_record['key']
+        template['s3']['bucket']['arn'] = 'arn:aws:s3:::{}'.format(source)
+        template['s3']['bucket']['name'] = source
 
+        # Create the mocked s3 object in the designated bucket with the random key
+        put_mocked_s3_object(source, test_record['key'], data)
     elif service == 'kinesis':
-        kinesis_path = os.path.join(DIR_TEMPLATES, 'kinesis.json')
-        with open(kinesis_path, 'r') as kinesis_template:
-            try:
-                template = json.load(kinesis_template)
-            except ValueError as err:
-                LOGGER_CLI.error('Error loading kinesis.json: %s', err)
-                return
-
         template['kinesis']['data'] = base64.b64encode(data)
         template['eventSourceARN'] = 'arn:aws:kinesis:us-east-1:111222333:stream/{}'.format(source)
-        return template
-
     elif service == 'sns':
+        # TODO implement sns testing
         pass
-
     else:
         LOGGER_CLI.info('Invalid service %s', service)
+
+    return template
 
 def check_keys(test_record):
     """Check the test_record contains the required keys
@@ -133,7 +142,7 @@ def check_keys(test_record):
         test_record: Test record metadata dict
 
     Returns:
-        Boolean result of key set comparison
+        boolean result of key set comparison
     """
     req_keys = {
         'data',
@@ -175,8 +184,11 @@ def apply_helpers(test_record):
 
     find_and_apply_helpers(test_record)
 
-def test_kinesis_alert_rules():
-    """Integration test the 'Alert' Lambda function with Kinesis records"""
+def test_alert_rules():
+    """Integration test the 'Alert' Lambda function with various record types"""
+    # Start the mock_s3 instance here so we can test with mocked objects project-wide
+    BOTO_MOCKER.start()
+
     for root, _, rule_files in os.walk(DIR_RULES):
         for rule_file in rule_files:
             rule_name = rule_file.split('.')[0]
@@ -193,20 +205,48 @@ def test_kinesis_alert_rules():
             if not test_records:
                 LOGGER_CLI.error('Improperly formatted test file: %s', rule_file_path)
                 continue
-
-            if len(test_records) == 0:
+            elif len(test_records) == 0:
                 LOGGER_CLI.error('No records to test for %s', rule_name)
                 continue
 
-            for test_record in test_records:
+            # Go backwards over the records so we can remove improper ones
+            # safely without unnecessary copying/modifying of the list
+            for test_record in reversed(test_records):
                 if not check_keys(test_record):
-                    LOGGER_CLI.error('Improperly formatted test_record: %s',
-                                    test_record)
+                    LOGGER_CLI.error('Discarding improperly formatted record for service %s: %s',
+                                     test_record['service'],
+                                     test_record)
+                    # Removing an improperly formatted record here allows us to
+                    # continue with current tests, while still logging it above
+                    test_records.pop(test_records.index(test_record))
                     continue
+
                 apply_helpers(test_record)
-                test_record['kinesis_data'] = format_record(test_record)
+                service_record_key = '{}_record'.format(test_record['service'])
+                test_record[service_record_key] = format_record(test_record)
 
             test_rule(rule_name, contents)
+
+    BOTO_MOCKER.stop()
+
+def put_mocked_s3_object(bucket_name, key_name, body_value):
+    """Create a mock AWS S3 object for testing
+
+    Args:
+        bucket_name: the bucket in which to place the object (string)
+        key_name: the key to use for the S3 object (string)
+        body_value: the actual value to use for the object (string)
+    """
+    s3_resource = boto3.resource('s3', region_name='us-east-1')
+    s3_resource.create_bucket(Bucket=bucket_name)
+    obj = s3_resource.Object(bucket_name, key_name)
+    response = obj.put(Body=body_value)
+
+    # Log if this was not a success (this should not fail for mocked objects)
+    if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+        LOGGER_CLI.error('Could not put mock object with key %s in s3 bucket with name %s',
+                         key_name,
+                         bucket_name)
 
 def stream_alert_test(options):
     """Integration testing handler
@@ -219,15 +259,9 @@ def stream_alert_test(options):
     else:
         LOGGER_SA.setLevel(logging.INFO)
 
-    if options.source == 'kinesis':
-        if options.func == 'alert':
-            test_kinesis_alert_rules()
+    if options.func == 'alert':
+        test_alert_rules()
 
-        elif options.func == 'output':
-            # TODO(jack) handle s3 event formatting
-            pass
-
-    elif options.source == 's3':
-        if options.func == 'alert':
-            # TODO(jack) handle s3 event formatting
-            pass
+    elif options.func == 'output':
+        # TODO(jack) test output
+        raise NotImplementedError

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -129,7 +129,7 @@ def format_record(test_record):
         template['eventSourceARN'] = 'arn:aws:kinesis:us-east-1:111222333:stream/{}'.format(source)
     elif service == 'sns':
         # TODO implement sns testing
-        pass
+        raise NotImplementedError
     else:
         LOGGER_CLI.info('Invalid service %s', service)
 

--- a/test/integration/rules/invalid_subnet.json
+++ b/test/integration/rules/invalid_subnet.json
@@ -39,6 +39,46 @@
       "trigger": false,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": {
+        "name": "logged_in_users",
+        "hostIdentifier": "host3",
+        "calendarTime": "Tue Feb 29 20:20:09 UTC 2017",
+        "unixTime": "1488309540",
+        "columns": {
+          "host": "10.54.0.21",
+          "user": "sam"
+        },
+        "action": "added",
+        "decorations": {
+          "environment": "qa"
+        }
+      },
+      "description": "user logging in from an untrusted subnet",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
+    },
+    {
+      "data": {
+        "name": "logged_in_users",
+        "hostIdentifier": "host4",
+        "calendarTime": "Tue Feb 27 18:18:08 UTC 2017",
+        "unixTime": "1488309540",
+        "columns": {
+          "host": "10.2.0.99",
+          "user": "mike"
+        },
+        "action": "added",
+        "decorations": {
+          "environment": "qa"
+        }
+      },
+      "description": "user logging in from the trusted subnet",
+      "trigger": false,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/invalid_user.json
+++ b/test/integration/rules/invalid_user.json
@@ -39,6 +39,46 @@
       "trigger": false,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": {
+        "name": "logged_in_users",
+        "hostIdentifier": "host3",
+        "calendarTime": "Tue Feb 28 19:19:07 UTC 2017",
+        "unixTime": "1488309540",
+        "columns": {
+          "host": "10.2.0.16",
+          "user": "sam"
+        },
+        "action": "added",
+        "decorations": {
+          "environment": "qa"
+        }
+      },
+      "description": "user not in the whitelist",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
+    },
+    {
+      "data": {
+        "name": "logged_in_users",
+        "hostIdentifier": "host4",
+        "calendarTime": "Tue Feb 28 19:19:07 UTC 2017",
+        "unixTime": "1488309540",
+        "columns": {
+          "host": "10.2.0.16",
+          "user": "bob"
+        },
+        "action": "added",
+        "decorations": {
+          "environment": "qa"
+        }
+      },
+      "description": "user in the whitelist",
+      "trigger": false,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/sample_csv_rule.json
+++ b/test/integration/rules/sample_csv_rule.json
@@ -6,6 +6,13 @@
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": "Jan 01 2017,1487095529,test-host-2,this is test data for rules,cluster 5",
+      "description": "host is test-host-2",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/sample_json_rule.json
+++ b/test/integration/rules/sample_json_rule.json
@@ -12,6 +12,19 @@
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": {
+        "name": "name-1",
+        "host": "test-host-1",
+        "data": {
+          "time": "Jan 01, 2017"
+        }
+      },
+      "description": "host is test-host-1",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/sample_kv_rule.json
+++ b/test/integration/rules/sample_kv_rule.json
@@ -6,6 +6,13 @@
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": "type=test msg=fatal uid=100 time=1488013995",
+      "description": "fatal message from uid 100",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/sample_kv_rule_last_hour.json
+++ b/test/integration/rules/sample_kv_rule_last_hour.json
@@ -6,6 +6,13 @@
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": "type=start msg=info uid=0 time=<helper:last_hour>",
+      "description": "info message from uid 0 in the last hour",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/rules/sample_syslog_rule.json
+++ b/test/integration/rules/sample_syslog_rule.json
@@ -6,6 +6,13 @@
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
+    },
+    {
+      "data": "Jan 01 12:00:12 test-host-2 sudo[159]: COMMAND sudo rm /tmp/badstuff",
+      "description": "sudo command ran",
+      "trigger": true,
+      "source": "example_s3_bucket",
+      "service": "s3"
     }
   ]
 }

--- a/test/integration/templates/s3.json
+++ b/test/integration/templates/s3.json
@@ -14,7 +14,7 @@
     },
     "bucket": {
       "arn": "arn:aws:s3:::mybucket",
-      "name": "sourcebucket",
+      "name": "mybucket",
       "ownerIdentity": {
         "principalId": "EXAMPLE"
       }


### PR DESCRIPTION
to @airbnb/streamalert-maintainers

size: small
resolves: #61

## changes ##
Slight refactor to `test.py` to allow for a more generic way of testing various services.
Updating `sources.json` to include various source log types for s3.
`requirements.txt` now includes `moto==0.4.31`, as this is now used for boto3 mocking.
Updated integration rule files to include s3 service examples.