### PR TITLE
[lambda][rule] processed logs will now be sent immediately to the alert processor

### DIFF
--- a/stream_alert/rule_processor/config.py
+++ b/stream_alert/rule_processor/config.py
@@ -92,8 +92,10 @@ def load_env(context):
         context: The AWS Lambda context object.
 
     Returns:
-        {'lambda_function_name': 'function_name',
-         'lambda_alias': 'development|production'}
+        {'lambda_region': 'region_name',
+         'account_id': <ACCOUNT_ID>,
+         'lambda_function_name': 'function_name',
+         'lambda_alias': 'qualifier'}
     """
     env = {}
     if context:
@@ -103,6 +105,8 @@ def load_env(context):
         env['lambda_function_name'] = arn[6]
         env['lambda_alias'] = arn[7]
     else:
-        env['lambda_alias'] = 'development'
         env['lambda_region'] = 'us-east-1'
+        env['account_id'] = '123456789012'
+        env['lambda_function_name'] = 'test_streamalert_rule_processor'
+        env['lambda_alias'] = 'development'
     return env

--- a/stream_alert/rule_processor/config.py
+++ b/stream_alert/rule_processor/config.py
@@ -93,7 +93,7 @@ def load_env(context):
 
     Returns:
         {'lambda_function_name': 'function_name',
-         'lambda_alias': 'staging|development|production'}
+         'lambda_alias': 'development|production'}
     """
     env = {}
     if context:
@@ -104,4 +104,5 @@ def load_env(context):
         env['lambda_alias'] = arn[7]
     else:
         env['lambda_alias'] = 'development'
+        env['lambda_region'] = 'us-east-1'
     return env

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -68,12 +68,11 @@ class StreamAlert(object):
             else:
                 LOGGER.info('Unsupported service: %s', payload.service)
 
+        LOGGER.debug('%s alerts triggered', len(self.alerts))
+        LOGGER.debug('\n%s\n', json.dumps(self.alerts, indent=4))
+
         if self.return_alerts:
             return self.alerts
-
-        if self.env['lambda_alias'] == 'development':
-            LOGGER.info('%s alerts triggered', len(self.alerts))
-            LOGGER.info('\n%s\n', json.dumps(self.alerts, indent=4))
 
     def _kinesis_process(self, payload, classifier):
         """Process Kinesis data for alerts"""
@@ -123,6 +122,5 @@ class StreamAlert(object):
 
         if self.return_alerts:
             self.alerts.extend(alerts)
-            return
 
         self.sinker.sink(alerts)

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -9,24 +9,29 @@ from stream_alert.rule_processor.rules_engine import StreamRules
 from stream_alert.rule_processor.sink import StreamSink
 
 logging.basicConfig()
-level = os.environ.get('LOGGER_LEVEL', 'INFO')
+LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO')
 LOGGER = logging.getLogger('StreamAlert')
-LOGGER.setLevel(level.upper())
+LOGGER.setLevel(LEVEL.upper())
 
 
 class StreamAlert(object):
     """Wrapper class for handling all StreamAlert classificaiton and processing"""
-    def __init__(self, **kwargs):
+    def __init__(self, context, return_alerts=False):
         """
         Args:
+            context: An AWS context object which provides metadata on the currently
+                executing lambda function.
             return_alerts: If the user wants to handle the sinking
                 of alerts to external endpoints, return a list of
                 generated alerts.
         """
-        self.return_alerts = kwargs.get('return_alerts')
+        self.return_alerts = return_alerts
+        self.env = load_env(context)
+        # Instantiate the sink here to handle sending the triggered alerts to the alert processor
+        self.sinker = StreamSink(self.env)
         self.alerts = []
 
-    def run(self, event, context):
+    def run(self, event):
         """StreamAlert Lambda function handler.
 
         Loads the configuration for the StreamAlert function which contains:
@@ -37,8 +42,6 @@ class StreamAlert(object):
         Args:
             event: An AWS event mapped to a specific source/entity (kinesis stream or
                 an s3 bucket event) containing data emitted to the stream.
-            context: An AWS context object which provides metadata on the currently
-                executing lambda function.
 
         Returns:
             None
@@ -46,13 +49,13 @@ class StreamAlert(object):
         LOGGER.debug('Number of Records: %d', len(event.get('Records', [])))
 
         config = load_config()
-        env = load_env(context)
 
         for record in event.get('Records', []):
             payload = StreamPayload(raw_record=record)
             classifier = StreamClassifier(config=config)
 
-            # If the kinesis stream or s3 bucket is not in our config, go onto the next record
+            # If the kinesis stream, s3 bucket, or sns topic is not in our config,
+            # go onto the next record
             if not classifier.map_source(payload):
                 continue
 
@@ -65,48 +68,61 @@ class StreamAlert(object):
             else:
                 LOGGER.info('Unsupported service: %s', payload.service)
 
-        # returns the list of generated alerts
         if self.return_alerts:
             return self.alerts
-        # send alerts to SNS
-        self._send_alerts(env, payload)
+
+        if self.env['lambda_alias'] == 'development':
+            LOGGER.info('%s alerts triggered', len(self.alerts))
+            LOGGER.info('\n%s\n', json.dumps(self.alerts, indent=4))
 
     def _kinesis_process(self, payload, classifier):
         """Process Kinesis data for alerts"""
         data = StreamPreParsers.pre_parse_kinesis(payload.raw_record)
-        self.process_alerts(classifier, payload, data)
+        self._process_alerts(classifier, payload, data)
 
     def _s3_process(self, payload, classifier):
         """Process S3 data for alerts"""
-        s3_file = StreamPreParsers.pre_parse_s3(payload.raw_record)
+        s3_file, s3_object_size = StreamPreParsers.pre_parse_s3(payload.raw_record)
+        count, processed_size = 0, 0
         for data in StreamPreParsers.read_s3_file(s3_file):
             payload.refresh_record(data)
-            self.process_alerts(classifier, payload, data)
+            self._process_alerts(classifier, payload, data)
+            # Add the current data to the total processed size, +1 to account for line feed
+            processed_size += (len(data) + 1)
+            count += 1
+            # Log an info message on every 100 lines processed
+            if count % 100 == 0:
+                avg_record_size = (processed_size - 1 / count)
+                approx_record_count = s3_object_size / avg_record_size
+                LOGGER.info('Processed %s records out of an approximate total of %s '
+                            '(average record size: %s bytes, total size: %s bytes)',
+                            count, approx_record_count, avg_record_size, s3_object_size)
 
     def _sns_process(self, payload, classifier):
         """Process SNS data for alerts"""
         data = StreamPreParsers.pre_parse_sns(payload.raw_record)
-        self.process_alerts(classifier, payload, data)
+        self._process_alerts(classifier, payload, data)
 
-    def _send_alerts(self, env, payload):
-        """Send generated alerts to correct places"""
-        if self.alerts:
-            if env['lambda_alias'] == 'development':
-                LOGGER.info('%s alerts triggered', len(self.alerts))
-                LOGGER.info('\n%s\n', json.dumps(self.alerts, indent=4))
-            else:
-                StreamSink(self.alerts, env).sink()
-        elif payload.valid:
-            LOGGER.debug('Valid data, no alerts')
+    def _process_alerts(self, classifier, payload, data):
+        """Process records for alerts and send them to the correct places
 
-    def process_alerts(self, classifier, payload, data):
-        """Process records for alerts"""
+        Args:
+            classifier [StreamClassifier]: Handler for classifying a record's data
+            payload [StreamPayload]: StreamAlert payload object being processed
+            data [string]: Pre parsed data string from a raw_event to be parsed
+        """
         classifier.classify_record(payload, data)
-        if payload.valid:
-            alerts = StreamRules.process(payload)
-            if alerts:
-                self.alerts.extend(alerts)
-        else:
-            LOGGER.error('Invalid data: %s\n%s',
-                         payload,
-                         json.dumps(payload.raw_record, indent=4))
+        if not payload.valid:
+            LOGGER.error('Invalid data: %s\n%s', payload, json.dumps(payload.raw_record, indent=4))
+            return
+
+        alerts = StreamRules.process(payload)
+        if not alerts:
+            LOGGER.debug('Valid data, no alerts')
+            return
+
+        if self.return_alerts:
+            self.alerts.extend(alerts)
+            return
+
+        self.sinker.sink(alerts)

--- a/stream_alert/rule_processor/main.py
+++ b/stream_alert/rule_processor/main.py
@@ -22,4 +22,4 @@ from rules import (
 
 def handler(event, context):
     """Main Lambda handler function"""
-    StreamAlert().run(event, context)
+    StreamAlert(context).run(event)

--- a/stream_alert/rule_processor/pre_parsers.py
+++ b/stream_alert/rule_processor/pre_parsers.py
@@ -24,7 +24,7 @@ import urllib
 import boto3
 
 logging.basicConfig()
-logger = logging.getLogger('StreamAlert')
+LOGGER = logging.getLogger('StreamAlert')
 
 class S3ObjectSizeError(Exception):
     pass
@@ -64,7 +64,7 @@ class StreamPreParsers(object):
         size = int(raw_record['s3']['object']['size'])
         downloaded_s3_object = cls._download_s3_object(client, bucket, key, size)
 
-        return downloaded_s3_object
+        return downloaded_s3_object, size
 
     @classmethod
     def pre_parse_sns(cls, raw_record):
@@ -106,7 +106,7 @@ class StreamPreParsers(object):
         # remove the file
         os.remove(downloaded_s3_object)
         if not os.path.exists(downloaded_s3_object):
-            logger.debug('Removed temp file - %s', downloaded_s3_object)
+            LOGGER.debug('Removed temp file - %s', downloaded_s3_object)
 
     @classmethod
     def _download_s3_object(cls, client, bucket, key, size):
@@ -131,15 +131,15 @@ class StreamPreParsers(object):
         if size_mb > 128:
             raise S3ObjectSizeError('S3 object to download is above 128MB')
 
-        logger.debug('/tmp directory contents:%s ', os.listdir('/tmp'))
-        logger.debug(os.popen('df -h /tmp | tail -1').read().strip())
+        LOGGER.debug('/tmp directory contents:%s ', os.listdir('/tmp'))
+        LOGGER.debug(os.popen('df -h /tmp | tail -1').read().strip())
 
         if size_mb:
             display_size = '{}MB'.format(size_mb)
         else:
             display_size = '{}KB'.format(size_kb)
-        logger.debug('Starting download from S3 - %s/%s [%s]',
-                    bucket, key, display_size)
+
+        LOGGER.debug('Starting download from S3 - %s/%s [%s]', bucket, key, display_size)
 
         suffix = key.replace('/', '-')
         _, downloaded_s3_object = tempfile.mkstemp(suffix=suffix)
@@ -148,6 +148,6 @@ class StreamPreParsers(object):
             client.download_fileobj(bucket, key, data)
 
         end_time = time.time() - start_time
-        logger.debug('Completed download in %s seconds', round(end_time, 2))
+        LOGGER.debug('Completed download in %s seconds', round(end_time, 2))
 
         return downloaded_s3_object

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -113,7 +113,7 @@ def test_rule(rule_name, test_record, formatted_record):
     else:
         expected_alert_count = (0, 1)[test_record['trigger']]
 
-    alerts = StreamAlert(return_alerts=True).run(event, None)
+    alerts = StreamAlert(None, True).run(event)
     # we only want alerts for the specific rule passed in
     matched_alert_count = len([x for x in alerts if x['metadata']['rule_name'] == rule_name])
 
@@ -166,6 +166,7 @@ def format_record(test_record):
         # Set the S3 object key to a random value for testing
         test_record['key'] = ('{:032X}'.format(random.randrange(16**32)))
         template['s3']['object']['key'] = test_record['key']
+        template['s3']['object']['size'] = len(data)
         template['s3']['bucket']['arn'] = 'arn:aws:s3:::{}'.format(source)
         template['s3']['bucket']['name'] = source
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -24,7 +24,7 @@ import time
 import zlib
 
 import boto3
-from moto import mock_s3
+from moto import mock_s3, mock_sns
 
 from stream_alert.rule_processor.handler import StreamAlert
 from stream_alert_cli.logger import LOGGER_CLI, LOGGER_SA
@@ -33,7 +33,8 @@ from stream_alert_cli.logger import LOGGER_CLI, LOGGER_SA
 import stream_alert.rule_processor.main
 # pylint: enable=unused-import
 
-BOTO_MOCKER = mock_s3()
+BOTO_MOCKER_S3 = mock_s3()
+BOTO_MOCKER_SNS = mock_sns()
 
 DIR_RULES = 'test/integration/rules'
 DIR_TEMPLATES = 'test/integration/templates'
@@ -113,7 +114,18 @@ def test_rule(rule_name, test_record, formatted_record):
     else:
         expected_alert_count = (0, 1)[test_record['trigger']]
 
+    # Start mocked sns
+    BOTO_MOCKER_SNS.start()
+
+    # Create the topic used for the mocking of alert sending
+    boto3.client('sns', region_name='us-east-1').create_topic(Name='test_streamalerts')
+
+    # Run the rule processor. Passing 'None' for context will load a mocked object later
     alerts = StreamAlert(None, True).run(event)
+
+    # Stop mocked sns
+    BOTO_MOCKER_SNS.stop()
+
     # we only want alerts for the specific rule passed in
     matched_alert_count = len([x for x in alerts if x['metadata']['rule_name'] == rule_name])
 
@@ -255,7 +267,7 @@ def test_alert_rules():
         boolean indicating if all tests passed
     """
     # Start the mock_s3 instance here so we can test with mocked objects project-wide
-    BOTO_MOCKER.start()
+    BOTO_MOCKER_S3.start()
     all_tests_passed = True
 
     # Create a list for pass/fails. The first value in the list is a list of tuples for failures,
@@ -308,7 +320,7 @@ def test_alert_rules():
     # Report on the final test results
     report_output_summary(rules_fail_pass)
 
-    BOTO_MOCKER.stop()
+    BOTO_MOCKER_S3.stop()
 
     return all_tests_passed
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -133,5 +133,7 @@ def test_load_env():
     context.invoked_function_arn = 'arn:aws:lambda:us-east-1:555555555555:function:streamalert_testing:production'
 
     env = load_env(context)
+    assert_equal(env['lambda_region'], 'us-east-1')
+    assert_equal(env['account_id'], '555555555555')
     assert_equal(env['lambda_function_name'], 'streamalert_testing')
     assert_equal(env['lambda_alias'], 'production')

--- a/test/unit/test_pre_parsers.py
+++ b/test/unit/test_pre_parsers.py
@@ -53,7 +53,7 @@ def test_pre_parse_s3():
             },
             'object': {
                 'key': key_name,
-                'size': 1000
+                'size': 30
             }
         }
     }
@@ -63,8 +63,9 @@ def test_pre_parse_s3():
     obj = s3_resource.Object(bucket_name, key_name)
     obj.put(Body=body_value)
 
-    s3_file = StreamPreParsers.pre_parse_s3(raw_record)
+    s3_file, size = StreamPreParsers.pre_parse_s3(raw_record)
     data = StreamPreParsers.read_s3_file(s3_file).next()
     assert_equal(body_value, data)
+    assert_equal(size, 30)
 
     BOTO_MOCKER.stop()

--- a/test/unit/test_sink.py
+++ b/test/unit/test_sink.py
@@ -42,13 +42,13 @@ class TestStreamSink(object):
 
     def test_sns_topic_arn(self):
         """Sink SNS Messaging - Topic ARN"""
-        sinker = sink.StreamSink([], self.env)
+        sinker = sink.StreamSink(self.env)
         arn = sinker._get_sns_topic_arn()
         assert_equal(arn, 'arn:aws:sns:us-east-1:123456789012:unittest_prod_streamalerts')
 
     def test_message_size_check(self):
         """Sink SNS Messaging - Message Blob Size Check"""
-        sinker = sink.StreamSink([], self.env)
+        sinker = sink.StreamSink(self.env)
         passed = sinker._sns_message_size_check(get_payload(1000))
         assert_equal(passed, True)
         passed = sinker._sns_message_size_check(get_payload((256*1024)+1))


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: medium

## changes ##
* Refactoring the rule processor so alerts are sent to the alert processor (via sns) as they are processed.
  * Prior to these changes, we would first iterator over all logs and apply the rule logic against them, caching any that matched a rule along the way. We would finally send them to the alert processor (one at a time) after all logs had been processed.
  * These change will make this all happen sequentially and any logs that match a rule will get sent as we process (instead of caching and sending at the end).
* Will log a message on every 100 records processed from s3 so we can track progress.
  * Adding some logic that will also try to estimate the number of records in the entire file during processing (we use a generator to avoid reading all the lines multiple times, and getting the exact line count would require reading the entire file twice).
* Other indirect gains:
  * boto3 client creation now happens when the `StreamSink` class is instantiated and recycled to avoid continuously re-creating it.
  * the `StreamSink` class does not cache the alerts list and will send on demand
* Removing/updating some old code (ie: things related to `staging`) that is no longer relevant.
* Updating tests where applicable
