### PR TITLE
[tf] add default value for flow_log module provider

### DIFF
--- a/terraform/modules/tf_stream_alert_flow_logs/variables.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/variables.tf
@@ -1,6 +1,8 @@
 variable "destination_stream_arn" {}
 
-variable "region" {}
+variable "region" {
+  default = "us-east-1"
+}
 
 variable "flow_log_group_name" {}
 


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 

* Fixes a bug in the CLI `lambda deploy`.  If no default value is provided, Terraform throws errors during lambda function deployment.