### PR TITLE
[outputs] fixing bug where alert metadata was sent with alert

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -272,7 +272,7 @@ class SlackOutput(StreamOutputBase):
                     ...
         """
         # Convert the alert we have to a nicely formatted string for slack
-        alert_text = '\n'.join(cls._json_to_slack_mrkdwn(alert, 0))
+        alert_text = '\n'.join(cls._json_to_slack_mrkdwn(alert['record'], 0))
         # Slack requires escaping the characters: '&', '>' and '<' and cgi does just that
         alert_text = cgi.escape(alert_text)
         messages = []


### PR DESCRIPTION
to @airbnb/streamalert-maintainers 
size: small

* Fixing bug where alert metadata would be unnecessarily sent with the alert body in the Slack message