### PR TITLE
[tf] ensure legacy output processor bucket names are retained

### DIFF
--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -61,7 +61,7 @@ resource "aws_s3_bucket" "streamalerts" {
 
 // Legacy S3 bucket name - All alerts should be copied to the bucket created above.
 resource "aws_s3_bucket" "stream_alert_output" {
-  bucket        = "${var.prefix}.${var.cluster}.stream.alert.output.processor.results"
+  bucket        = "${replace("${var.prefix}.${var.cluster}.stream.alert.output.processor.results", "_", ".")}"
   acl           = "private"
   force_destroy = false
 }


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small

Retain the legacy bucket names by replacing all `_` with `.` as it previously was.