### PR TITLE
[core] check loaded boolean type before converting

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -308,7 +308,7 @@ class StreamClassifier(object):
                     return False
 
             elif value == 'boolean':
-                payload[key] = payload[key].lower() == 'true'
+                payload[key] = str(payload[key].lower()) == 'true'
 
             elif isinstance(value, list):
                 pass


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small

* Check the loaded type of the value to convert to `boolean` before casting.  JSON may load a boolean into its correct type while other parsers will need to be converted from a string/unicode.