### PR TITLE
[lambda][output] revert: adding `incident_key` for pagerduty output

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -103,7 +103,6 @@ class PagerDutyOutput(StreamOutputBase):
         values_json = json.dumps({
             'service_key': creds['service_key'],
             'event_type': 'trigger',
-            'incident_key': kwargs['rule_name'],
             'description': message,
             'details': kwargs['alert'],
             'client': 'StreamAlert'


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: small

### changes ###
Revert of the change made for issue #58 to support de-duplication of incident on PagerDuty. See reopened and updated issue for more context.