### PR TITLE
[lambda][rule_processor] env var log level and logger.error for invalid events

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -10,7 +10,9 @@ from stream_alert.rule_processor.sink import StreamSink
 
 logging.basicConfig()
 logger = logging.getLogger('StreamAlert')
-logger.setLevel(logging.INFO)
+level = os.environ.get('LOGGER_LEVEL', 'INFO')
+logger.setLevel(level.upper())
+
 
 class StreamAlert(object):
     """Wrapper class for handling all StreamAlert classificaiton and processing"""
@@ -63,11 +65,11 @@ class StreamAlert(object):
             else:
                 logger.info('Unsupported service: %s', payload.service)
 
-        # Give the user control over handling generated alerts
+        # returns the list of generated alerts
         if self.return_alerts:
             return self.alerts
-        else:
-            self.send_alerts(env)
+        # send alerts to SNS
+        self.send_alerts(env, payload)
 
     def kinesis_process(self, payload, classifier):
         """Process Kinesis data for alerts"""
@@ -84,7 +86,7 @@ class StreamAlert(object):
             classifier.classify_record(payload, data)
             self.process_alerts(payload)
 
-    def send_alerts(self, env):
+    def send_alerts(self, env, payload):
         """Send generated alerts to correct places"""
         if self.alerts:
             if env['lambda_alias'] == 'development':
@@ -92,7 +94,7 @@ class StreamAlert(object):
                 logger.info('\n%s\n', json.dumps(self.alerts, indent=4))
             else:
                 StreamSink(self.alerts, env).sink()
-        else:
+        elif payload.valid:
             logger.debug('Valid data, no alerts')
 
     def process_alerts(self, payload):
@@ -102,4 +104,6 @@ class StreamAlert(object):
             if alerts:
                 self.alerts.extend(alerts)
         else:
-            logger.debug('Invalid data: %s', payload)
+            logger.error('Invalid data: %s\n%s',
+                         payload,
+                         json.dumps(payload.raw_record, indent=4))


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: tiny

## Changes
* Support the usage of AWS Lambda Environment variables to control logger level (coming soon).
* Log an error when unexpected events invoke the Lambda function.
* Fix a bug where 'Valid data, no alerts' was printing against invalid payloads.