### PR TITLE
[core] disable decorator

### DIFF
--- a/rules/sample_matchers.py
+++ b/rules/sample_matchers.py
@@ -15,17 +15,21 @@ You can also supply multiple matchers for many common scenarios:
 from helpers.base import in_set, last_hour
 from stream_alert.rule_processor.rules_engine import StreamRules
 
-matcher = StreamRules.matcher
+matcher = StreamRules.matcher()
 
 # basic matcher for checking environments
-@matcher()
+@matcher
 def production_env(rec):
     env = rec['env']
     return env == 'production'
 
 
 # matcher layout
-@matcher()
+@matcher
 def matcher_name(rec):
     """Description"""
     return True
+
+@matcher
+def json_test_matcher(rec):
+    return rec['name'] == 'name-1'

--- a/rules/sample_rules.py
+++ b/rules/sample_rules.py
@@ -2,6 +2,7 @@ from helpers.base import in_set, last_hour
 from stream_alert.rule_processor.rules_engine import StreamRules
 
 rule = StreamRules.rule
+disable = StreamRules.disable()
 
 # # Note: This is the rule layout
 # @rule(logs=['foo'],
@@ -47,12 +48,12 @@ def invalid_subnet(rec):
 
 
 @rule(logs=['json_log'],
-      matchers=[],
+      matchers=['json_test_matcher'],
       outputs=['s3'])
 def sample_json_rule(rec):
     return rec['host'] == 'test-host-1'
 
-
+@disable
 @rule(logs=['syslog_log'],
       matchers=[],
       outputs=['pagerduty'])

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -94,6 +94,16 @@ class StreamRules(object):
         return decorator
 
     @classmethod
+    def disable(cls):
+        """Disables a rule from being run by removing it from the internal rules dict"""
+        def decorator(rule):
+            rule_name = rule.__name__
+            if rule_name in cls.__rules:
+                del cls.__rules[rule_name]
+            return rule
+        return decorator
+
+    @classmethod
     def match_event(cls, record, rule):
         """Evaluate matchers on a record.
 

--- a/test/integration/rules/sample_syslog_rule.json
+++ b/test/integration/rules/sample_syslog_rule.json
@@ -3,14 +3,14 @@
     {
       "data": "Jan 01 12:00:12 test-host-1 sudo[151]: COMMAND sudo rm /tmp/test",
       "description": "sudo command ran",
-      "trigger": true,
+      "trigger": false,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
     },
     {
       "data": "Jan 01 12:00:12 test-host-2 sudo[159]: COMMAND sudo rm /tmp/badstuff",
       "description": "sudo command ran",
-      "trigger": true,
+      "trigger": false,
       "source": "example_s3_bucket",
       "service": "s3"
     }


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
size: small
resolves #75 

* Add a new `@disable` decorator in the rules_engine to easily disable rules
* Update unit test cases
* Update sample configuration/rules/tests with a test matcher + disable implementation