### PR TITLE
Cloudtrail Example Schema, Rule, and Test

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -55,5 +55,86 @@
       "decorations": {}
     },
     "parser": "json"
+  },
+  "cloudtrail:v1.05": {
+    "schema": {
+      "eventVersion": "string",
+      "eventID": "string",
+      "eventTime": "string",
+      "sharedEventID": "string",
+      "requestParameters": {
+        "roleSessionName": "string",
+        "roleArn": "string"
+      },
+      "eventType": "string",
+      "responseElements": {
+        "credentials": {
+          "sessionToken": "string",
+          "accessKeyId": "string",
+          "expiration": "string"
+        }
+      },
+      "awsRegion": "string",
+      "eventName": "string",
+      "userIdentity": {
+        "type": "string",
+        "invokedBy": "string"
+      },
+      "eventSource": "string",
+      "requestID": "string",
+      "userAgent": "string",
+      "sourceIPAddress": "string",
+      "resources": {},
+      "recipientAccountId": "string"
+    },
+    "parser": "json",
+    "hints": {
+      "records": "Records[*]"
+    }
+  },
+  "cloudtrail:v1.04": {
+    "schema": {
+      "eventVersion": "string",
+      "errorCode": "string",
+      "eventTime": "string",
+      "requestParameters": {
+          "policy": {},
+          "bucketName": "string"
+      },
+      "eventType": "string",
+      "errorMessage": "string",
+      "responseElements": "string",
+      "awsRegion": "string",
+      "eventName": "string",
+      "userIdentity": {
+          "sessionContext": {
+              "sessionIssuer": {
+                  "userName": "string",
+                  "type": "string",
+                  "arn": "string",
+                  "principalId": "string",
+                  "accountId": "string"
+              },
+              "attributes": {
+                  "creationDate": "string",
+                  "mfaAuthenticated": "string"
+              }
+          },
+          "type": "string",
+          "arn": "string",
+          "principalId": "string",
+          "accountId": "integer"
+      },
+      "eventSource": "string",
+      "requestID": "string",
+      "userAgent": "string",
+      "eventID": "string",
+      "sourceIPAddress": "string",
+      "recipientAccountId": "integer"
+    },
+    "parser": "json",
+    "hints": {
+      "records": "Records[*]"
+    }
   }
 }

--- a/conf/sources.json
+++ b/conf/sources.json
@@ -17,7 +17,8 @@
 				"syslog_log",
 				"kv_log",
 				"csv_log",
-				"osquery"
+				"osquery",
+				"cloudtrail"
 			]
 		}
 	}

--- a/rules/sample_rules.py
+++ b/rules/sample_rules.py
@@ -86,3 +86,19 @@ def sample_kv_rule_last_hour(rec):
         rec['uid'] == 0 and
         last_hour(rec['time'])
     )
+
+
+@rule(logs=['cloudtrail:v1.05'],
+      matchers=[],
+      outputs=['slack'])
+def sample_cloudtrail_rule(rec):
+    whitelist_services = {
+        'lambda.amazonaws.com',
+        'kinesis.amazonaws.com'
+    }
+
+    return (
+        rec['eventName'] == 'AssumeRole' and
+        rec['awsRegion'] == 'us-east-1' and
+        in_set(rec['userIdentity']['invokedBy'], whitelist_services)
+    )

--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -304,17 +304,17 @@ class StreamClassifier(object):
                 if len(value) == 0:
                     pass
                 else:
-                    schema = schema[key]
                     # handle nested csv
                     if isinstance(payload[key], str):
                         options['hints'] = options['hints'][key]
                         parse_csv = get_parser('csv')
                         parsed_nested_key = parse_csv(payload[key],
-                                                      schema,
+                                                      schema[key],
                                                       options).parse()
                         # Call the first element since a list is returned
                         payload[key] = parsed_nested_key[0]
-                    self._convert_type(payload[key], schema, options)
+
+                    self._convert_type(payload[key], schema[key], options)
             else:
                 logger.error('Invalid declared type - %s', value)
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -64,7 +64,11 @@ def test_rule(rule_name, test_record, formatted_record):
     """
     event = {'Records': [formatted_record]}
 
-    expected_alert_count = (0, 1)[test_record['trigger']]
+    trigger_count = test_record.get('trigger_count')
+    if trigger_count:
+        expected_alert_count = trigger_count
+    else:
+        expected_alert_count = (0, 1)[test_record['trigger']]
 
     alerts = StreamAlert(return_alerts=True).run(event, None)
     # we only want alerts for the specific rule passed in
@@ -148,8 +152,16 @@ def check_keys(test_record):
         'source',
         'trigger'
     }
+
+    optional_keys = {
+        'trigger_count'
+    }
+
     record_keys = set(test_record.keys())
-    return req_keys == record_keys
+    return (
+        req_keys == record_keys or
+        optional_keys.issubset(record_keys)
+    )
 
 def apply_helpers(test_record):
     """Detect and apply helper functions to test fixtures

--- a/test/integration/rules/sample_cloudtrail_rule.json
+++ b/test/integration/rules/sample_cloudtrail_rule.json
@@ -1,0 +1,87 @@
+{
+  "records": [
+    {
+      "data": {
+        "Records": [
+          {
+            "eventVersion": "1.05",
+            "userIdentity": {
+              "type": "AWSService",
+              "invokedBy": "lambda.amazonaws.com"
+            },
+            "eventTime": "2017-01-01T23:00:00Z",
+            "eventSource": "sts.amazonaws.com",
+            "eventName": "AssumeRole",
+            "awsRegion": "us-east-1",
+            "sourceIPAddress": "lambda.amazonaws.com",
+            "userAgent": "lambda.amazonaws.com",
+            "requestParameters": {
+              "roleSessionName": "lambda_name",
+              "roleArn": "arn:aws:iam::account:role/lambda"
+            },
+            "responseElements": {
+              "credentials": {
+                "sessionToken": "cccccccccccccccccccccccccccccccccccccccc",
+                "accessKeyId": "AAAAAAAAAAAAAAAA",
+                "expiration": "Jan 01, 2017 11:00:00 AM"
+              }
+            },
+            "requestID": "666666-666666-6666666-6666",
+            "eventID": "6666666-666666-66666-666666",
+            "resources": [
+              {
+                "ARN": "arn:aws:iam::account:role/lambda",
+                "accountId": "11111111111",
+                "type": "AWS::IAM::Role"
+              }
+            ],
+            "eventType": "AwsApiCall",
+            "recipientAccountId": "11111111111",
+            "sharedEventID": "66666-6666-66666-66666666"
+          },
+          {
+            "eventVersion": "1.05",
+            "userIdentity": {
+              "type": "AWSService",
+              "invokedBy": "kinesis.amazonaws.com"
+            },
+            "eventTime": "2017-01-01T23:00:00Z",
+            "eventSource": "sts.amazonaws.com",
+            "eventName": "AssumeRole",
+            "awsRegion": "us-east-1",
+            "sourceIPAddress": "servivce.amazonaws.com",
+            "userAgent": "kinesis.amazonaws.com",
+            "requestParameters": {
+              "roleSessionName": "kinesis_name",
+              "roleArn": "arn:aws:iam::account:role/kinesis"
+            },
+            "responseElements": {
+              "credentials": {
+                "sessionToken": "dddddddddddddddddddddddddddddddddddddddd",
+                "accessKeyId": "AAAAAAAAAAAAAAAA",
+                "expiration": "Jan 01, 2017 11:00:00 AM"
+              }
+            },
+            "requestID": "777777-77777-7777777-7777",
+            "eventID": "777777-777777-777777-777777",
+            "resources": [
+              {
+                "ARN": "arn:aws:iam::account:role/kinesis",
+                "accountId": "11111111111",
+                "type": "AWS::IAM::Role"
+              }
+            ],
+            "eventType": "AwsApiCall",
+            "recipientAccountId": "11111111111",
+            "sharedEventID": "777777-7777-77777-7777777777"
+          }
+        ]
+      },
+      "description": "cloudtrail test",
+      "trigger": true,
+      "trigger_count": 2,
+      "source": "example_s3_bucket",
+      "service": "s3"
+    }
+  ]
+}


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size medium

## Changes
* Add default log types for `cloudtrail` eventVersions `1.04` and `1.05`.
* Add example rule for Cloudtrail
* Fix KeyError bugs in the `JSONParser` and `classifier` when parsing nested S3 data.
* Fix a bug in the `JSONParser. _key_check` where invalid records were not being removed due to the iteration technique.
* Support a new `trigger_count` key in test records to indicate the number of alerts generated by a nested record.