### PR TITLE
[tf] add aws provider and update docs for flow_log module

### DIFF
--- a/terraform/modules/tf_stream_alert_flow_logs/README.md
+++ b/terraform/modules/tf_stream_alert_flow_logs/README.md
@@ -1,22 +1,32 @@
 # Stream Alert VPC Flow Log Terraform Module
-* This Terraform module enables flow logs for specified VPCs, subnets, and ENIs
-the specified kinesis stream, and the necessary IAM roles for everything to work
+* This Terraform module enables network flow logs for specified AWS VPCs, Subnets, and ENIs to send to a specified AWS Kinesis Stream.
 
 ## Components
 Creates the following:
-* A cloudwatch log group for the flow logs
-* A subscription filter delivering the logs to the specified destination stream
-* Enables flow logs for VPC resources specified in `var.targets`
+* A CloudWatch log group to store the flow logs.
+* A subscription filter delivering the logs to the specified destination Kinesis Stream.
+* Enables flow logs for VPC resources specified in `var.targets`.
+* IAM Roles and Policies to allow flow logs to be delivered.
 
 
 ## Example
 ```
+variable "flow_log_targets" {
+  type = "map"
+
+  default = {
+    "vpcs"    = ["vpc-id-1", "vpc-id-2"]
+    "subnets" = ["subnet-id-1"]
+    "enis"    = ["eni-id-1"]
+  }
+}
+
 module "flow_logs_prod" {
   source                 = "modules/tf_stream_alert_flow_logs"
-  destination_stream_arn = "${module.kinesis_prod.arn}"
-  targets                = "${var.flow_log_settings["prod"]}"
-  region                 = "${lookup(var.clusters, "prod")}"
-  flow_log_group_name    = "${var.prefix}_prod_stream_alert_flow_logs"
+  flow_log_group_name    = "prefix_cluster_streamalert_flow_logs"
+  destination_stream_arn = "arn:aws:kinesis:region:account-id:stream/stream-name"
+  targets                = "${var.flow_log_targets}"
+  region                 = "us-east-1"
 }
 ```
 
@@ -30,13 +40,13 @@ module "flow_logs_prod" {
   </tr>
   <tr>
     <td>destination_stream_arn</td>
-    <td>ARN of the kinesis stream that will receive the flow logs</td>
+    <td>ARN of the Kinesis Stream which receives the flow logs</td>
     <td>None</td>
     <td>True</td>
   </tr>
   <tr>
     <td>region</td>
-    <td>The AWS region for your cluster</td>
+    <td>The AWS region of your VPC(s), Subnet(s), or ENI(s)</td>
     <td>None</td>
     <td>True</td>
   </tr>

--- a/terraform/modules/tf_stream_alert_flow_logs/main.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
 resource "aws_flow_log" "vpc_flow_log" {
   count          = "${length(var.targets["vpcs"])}"
   vpc_id         = "${element(var.targets["vpcs"],count.index)}"


### PR DESCRIPTION
to @strcrzy 
cc @airbnb/streamalert-maintainers 
size small

* Add a specific `aws` provider for the `tf_stream_alert_flow_logs` Terraform module to account for multi-region resources.
* Update documentation for this change and for additional details.