### PR TITLE
Sink py fix and compress testing support

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -183,5 +183,32 @@
       }
     },
     "parser": "json"
+  },
+  "cloudwatch:flow_logs": {
+    "schema": {
+      "protocol": "integer",
+      "source": "string",
+      "destination": "string",
+      "srcport": "integer",
+      "destport": "integer",
+      "action": "string",
+      "packets": "integer",
+      "bytes": "integer",
+      "windowstart": "integer",
+      "windowend": "integer",
+      "version": "integer",
+      "eni": "string",
+      "account": "integer",
+      "flowlogstatus": "string"
+    },
+    "parser": "gzip-json",
+    "hints": {
+      "records": "logEvents[*].extractedFields",
+      "envelope": {
+        "logGroup": "string",
+        "logStream": "string",
+        "owner": "integer"
+      }
+    }
   }
 }

--- a/rules/sample_rules.py
+++ b/rules/sample_rules.py
@@ -92,6 +92,7 @@ def sample_kv_rule_last_hour(rec):
       matchers=[],
       outputs=['slack'])
 def sample_cloudtrail_rule(rec):
+    """Non Lambda/Kinesis service AssumedRole"""
     whitelist_services = {
         'lambda.amazonaws.com',
         'kinesis.amazonaws.com'
@@ -100,7 +101,7 @@ def sample_cloudtrail_rule(rec):
     return (
         rec['eventName'] == 'AssumeRole' and
         rec['awsRegion'] == 'us-east-1' and
-        in_set(rec['userIdentity']['invokedBy'], whitelist_services)
+        not in_set(rec['userIdentity']['invokedBy'], whitelist_services)
     )
 
 
@@ -108,6 +109,7 @@ def sample_cloudtrail_rule(rec):
       matchers=[],
       outputs=['s3'])
 def sample_cloudwatch_events_rule(rec):
+    """Any activity on EC2"""
     return rec['source'] == 'aws.ec2'
 
 
@@ -115,5 +117,16 @@ def sample_cloudwatch_events_rule(rec):
       matchers=[],
       outputs=['s3'])
 def sample_cloudwatch_cloudtrail_rule(rec):
+    """IAM Key Decrypt operation"""
     return rec['detail']['eventName'] == 'Decrypt'
 
+
+@rule(logs=['cloudwatch:flow_logs'],
+      matchers=[],
+      outputs=['slack'])
+def sample_cloudwatch_flog_log_rule(rec):
+    """Successful SSH connection"""
+    return (
+        rec['destport'] == 22 and
+        rec['action'] == 'ACCEPT'
+    )

--- a/stream_alert/rule_processor/sink.py
+++ b/stream_alert/rule_processor/sink.py
@@ -87,9 +87,8 @@ class StreamSink(object):
             region: Which AWS region the SNS topic exists in.
             topic: The name of the SNS topic.
         """
-        prefix, cluster = self.env['lambda_function_name'].split('_')[0:2]
-        # dynamically generate the SNS topic name: prefix_cluster_streamalerts
-        topic = '_'.join([prefix, cluster, 'streamalerts'])
+        topic = self.env['lambda_function_name'].replace('_streamalert_rule_processor',
+                                                         '_streamalerts')
 
         return 'arn:aws:sns:{region}:{account_id}:{topic}'.format(
             region=self.env['lambda_region'],

--- a/test/integration/rules/sample_cloudtrail_rule.json
+++ b/test/integration/rules/sample_cloudtrail_rule.json
@@ -7,17 +7,17 @@
             "eventVersion": "1.05",
             "userIdentity": {
               "type": "AWSService",
-              "invokedBy": "lambda.amazonaws.com"
+              "invokedBy": "sns.amazonaws.com"
             },
             "eventTime": "2017-01-01T23:00:00Z",
             "eventSource": "sts.amazonaws.com",
             "eventName": "AssumeRole",
             "awsRegion": "us-east-1",
-            "sourceIPAddress": "lambda.amazonaws.com",
-            "userAgent": "lambda.amazonaws.com",
+            "sourceIPAddress": "sns.amazonaws.com",
+            "userAgent": "sns.amazonaws.com",
             "requestParameters": {
-              "roleSessionName": "lambda_name",
-              "roleArn": "arn:aws:iam::account:role/lambda"
+              "roleSessionName": "sns_name",
+              "roleArn": "arn:aws:iam::account:role/sns"
             },
             "responseElements": {
               "credentials": {
@@ -30,7 +30,7 @@
             "eventID": "6666666-666666-66666-666666",
             "resources": [
               {
-                "ARN": "arn:aws:iam::account:role/lambda",
+                "ARN": "arn:aws:iam::account:role/sns",
                 "accountId": "11111111111",
                 "type": "AWS::IAM::Role"
               }
@@ -43,17 +43,17 @@
             "eventVersion": "1.05",
             "userIdentity": {
               "type": "AWSService",
-              "invokedBy": "kinesis.amazonaws.com"
+              "invokedBy": "elasticbeanstalk.amazonaws.com"
             },
             "eventTime": "2017-01-01T23:00:00Z",
             "eventSource": "sts.amazonaws.com",
             "eventName": "AssumeRole",
             "awsRegion": "us-east-1",
             "sourceIPAddress": "servivce.amazonaws.com",
-            "userAgent": "kinesis.amazonaws.com",
+            "userAgent": "elasticbeanstalk.amazonaws.com",
             "requestParameters": {
-              "roleSessionName": "kinesis_name",
-              "roleArn": "arn:aws:iam::account:role/kinesis"
+              "roleSessionName": "elasticbeanstalk_name",
+              "roleArn": "arn:aws:iam::account:role/elasticbeanstalk"
             },
             "responseElements": {
               "credentials": {
@@ -66,7 +66,7 @@
             "eventID": "777777-777777-777777-777777",
             "resources": [
               {
-                "ARN": "arn:aws:iam::account:role/kinesis",
+                "ARN": "arn:aws:iam::account:role/elasticbeanstalk",
                 "accountId": "11111111111",
                 "type": "AWS::IAM::Role"
               }

--- a/test/integration/rules/sample_cloudwatch_flog_log_rule.json
+++ b/test/integration/rules/sample_cloudwatch_flog_log_rule.json
@@ -1,0 +1,43 @@
+{
+  "records": [
+    {
+      "data": {
+        "owner": 123456789101,
+        "logGroup": "rule-test-group",
+        "logStream": "rule-test-stream",
+        "subscriptionFilters": [
+          "flow_logs_to_lambda"
+        ],
+        "messageType": "DATA_MESSAGE",
+        "logEvents": [
+          {
+            "extractedFields": {
+              "protocol": 7,
+              "source": "10.0.5.1",
+              "destination": "23.16.23.123",
+              "srcport": "35446",
+              "destport": "22",
+              "action": "ACCEPT",
+              "packets": 1,
+              "bytes": 100,
+              "windowstart": 1490996987,
+              "windowend": 1490996995,
+              "version": 1,
+              "eni": "eni-id",
+              "account": 123456789101,
+              "flowlogstatus": "running"
+            },
+            "timestamp": 1490996995,
+            "message": "string message representing the extracted fields",
+            "id": "123451234123412341234123412341235123512351235"
+          }
+        ]
+      },
+      "description": "cloudwatch flow log SSH event",
+      "trigger": true,
+      "compress": true,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    }
+  ]
+}

--- a/test/unit/test_sink.py
+++ b/test/unit/test_sink.py
@@ -36,7 +36,7 @@ class TestStreamSink(object):
         self.env = {
             'lambda_region': 'us-east-1',
             'account_id': '123456789012',
-            'lambda_function_name': 'unittest_prod_stream_alert_test',
+            'lambda_function_name': 'unittest_prod_streamalert_rule_processor',
             'lambda_alias': 'production'
         }
 


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: medium

* Fix a bug in `rule_processor:sink.py` to more reliably generate the SNS topic name.
* Add support in the sample `logs.json` for `cloudwatch` flow logs.
* Support testing of `flow_logs` via compressing events for the `gzip-json` parser.
* Add sample rule and test for `flow_logs`
* Add rules descriptions to previous  `cloudwatch` rules