### PR TITLE
[terraform] CloudTrail Support

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -85,7 +85,7 @@
       "userAgent": "string",
       "sourceIPAddress": "string",
       "resources": {},
-      "recipientAccountId": "string"
+      "recipientAccountId": "integer"
     },
     "parser": "json",
     "hints": {
@@ -113,7 +113,7 @@
                   "type": "string",
                   "arn": "string",
                   "principalId": "string",
-                  "accountId": "string"
+                  "accountId": "integer"
               },
               "attributes": {
                   "creationDate": "string",
@@ -136,5 +136,52 @@
     "hints": {
       "records": "Records[*]"
     }
+  },
+  "cloudwatch:cloudtrail": {
+    "schema": {
+      "account": "integer",
+      "region": "string",
+      "detail": {
+        "eventVersion": "string",
+        "eventID": "string",
+        "eventTime": "string",
+        "readOnly": "string",
+        "requestParameters": {},
+        "eventType": "string",
+        "responseElements": {},
+        "awsRegion": "string",
+        "eventName": "string",
+        "userIdentity": {},
+        "eventSource": "string",
+        "requestID": "string",
+        "userAgent": "string",
+        "sourceIPAddress": "string",
+        "resources": {}
+      },
+      "detail-type": "string",
+      "source": "string",
+      "version": "string",
+      "time": "string",
+      "id": "string",
+      "resources": {}
+    },
+    "parser": "json"
+  },
+  "cloudwatch:ec2_event": {
+    "schema": {
+      "version": "string",
+      "id": "string",
+      "detail-type": "string",
+      "source": "string",
+      "account": "integer",
+      "time": "string",
+      "region": "string",
+      "resources": {},
+      "detail": {
+        "instance-id": "string",
+        "state": "string"
+      }
+    },
+    "parser": "json"
   }
 }

--- a/conf/sources.json
+++ b/conf/sources.json
@@ -6,7 +6,8 @@
 				"syslog_log",
 				"kv_log",
 				"csv_log",
-				"osquery"
+				"osquery",
+				"cloudwatch"
 			]
 		}
 	},

--- a/rules/sample_rules.py
+++ b/rules/sample_rules.py
@@ -102,3 +102,18 @@ def sample_cloudtrail_rule(rec):
         rec['awsRegion'] == 'us-east-1' and
         in_set(rec['userIdentity']['invokedBy'], whitelist_services)
     )
+
+
+@rule(logs=['cloudwatch:ec2_event'],
+      matchers=[],
+      outputs=['s3'])
+def sample_cloudwatch_events_rule(rec):
+    return rec['source'] == 'aws.ec2'
+
+
+@rule(logs=['cloudwatch:cloudtrail'],
+      matchers=[],
+      outputs=['s3'])
+def sample_cloudwatch_cloudtrail_rule(rec):
+    return rec['detail']['eventName'] == 'Decrypt'
+

--- a/terraform/modules/tf_stream_alert_cloudtrail/README.md
+++ b/terraform/modules/tf_stream_alert_cloudtrail/README.md
@@ -1,0 +1,85 @@
+# Stream Alert CloudTrail Terraform Module
+Configure CloudTrail to deliver AWS API calls to AWS Kinesis and Amazon S3.
+
+## Components
+* Configures CloudTrail to log into an S3 bucket.
+* Configures a CloudWatch Event to log all API calls to Kinesis.
+* Creates an IAM Role/Policy to allow CloudWatch Events to deliver to Kinesis.
+
+## Example
+For users with no existing CloudTrail:
+```
+module "cloudtrail" {
+  source         = "modules/tf_stream_alert_cloudtrail"
+  prefix         = "streamalert"
+  cluster        = "prod"
+  enable_logging = true
+  account_id     = "111111111112"
+  kinesis_arn    = "arn:aws:kinesis:region:account-id:stream/stream-name"
+}
+```
+
+To skip the creation of a CloudTrail, set the `existing_trail` option to `true`:
+```
+module "cloudtrail" {
+  source         = "modules/tf_stream_alert_cloudtrail"
+  prefix         = "streamalert"
+  cluster        = "prod"
+  enable_logging = true
+  existing_trail = true
+  account_id     = "111111111112"
+  kinesis_arn    = "arn:aws:kinesis:region:account-id:stream/stream-name"
+}
+```
+
+## Inputs
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Description</th>
+    <th>Default</th>
+    <th>Required</th>
+  </tr>
+  <tr>
+    <td>prefix</td>
+    <td>Resource prefix namespace</td>
+    <td>None</td>
+    <td>True</td>
+  </tr>
+  <tr>
+    <td>cluster</td>
+    <td>Name of the cluster</td>
+    <td>None</td>
+    <td>True</td>
+  </tr>
+  <tr>
+    <td>enable_logging</td>
+    <td>Enables logging for the CloudTrail</td>
+    <td>true</td>
+    <td>False</td>
+  </tr>
+  <tr>
+    <td>existing_trail</td>
+    <td>Do you have an existing CloudTrail?</td>
+    <td>false</td>
+    <td>False</td>
+  </tr>
+  <tr>
+    <td>is_global_trail</td>
+    <td>Log API calls from all AWS regions</td>
+    <td>true</td>
+    <td>False</td>
+  </tr>
+  <tr>
+    <td>account_id</td>
+    <td>AWS account ID</td>
+    <td>None</td>
+    <td>True</td>
+  </tr>
+  <tr>
+    <td>kinesis_arn</td>
+    <td>The ARN of the Kinesis Stream to deliver CloudTrail logs</td>
+    <td>None</td>
+    <td>True</td>
+  </tr>
+</table>

--- a/terraform/modules/tf_stream_alert_cloudtrail/iam.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/iam.tf
@@ -1,0 +1,45 @@
+// Role for CloudWatch events
+resource "aws_iam_role" "streamalert_cloudwatch_role" {
+  name = "${var.prefix}_${var.cluster}_streamalert_cloudwatch_role"
+  path = "/streamalert/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+// Policy for CloudWatch to allow write access to Kinesis
+resource "aws_iam_role_policy" "streamalert_cloudwatch_policy" {
+  name = "${var.prefix}_${var.cluster}_streamalert_cloudwatch"
+  role = "${aws_iam_role.streamalert_cloudwatch_role.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:PutRecord",
+                "kinesis:PutRecords"
+            ],
+            "Resource": [
+                "${var.kinesis_arn}"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -1,0 +1,74 @@
+// StreamAlert CloudTrail
+resource "aws_cloudtrail" "streamalert" {
+  name                          = "${var.prefix}.${var.cluster}.streamalert.cloudtrail"
+  s3_bucket_name                = "${aws_s3_bucket.cloudtrail_bucket.id}"
+  s3_key_prefix                 = "cloudtrail"
+  enable_logging                = "${var.enable_logging}"
+  include_global_service_events = true
+  is_multi_region_trail         = "${var.is_global_trail}"
+  count                         = "${var.existing_trail ? 0 : 1}"
+}
+
+// S3 bucket for CloudTrail output
+resource "aws_s3_bucket" "cloudtrail_bucket" {
+  bucket        = "${var.prefix}.${var.cluster}.streamalert.cloudtrail"
+  force_destroy = false
+  count         = "${var.existing_trail ? 0 : 1}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "AWSCloudTrailAclCheck",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "cloudtrail.amazonaws.com"
+          },
+          "Action": "s3:GetBucketAcl",
+          "Resource": "arn:aws:s3:::${var.prefix}.${var.cluster}.streamalert.cloudtrail"
+      },
+      {
+          "Sid": "AWSCloudTrailWrite",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "cloudtrail.amazonaws.com"
+          },
+          "Action": "s3:PutObject",
+          "Resource": "arn:aws:s3:::${var.prefix}.${var.cluster}.streamalert.cloudtrail/*",
+          "Condition": {
+              "StringEquals": {
+                  "s3:x-amz-acl": "bucket-owner-full-control"
+              }
+          }
+      }
+  ]
+}
+POLICY
+
+  tags {
+    Name    = "${var.prefix}.${var.cluster}.streamalert.cloudtrail"
+    Cluster = "${var.cluster}"
+  }
+}
+
+// Cloudwatch event to capture Cloudtrail API calls
+resource "aws_cloudwatch_event_rule" "all_events" {
+  name        = "${var.prefix}_${var.cluster}_streamalert_all_events"
+  description = "Capture all CloudWatch events"
+  role_arn    = "${aws_iam_role.streamalert_cloudwatch_role.arn}"
+
+  event_pattern = <<PATTERN
+{
+  "detail-type": [
+    "AWS API Call via CloudTrail"
+  ]
+}
+PATTERN
+}
+
+// The Kinesis destination for Cloudwatch events
+resource "aws_cloudwatch_event_target" "kinesis" {
+  rule = "${aws_cloudwatch_event_rule.all_events.name}"
+  arn  = "${var.kinesis_arn}"
+}

--- a/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
@@ -1,0 +1,27 @@
+variable "account_id" {
+  type = "string"
+}
+
+variable "cluster" {
+  type = "string"
+}
+
+variable "kinesis_arn" {
+  type = "string"
+}
+
+variable "prefix" {
+  type = "string"
+}
+
+variable "enable_logging" {
+  default = true
+}
+
+variable "existing_trail" {
+  default = false
+}
+
+variable "is_global_trail" {
+  default = true
+}

--- a/test/integration/rules/sample_cloudwatch_cloudtrail_rule.json
+++ b/test/integration/rules/sample_cloudwatch_cloudtrail_rule.json
@@ -1,0 +1,63 @@
+{
+  "records": [
+    {
+      "data": {
+        "account": "0123456789012",
+        "region": "us-east-1",
+        "detail": {
+            "eventVersion": "1.05",
+            "eventID": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "eventTime": "2017-03-20T20:32:31Z",
+            "requestParameters": {
+                "encryptionContext": {
+                    "aws:s3:arn": "arn:aws:s3:::dummy.streamalert.terraform.state/stream_alert_state/terraform.tfstate"
+                }
+            },
+            "eventType": "AwsApiCall",
+            "responseElements": null,
+            "awsRegion": "us-east-1",
+            "eventName": "Decrypt",
+            "readOnly": true,
+            "userIdentity": {
+                "userName": "testuser",
+                "principalId": "ADFJIBU4IGBH76Q27GJWO",
+                "accessKeyId": "AAISIYBWMMHF6I7N01FQ",
+                "invokedBy": "internal.amazonaws.com",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2017-03-20T20:32:31Z",
+                        "mfaAuthenticated": "false"
+                    }
+                },
+                "type": "IAMUser",
+                "arn": "arn:aws:iam::0123456789012:user/testuser",
+                "accountId": "0123456789012"
+            },
+            "eventSource": "kms.amazonaws.com",
+            "requestID": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "userAgent": "internal.amazonaws.com",
+            "sourceIPAddress": "internal.amazonaws.com",
+            "resources": [
+                {
+                    "type": "AWS::KMS::Key",
+                    "ARN": "arn:aws:kms:us-east-1:0123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "accountId": "0123456789012"
+                }
+            ]
+        },
+        "detail-type": "AWS API Call via CloudTrail",
+        "source": "aws.kms",
+        "version": "0",
+        "time": "2017-03-20T20:32:31Z",
+        "id": "eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa",
+        "resources": []
+      },
+      "description": "cloudwatch cloudtrail 'Decrypt' event log",
+      "trigger": true,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    }
+  ]
+}
+
+

--- a/test/integration/rules/sample_cloudwatch_events_rule.json
+++ b/test/integration/rules/sample_cloudwatch_events_rule.json
@@ -1,0 +1,26 @@
+{
+  "records": [
+    {
+      "data": {
+        "version": "0",
+        "id": "6a7e8feb-b491-4cf7-a9f1-bf3703467718",
+        "detail-type": "AWS EC2 API Call Notification",
+        "source": "aws.ec2",
+        "account": "111122223333",
+        "time": "2015-12-22T18:43:48Z",
+        "region": "us-east-1",
+        "resources": [
+          "arn:aws:ec2:us-east-1:123456789012:instance/i-01234567"
+        ],
+        "detail": {
+          "instance-id": "i-01234567",
+          "state": "terminated"
+        }
+      },
+      "description": "cloudwatch events test for source=aws.ec2",
+      "trigger": true,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    }
+  ]
+}


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: medium

## Changes
Adds a new Terraform module called `tf_stream_alert_cloudtrail` which accepts a Kinesis Stream as input to write CloudTrail logs to.

The module creates the following:
* AWS CloudTrail with a S3 bucket for long term storage.  If a user has an existing Cloudtrail, they can skip the creation via the `existing_trail` flag in the module (see `README.md` for example).
* CloudWatch event rule to forward all API calls (in all regions) to a designated Kinesis stream.
* IAM policy/role to allow CloudWatch Events to PutRecords to Kinesis.

Additionally, this change comes with two new schema types: `cloudwatch:cloudtrail` and `cloudwatch:ec2_event` along with a rule test/example rules. 

## Testing
All testing was performed in a test AWS account, where end-to-end alerting was verified via S3. 