### PR TITLE
Optional Top Level Keys and Configuration Log Option

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -41,8 +41,10 @@
       "time": "integer"
     },
     "parser": "kv",
-    "delimiter": " ",
-    "separator": "="
+    "configuration": {
+      "delimiter": " ",
+      "separator": "="  
+    }
   },
   "osquery": {
     "schema": {
@@ -88,8 +90,8 @@
       "recipientAccountId": "integer"
     },
     "parser": "json",
-    "hints": {
-      "records": "Records[*]"
+    "configuration": {
+      "json_path": "Records[*]"
     }
   },
   "cloudtrail:v1.04": {
@@ -133,8 +135,8 @@
       "recipientAccountId": "integer"
     },
     "parser": "json",
-    "hints": {
-      "records": "Records[*]"
+    "configuration": {
+      "json_path": "Records[*]"
     }
   },
   "cloudwatch:cloudtrail": {
@@ -202,9 +204,9 @@
       "flowlogstatus": "string"
     },
     "parser": "gzip-json",
-    "hints": {
-      "records": "logEvents[*].extractedFields",
-      "envelope": {
+    "configuration": {
+      "json_path": "logEvents[*].extractedFields",
+      "envelope_keys": {
         "logGroup": "string",
         "logStream": "string",
         "owner": "integer"

--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -222,35 +222,33 @@ class StreamClassifier(object):
         Returns:
             A boolean representing the success of the parse.
         """
-
         log_metadata = self.log_metadata(payload)
         # TODO(jack) make this process more efficient.
         # Separate out parsing with key matching.
         # Right now, if keys match but the type/parser is correct,
         # it has to start over
         for log_name, attributes in log_metadata.iteritems():
-            # short circuit parser determination
+            # Short circuit parser determination
             if not payload.type:
                 parser_name = attributes['parser']
             else:
                 parser_name = payload.type
 
             options = {}
-            options['hints'] = attributes.get('hints')
-            options['delimiter'] = attributes.get('delimiter')
-            options['separator'] = attributes.get('separator')
+            options['hints'] = attributes.get('hints', {})
+            options['configuration'] = attributes.get('configuration', {})
             options['parser'] = parser_name
-            options['service'] = payload.service
+
             schema = attributes['schema']
 
-            # Setup the parser
+            # Setup the parser class
             parser_class = get_parser(parser_name)
             parser = parser_class(data, schema, options)
             options['nested_keys'] = parser.__dict__.get('nested_keys')
             # A list of parsed records
             parsed_data = parser.parse()
 
-            # Used for short circuiting parser determination
+            # Set the payload type to short circuit parser determination
             if parser.payload_type:
                 payload.type = parser.payload_type
 

--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -257,8 +257,10 @@ class StreamClassifier(object):
                 logger.debug('parsed_data: %s', parsed_data)
                 typed_data = []
                 for data in parsed_data:
-                    # convert data types per the schema
-                    typed_data.append(self._convert_type(data, schema, options))
+                    # Convert data types per the schema
+                    # Use the parser.schema due to updates caused by
+                    #   configuration settings such as envelope and optional_keys
+                    typed_data.append(self._convert_type(data, parser.schema, options))
 
                 if typed_data:
                     payload.log_source = log_name
@@ -294,14 +296,14 @@ class StreamClassifier(object):
             elif value == 'integer':
                 try:
                     payload[key] = int(payload[key])
-                except ValueError as e:
+                except ValueError:
                     logger.error('Invalid schema - %s is not an int', key)
                     return False
 
             elif value == 'float':
                 try:
                     payload[key] = float(payload[key])
-                except ValueError as e:
+                except ValueError:
                     logger.error('Invalid schema - %s is not a float', key)
                     return False
 

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -180,7 +180,7 @@ class JSONParser(ParserBase):
                     json_payload[key_name] = default_optional_values(value_type)
 
         # Handle jsonpath extraction of records
-        if config_options and len(config_options) and records_schema:
+        if config_options and records_schema:
             records_jsonpath = jsonpath_rw.parse(records_schema)
             if len(envelope_schema):
                 self.schema.update({'envelope': envelope_schema})

--- a/test/scripts/autopep8.sh
+++ b/test/scripts/autopep8.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+autopep8 --in-place --aggressive --aggressive $1

--- a/test/scripts/unit_tests.sh
+++ b/test/scripts/unit_tests.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-nosetests test/unit --with-coverage --cover-package=stream_alert
+nosetests test/unit --with-coverage --cover-package=stream_alert --cover-package=stream_alert_cli --cover-min-percentage=80

--- a/test/unit/conf/logs.json
+++ b/test/unit/conf/logs.json
@@ -59,8 +59,6 @@
   },
   "test_log_type_kv_auditd": {
     "parser": "kv",
-    "delimiter": " ",
-    "separator": "=",
     "schema": {
       "type": "string",
       "msg": "string",
@@ -104,6 +102,10 @@
       "ogid": "integer",
       "rdev": "string",
       "obj": "string"
+    },
+    "configuration": {
+      "delimiter": " ",
+      "separator": "="
     }
   },
   "test_log_type_csv": {
@@ -169,30 +171,30 @@
       "results": "string"
     },
     "parser": "json",
-    "hints": {
-      "records": "$.profiles[*].controls[*]"
+    "configuration": {
+      "json_path": "$.profiles[*].controls[*]"
     }
   },
   "test_cloudtrail": {
     "parser": "json",
     "schema": {
-          "eventVersion": "string",
-          "eventID": "string",
-          "eventTime": "string",
-          "requestParameters": {},
-          "eventType": "string",
-          "responseElements": "string",
-          "awsRegion": "string",
-          "eventName": "string",
-          "userIdentity": {},
-          "eventSource": "string",
-          "requestID": "string",
-          "userAgent": "string",
-          "sourceIPAddress": "string",
-          "recipientAccountId": "string"
+      "eventVersion": "string",
+      "eventID": "string",
+      "eventTime": "string",
+      "requestParameters": {},
+      "eventType": "string",
+      "responseElements": "string",
+      "awsRegion": "string",
+      "eventName": "string",
+      "userIdentity": {},
+      "eventSource": "string",
+      "requestID": "string",
+      "userAgent": "string",
+      "sourceIPAddress": "string",
+      "recipientAccountId": "string"
     },
-    "hints" : {
-      "records": "Records[*]"
+    "configuration": {
+      "json_path": "Records[*]"
     }
   },
   "test_cloudwatch": {
@@ -213,9 +215,9 @@
       "flowlogstatus": "string"
     },
     "parser": "gzip-json",
-    "hints": {
-      "records": "logEvents[*].extractedFields",
-      "envelope": {
+    "configuration": {
+      "json_path": "logEvents[*].extractedFields",
+      "envelope_keys": {
         "logGroup": "string",
         "logStream": "string",
         "owner": "integer"

--- a/test/unit/conf/logs.json
+++ b/test/unit/conf/logs.json
@@ -5,6 +5,13 @@
       "key1": [],
       "key2": "string",
       "key3": "integer"
+    },
+    "configuration": {
+      "optional_top_level_keys": {
+        "key9": "boolean",
+        "key10": {},
+        "key11": "float"
+      }
     }
   },
   "test_log_type_json_2": {
@@ -39,6 +46,11 @@
         "env": "string",
         "cluster": "string",
         "number": "integer"
+      }
+    },
+    "configuration": {
+      "optional_top_level_keys": {
+        "log_type": "string"
       }
     }
   },

--- a/test/unit/test_classifier.py
+++ b/test/unit/test_classifier.py
@@ -52,7 +52,7 @@ class TestStreamPayload(object):
                               .format(kinesis_stream),
             'kinesis': {
                 'data': base64.b64encode(kinesis_data)
-                              }
+            }
         }
         return raw_record
 

--- a/test/unit/test_classifier.py
+++ b/test/unit/test_classifier.py
@@ -20,13 +20,12 @@ limitations under the License.
 import base64
 import json
 
-from collections import OrderedDict
-
-from nose.tools import assert_equal, assert_not_equal, nottest
+from nose.tools import assert_equal, assert_not_equal
 
 from stream_alert.rule_processor.classifier import StreamPayload, StreamClassifier
 from stream_alert.rule_processor.pre_parsers import StreamPreParsers
 from stream_alert.rule_processor.config import load_config
+
 
 class TestStreamPayload(object):
     @classmethod
@@ -50,10 +49,10 @@ class TestStreamPayload(object):
         raw_record = {
             'eventSource': 'aws:kinesis',
             'eventSourceARN': 'arn:aws:kinesis:us-east-1:123456789012:stream/{}'
-                .format(kinesis_stream),
+                              .format(kinesis_stream),
             'kinesis': {
                 'data': base64.b64encode(kinesis_data)
-            }
+                              }
         }
         return raw_record
 
@@ -63,7 +62,7 @@ class TestStreamPayload(object):
         kinesis_data = kwargs['kinesis_data']
         kinesis_record = self.make_kinesis_record(kinesis_stream=kinesis_stream,
                                                   kinesis_data=kinesis_data)
-        
+
         payload = StreamPayload(raw_record=kinesis_record)
         return payload
 
@@ -82,7 +81,6 @@ class TestStreamPayload(object):
         """Teardown after each method"""
         pass
 
-
     def test_refresh_record(self):
         """Payload Record Refresh"""
         kinesis_data = json.dumps({
@@ -100,12 +98,11 @@ class TestStreamPayload(object):
             'key6': 'key6data'
         })
         second_record = self.make_kinesis_record(kinesis_stream='test_kinesis_stream',
-                                 kinesis_data=new_kinesis_data)
+                                                 kinesis_data=new_kinesis_data)
         payload.refresh_record(second_record)
 
         # check newly loaded record
         assert_equal(payload.raw_record, second_record)
-
 
     def test_map_source_1(self):
         """Payload Source Mapping 1"""
@@ -132,7 +129,6 @@ class TestStreamPayload(object):
         assert_equal(payload.entity, 'test_kinesis_stream')
         assert_equal(set(metadata.keys()), test_kinesis_stream_logs)
 
-
     def test_map_source_2(self):
         """Payload Source Mapping 2"""
         data_encoded = base64.b64encode('test_map_source_data_2')
@@ -154,9 +150,8 @@ class TestStreamPayload(object):
         assert_equal(payload.entity, 'test_stream_2')
         assert_equal(set(metadata.keys()), test_stream_2_logs)
 
-
-    def test_classify_record_kinesis_json(self):
-        """Payload Classify JSON"""
+    def test_classify_record_kinesis_json_optional(self):
+        """Payload Classify JSON - optional fields"""
         kinesis_data = json.dumps({
             'key1': [
                 {
@@ -169,7 +164,11 @@ class TestStreamPayload(object):
                 }
             ],
             'key2': 'more sample data',
-            'key3': '1'
+            'key3': '1',
+            'key10': {
+                'test-field': 1,
+                'test-field2': 2
+            }
         })
         payload = self.payload_generator(kinesis_stream='test_kinesis_stream',
                                          kinesis_data=kinesis_data)
@@ -191,11 +190,18 @@ class TestStreamPayload(object):
         assert_equal(payload.type, 'json')
         assert_not_equal(payload.type, 'csv')
 
-        # record type test
-        assert_equal(type(payload.records[0]['key1']), list)
+        # record value tests
         assert_equal(len(payload.records[0]['key1']), 2)
+        assert_equal(payload.records[0]['key3'], 1)
         assert_equal(payload.records[0]['key1'][1]['test4'], 4)
 
+        # optional field tests
+        assert_equal(payload.records[0]['key11'], 0.0)
+        assert_equal(payload.records[0]['key9'], False)
+        assert_equal(len(payload.records[0]['key10']), 2)
+
+        # record type tests
+        assert_equal(type(payload.records[0]['key1']), list)
         assert_equal(type(payload.records[0]['key2']), str)
         assert_equal(type(payload.records[0]['key3']), int)
 
@@ -232,7 +238,6 @@ class TestStreamPayload(object):
         assert_equal(payload.records[0]['key5'], 10.001)
         assert_equal(payload.records[0]['key6'], 10)
         assert_equal(payload.records[0]['key7'], False)
-
 
     def test_classify_record_kinesis_nested_json(self):
         """Payload Classify Nested JSON"""
@@ -272,7 +277,6 @@ class TestStreamPayload(object):
         # record value test
         assert_equal(payload.records[0]['date'], 'Jan 01 2017')
         assert_equal(payload.records[0]['data']['key1'], 'test')
-
 
     def test_classify_record_kinesis_nested_json_osquery(self):
         """Payload Classify JSON osquery"""
@@ -324,7 +328,7 @@ class TestStreamPayload(object):
         assert_equal(payload.records[0]['columns']['key1'], 'test')
         assert_equal(payload.records[0]['decorations']['cluster'], 'eu-east')
         assert_equal(payload.records[0]['decorations']['number'], 100)
-
+        assert_equal(payload.records[0]['log_type'], '')
 
     def test_classify_record_kinesis_nested_json_missing_subkey_fields(self):
         """Payload Classify Nested JSON Missing Subkeys"""
@@ -346,7 +350,7 @@ class TestStreamPayload(object):
             }
         })
         payload = self.payload_generator(kinesis_stream='test_stream_2',
-                                               kinesis_data=kinesis_data)
+                                         kinesis_data=kinesis_data)
 
         classifier = StreamClassifier(config=self.config)
         classifier.map_source(payload)
@@ -357,7 +361,6 @@ class TestStreamPayload(object):
         # invalid record test
         assert_equal(payload.valid, False)
         assert_equal(payload.records, None)
-
 
     def test_classify_record_kinesis_nested_json_with_data(self):
         """Payload Classify Nested JSON Generic"""
@@ -374,7 +377,7 @@ class TestStreamPayload(object):
             }
         })
         payload = self.payload_generator(kinesis_stream='test_kinesis_stream',
-                                               kinesis_data=kinesis_data)
+                                         kinesis_data=kinesis_data)
 
         classifier = StreamClassifier(config=self.config)
         classifier.map_source(payload)
@@ -385,7 +388,7 @@ class TestStreamPayload(object):
         # valid record test
         assert_equal(payload.valid, True)
         assert_equal(type(payload.records[0]), dict)
-        
+
         # log type test
         assert_equal(payload.log_source, 'test_log_type_json_nested_with_data')
 
@@ -404,12 +407,11 @@ class TestStreamPayload(object):
         assert_equal(payload.records[0]['date'], 'Jan 01 2017')
         assert_equal(payload.records[0]['data']['source'], 'dev-app-1')
 
-
     def test_classify_record_kinesis_csv(self):
         """Payload Classify CSV"""
         csv_data = 'jan102017,0100,host1,thisis some data with keyword1 in it'
         payload = self.payload_generator(kinesis_stream='test_kinesis_stream',
-                                               kinesis_data=csv_data)
+                                         kinesis_data=csv_data)
 
         classifier = StreamClassifier(config=self.config)
         classifier.map_source(payload)
@@ -432,7 +434,6 @@ class TestStreamPayload(object):
 
         # log source test
         assert_equal(payload.log_source, 'test_log_type_csv')
-
 
     def test_classify_record_kinesis_csv_nested(self):
         """Payload Classify Nested CSV"""
@@ -466,7 +467,6 @@ class TestStreamPayload(object):
 
         # log source test
         assert_equal(payload.log_source, 'test_log_type_csv_nested')
-
 
     def test_classify_record_kinesis_kv(self):
         """Payload Classify KV"""
@@ -508,7 +508,6 @@ class TestStreamPayload(object):
         assert_not_equal(payload.type, 'csv')
         assert_not_equal(payload.type, 'json')
 
-
     def test_classify_record_syslog(self):
         """Payload Classify Syslog"""
         test_data_1 = (
@@ -548,7 +547,9 @@ class TestStreamPayload(object):
             if name == 'test_1':
                 assert_equal(payload.records[0]['host'], 'vagrant-ubuntu-trusty-64')
                 assert_equal(payload.records[0]['application'], 'sudo')
-                assert_equal(payload.records[0]['message'], 'pam_unix(sudo:session): session opened for user root by (uid=0)')
+                assert_equal(payload.records[0]['message'], 'pam_unix(sudo:session):'
+                                                            ' session opened for user'
+                                                            ' root by (uid=0)')
             elif name == 'test_2':
                 assert_equal(payload.records[0]['host'], 'macbook004154test')
                 assert_equal(payload.records[0]['application'], 'authd')

--- a/test/unit/test_gzip_json_parser.py
+++ b/test/unit/test_gzip_json_parser.py
@@ -44,13 +44,27 @@ class TestGzipJsonParser(object):
     def test_cloudwatch(self):
         """Parse CloudWatch JSON"""
         schema = self.config['logs']['test_cloudwatch']['schema']
-        options = { "hints": self.config['logs']['test_cloudwatch']['hints']}
+        options = {
+            'configuration': self.config['logs']['test_cloudwatch']['configuration']
+        }
+
         with open('test/unit/fixtures/cloudwatch.json','r') as fixture_file:
             data = fixture_file.readlines()
         data_record = zlib.compress(data[0].strip())
-        parsed_result = self.parser_helper(data=data_record, schema=schema, options=options)
+
+        parsed_result = self.parser_helper(data=data_record,
+                                           schema=schema,
+                                           options=options)
+
         assert_not_equal(parsed_result, False)
         assert_equal(80,len(parsed_result))
+
+        expected_keys = (u'protocol', u'source', u'destination', u'srcport',
+                         u'destport', u'eni', u'action', u'packets', u'bytes',
+                         u'windowstart', u'windowend', u'version', u'account',
+                         u'flowlogstatus',u'envelope')
+        expected_envelope_keys = (u'logGroup', u'logStream', u'owner')
+
         for result in parsed_result:
-            assert_equal(sorted((u'protocol', u'source', u'destination', u'srcport', u'destport', u'eni', u'action', u'packets', u'bytes', u'windowstart', u'windowend', u'version', u'account', u'flowlogstatus',u'envelope')), sorted(result.keys()))
-            assert_equal(sorted((u"logGroup",u"logStream",u"owner")),sorted(result['envelope'].keys()))
+            assert_equal(sorted(expected_keys), sorted(result.keys()))
+            assert_equal(sorted(expected_envelope_keys),sorted(result['envelope'].keys()))

--- a/test/unit/test_json_parser.py
+++ b/test/unit/test_json_parser.py
@@ -2,15 +2,11 @@ from stream_alert.rule_processor.config import load_config
 from stream_alert.rule_processor.parsers import get_parser
 
 import json
-import zlib
 
 from nose.tools import (
-    assert_equal,
-    assert_not_equal,
-    nottest,
-    assert_raises,
-    raises
+    assert_equal,    
 )
+
 
 class TestJSONParser(object):
     @classmethod
@@ -87,15 +83,15 @@ class TestJSONParser(object):
                                            options=options)
 
         assert_equal(len(parsed_result), 2)
-        inspec_keys = (u'impact', u'code', u'tags', u'source_location', u'refs', 
+        inspec_keys = (u'impact', u'code', u'tags', u'source_location', u'refs',
                        u'title', u'results', u'id', u'desc')
-        assert_equal(sorted((inspec_keys)),sorted(parsed_result[0].keys()))
+        assert_equal(sorted((inspec_keys)), sorted(parsed_result[0].keys()))
 
     def test_cloudtrail(self):
         """Parse Cloudtrail JSON"""
         schema = self.config['logs']['test_cloudtrail']['schema']
         options = {
-            'configuration' : self.config['logs']['test_cloudtrail']['configuration']
+            'configuration': self.config['logs']['test_cloudtrail']['configuration']
         }
         # load fixture file
         with open('test/unit/fixtures/cloudtrail.json', 'r') as fixture_file:
@@ -104,7 +100,7 @@ class TestJSONParser(object):
         data_record = data[0].strip()
         # setup json parser
         parsed_result = self.parser_helper(data=data_record,
-                                           schema=schema, 
+                                           schema=schema,
                                            options=options)
 
         assert_equal(len(parsed_result), 2)
@@ -142,3 +138,41 @@ class TestJSONParser(object):
         assert_equal(set(parsed_data[0].keys()), {'name', 'age', 'city', 'state'})
         assert_equal(parsed_data[0]['name'], 'john')
         assert_equal(type(parsed_data[0]['age']), int)
+
+    def test_optional_keys_json(self):
+        """Parse JSON with optional top level keys"""
+        schema = {
+            'name': 'string',
+            'host': 'string',
+            'columns': {}
+        }
+        options = {
+            'configuration': {
+                'optional_top_level_keys': {
+                    'ids': [],
+                    'results': {},
+                    'host-id': 'integer',
+                    'valid': 'boolean'
+                }
+            }
+        }
+        data = json.dumps({
+            'name': 'unit-test',
+            'host': 'unit-test-host-1',
+            'columns': {
+                'test-column': 1
+            },
+            'valid': 'true'
+        })
+        parsed_result = self.parser_helper(data=data,
+                                           schema=schema,
+                                           options=options)
+
+        # tests
+        assert_equal(parsed_result[0]['host'], 'unit-test-host-1')
+        assert_equal(parsed_result[0]['valid'], 'true')
+
+        # test optional fields
+        assert_equal(parsed_result[0]['host-id'], 0)
+        assert_equal(parsed_result[0]['ids'], [])
+        assert_equal(parsed_result[0]['results'], {})

--- a/test/unit/test_json_parser.py
+++ b/test/unit/test_json_parser.py
@@ -1,5 +1,7 @@
 from stream_alert.rule_processor.config import load_config
 from stream_alert.rule_processor.parsers import get_parser
+
+import json
 import zlib
 
 from nose.tools import (
@@ -49,11 +51,18 @@ class TestJSONParser(object):
             'result': 'string'
         }
         options = {
-            "hints": {
-                "records": "profiles.controls[*]"
+            'configuration': {
+                'json_path': 'profiles.controls[*]'
             }
         }
-        data = '{"profiles": {"controls": [{"name": "infra-test-1", "result": "fail"}]}}'
+        data = json.dumps({
+            'profiles': {
+                'controls': [{
+                    'name': 'test-infra-1',
+                    'result': 'fail'
+                }]
+            }
+        })
 
         # get parsed data
         parsed_data = self.parser_helper(data=data, schema=schema, options=options)
@@ -64,29 +73,40 @@ class TestJSONParser(object):
     def test_inspec(self):
         """Parse Inspec JSON"""
         schema = self.config['logs']['test_inspec']['schema']
-        options = { "hints" : self.config['logs']['test_inspec']['hints'] }
+        options = {
+            'configuration': self.config['logs']['test_inspec']['configuration']
+        }
         # load fixture file
         with open('test/unit/fixtures/inspec.json', 'r') as fixture_file:
             data = fixture_file.readlines()
 
         data_record = data[0].strip()
         # setup json parser
-        parsed_result = self.parser_helper(data=data_record, schema=schema, options=options)
+        parsed_result = self.parser_helper(data=data_record,
+                                           schema=schema,
+                                           options=options)
+
         assert_equal(len(parsed_result), 2)
-        assert_equal(sorted((u'impact', u'code', u'tags', u'source_location', u'refs', u'title',
-            u'results', u'id', u'desc')),sorted(parsed_result[0].keys()))
+        inspec_keys = (u'impact', u'code', u'tags', u'source_location', u'refs', 
+                       u'title', u'results', u'id', u'desc')
+        assert_equal(sorted((inspec_keys)),sorted(parsed_result[0].keys()))
 
     def test_cloudtrail(self):
         """Parse Cloudtrail JSON"""
         schema = self.config['logs']['test_cloudtrail']['schema']
-        options = { "hints" : self.config['logs']['test_cloudtrail']['hints'] }
+        options = {
+            'configuration' : self.config['logs']['test_cloudtrail']['configuration']
+        }
         # load fixture file
         with open('test/unit/fixtures/cloudtrail.json', 'r') as fixture_file:
             data = fixture_file.readlines()
 
         data_record = data[0].strip()
         # setup json parser
-        parsed_result = self.parser_helper(data=data_record, schema=schema, options=options)
+        parsed_result = self.parser_helper(data=data_record,
+                                           schema=schema, 
+                                           options=options)
+
         assert_equal(len(parsed_result), 2)
         assert_equal(len(parsed_result[0].keys()), 14)
         assert_equal(len(parsed_result[1].keys()), 14)

--- a/test/unit/test_kv_parser.py
+++ b/test/unit/test_kv_parser.py
@@ -39,9 +39,10 @@ class TestKVParser(object):
             'result': 'string'
         }
         options = {
-            'separator': ':',
-            'delimiter': ',',
-            'service': 'kinesis'
+            'configuration': {
+                'separator': ':',
+                'delimiter': ',',
+            }
         }
         data = 'name:joe bob,result:success'
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: medium
resolves #95 

## Library Changes
* Nest all `conf/log` type options under a new key called `configuration`
  * `hints` stays at the top level, since it's not an option, but rather a guard.
  * `delimiter`, `separator` move under `configuration`.
  * `envelope` is now called `envelope_keys` and nested under `configuration`.
  * `records` is now called `json_path` and also nested under `configuration`.
* Create a new `configuration` key called `optional_top_level_keys`.
  * The goal of this option is to allow log schemas to have optional keys with specific types.
  * Sets default values for optional keys not in a specific incoming record.
* Fix various `pylint` offenses.

## Other Changes
* Update unit tests
* Update sample configurations
* Update scripts
  * Add an `autopep`  helper script
  * Update the `unit_test.sh` script to test the `stream_alert_cli` package
  * Enforce 80%+ code coverage for this repo

## Notes
* I will update documentation once the proposed changes are accepted.
* This will break most existing `conf/logs.json` settings if the keys are not updated as described above. 