### PR TITLE
streamalert - rules.rst - outputs

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -90,7 +90,7 @@ Parameter Details
 logs
 ~~~~~~~~~~~
 
-``logs`` define the log sources the rule supports; The ``def`` function block is not run unless this condition is satisfied.
+``logs`` define the log sources the rule supports; The ``def`` function block is not run unless this condition is satisfied. Your rule(s) must define at least one log source.
 
 A rule can be run against multiple log sources if desired.
 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -124,7 +124,7 @@ This is achieved by looking for a particular field in the log. The code:
 outputs
 ~~~~~~~
 
-``outputs`` define where the alert should be sent to if the return value of a rule is ``True``.
+``outputs`` define where the alert should be sent to if the return value of a rule is ``True``. Your rule(s) must define at least one output.
 
 StreamAlert supports sending alerts to PagerDuty, Slack, Amazon S3 and Phantom.
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 

Denote that one element must exist in `outputs`