### PR TITLE
[docs] updating documentation on outputs

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -8,13 +8,110 @@ StreamAlert comes with a flexible alerting framework that can integrate with new
 
 Out of the box, StreamAlert supports:
 
-* **S3**
+* **AWS Lambda**
+* **AWS S3**
 * **PagerDuty**
+* **Phantom**
 * **Slack**
 
-It can also be extended to support any API.  Outputs will be more modular in the near future to better support additional outputs and public contributions.
+StreamAlert can be extended to support any API. Creating a new output to send alerts to is easily accomplished through inheritance from the ``StreamOutputBase`` class. More on that in the `Adding Support for New Services`_ section below.
+
+With the addition of an output configuration, multiple outputs per service are now possible.
+As an example, it is now possible for rules to dispatch alerts to multiple people or channels in Slack.
 
 Adhering to the secure by default principle, all API credentials are encrypted and decrypted using AWS Key Management Service (KMS).
+Credentials are stored on AWS S3 and are not packaged with the StreamAlert code. They are downloaded and decrypted on an as-needed basis.
+Credentials are never cached on disk in a decrypted state.
+
+Configuration
+-------------
+
+Adding a new configuration for a currently supported service is handled using ``stream_alert_cli.py``:
+
+ - ``python stream_alert_cli.py output new --service <SERVICE_NAME>``
+    - ``<SERVICE_NAME>`` above should be one of the following supported service identifiers: ``aws-lambda``, ``aws-s3``, ``pagerduty``, ``phantom``, or ``slack``
+
+For example:
+ - ``python stream_alert_cli.py output new --service slack``
+
+The above command will then prompt the user for a ``descriptor`` to use for this configuration::
+
+ Please supply a short and unique descriptor for this Slack integration (ie: channel, group, etc):
+
+After a ``descriptor`` is provided, the user is then prompted for the Slack webhook URL::
+
+ Please supply the full Slack webhook url, including the secret:
+
+.. Note:: The user input for the Slack webhook URL will be masked. This 'masking' approach currently applies to any potentially sensitive information the user may have to enter on the cli and can be enforced through any new services that are implemented.
+
+Adding Support for New Services
+-------------------------------
+
+Adding support for a new service involves five steps:
+
+1. Create a subclass of ``StreamOutputBase`` in the `stream_alert/alert_processor/outputs.py` file.
+
+   - For reference, ``StreamOutputBase`` is declared in ``stream_alert/alert_processor/output_base.py``
+
+2. Implement the following methods, at a minimum:
+
+.. code-block:: python
+
+  def get_user_defined_properties(self):
+    """Returns any properties for this output that must be provided by the user
+    At a minimum, this method should prompt the user for a 'descriptor' value to
+    use for configuring any outputs added for this service.
+
+    Returns:
+        [OrderedDict] Contains various OutputProperty items
+    """
+    return OrderedDict([
+        ('descriptor',
+         OutputProperty(description='a short and unique descriptor for this service configuration '
+                                    '(ie: name of integration/channel/service/etc)'))
+    ])
+
+  def dispatch(self, **kwargs):
+    """Handles the actual sending of alerts to the configured service.
+    Any external API calls for this service should be added here.
+    This method should call the `_log_status()` base class method upon completion.
+    """
+    ...
+    self._log_status(boolean)
+
+**Note**: The ``OutputProperty`` object used in ``get_user_defined_properties`` is a namedtuple consisting of a few properties:
+
+:description:
+ A description that is used when prompting the user for input. This is to help describe what is expected from the user for this property.
+ At a bare minimum, this property **should** be set for all instances of ``OutputProperty``.
+ Default is: ``''`` (empty string)
+:value:
+ The actual value that the user enters for this property. This is replaced using ``namedtuple._replace`` during user input.
+ Default is: ``''`` (empty string)
+:input_restrictions:
+ A ``set`` of character values that should be restricted from user input for this property.
+ Default is: ``{' ', ':'}``
+:mask_input:
+ A ``boolean`` that indicates whether the user's input should be masked using ``getpass`` during entry. This should be set for any input that is potentially sensitive.
+ Default is: ``False``
+:cred_requirement:
+ A ``boolean`` that indicates whether this value is required for API access with this service. Ultimately, setting this value to ``True`` indicates
+ that the value should be encrypted and stored in AWS S3.
+ Default is: ``False``
+
+
+3. Implement the private ``__service__`` property within the new subclass.
+
+   - This should be a string value that corresponds to an identifier that best represents this service. (ie: ``__service__ = 'aws-s3'``)
+
+4. Add the ``@output`` class decorator to the new subclass so it registered when the `outputs` module is loaded.
+
+5. To allow the cli to configure a new integration for this service, add the value used above for the ``__service__`` property to the ``stream_alert_cli.py`` file.
+
+   - The ``output_parser`` contains a ``choices`` list for ``--service`` that must include this new service.
+
+
+.. Note:: New AWS Service outputs should subclass ``AWSOutput`` instead of ``StreamOutputBase``
 
 Strategy
 --------


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
cc @mime-frame 
size: small

* Adding documentation updates to reflect changes made to the alert processor lambda function
  * Demonstrates how to configure a new output for a currently supported service.
  * Walks through the steps that need to be taken to implement support for sending to a new service.
  * Updated to include Phantom as a supported output.
  * Updated to include AWS Lambda as a supported output.