### PR TITLE
[parsers] fixing envelope_key value bug

### DIFF
--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -197,7 +197,7 @@ class JSONParser(ParserBase):
         envelope_schema = self.options.get('envelope_keys')
         # If envelope_keys are declared, and this payload does not have every key specified
         # in these envelope_keys, then it's safe to skip trying to extract records using json_path
-        if envelope_schema and not all(json_payload.get(x) for x in envelope_schema.keys()):
+        if envelope_schema and not all(x in json_payload for x in envelope_schema):
             return [json_payload]
 
         json_records = []


### PR DESCRIPTION
to @austinbyers 
cc @airbnb/streamalert-maintainers 

* Fixing bug where an empty value for a key that is an `envelope_key` would cause `envelope_key` validation to fail in the json parser. Making this change so the code will now look if the _key_ exists, and not worry about what _value_ said key has.