### PR TITLE
[lambda][output] fixing alert dispatching bugs

### DIFF
--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -1,6 +1,6 @@
 {
     "aws-s3": {
-        "sample.bucket": "sample_bucket_arn"
+        "sample.bucket": "sample_bucket_name"
     },
     "pagerduty": [
         "sample_integration"

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -95,6 +95,7 @@ def run(loaded_sns_message, context):
         except ValueError:
             LOGGER.error('outputs for rules must be declared with both a service and a '
                          'descriptor for the integration (ie: \'slack:my_channel\')')
+            continue
 
         if not service in config or not descriptor in config[service]:
             LOGGER.error('The output %s does not exist!', output)
@@ -114,7 +115,7 @@ def run(loaded_sns_message, context):
         output_dispatcher.dispatch(
             descriptor=descriptor,
             rule_name=rule_name,
-            alert=alert
+            alert=alert['record']
             )
         # except BaseException as err:
         #     LOGGER.error('an error occurred while sending alert to %s: %s',

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -255,9 +255,9 @@ class SlackOutput(StreamOutputBase):
         creds = self._load_creds(kwargs['descriptor'])
         url = os.path.join(creds['url'])
 
-        slack_message = json.dumps({'text': '```{}```'.format(
-            json.dumps(kwargs['alert'], indent=4)
-        )})
+        slack_message = json.dumps({'text': '```StreamAlert Rule Triggered - {}\n{}```'
+                                            .format(kwargs['rule_name'],
+                                                    json.dumps(kwargs['alert'], indent=4))})
 
         resp = self._request_helper(url, slack_message)
         success = self._check_http_response(resp)


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: small

## Changes ##
* Fixing bug that would attempt to send alerts even if there was an error getting the configured output.
* Updating dispatching so only the record itself gets sent and not the included metadata.
* Changing wording of s3 example output.