### PR TITLE
[parser] nested json records will now have optional keys applied

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -246,6 +246,8 @@
       "cb_server": "string",
       "computer_name": "string",
       "event_type": "string",
+      "filetype": "integer",
+      "filetype_name": "string",
       "link_process": "string",
       "link_sensor": "string",
       "md5": "string",

--- a/conf/logs.json
+++ b/conf/logs.json
@@ -265,10 +265,10 @@
           "ingress.event.filemod"
         ]
       },
-      "optional_top_level_keys": {
-        "filetype": "integer",
-        "filetype_name": "string"
-      }
+      "optional_top_level_keys": [
+        "filetype",
+        "filetype_name"
+      ]
     }
   },
   "carbonblack:binaryinfo.host.observed": {

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -214,17 +214,19 @@ class JSONParser(ParserBase):
                 elif key == OrderedDict():
                     return dict()
 
-            for key_name, value_type in optional_keys.iteritems():
+            for key_name in optional_keys:
                 # Instead of doing a schema.update() here with a default value type,
                 # we should enforce having any optional keys declared within the schema
                 # and log an error if that is not the case
                 if key_name not in schema:
-                    LOGGER.error('Optional key \'%s\' not found in schema', key_name)
+                    LOGGER.error('Optional top level key \'%s\' '
+                                 'not found in declared log schema', key_name)
+                    continue
                 # If the optional key isn't in our parsed json payload
                 for record in json_records:
                     if key_name not in record:
                         # Set default value
-                        record[key_name] = default_optional_values(value_type)
+                        record[key_name] = default_optional_values(schema[key_name])
 
         return json_records
 

--- a/test/unit/conf/logs.json
+++ b/test/unit/conf/logs.json
@@ -4,14 +4,17 @@
     "schema": {
       "key1": [],
       "key2": "string",
-      "key3": "integer"
+      "key3": "integer",
+      "key9": "boolean",
+      "key10": {},
+      "key11": "float"
     },
     "configuration": {
-      "optional_top_level_keys": {
-        "key9": "boolean",
-        "key10": {},
-        "key11": "float"
-      }
+      "optional_top_level_keys": [
+        "key9",
+        "key10",
+        "key11"
+      ]
     }
   },
   "test_log_type_json_2": {
@@ -35,23 +38,24 @@
   "test_log_type_json_nested_osquery": {
     "parser": "json",
     "schema": {
-      "name": "string",
-      "hostIdentifier": "string",
-      "calendarTime": "string",
-      "unixTime": "integer",
-      "columns": {},
       "action": "string",
+      "calendarTime": "string",
+      "columns": {},
       "decorations": {
         "role": "string",
         "env": "string",
         "cluster": "string",
         "number": "integer"
-      }
+      },
+      "hostIdentifier": "string",
+      "log_type": "string",
+      "name": "string",
+      "unixTime": "integer"
     },
     "configuration": {
-      "optional_top_level_keys": {
-        "log_type": "string"
-      }
+      "optional_top_level_keys": [
+        "log_type"
+      ]
     }
   },
   "test_log_type_json_nested_with_data": {


### PR DESCRIPTION
to @jacknagz , @mime-frame 
cc @airbnb/streamalert-maintainers 
resolves: #166
size: small

## changes ##
* Nested json records that get extracted via `json_path` will now have `optional_top_level_keys` applied.
* Removing the need to call `update` on a schema to add the default value, and instead logging an error if the key does not exist in the schema. This informs the user that the `optional_top_level_keys` should also be declared as part of the `schema` in logs.json.

## todo ##
* A future PR is to come with a note added to the docs about the need for `optional_top_level_keys` to be declared in the schema.