### PR TITLE
[tf] pass inputs/outputs variables into stream_alert module via cluster template

### DIFF
--- a/terraform/templates/cluster_template
+++ b/terraform/templates/cluster_template
@@ -14,6 +14,10 @@ module "stream_alert_{{ cluster_name }}" {
   alert_processor_config        = "${var.alert_processor_config}"
   alert_processor_lambda_config = "${var.alert_processor_lambda_config}"
   alert_processor_versions      = "${var.alert_processor_versions}"
+
+  output_lambda_functions = "${var.aws-lambda}"
+  output_s3_buckets       = "${var.aws-s3}"
+  input_sns_topics        = "${var.aws-sns}"
 }
 
 // Cloudwatch alerts for production Lambda functions


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size small

make sure we pass in the loaded s3/lambda/sns inputs/outputs through to the `stream_alert` terraform module