### PR TITLE
List, Boolean, and Float Schema Types

### DIFF
--- a/docs/source/conf-schemas.rst
+++ b/docs/source/conf-schemas.rst
@@ -28,7 +28,7 @@ Schemas are defined in ``conf/logs.json``
       "recipientAccountId": "string"
     },
     "hints" : {
-      "records": "Records[*]"
+      "records": "Records[*]"               # JSONPath to records
     }
   },
   ....
@@ -38,8 +38,9 @@ Here are the basics:
 
 * Keys defined in the ``schema`` must exist
 * Values are weakly/loosely typed and enforced
-* Arrays imply zero or more elements
-* An empty map ({}) implies zero or more elements
+* Supported types: ``string``, ``integer``, ``boolean``, ``float``, ``{}``, and ``[]``
+* An empty array (``[]``) imply zero or more elements of any type
+* An empty map (``{}``) implies zero or more key/value pairs
 * Schemas can be as tight or as loose as you want (see Example: osquery)
 * If you have nested records, you can specify a JSONPath to your ``records`` with ``hints``
 

--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -300,7 +300,21 @@ class StreamClassifier(object):
                     logger.error('Invalid schema - %s is not an int', key)
                     return False
 
+            elif value == 'float':
+                try:
+                    payload[key] = float(payload[key])
+                except ValueError as e:
+                    logger.error('Invalid schema - %s is not a float', key)
+                    return False
+
+            elif value == 'boolean':
+                payload[key] = payload[key].lower() == 'true'
+
+            elif isinstance(value, list):
+                pass
+
             elif isinstance(value, (OrderedDict)):
+                # allow for any value to exist in the map
                 if len(value) == 0:
                     pass
                 else:

--- a/test/unit/conf/logs.json
+++ b/test/unit/conf/logs.json
@@ -2,7 +2,7 @@
   "test_log_type_json": {
     "parser": "json",
     "schema": {
-      "key1": "string",
+      "key1": [],
       "key2": "string",
       "key3": "integer"
     }
@@ -10,10 +10,10 @@
   "test_log_type_json_2": {
     "parser": "json",
     "schema": {
-      "key4": "string",
-      "key5": "string",
-      "key6": "string",
-      "key7": "string"
+      "key4": "boolean",
+      "key5": "float",
+      "key6": "integer",
+      "key7": "boolean"
     }
   },
   "test_log_type_json_nested": {


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small
resolves #77 

* Support `[]`, `boolean`, and `float` schema types.
* Update docs.
* Add unit test coverage for these changes.