### PR TITLE
[tf] Additional Lambda/Kinesis CloudWatch Alarms

### DIFF
--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -1,6 +1,8 @@
 // Setup Cloudwatch alarms for all Lambda function aliases (environments)
 // Send alerts to given SNS topics.
-resource "aws_cloudwatch_metric_alarm" "stream_alert_invocation_errors" {
+
+// Lambda: Invocation Errors
+resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_invocation_errors" {
   count               = "${length(var.lambda_functions)}"
   alarm_name          = "${element(var.lambda_functions, count.index)}_invocation_errors"
   namespace           = "AWS/Lambda"
@@ -16,5 +18,81 @@ resource "aws_cloudwatch_metric_alarm" "stream_alert_invocation_errors" {
   dimensions {
     FunctionName = "${element(var.lambda_functions, count.index)}"
     Resource     = "${element(var.lambda_functions, count.index)}:production"
+  }
+}
+
+// Lambda: Throttles
+resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_throttles" {
+  count               = "${length(var.lambda_functions)}"
+  alarm_name          = "${element(var.lambda_functions, count.index)}_throttles"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "0"
+  evaluation_periods  = "1"
+  period              = "300"
+  alarm_description   = "StreamAlert Lambda Throttles: ${element(var.lambda_functions, count.index)}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    FunctionName = "${element(var.lambda_functions, count.index)}"
+    Resource     = "${element(var.lambda_functions, count.index)}:production"
+  }
+}
+
+// Lambda: IteratorAge
+resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_iterator_age" {
+  count               = "${length(var.lambda_functions)}"
+  alarm_name          = "${element(var.lambda_functions, count.index)}_iterator_age"
+  namespace           = "AWS/Lambda"
+  metric_name         = "IteratorAge"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "43000000"
+  evaluation_periods  = "1"
+  period              = "300"
+  alarm_description   = "StreamAlert Lambda High Iterator Age: ${element(var.lambda_functions, count.index)}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    FunctionName = "${element(var.lambda_functions, count.index)}"
+    Resource     = "${element(var.lambda_functions, count.index)}:production"
+  }
+}
+
+// Kinesis: Iterator Age
+resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_iterator_age" {
+  alarm_name          = "${var.kinesis_stream}_high_iterator_age"
+  namespace           = "AWS/Kinesis"
+  metric_name         = "GetRecords.IteratorAgeMilliseconds"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "43000000"                                                     // 12 hours
+  evaluation_periods  = "1"
+  period              = "300"
+  alarm_description   = "StreamAlert Kinesis High Iterator Age: ${var.kinesis_stream}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    StreamName = "${var.kinesis_stream}"
+  }
+}
+
+// Kinesis: Write Throughput Exceeded
+resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_write_exceeded" {
+  alarm_name          = "${var.kinesis_stream}_write_exceeded"
+  namespace           = "AWS/Kinesis"
+  metric_name         = "WriteProvisionedThroughputExceeded"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "0"
+  evaluation_periods  = "1"
+  period              = "300"
+  alarm_description   = "StreamAlert Kinesis Write Throughput Exceeded: ${var.kinesis_stream}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    StreamName = "${var.kinesis_stream}"
   }
 }

--- a/terraform/modules/tf_stream_alert_monitoring/variables.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/variables.tf
@@ -1,5 +1,11 @@
 variable "sns_topic_arn" {}
 
+// Kinesis Stream name
+variable "kinesis_stream" {
+  type = "string"
+}
+
+// List of Lambda Function names
 variable "lambda_functions" {
   type    = "list"
   default = []

--- a/terraform/templates/cluster_template
+++ b/terraform/templates/cluster_template
@@ -20,10 +20,13 @@ module "stream_alert_{{ cluster_name }}" {
 module "cloudwatch_monitoring_{{ cluster_name }}" {
   source           = "modules/tf_stream_alert_monitoring"
   sns_topic_arn   = "${module.stream_alert_{{ cluster_name }}.sns_topic_arn}"
+
   lambda_functions = [
     "${lookup(var.account, "prefix")}_{{ cluster_name }}_streamalert_rule_processor",
     "${lookup(var.account, "prefix")}_{{ cluster_name }}_streamalert_alert_processor"
   ]
+
+  kinesis_stream = "${lookup(var.account, "prefix")}_{{ cluster_name }}_stream_alert_kinesis"
 }
 
 // Kinesis Stream and Firehose to send data to the Lambda function


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size small

Provides a richer set of alarms regarding:

* Lambda Throttles - Too many concurrent executions
* Lambda IteratorAge - Lambda falling behind processing
* Kinesis IteratorAge - The age of the last GetRecord request
* Kinesis Write Exceeded - Hitting shard limiits