### PR TITLE
Support Alert Processor in VPC, Various Bug Fixes

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -152,6 +152,13 @@ def terraform_runner(options):
         tf_runner()
 
     elif options.subcommand == 'destroy':
+        if options.target:
+            target = options.target
+            targets = ['module.{}_{}'.format(target, cluster)
+                       for cluster in CONFIG['clusters'].keys()]
+            tf_runner(targets=targets, action='destroy')
+            return
+
         # Migrate back to local state so Terraform can successfully
         # destroy the S3 bucket used by the backend.
         terraform_generate(config=CONFIG, init=True)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -256,21 +256,25 @@ def tf_runner(**kwargs):
 
 def status():
     """Display current AWS infrastructure built by Terraform"""
-    print 'Cluster Info\n'
     for cluster, region in CONFIG['clusters'].iteritems():
-        print '==== {} ==='.format(cluster)
+        print '\n======== {} ========'.format(cluster)
         print 'Region: {}'.format(region)
-        print ('Lambda settings: \n\tTimeout: {}\n\tMemory: {}'
+        print ('Alert Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
                '\n\tProd Version: {}').format(
-                   CONFIG['lambda_settings'][cluster][0],
-                   CONFIG['lambda_settings'][cluster][1],
-                   CONFIG['lambda_function_prod_versions'][cluster])
-        print 'Kinesis settings: \n\tShards: {}\n\tRetention: {}\n'.format(
-            CONFIG['kinesis_settings'][cluster][0],
-            CONFIG['kinesis_settings'][cluster][1]
+                   CONFIG['alert_processor_lambda_config'][cluster][0],
+                   CONFIG['alert_processor_lambda_config'][cluster][1],
+                   CONFIG['alert_processor_versions'][cluster])
+        print ('Rule Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
+               '\n\tProd Version: {}').format(
+                   CONFIG['rule_processor_lambda_config'][cluster][0],
+                   CONFIG['rule_processor_lambda_config'][cluster][1],
+                   CONFIG['rule_processor_versions'][cluster])
+        print 'Kinesis settings: \n\tShards: {}\n\tRetention: {}'.format(
+            CONFIG['kinesis_streams_config'][cluster][0],
+            CONFIG['kinesis_streams_config'][cluster][1]
         )
 
-    print 'User access keys'
+    print '\nUser Access Keys:'
     run_command(['terraform', 'output'])
 
 

--- a/terraform/modules/tf_stream_alert/README.md
+++ b/terraform/modules/tf_stream_alert/README.md
@@ -41,6 +41,24 @@ module "stream_alert" {
     <td>True</td>
   </tr>
   <tr>
+    <td>alert_processor_vpc_enabled</td>
+    <td>To enable/disable placing the Alert Processor inside a VPC</td>
+    <td>False</td>
+    <td>False/td>
+  </tr>
+  <tr>
+    <td>alert_processor_vpc_subnet_ids</td>
+    <td>The subnet IDs to place the Alert Processor</td>
+    <td>[]</td>
+    <td>False</td>
+  </tr>
+  <tr>
+    <td>alert_processor_vpc_security_group_ids</td>
+    <td>The security group IDs to assign to the Alert Processor</td>
+    <td>[]</td>
+    <td>False</td>
+  </tr>
+  <tr>
     <td>region</td>
     <td>The AWS region for your stream</td>
     <td>None</td>

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -1,150 +1,141 @@
+/*
 // Rule Processor Execution Role
+*/
 resource "aws_iam_role" "streamalert_rule_processor_role" {
   name = "${var.prefix}_${var.cluster}_streamalert_rule_processor_role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role_policy.json}"
 }
 
-// Allow the Rule Processor to send alerts to SNS
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+// Policy: Allow the Rule Processor to send alerts to SNS
 resource "aws_iam_role_policy" "streamalert_rule_processor_sns" {
   name = "${var.prefix}_${var.cluster}_streamalert_rule_processor_send_to_sns"
   role = "${aws_iam_role.streamalert_rule_processor_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "sns:Publish",
-        "sns:Subscribe"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_sns_topic.streamalert.arn}"
-    }
-  ]
-}
-EOF
+  policy = "${data.aws_iam_policy_document.rule_processor_sns.json}"
 }
 
+data "aws_iam_policy_document" "rule_processor_sns" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+      "sns:Subscribe",
+    ]
+
+    resources = [
+      "${aws_sns_topic.streamalert.arn}",
+    ]
+  }
+}
+
+/*
 // Alert Processor Execution Role
+*/
 resource "aws_iam_role" "streamalert_alert_processor_role" {
   name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role_policy.json}"
 }
 
-// Allow the Alert Processor to decrypt secrets
+// Policy: Allow the Alert Processor to decrypt secrets
 resource "aws_iam_role_policy" "streamalert_alert_processor_kms" {
   name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_kms"
   role = "${aws_iam_role.streamalert_alert_processor_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "kms:Decrypt",
-        "kms:DescribeKey"
-      ],
-      "Effect": "Allow",
-      "Resource": "${var.kms_key_arn}"
-    }
-  ]
-}
-EOF
+  policy = "${data.aws_iam_policy_document.rule_processor_kms_decrypt.json}"
 }
 
-// Allow the Alert Processor to write objects to S3
-// Default s3 bucket created by this module.
+data "aws_iam_policy_document" "rule_processor_kms_decrypt" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+
+    resources = [
+      "${var.kms_key_arn}",
+    ]
+  }
+}
+
+// Policy: Allow the Alert Processor to write objects to S3.
+//         The default S3 bucket is also created by this module.
 resource "aws_iam_role_policy" "streamalert_alert_processor_s3" {
   name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_s3_default"
   role = "${aws_iam_role.streamalert_alert_processor_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.streamalerts.arn}/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::${var.prefix}.streamalert.secrets/*"
-      ]
-    }
-  ]
-}
-EOF
+  policy = "${data.aws_iam_policy_document.alert_processor_s3.json}"
 }
 
-// Allow the Alert Processor to write cloudwatch logs
+data "aws_iam_policy_document" "alert_processor_s3" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.streamalerts.arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.prefix}.streamalert.secrets/*",
+    ]
+  }
+}
+
+// Policy: Allow the Alert Processor to write cloudwatch logs
 resource "aws_iam_role_policy" "streamalert_alert_processor_cloudwatch" {
   name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_cloudwatch"
   role = "${aws_iam_role.streamalert_alert_processor_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
+  policy = "${data.aws_iam_policy_document.alert_processor_cloudwatch.json}"
 }
 
-// Allow the Alert Processor to invoke Lambda
+data "aws_iam_policy_document" "alert_processor_cloudwatch" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+// Policy: Allow the Alert Processor to invoke Lambda functions
 resource "aws_iam_role_policy" "streamalert_alert_processor_lambda" {
   count = "${length(keys(var.output_lambda_functions))}"
   name  = "${var.prefix}_${var.cluster}_streamalert_alert_processor_lambda_${element(keys(var.output_lambda_functions), count.index)}"
@@ -166,7 +157,7 @@ resource "aws_iam_role_policy" "streamalert_alert_processor_lambda" {
 EOF
 }
 
-// Allow the Alert Processor to send to arbitrary S3 buckets as outputs
+// Policy: Allow the Alert Processor to send to arbitrary S3 buckets as outputs
 resource "aws_iam_role_policy" "streamalert_alert_processor_s3_outputs" {
   count = "${length(keys(var.output_s3_buckets))}"
   name  = "${var.prefix}_${var.cluster}_streamalert_alert_processor_s3_output_${element(keys(var.output_s3_buckets), count.index)}"
@@ -188,4 +179,31 @@ resource "aws_iam_role_policy" "streamalert_alert_processor_s3_outputs" {
   ]
 }
 EOF
+}
+
+// Policy: Allow the Alert Processor to run in a VPC
+resource "aws_iam_role_policy" "streamalert_alert_processor_vpc" {
+  count = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+  name  = "${var.prefix}_${var.cluster}_streamalert_alert_processor_vpc"
+  role  = "${aws_iam_role.streamalert_alert_processor_role.id}"
+
+  policy = "${data.aws_iam_policy_document.alert_processor_vpc.json}"
+}
+
+data "aws_iam_policy_document" "alert_processor_vpc" {
+  count = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -37,7 +37,33 @@ resource "aws_lambda_permission" "sns_inputs" {
 
 // AWS Lambda Function: StreamAlert Alert Processor
 //    Send alerts to declared outputs
+
+// Lambda Function inside a VPC
+resource "aws_lambda_function" "streamalert_alert_processor_vpc" {
+  count         = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+  function_name = "${var.prefix}_${var.cluster}_streamalert_alert_processor"
+  description   = "StreamAlert Alert Processor"
+  runtime       = "python2.7"
+  role          = "${aws_iam_role.streamalert_alert_processor_role.arn}"
+  handler       = "${lookup(var.alert_processor_config, "handler")}"
+  memory_size   = "${element(var.alert_processor_lambda_config["${var.cluster}"], 1)}"
+  timeout       = "${element(var.alert_processor_lambda_config["${var.cluster}"], 0)}"
+  s3_bucket     = "${lookup(var.alert_processor_config, "source_bucket")}"
+  s3_key        = "${lookup(var.alert_processor_config, "source_object_key")}"
+
+  vpc_config {
+    subnet_ids         = "${var.alert_processor_vpc_subnet_ids}"
+    security_group_ids = "${var.alert_processor_vpc_security_group_ids}"
+  }
+
+  tags {
+    Name = "StreamAlert"
+  }
+}
+
+// Non VPC Lambda Function
 resource "aws_lambda_function" "streamalert_alert_processor" {
+  count         = "${var.alert_processor_vpc_enabled ? 0 : 1}"
   function_name = "${var.prefix}_${var.cluster}_streamalert_alert_processor"
   description   = "StreamAlert Alert Processor"
   runtime       = "python2.7"
@@ -54,15 +80,40 @@ resource "aws_lambda_function" "streamalert_alert_processor" {
 }
 
 // StreamAlert Output Processor Production Alias
+// VPC
+resource "aws_lambda_alias" "alert_processor_production_vpc" {
+  count            = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+  name             = "production"
+  description      = "Production StreamAlert Alert Processor Alias"
+  function_name    = "${aws_lambda_function.streamalert_alert_processor_vpc.arn}"
+  function_version = "${var.alert_processor_versions["${var.cluster}"]}"
+}
+
+// Non VPC
 resource "aws_lambda_alias" "alert_processor_production" {
+  count            = "${var.alert_processor_vpc_enabled ? 0 : 1}"
   name             = "production"
   description      = "Production StreamAlert Alert Processor Alias"
   function_name    = "${aws_lambda_function.streamalert_alert_processor.arn}"
   function_version = "${var.alert_processor_versions["${var.cluster}"]}"
 }
 
-// Allow SNS to invoke the StreamAlert Output Processor
+// Allow SNS to invoke the Alert Processor
+// VPC
+resource "aws_lambda_permission" "with_sns_vpc" {
+  count         = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.streamalert_alert_processor_vpc.arn}"
+  principal     = "sns.amazonaws.com"
+  source_arn    = "${aws_sns_topic.streamalert.arn}"
+  qualifier     = "production"
+  depends_on    = ["aws_lambda_alias.alert_processor_production_vpc"]
+}
+
+// Non VPC
 resource "aws_lambda_permission" "with_sns" {
+  count         = "${var.alert_processor_vpc_enabled ? 0 : 1}"
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.streamalert_alert_processor.arn}"

--- a/terraform/modules/tf_stream_alert/sns.tf
+++ b/terraform/modules/tf_stream_alert/sns.tf
@@ -5,7 +5,17 @@ resource "aws_sns_topic" "streamalert" {
 }
 
 // Subscribe the Alert Processor Lambda function to the SNS topic
+// VPC
+resource "aws_sns_topic_subscription" "alert_processor_vpc" {
+  count     = "${var.alert_processor_vpc_enabled ? 1 : 0}"
+  topic_arn = "${aws_sns_topic.streamalert.arn}"
+  endpoint  = "${aws_lambda_function.streamalert_alert_processor_vpc.arn}:production"
+  protocol  = "lambda"
+}
+
+// Non VPC
 resource "aws_sns_topic_subscription" "alert_processor" {
+  count     = "${var.alert_processor_vpc_enabled ? 0 : 1}"
   topic_arn = "${aws_sns_topic.streamalert.arn}"
   endpoint  = "${aws_lambda_function.streamalert_alert_processor.arn}:production"
   protocol  = "lambda"

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -62,3 +62,17 @@ variable "input_sns_topics" {
   type    = "map"
   default = {}
 }
+
+variable "alert_processor_vpc_enabled" {
+  default = false
+}
+
+variable "alert_processor_vpc_subnet_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "alert_processor_vpc_security_group_ids" {
+  type    = "list"
+  default = []
+}

--- a/variables.json
+++ b/variables.json
@@ -6,7 +6,7 @@
         "region": "us-east-1"
     },
     "alert_processor_config": {
-        "handler": "main.handler",
+        "handler": "stream_alert.alert_processor.main.handler",
         "source_bucket": "PREFIX_GOES_HERE.streamalert.source",
         "source_current_hash": "auto_generated",
         "source_object_key": "auto_generated",


### PR DESCRIPTION
to: @austinbyers @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium

### Background

The primary purpose of this PR is to support the Alert Processor running from within an AWS VPC (Virtual Private Cloud).  The benefit of this change is that alerting logic will be able to reach into private services/resources behind a firewall or security groups in AWS cloud.  An example of this is an alert with Phantom as an output, or any other orchestration trigger as a result of a StreamAlert.

Along the way, I identified other small bugs with the CLI that I have also fixed.  

### Changes
* Modify the `tf_stream_alert` Terraform module to support running the Alert Processor from within a VPC.
* Fix the `stream_alert_cli.py terraform status` command.
* Added an option to `stream_alert_cli.py terraform destroy` to allow destruction of selective modules.
* Fix the `handler` import path for the `alert_processor`

### Usage
Important! To enable the`alert_processor` from within a VPC, you must first add the following to your cluster config:

Example:
```
# terraform/prod.tf

        "stream_alert_prod": {
             ...
            "alert_processor_vpc_subnet_ids": [
              "subnet-55566a3f"
            ],
            "alert_processor_vpc_security_group_ids": [
              "sg-e777f9ab"
            ],
            "alert_processor_vpc_enabled": true,
            ...
        }

```

You will have to destroy the existing alert processor, you can do it with the following command:

```
$ cd terraform
$ terraform destroy -target=module.stream_alert_<cluster-name>.aws_lambda_function.streamalert_alert_processor
```

Then, run:
```
$ python stream_alert_cli.py terraform build
```
