### PR TITLE
[lambda][alert] fix a bug in getting the s3 bucket name to send alerts

### DIFF
--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -153,8 +153,9 @@ class StreamOutput(object):
     def _get_bucket_name(context):
         """Return the lambda function name for the currently executing Lambda function."""
         lambda_func_name = context.invoked_function_arn.split(':')[6]
-        prefix, cluster = lambda_func_name.split('_')[0:2]
-        return '.'.join([prefix, cluster, 'streamalerts'])
+        bucket = lambda_func_name.replace('_streamalert_alert_processor',
+                                                         '_streamalerts')
+        return bucket.replace('_', '.')
 
     def _setup_output_creds(self, output):
         """Decrypt credentials and store them in the `creds` attribute.


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small

Terraform replaces all `_` with `.` to generate the name of the [StreamAlerts S3 bucket](https://github.com/airbnb/streamalert/blob/master/terraform/modules/tf_stream_alert/main.tf#L56-L60).  This change must also occur in the Lambda function to ensure we send alerts to the correct bucket. 