### PR TITLE
Remove base64 encoding from SNS input

### DIFF
--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -229,7 +229,7 @@ class JSONParser(ParserBase):
             [list] A list of dictionaries representing parsed records.
             [boolean] False if the data is not JSON or the data does not follow the schema.
         """
-        if isinstance(data, str):
+        if type(data) in {unicode, str}:
             try:
                 data = json.loads(data)
             except ValueError as err:

--- a/stream_alert/rule_processor/pre_parsers.py
+++ b/stream_alert/rule_processor/pre_parsers.py
@@ -73,9 +73,9 @@ class StreamPreParsers(object):
         Args:
             raw_record (dict): An SNS message.
 
-        Returns: (string) Base64 decoded data.
+        Returns: (string) SNS message data.
         """
-        return base64.b64decode(raw_record['Sns']['Message'])
+        return raw_record['Sns']['Message']
 
     @classmethod
     def read_s3_file(cls, downloaded_s3_object):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -140,7 +140,7 @@ def format_record(test_record):
         template['eventSourceARN'] = 'arn:aws:kinesis:us-east-1:111222333:stream/{}'.format(source)
 
     elif service == 'sns':
-        template['Sns']['Message'] = base64.b64encode(data)
+        template['Sns']['Message'] = data
         template['EventSubscriptionArn'] = 'arn:aws:sns:us-east-1:111222333:{}'.format(source)
     else:
         LOGGER_CLI.info('Invalid service %s', service)

--- a/test/unit/test_pre_parsers.py
+++ b/test/unit/test_pre_parsers.py
@@ -34,7 +34,7 @@ def test_pre_parse_kinesis():
 def test_pre_parse_sns():
     """Pre-Parse SNS Test"""
     test_data = 'Hello world'
-    raw_record = {'Sns': {'Message': base64.b64encode(test_data)}}
+    raw_record = {'Sns': {'Message': test_data}}
     data = StreamPreParsers.pre_parse_sns(raw_record)
     assert_equal(data, test_data)
 


### PR DESCRIPTION
Incoming SNS data should not be assumed to be base64-encoded, because it is designed to be a simple notification for email, texting, etc.

For example, the SNS message that the rule processor uses to [invoke the alert processor](https://github.com/airbnb/streamalert/blob/abb--sns-no-base64/stream_alert/rule_processor/sink.py#L112) is not base64-encoded.

@airbnb/streamalert-maintainers 