### PR TITLE
streamalert - fix rtd search links

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,3 @@
+# pinning sphinx to 1.4.* due to search issues with rtd:
+# https://github.com/rtfd/readthedocs-sphinx-ext/issues/25
+sphinx ==1.4.*

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,4 @@
 # pinning sphinx to 1.4.* due to search issues with rtd:
 # https://github.com/rtfd/readthedocs-sphinx-ext/issues/25
+# https://github.com/rtfd/readthedocs.org/issues/2708
 sphinx ==1.4.*


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 

This should fix the issue where readthedocs links don't work: https://github.com/airbnb/streamalert/issues/63

Example of someone else that implemented this fix: https://github.com/pytest-dev/pytest/issues/2302