### PR TITLE
[testing] improving rule processor test output by adding some summary info

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -38,6 +38,7 @@ BOTO_MOCKER = mock_s3()
 DIR_RULES = 'test/integration/rules'
 DIR_TEMPLATES = 'test/integration/templates'
 COLOR_RED = '\033[0;31;1m'
+COLOR_YELLOW = '\033[0;33;1m'
 COLOR_GREEN = '\033[0;32;1m'
 COLOR_RESET = '\033[0m'
 
@@ -68,10 +69,10 @@ def report_output_summary(rules_fail_pass):
 
     # Check if there were failed tests and report on them appropriately
     if rules_fail_pass[0]:
-        # Print a message indicating how many of the total tests failed
-        print '{}({}/{})\tTests Failed'.format(COLOR_RED, failed_tests, total_tests)
-
         color = COLOR_RED
+        # Print a message indicating how many of the total tests failed
+        print '{}({}/{})\tTests Failed'.format(color, failed_tests, total_tests)
+
         # Iterate over the rule_name values in the failed list and report on them
         for i, failure in enumerate(rules_fail_pass[0]):
             if i == failed_tests-1:
@@ -79,6 +80,18 @@ def report_output_summary(rules_fail_pass):
                 color = COLOR_RESET
             print '\t({}/{}) test failed for rule: {} [{}]{}'.format(i+1, failed_tests, failure[0],
                                                                      failure[1], color)
+
+    # Check if there were any warnings and report on them
+    if rules_fail_pass[2]:
+        color = COLOR_YELLOW
+        warning_count = len(rules_fail_pass[2])
+        print '{}{} \tWarning{}'.format(color, warning_count, ('','s')[warning_count>1])
+
+        for i, failure in enumerate(rules_fail_pass[2]):
+            if i == warning_count-1:
+                # Change the color back so std out is not yellow
+                color = COLOR_RESET
+            print '\t({}/{}) {} [{}]{}'.format(i+1, warning_count, failure[1], failure[0], color)
 
 def test_rule(rule_name, test_record, formatted_record):
     """Feed formatted records into StreamAlert and check for alerts
@@ -240,58 +253,61 @@ def test_alert_rules():
     """
     # Start the mock_s3 instance here so we can test with mocked objects project-wide
     BOTO_MOCKER.start()
-    tests_passed = True
+    all_tests_passed = True
 
     # Create a list for pass/fails. The first value in the list is a list of tuples for failures,
     # and the second is list of tuples for passes. Tuple is (rule_name, rule_description)
-    rules_fail_pass = [[], []]
+    rules_fail_pass = [[], [], []]
 
     for root, _, rule_files in os.walk(DIR_RULES):
         for rule_file in rule_files:
             rule_name = rule_file.split('.')[0]
             rule_file_path = os.path.join(root, rule_file)
 
-            # Print rule name for section header
-            print '\n{}'.format(rule_name)
-
             with open(rule_file_path, 'r') as rule_file_handle:
                 try:
                     contents = json.load(rule_file_handle)
                     test_records = contents['records']
                 except (ValueError, KeyError) as err:
-                    tests_passed = False
-                    LOGGER_CLI.error('Improperly formatted file (%s) %s: %s',
-                                     rule_file_path, type(err).__name__, err)
+                    all_tests_passed = False
+                    message = 'improperly formatted file - {}: {}'.format(type(err).__name__, err)
+                    rules_fail_pass[2].append((rule_file, message))
                     continue
 
             if len(test_records) == 0:
-                tests_passed = False
-                LOGGER_CLI.error('No records to test for %s', rule_name)
+                all_tests_passed = False
+                rules_fail_pass[2].append((rule_file, 'no records to test in file'))
                 continue
 
+            print_header = True
             # Go over the records and test the applicable rule
             for test_record in test_records:
                 if not check_keys(test_record):
-                    report_output([test_record['service'],
-                                   'Improperly formatted record: {}'.format(test_record)],
-                                  True)
-                    tests_passed = False
+                    all_tests_passed = False
+                    message = 'improperly formatted record: {}'.format(test_record)
+                    rules_fail_pass[2].append((rule_file, message))
                     continue
+
+                if print_header:
+                    # Print rule name for section header, but only if we get to a point
+                    # where there is a record to actually be tested. this avoid blank sections
+                    print '\n{}'.format(rule_name)
+                    print_header = not print_header
 
                 apply_helpers(test_record)
                 formatted_record = format_record(test_record)
-                passed = test_rule(rule_name, test_record, formatted_record)
-                tests_passed = passed and tests_passed
+                current_test_passed = test_rule(rule_name, test_record, formatted_record)
+                all_tests_passed = current_test_passed and all_tests_passed
 
                 # Add the name of the rule to the applicable pass or fail list
-                rules_fail_pass[passed].append((rule_name, test_record['description']))
+                rules_fail_pass[current_test_passed].append((rule_name, test_record['description']))
 
     # Report on the final test results
     report_output_summary(rules_fail_pass)
 
     BOTO_MOCKER.stop()
 
-    return tests_passed
+    return all_tests_passed
 
 def put_mocked_s3_object(bucket_name, key_name, body_value):
     """Create a mock AWS S3 object for testing

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -65,7 +65,7 @@ def report_output_summary(rules_fail_pass):
     total_tests = failed_tests + passed_tests
 
     # Print a message indicating how many of the total tests passed
-    print '{}({}/{})\tTests Passed{}'.format(COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
+    print '\n\n{}({}/{})\tTests Passed{}'.format(COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
 
     # Check if there were failed tests and report on them appropriately
     if rules_fail_pass[0]:
@@ -74,24 +74,26 @@ def report_output_summary(rules_fail_pass):
         print '{}({}/{})\tTests Failed'.format(color, failed_tests, total_tests)
 
         # Iterate over the rule_name values in the failed list and report on them
-        for i, failure in enumerate(rules_fail_pass[0]):
-            if i == failed_tests-1:
+        for index, failure in enumerate(rules_fail_pass[0]):
+            if index == failed_tests-1:
                 # Change the color back so std out is not red
                 color = COLOR_RESET
-            print '\t({}/{}) test failed for rule: {} [{}]{}'.format(i+1, failed_tests, failure[0],
-                                                                     failure[1], color)
+            print '\t({}/{}) test failed for rule: {} [{}]{}'.format(index+1, failed_tests,
+                                                                     failure[0], failure[1],
+                                                                     color)
 
     # Check if there were any warnings and report on them
     if rules_fail_pass[2]:
         color = COLOR_YELLOW
         warning_count = len(rules_fail_pass[2])
-        print '{}{} \tWarning{}'.format(color, warning_count, ('','s')[warning_count>1])
+        print '{}{} \tWarning{}'.format(color, warning_count, ('', 's')[warning_count > 1])
 
-        for i, failure in enumerate(rules_fail_pass[2]):
-            if i == warning_count-1:
+        for index, failure in enumerate(rules_fail_pass[2]):
+            if index == warning_count-1:
                 # Change the color back so std out is not yellow
                 color = COLOR_RESET
-            print '\t({}/{}) {} [{}]{}'.format(i+1, warning_count, failure[1], failure[0], color)
+            print '\t({}/{}) {} [{}]{}'.format(index+1, warning_count, failure[1],
+                                               failure[0], color)
 
 def test_rule(rule_name, test_record, formatted_record):
     """Feed formatted records into StreamAlert and check for alerts
@@ -268,7 +270,7 @@ def test_alert_rules():
                 try:
                     contents = json.load(rule_file_handle)
                     test_records = contents['records']
-                except (ValueError, KeyError) as err:
+                except Exception as err:
                     all_tests_passed = False
                     message = 'improperly formatted file - {}: {}'.format(type(err).__name__, err)
                     rules_fail_pass[2].append((rule_file, message))


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: small

## changes ##
* Updating the rule processor testing output to show a summary at the end indicating how many tests passed and how many failed out of the total ran.
* The tail of the output will now appear like the following if there are failures:
```
(33/35)	Tests Passed
(2/35)	Tests Failed
	(1/2) test failed for rule: invalid_user [user not in the whitelist (john)]
	(2/2) test failed for rule: sample_cloudwatch_cloudtrail_rule [cloudwatch cloudtrail 'Decrypt' event log]
```
* The `(#/#) Tests Passed` line will also be green, while all lines following it related to failures will be red.
* If all tests pass, only the first line above will be output, but would be:
```
(35/35)	Tests Passed
```
* This should aid in seeing which rules are passing and which are failing as the amount of rules being tested grows.


### update ###
* adding warnings as part of the output. Warnings can occur for three reasons:
  * test file (rule file) is not properly formatted json
  * test file contains a 'records' root key with 0 test records
  * test file contains records that are malformed
* The output for warnings will look like:
```
3 	Warnings
	(1/3) improperly formatted file - ValueError: Extra data: line 1 column 8 - line 1 column 13 (char 7 - 12) [carbonblack_ingress_event_regmod2.json]
	(2/3) no records to test in file [invalid_subnet2.json]
	(3/3) improperly formatted record: {u'test': 20} [sample_cloudwatch_cloudtrail_rule2.json]
```