### PR TITLE
[tf] ensure streamalerts bucket follows DNS naming scheme

### DIFF
--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -54,7 +54,7 @@ resource "aws_lambda_permission" "with_sns" {
 
 // S3 bucket for S3 outputs
 resource "aws_s3_bucket" "streamalerts" {
-  bucket        = "${var.prefix}.${var.cluster}.streamalerts"
+  bucket        = "${replace("${var.prefix}.${var.cluster}.streamalerts", "_", ".")}"
   acl           = "private"
   force_destroy = false
 }


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small

Ensure that the `streamalerts` bucket ID follows the DNS scheme defined in other TF modules