### PR TITLE
S3 Versioning, Cleanup, and Tagging

### DIFF
--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -69,6 +69,10 @@ resource "aws_s3_bucket" "streamalerts" {
   bucket        = "${replace("${var.prefix}.${var.cluster}.streamalerts", "_", ".")}"
   acl           = "private"
   force_destroy = false
+
+  versioning {
+    enabled = true
+  }
 }
 
 // Legacy S3 bucket name - All alerts should be copied to the bucket created above.

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -10,6 +10,10 @@ resource "aws_lambda_function" "streamalert_rule_processor" {
   timeout       = "${element(var.rule_processor_lambda_config["${var.cluster}"], 0)}"
   s3_bucket     = "${lookup(var.rule_processor_config, "source_bucket")}"
   s3_key        = "${lookup(var.rule_processor_config, "source_object_key")}"
+
+  tags {
+    Name = "StreamAlert"
+  }
 }
 
 // StreamAlert Processor Production Alias
@@ -43,6 +47,10 @@ resource "aws_lambda_function" "streamalert_alert_processor" {
   timeout       = "${element(var.alert_processor_lambda_config["${var.cluster}"], 0)}"
   s3_bucket     = "${lookup(var.alert_processor_config, "source_bucket")}"
   s3_key        = "${lookup(var.alert_processor_config, "source_object_key")}"
+
+  tags {
+    Name = "StreamAlert"
+  }
 }
 
 // StreamAlert Output Processor Production Alias

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -74,10 +74,3 @@ resource "aws_s3_bucket" "streamalerts" {
     enabled = true
   }
 }
-
-// Legacy S3 bucket name - All alerts should be copied to the bucket created above.
-resource "aws_s3_bucket" "stream_alert_output" {
-  bucket        = "${replace("${var.prefix}.${var.cluster}.stream.alert.output.processor.results", "_", ".")}"
-  acl           = "private"
-  force_destroy = false
-}

--- a/terraform/modules/tf_stream_alert_cloudtrail/iam.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/iam.tf
@@ -1,45 +1,41 @@
-// Role for CloudWatch events
+// IAM Role: CloudWatch Events
 resource "aws_iam_role" "streamalert_cloudwatch_role" {
   name = "${var.prefix}_${var.cluster}_streamalert_cloudwatch_role"
   path = "/streamalert/"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.streamalert_cloudwatch_role_assume_role_policy.json}"
 }
 
-// Policy for CloudWatch to allow write access to Kinesis
+data "aws_iam_policy_document" "streamalert_cloudwatch_role_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+// IAM Policy: Allow CloudWatch to write events to Kinesis Streams
 resource "aws_iam_role_policy" "streamalert_cloudwatch_policy" {
   name = "${var.prefix}_${var.cluster}_streamalert_cloudwatch"
   role = "${aws_iam_role.streamalert_cloudwatch_role.id}"
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "kinesis:PutRecord",
-                "kinesis:PutRecords"
-            ],
-            "Resource": [
-                "${var.kinesis_arn}"
-            ]
-        }
-    ]
+  policy = "${data.aws_iam_policy_document.kinesis_put_records.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "kinesis_put_records" {
+  statement {
+    sid = "CloudWatchEventsPutKinesisRecords"
+
+    actions = [
+      "kinesis:PutRecord",
+      "kinesis:PutRecords",
+    ]
+
+    resources = [
+      "${var.kinesis_arn}",
+    ]
+  }
 }

--- a/terraform/modules/tf_stream_alert_kinesis/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis/main.tf
@@ -26,8 +26,8 @@ resource "aws_kinesis_stream" "stream_alert_stream" {
   ]
 
   tags {
-    Application = "StreamAlert"
-    Cluster     = "${var.cluster_name}"
+    Name    = "StreamAlert"
+    Cluster = "${var.cluster_name}"
   }
 }
 
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "firehose_store" {
   }
 
   tags {
-    Application = "StreamAlert"
-    Cluster     = "${var.cluster_name}"
+    Name    = "StreamAlert"
+    Cluster = "${var.cluster_name}"
   }
 }

--- a/terraform/modules/tf_stream_alert_kinesis/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis/main.tf
@@ -36,6 +36,10 @@ resource "aws_s3_bucket" "firehose_store" {
   acl           = "private"
   force_destroy = false
 
+  versioning {
+    enabled = true
+  }
+
   tags {
     Application = "StreamAlert"
     Cluster     = "${var.cluster_name}"


### PR DESCRIPTION
to @ryandeivert 
cc @airbnb/streamalert-maintainers 

* Enable S3 versioning
* Cleanup tagging on Lambda/Kinesis resources for easier tracking
* Begin to use Terraform policy data resources over JSON strings (provides more reliability when running Terraform)