### PR TITLE
[cli] makes sure to write the new config format to disk

### DIFF
--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -72,6 +72,7 @@ class CLIConfig(object):
         if self.version == 1:
             self.config = self._convert_schema()
             self.version = self._detect_version()
+            self.write()
 
     def __repr__(self):
         return json.dumps(self.config)

--- a/test/unit/stream_alert_cli/test_config.py
+++ b/test/unit/stream_alert_cli/test_config.py
@@ -21,7 +21,7 @@ import json
 import io
 
 from nose.tools import assert_equal, assert_not_equal, nottest
-from mock import patch
+from mock import patch, mock_open
 
 from stream_alert_cli.config import CLIConfig
 
@@ -83,13 +83,8 @@ class TestCLIConfig(object):
             sort_keys=True
         )
 
-        def load_config(path):
-            if path == 'variables.json':
-                return io.BytesIO(v1_config_pretty)
-
         # mock the opening of `variables.json`
-        with patch('__builtin__.open') as mocked_open:
-            mocked_open.side_effect = load_config
+        with patch('__builtin__.open', mock_open(read_data=v1_config_pretty), create=True) as m:            
             cli_config = CLIConfig()
 
             assert_equal(cli_config.version, 2)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small

* When reading a v1 config, make sure to write it to disk.  This ensures that when we invoke Terraform with the new cluster format, all the variables are properly loaded.