### PR TITLE
[streamalert] docs - remove requirements.txt

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,0 @@
-# pinning sphinx to 1.4.* due to search issues with rtd:
-# https://github.com/rtfd/readthedocs-sphinx-ext/issues/25
-# https://github.com/rtfd/readthedocs.org/issues/2708
-sphinx ==1.4.*


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 

Search is broken again on ReadTheDocs.
(search for anything and click on a link)

Supposedly, this is now addressed via https://github.com/rtfd/readthedocs-sphinx-ext/pull/26

This PR removes version pinning to give it a try