### PR TITLE
[classifier] break out of loop on first schema match

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -277,6 +277,7 @@ class StreamClassifier(object):
             LOGGER.debug('schema: %s', schema)
             if parsed_data:
                 valid_parses.append((log_name, parser, parsed_data))
+                break
 
         if not valid_parses:
             return False


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size small

Break out of the classification parse method once a successful schema match is found