### PR TITLE
[lambda][rule] send alerts with rule docstring

### DIFF
--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -69,9 +69,10 @@ def run(loaded_sns_message, context):
         The alert is another dict with the following structure:
 
         {
-            'rule_name': rule.rule_name,
             'record': record,
             'metadata': {
+                'rule_name': rule.rule_name,
+                'rule_description': rule.rule_function.__doc__,
                 'log': str(payload.log_source),
                 'outputs': rule.outputs,
                 'type': payload.type,
@@ -84,7 +85,7 @@ def run(loaded_sns_message, context):
     """
     LOGGER.debug(loaded_sns_message)
     alert = loaded_sns_message['default']
-    rule_name = alert['rule_name']
+    rule_name = alert['metadata']['rule_name']
 
     # strip out unnecessary keys and sort
     alert = sort_dict(alert)

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -219,6 +219,7 @@ class StreamOutputBase(object):
             raise OutputRequestFailure('Failed to send to {} - [{}] {}'.format(err.url,
                                                                                err.code,
                                                                                err.read()))
+
     @staticmethod
     def _check_http_response(resp):
         return resp and (200 <= resp.getcode() <= 299)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -215,9 +215,10 @@ class StreamRules(object):
                 rule_result = cls.process_rule(record, rule)
                 if rule_result:
                     alert = {
-                        'rule_name': rule.rule_name,
                         'record': record,
                         'metadata': {
+                            'rule_name': rule.rule_name,
+                            'rule_description': rule.rule_function.__doc__,
                             'log': str(payload.log_source),
                             'outputs': rule.outputs,
                             'type': payload.type,

--- a/stream_alert/rule_processor/sink.py
+++ b/stream_alert/rule_processor/sink.py
@@ -55,9 +55,10 @@ class StreamSink(object):
         Sends a message to SNS with the following JSON format:
             {default: [
                 {
-                    'rule_name': rule.rule_name,
                     'record': record,
                     'metadata': {
+                        'rule_name': rule.rule_name,
+                        'rule_description': rule.rule_function.__doc__,
                         'log': str(payload.log_source),
                         'outputs': rule.outputs,
                         'type': payload.type,

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -73,7 +73,7 @@ def test_rule(rule_name, test_record, formatted_record):
 
     alerts = StreamAlert(return_alerts=True).run(event, None)
     # we only want alerts for the specific rule passed in
-    matched_alert_count = len([x for x in alerts if x['rule_name'] == rule_name])
+    matched_alert_count = len([x for x in alerts if x['metadata']['rule_name'] == rule_name])
 
     report_output([test_record['service'], test_record['description']],
                   matched_alert_count != expected_alert_count)

--- a/test/unit/test_rules_engine.py
+++ b/test/unit/test_rules_engine.py
@@ -83,6 +83,7 @@ class TestStreamRules(object):
         @rule(logs=['test_log_type_json_nested_with_data'],
               outputs=['s3:sample.bucket'])
         def alert_format_test(rec):
+            """Format test docstring"""
             return rec['application'] == 'web-app'
 
         kinesis_data = {
@@ -105,14 +106,16 @@ class TestStreamRules(object):
         # process payloads
         alerts = StreamRules.process(payload)
 
-        alert_keys = {'rule_name', 'metadata', 'record'}
-        metadata_keys = {'log', 'outputs', 'type', 'source'}
+        alert_keys = {'metadata', 'record'}
+        metadata_keys = {'rule_name', 'rule_description', 'log', 'outputs', 'type', 'source'}
         assert_equal(set(alerts[0].keys()), alert_keys)
+        assert_equal(type(alerts[0]['metadata']), dict)
         assert_equal(set(alerts[0]['metadata'].keys()), metadata_keys)
 
         # test alert fields
-        assert_equal(type(alerts[0]['rule_name']), str)
         assert_equal(type(alerts[0]['record']), dict)
+        assert_equal(type(alerts[0]['metadata']['rule_name']), str)
+        assert_equal(type(alerts[0]['metadata']['rule_description']), str)
         assert_equal(type(alerts[0]['metadata']['outputs']), list)
         assert_equal(type(alerts[0]['metadata']['type']), str)
         assert_equal(type(alerts[0]['metadata']['source']), dict)
@@ -170,15 +173,15 @@ class TestStreamRules(object):
         assert_equal(len(alerts), 3)
 
         # alert 2 tests
-        assert_equal(alerts[2]['rule_name'], 'chef_logs')
+        assert_equal(alerts[2]['metadata']['rule_name'], 'chef_logs')
         assert_equal(alerts[2]['metadata']['outputs'], ['pagerduty:sample_integration'])
 
         # alert 1 tests
-        assert_equal(alerts[1]['rule_name'], 'minimal_rule')
+        assert_equal(alerts[1]['metadata']['rule_name'], 'minimal_rule')
         assert_equal(alerts[1]['metadata']['outputs'], ['s3:sample.bucket'])
 
         # alert 0 tests
-        assert_equal(alerts[0]['rule_name'], 'test_nest')
+        assert_equal(alerts[0]['metadata']['rule_name'], 'test_nest')
         assert_equal(alerts[0]['metadata']['outputs'], ['pagerduty:sample_integration'])
 
     def test_process_req_subkeys(self):
@@ -232,8 +235,8 @@ class TestStreamRules(object):
         assert_equal(len(alerts), 2)
 
         # alert tests
-        assert_equal(alerts[0]['rule_name'], 'web_server')
-        assert_equal(alerts[1]['rule_name'], 'data_location')
+        assert_equal(alerts[0]['metadata']['rule_name'], 'web_server')
+        assert_equal(alerts[1]['metadata']['rule_name'], 'data_location')
 
     def test_syslog_rule(self):
         """Rule Engine - Syslog Rule"""
@@ -259,7 +262,7 @@ class TestStreamRules(object):
 
         # alert tests
         assert_equal(len(alerts), 1)
-        assert_equal(alerts[0]['rule_name'], 'syslog_sudo')
+        assert_equal(alerts[0]['metadata']['rule_name'], 'syslog_sudo')
         assert_equal(alerts[0]['record']['host'], 'vagrant-ubuntu-trusty-64')
         assert_equal(alerts[0]['metadata']['type'], 'syslog')
 
@@ -285,7 +288,7 @@ class TestStreamRules(object):
 
         # alert tests
         assert_equal(len(alerts), 1)
-        assert_equal(alerts[0]['rule_name'], 'nested_csv')
+        assert_equal(alerts[0]['metadata']['rule_name'], 'nested_csv')
 
     def test_rule_disable(self):
         """Rule Engine - Disable Rule"""
@@ -350,5 +353,5 @@ class TestStreamRules(object):
         # alert tests
         assert_equal(len(alerts), 2)
 
-        rule_name_alerts = set([x['rule_name'] for x in alerts])
+        rule_name_alerts = set([x['metadata']['rule_name'] for x in alerts])
         assert_equal(rule_name_alerts, set(['gid_500', 'auditd_bin_cat']))

--- a/test/unit/test_rules_engine.py
+++ b/test/unit/test_rules_engine.py
@@ -83,7 +83,7 @@ class TestStreamRules(object):
         @rule(logs=['test_log_type_json_nested_with_data'],
               outputs=['s3:sample.bucket'])
         def alert_format_test(rec):
-            """Format test docstring"""
+            """'alert_format_test' docstring for testing rule_description"""
             return rec['application'] == 'web-app'
 
         kinesis_data = {


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: medium
resolve: #25 

## changes ##
* Alerts will now include a `rule_description` key within the `metadata` dictionary that is packaged with the alert.
* Moving the `rule_name` key that is sent with the alert into the `metadata` dictionary as well since it makes more sense and is cleaner.
  * Alerts are now made up of two dictionaries: `metadata` (containing info related to this rule/alert) and `record` (containing the actual payload that triggered this alert).
* Updating tests to conform to the new `metadata` dict.
* Adding the `rule_description` as part of the alert sent to applicable configurations.
  * Slack will now receive a `rule_description` as part of the message text
  * PagerDuty will now receive a `rule_description` as part of the details
  * Phantom will now receive a `rule_description` as part of the container description
  * AWS S3 and Lambda do not receive `rule_description` as part of the alert (as it's not currently necessary and there is no obvious way to handle it).
* Setting a default placeholder for rules that do not provide a docstring to be used for `rule_description`: `'No rule description provided'`