### PR TITLE
[cli] changing back a bucket name that was used to test a recent feature

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -432,7 +432,7 @@ def configure_output(options):
     if config is False:
         return configure_output(options)
 
-    secrets_bucket = '{}.streamalert.secrets.test'.format(prefix)
+    secrets_bucket = '{}.streamalert.secrets'.format(prefix)
     secrets_key = output.output_cred_name(props['descriptor'].value)
 
     # Encrypt the creds and push them to S3


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

* Renaming secrets bucket back to the right name. This was changed to test catching a bucket not found error and properly report it.