### PR TITLE
[tests] alert processor unit tests

### DIFF
--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -1,9 +1,9 @@
 {
   "aws-s3": {
-    "sample.bucket": "sample_bucket_name"
+    "sample_bucket": "sample.bucket.name"
   },
   "aws-lambda": {
-    "sample_lambda": "arn:aws:lambda:region:account-id:function:function-name"
+    "sample_lambda": "function-name"
   },
   "pagerduty": [
     "sample_integration"

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -38,7 +38,7 @@ def handler(event, context):
     LOGGER.info('Running alert processor for %d records', len(records))
 
     # A failure to load the config will log the error in load_output_config and return here
-    config = load_output_config()
+    config = _load_output_config()
     if not config:
         return
 
@@ -100,7 +100,7 @@ def run(loaded_sns_message, region, function_name, config):
     rule_name = alert['metadata']['rule_name']
 
     # strip out unnecessary keys and sort
-    alert = sort_dict(alert)
+    alert = _sort_dict(alert)
 
     outputs = alert['metadata']['outputs']
     # Get the output configuration for this rule and send the alert to each
@@ -132,7 +132,7 @@ def run(loaded_sns_message, region, function_name, config):
             LOGGER.error('An error occurred while sending alert to %s:%s: %s. alert:\n%s',
                          service, descriptor, err, json.dumps(alert, indent=4))
 
-def sort_dict(unordered_dict):
+def _sort_dict(unordered_dict):
     """Recursively sort a dictionary
 
     Args:
@@ -144,20 +144,20 @@ def sort_dict(unordered_dict):
     result = OrderedDict()
     for key, value in sorted(unordered_dict.items(), key=lambda t: t[0]):
         if isinstance(value, dict):
-            result[key] = sort_dict(value)
+            result[key] = _sort_dict(value)
             continue
 
         result[key] = value
 
     return result
 
-def load_output_config():
+def _load_output_config(config_path='conf/outputs.json'):
     """Load the outputs configuration file from disk
 
     Returns:
         [dict] The output configuration settings
     """
-    with open('conf/outputs.json') as outputs:
+    with open(config_path) as outputs:
         try:
             config = json.load(outputs)
         except ValueError:

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -182,19 +182,6 @@ class StreamOutputBase(object):
             LOGGER.error('failed to send alert to %s', self.__service__)
 
     @staticmethod
-    def _format_prefix(s3_prefix):
-        """Return a bucket prefix that has been properly formatted
-
-        Args:
-            s3_prefix [string]: Qualifier value to format
-
-        Returns:
-            [string] The formatted value
-        """
-        s3_prefix = s3_prefix.replace('_streamalert_alert_processor', '')
-        return s3_prefix.replace('_', '.')
-
-    @staticmethod
     def _request_helper(url, data, headers=None, verify=True):
         """URL request helper to send a payload to an endpoint
 

--- a/test/scripts/autopep8.sh
+++ b/test/scripts/autopep8.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-autopep8 --in-place --aggressive --aggressive $1
+autopep8 --in-place --max-line-length 90 --aggressive --aggressive $1

--- a/test/scripts/unit_tests.sh
+++ b/test/scripts/unit_tests.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-nosetests test/unit --with-coverage --cover-package=stream_alert.rule_processor --cover-package=stream_alert_cli --cover-min-percentage=80
+nosetests test/unit --with-coverage --cover-package=stream_alert.rule_processor --cover-package=stream_alert.alert_processor --cover-package=stream_alert_cli --cover-min-percentage=80

--- a/test/scripts/unit_tests.sh
+++ b/test/scripts/unit_tests.sh
@@ -1,2 +1,7 @@
 #! /bin/bash
-nosetests test/unit --with-coverage --cover-package=stream_alert.rule_processor --cover-package=stream_alert.alert_processor --cover-package=stream_alert_cli --cover-min-percentage=80
+nosetests test/unit \
+--with-coverage \
+--cover-package=stream_alert.rule_processor \
+--cover-package=stream_alert.alert_processor \
+--cover-package=stream_alert_cli \
+--cover-min-percentage=80

--- a/test/unit/conf/outputs.json
+++ b/test/unit/conf/outputs.json
@@ -5,6 +5,9 @@
   "aws-lambda": {
     "unit_test_lambda": "unit_test_function"
   },
+  "pagerduty": [
+    "unit_test_integration"
+  ],
   "slack": [
     "unit_test_channel"
   ]

--- a/test/unit/conf/outputs.json
+++ b/test/unit/conf/outputs.json
@@ -1,0 +1,11 @@
+{
+  "aws-s3": {
+    "unit_test_bucket": "unit.test.bucket.name"
+  },
+  "aws-lambda": {
+    "unit_test_lambda": "unit_test_function"
+  },
+  "slack": [
+    "unit_test_channel"
+  ]
+}

--- a/test/unit/conf/outputs.json
+++ b/test/unit/conf/outputs.json
@@ -6,7 +6,10 @@
     "unit_test_lambda": "unit_test_function"
   },
   "pagerduty": [
-    "unit_test_integration"
+    "unit_test_pagerduty"
+  ],
+  "phantom": [
+    "unit_test_phantom"
   ],
   "slack": [
     "unit_test_channel"

--- a/test/unit/stream_alert_alert_processor/__init__.py
+++ b/test/unit/stream_alert_alert_processor/__init__.py
@@ -1,0 +1,20 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+from stream_alert.alert_processor.main import _load_output_config
+
+REGION = 'us-east-1'
+FUNCTION_NAME = 'corp-prefix_prod_streamalert_alert_processor'
+CONFIG = _load_output_config()

--- a/test/unit/stream_alert_alert_processor/helpers.py
+++ b/test/unit/stream_alert_alert_processor/helpers.py
@@ -15,6 +15,8 @@ limitations under the License.
 '''
 import json
 
+import boto3
+
 from mock import Mock
 
 from unit.stream_alert_alert_processor import (
@@ -76,6 +78,16 @@ def _get_mock_context():
                    function_name='corp-prefix_prod_streamalert_alert_processor')
 
     return context
+
+def _put_mock_creds(output_name, creds, bucket):
+    """Helper function to mock encrypt creds and put on s3"""
+    creds_string = json.dumps(creds)
+
+    kms_client = boto3.client('kms', region_name=REGION)
+    enc_creds = _encrypt_with_kms(kms_client, creds_string)
+
+    s3_client = boto3.client('s3', region_name=REGION)
+    _put_s3_test_object(s3_client, bucket, output_name, enc_creds)
 
 def _put_s3_test_object(client, bucket, key, data):
     client.create_bucket(Bucket=bucket)

--- a/test/unit/stream_alert_alert_processor/helpers.py
+++ b/test/unit/stream_alert_alert_processor/helpers.py
@@ -1,0 +1,87 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import json
+
+from mock import Mock
+
+from unit.stream_alert_alert_processor import (
+    REGION,
+    FUNCTION_NAME
+)
+
+def _construct_event(count):
+    """Helper to construct a valid test 'event' with an arbitrary number of records"""
+    event = {'Records': []}
+    for index in range(count):
+        event['Records'] = event['Records'] + [{'Sns': {'Message': json.dumps(_get_alert(index))}}]
+
+    return event
+
+def _encrypt_with_kms(client, data):
+    alias = 'alias/stream_alert_secrets_test'
+    client.create_alias(AliasName=alias, TargetKeyId='1234abcd-12ab-34cd-56ef-1234567890ab')
+
+    response = client.encrypt(KeyId=alias,
+                              Plaintext=data)
+
+    return response['CiphertextBlob']
+
+def _get_alert(index):
+    return {
+        'default': {
+            'record': {
+                'test_index': index,
+                'compressed_size': '9982',
+                'timestamp': '1496947381.18',
+                'node_id': '1',
+                'cb_server': 'cbserver',
+                'size': '21504',
+                'type': 'binarystore.file.added',
+                'file_path': '/tmp/5DA/AD8/0F9AA55DA3BDE84B35656AD8911A22E1.zip',
+                'md5': '0F9AA55DA3BDE84B35656AD8911A22E1'
+            },
+            'metadata': {
+                'log': 'carbonblack:binarystore.file.added',
+                'rule_name': 'cb_binarystore_file_added',
+                'outputs': [
+                    'slack:unit_test_channel'
+                ],
+                'source': {
+                    'service': 's3',
+                    'entity': 'corp-prefix.prod.cb.region'
+                },
+                'type': 'json',
+                'rule_description': 'Info about this rule and what actions to take'
+            }
+        }
+    }
+
+def _get_mock_context():
+    """Create a fake context object using Mock"""
+    arn = 'arn:aws:lambda:{}:555555555555:function:{}:production'
+    context = Mock(invoked_function_arn=(arn.format(REGION, FUNCTION_NAME)),
+                   function_name='corp-prefix_prod_streamalert_alert_processor')
+
+    return context
+
+def _put_s3_test_object(client, bucket, key, data):
+    client.create_bucket(Bucket=bucket)
+    client.put_object(
+        Body=data,
+        Bucket=bucket,
+        Key=key,
+        ServerSideEncryption='AES256'
+    )

--- a/test/unit/stream_alert_alert_processor/helpers.py
+++ b/test/unit/stream_alert_alert_processor/helpers.py
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 import json
+import os
+import shutil
+import tempfile
 
 import boto3
 
@@ -78,6 +81,11 @@ def _get_mock_context():
                    function_name='corp-prefix_prod_streamalert_alert_processor')
 
     return context
+
+def _remove_temp_secrets():
+    """"Blow away the stream_alert_secrets directory in temp"""
+    secrets_dir = os.path.join(tempfile.gettempdir(), "stream_alert_secrets")
+    shutil.rmtree(secrets_dir)
 
 def _put_mock_creds(output_name, creds, bucket):
     """Helper function to mock encrypt creds and put on s3"""

--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -84,7 +84,7 @@ def test_load_output_config():
     """Load outputs configuration file"""
     config = _load_output_config('test/unit/conf/outputs.json')
 
-    assert_equal(set(config.keys()), {'aws-s3', 'aws-lambda', 'slack'})
+    assert_equal(set(config.keys()), {'aws-s3', 'aws-lambda', 'pagerduty', 'slack'})
 
 def test_sort_dict():
     """Sorted Dict"""

--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -1,0 +1,100 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import json
+
+from collections import OrderedDict
+from mock import patch, call
+
+from nose.tools import assert_equal
+
+from stream_alert.alert_processor.main import (
+    _load_output_config,
+    _sort_dict,
+    handler
+)
+
+from unit.stream_alert_alert_processor import (
+    REGION,
+    FUNCTION_NAME,
+    CONFIG
+)
+
+from unit.stream_alert_alert_processor.helpers import _get_mock_context
+
+
+class TestAlertProcessor(object):
+    """Test base class for Alert Processor"""
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        pass
+
+@patch('logging.Logger.error')
+def test_handler_bad_message(log_mock):
+    """Main handler decode failure logging"""
+    context = _get_mock_context()
+    event = {'Records': [{'Sns': {'Message': 'this\nvalue\nshould\nfail\nto\ndecode'}}]}
+    handler(event, context)
+    assert_equal(str(log_mock.call_args_list[0]),
+                 str(call('An error occurred while decoding message to JSON: %s',
+                          ValueError('No JSON object could be decoded',))))
+
+@patch('logging.Logger.error')
+def test_handler_malformed_message(log_mock):
+    """Main handler decode failure logging"""
+    context = _get_mock_context()
+    message = {'not_default': {'record': {'size': '9982'}}}
+    event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
+    handler(event, context)
+    log_mock.assert_called_with('Malformed SNS: %s', message)
+
+@patch('stream_alert.alert_processor.main.run')
+def test_handler_run(run_mock):
+    """Main handler `run` call params"""
+    context = _get_mock_context()
+    message = {'default': {'record': {'size': '9982'}}}
+    event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
+    handler(event, context)
+    run_mock.assert_called_with(message, REGION, FUNCTION_NAME, CONFIG)
+
+def test_run():
+    """Main run test"""
+    # TODO(ryandeivert): add test for statements in the `run` method
+    pass
+
+def test_load_output_config():
+    """Load outputs configuration file"""
+    config = _load_output_config('test/unit/conf/outputs.json')
+
+    assert_equal(set(config.keys()), {'aws-s3', 'aws-lambda', 'slack'})
+
+def test_sort_dict():
+    """Sorted Dict"""
+    dict_to_sort = {'c': 100, 'd': 1000, 'a': 1, 'b': 10, 'e': 100, 'f': 10, 'g': 1}
+    sorted_dict = _sort_dict(dict_to_sort)
+
+    assert_equal(type(sorted_dict), OrderedDict)
+
+    index = 0
+    keys = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    for key in sorted_dict.keys():
+        assert_equal(keys[index], key)
+        index += 1

--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -84,7 +84,7 @@ def test_load_output_config():
     """Load outputs configuration file"""
     config = _load_output_config('test/unit/conf/outputs.json')
 
-    assert_equal(set(config.keys()), {'aws-s3', 'aws-lambda', 'pagerduty', 'slack'})
+    assert_equal(set(config.keys()), {'aws-s3', 'aws-lambda', 'pagerduty', 'phantom', 'slack'})
 
 def test_sort_dict():
     """Sorted Dict"""

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -1,0 +1,206 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import json
+import os
+import urllib2
+
+import boto3
+
+from mock import patch, Mock
+
+from moto import mock_s3, mock_kms
+from nose.tools import assert_equal
+
+from stream_alert.alert_processor.main import (
+    _load_output_config as load_config,
+    _sort_dict
+)
+
+from stream_alert.alert_processor.output_base import (
+    OutputProperty,
+    StreamOutputBase
+)
+
+from unit.stream_alert_alert_processor import (
+    REGION,
+    FUNCTION_NAME,
+    CONFIG
+)
+
+from unit.stream_alert_alert_processor.helpers import (
+    _encrypt_with_kms,
+    _put_s3_test_object
+)
+
+# Remove all abstractmethods from __abstractmethods__ so we can
+# instantiate StreamOutputBase for testing
+StreamOutputBase.__abstractmethods__ = frozenset()
+StreamOutputBase.__service__ = 'test_service'
+
+
+class TestLoadCreds(object):
+    """Test class for Loading Credentials"""
+    __dispatcher = None
+    __descriptor = 'channel_desc_test'
+    @classmethod
+    @mock_s3
+    @mock_kms
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        s3_client = boto3.client('s3', region_name=REGION)
+        kms_client = boto3.client('kms', region_name=REGION)
+        creds = {'url': 'http://www.foo.bar/test',
+                 'token': 'token_to_encrypt'}
+
+        cls.__dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
+
+        output_name = cls.__dispatcher.output_cred_name(cls.__descriptor)
+
+        creds_string = json.dumps(creds)
+
+        enc_creds = _encrypt_with_kms(kms_client, creds_string)
+
+        _put_s3_test_object(s3_client, cls.__dispatcher.secrets_bucket,
+                            output_name, enc_creds)
+
+    @mock_kms
+    @mock_s3
+    def test_load_creds(self):
+        """Load Credentials"""
+        loaded_creds = self.__dispatcher._load_creds(self.__descriptor)
+
+        assert_equal(len(loaded_creds), 2)
+        assert_equal(loaded_creds['url'], u'http://www.foo.bar/test')
+        assert_equal(loaded_creds['token'], u'token_to_encrypt')
+
+def test_output_property_default():
+    """OutputProperty defaults"""
+    prop = OutputProperty()
+
+    assert_equal(prop.description, '')
+    assert_equal(prop.value, '')
+    assert_equal(prop.input_restrictions, {' ', ':'})
+    assert_equal(prop.mask_input, False)
+    assert_equal(prop.cred_requirement, False)
+
+def test_local_temp_dir():
+    """Local Temp Dir"""
+    temp_dir = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)._local_temp_dir()
+    assert_equal(temp_dir.split('/')[-1], 'stream_alert_secrets')
+
+def test_get_secrets_bucket_name():
+    """Get Secrets Bucket Name"""
+    bucket_name = StreamOutputBase(REGION, FUNCTION_NAME,
+                                   CONFIG)._get_secrets_bucket_name(FUNCTION_NAME)
+    assert_equal(bucket_name, 'corp-prefix.streamalert.secrets')
+
+def test_output_cred_name():
+    """Output Cred Name"""
+    output_name = StreamOutputBase(REGION, FUNCTION_NAME,
+                                   CONFIG).output_cred_name('creds')
+
+    assert_equal(output_name, 'test_service/creds')
+
+@mock_s3
+def test_get_creds_from_s3():
+    """Get Creds From S3"""
+    descriptor = 'test_descriptor'
+    test_data = 'credential test string'
+
+    dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
+    bucket_name = dispatcher.secrets_bucket
+    key = dispatcher.output_cred_name(descriptor)
+
+    local_cred_location = os.path.join(dispatcher._local_temp_dir(), key)
+
+    client = boto3.client('s3', region_name=REGION)
+    _put_s3_test_object(client, bucket_name, key, test_data)
+
+    dispatcher._get_creds_from_s3(local_cred_location, descriptor)
+
+    with open(local_cred_location) as creds:
+        line = creds.readline()
+
+    assert_equal(line, test_data)
+
+@mock_kms
+def test_kms_decrypt():
+    """Credential KMS Decrypt"""
+    test_data = 'data to encrypt'
+    client = boto3.client('kms', region_name=REGION)
+
+    encrypted = _encrypt_with_kms(client, test_data)
+    decrypted = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)._kms_decrypt(encrypted)
+
+    assert_equal(decrypted, test_data)
+
+
+@patch('logging.Logger.info')
+def test_log_status_failed(log_mock):
+    """Log status success"""
+    dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)._log_status(True)
+    log_mock.assert_called_with('successfully sent alert to %s', 'test_service')
+
+
+@patch('logging.Logger.error')
+def test_log_status_failed(log_mock):
+    """Log status failed"""
+    dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)._log_status(False)
+    log_mock.assert_called_with('failed to send alert to %s', 'test_service')
+
+
+@patch('urllib2.urlopen')
+def test_check_http_response(mock_getcode):
+    """Check HTTP Response"""
+    # Test with a good code
+    mock_getcode.getcode.return_value = 200
+
+    dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
+    result = dispatcher._check_http_response(mock_getcode)
+
+    assert_equal(result, True)
+
+    # Test with a bad code
+    mock_getcode.getcode.return_value = 440
+    result = dispatcher._check_http_response(mock_getcode)
+
+    assert_equal(result, False)
+
+class TestFormatOutputConfig(object):
+    """Test class for Output Config formatting"""
+    __cached_name = StreamOutputBase.__service__
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        # Switch out the test service to one that is in the outputs.json file
+        StreamOutputBase.__service__ = 'slack'
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        StreamOutputBase.__service__ = cls.__cached_name
+
+    @staticmethod
+    def test_format_output_config():
+        """Format Output Config"""
+        props = {'descriptor': OutputProperty('test_desc', 'test_channel')}
+
+        formatted = StreamOutputBase(REGION, FUNCTION_NAME,
+                                     CONFIG).format_output_config(CONFIG, props)
+
+        assert_equal(len(formatted), 2)
+        assert_equal(formatted[0], 'sample_channel')
+        assert_equal(formatted[1], 'test_channel')

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -50,42 +50,6 @@ from unit.stream_alert_alert_processor.helpers import (
 StreamOutputBase.__abstractmethods__ = frozenset()
 StreamOutputBase.__service__ = 'test_service'
 
-
-class TestLoadCreds(object):
-    """Test class for Loading Credentials"""
-    __dispatcher = None
-    __descriptor = 'channel_desc_test'
-    @classmethod
-    @mock_s3
-    @mock_kms
-    def setup_class(cls):
-        """Setup the class before any methods"""
-        s3_client = boto3.client('s3', region_name=REGION)
-        kms_client = boto3.client('kms', region_name=REGION)
-        creds = {'url': 'http://www.foo.bar/test',
-                 'token': 'token_to_encrypt'}
-
-        cls.__dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
-
-        output_name = cls.__dispatcher.output_cred_name(cls.__descriptor)
-
-        creds_string = json.dumps(creds)
-
-        enc_creds = _encrypt_with_kms(kms_client, creds_string)
-
-        _put_s3_test_object(s3_client, cls.__dispatcher.secrets_bucket,
-                            output_name, enc_creds)
-
-    @mock_kms
-    @mock_s3
-    def test_load_creds(self):
-        """Load Credentials"""
-        loaded_creds = self.__dispatcher._load_creds(self.__descriptor)
-
-        assert_equal(len(loaded_creds), 2)
-        assert_equal(loaded_creds['url'], u'http://www.foo.bar/test')
-        assert_equal(loaded_creds['token'], u'token_to_encrypt')
-
 def test_output_property_default():
     """OutputProperty defaults"""
     prop = OutputProperty()

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -13,21 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import json
 import os
-import urllib2
 
 import boto3
 
-from mock import patch, Mock
+from mock import patch
 
 from moto import mock_s3, mock_kms
 from nose.tools import assert_equal, assert_is_not_none
-
-from stream_alert.alert_processor.main import (
-    _load_output_config as load_config,
-    _sort_dict
-)
 
 from stream_alert.alert_processor.output_base import (
     OutputProperty,
@@ -52,6 +45,7 @@ from unit.stream_alert_alert_processor.helpers import (
 StreamOutputBase.__abstractmethods__ = frozenset()
 StreamOutputBase.__service__ = 'test_service'
 
+
 def test_output_property_default():
     """OutputProperty defaults"""
     prop = OutputProperty()
@@ -63,15 +57,18 @@ def test_output_property_default():
     assert_equal(prop.cred_requirement, False)
 
 
-class TestSteamOutputBase(object):
-    """Test class for StreamOutputBase"""
+class TestStreamOutputBase(object):
+    """Test class for StreamOutputBase
+
+    Perform various tests for methods inherited by all output classes
+    """
     __dispatcher = None
     __descriptor = 'desc_test'
+
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
         cls.__dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
-        _remove_temp_secrets()
 
     @classmethod
     def teardown_class(cls):
@@ -131,13 +128,11 @@ class TestSteamOutputBase(object):
         self.__dispatcher._log_status(True)
         log_mock.assert_called_with('successfully sent alert to %s', 'test_service')
 
-
     @patch('logging.Logger.error')
     def test_log_status_failed(self, log_mock):
         """StreamOutputBase Log status failed"""
         self.__dispatcher._log_status(False)
         log_mock.assert_called_with('failed to send alert to %s', 'test_service')
-
 
     @patch('urllib2.urlopen')
     def test_check_http_response(self, mock_getcode):
@@ -175,6 +170,7 @@ class TestSteamOutputBase(object):
 class TestFormatOutputConfig(object):
     """Test class for Output Config formatting"""
     __cached_name = StreamOutputBase.__service__
+
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -42,6 +42,7 @@ from unit.stream_alert_alert_processor import (
 
 from unit.stream_alert_alert_processor.helpers import (
     _encrypt_with_kms,
+    _remove_temp_secrets,
     _put_mock_creds,
     _put_s3_test_object
 )
@@ -70,6 +71,7 @@ class TestSteamOutputBase(object):
     def setup_class(cls):
         """Setup the class before any methods"""
         cls.__dispatcher = StreamOutputBase(REGION, FUNCTION_NAME, CONFIG)
+        _remove_temp_secrets()
 
     @classmethod
     def teardown_class(cls):
@@ -154,6 +156,7 @@ class TestSteamOutputBase(object):
     @mock_kms
     def test_load_creds(self):
         """Load Credentials"""
+        _remove_temp_secrets()
         output_name = self.__dispatcher.output_cred_name(self.__descriptor)
 
         creds = {'url': 'http://www.foo.bar/test',

--- a/test/unit/stream_alert_alert_processor/test_outputs.py
+++ b/test/unit/stream_alert_alert_processor/test_outputs.py
@@ -1,0 +1,423 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import random
+import urllib2
+import zipfile
+
+from collections import OrderedDict, Counter
+from StringIO import StringIO
+
+from mock import patch
+from moto import mock_s3, mock_lambda
+from nose.tools import (
+    assert_equal,
+    assert_is_none,
+    assert_is_not_none,
+    assert_not_equal,
+    assert_set_equal
+)
+
+from stream_alert.alert_processor import outputs as outputs
+from stream_alert.alert_processor.outputs import *
+
+from stream_alert.alert_processor.main import _load_output_config as load_config
+from stream_alert.alert_processor.output_base import OutputProperty
+
+from unit.stream_alert_alert_processor import (
+    REGION,
+    FUNCTION_NAME,
+    CONFIG
+)
+
+from unit.stream_alert_alert_processor.helpers import (
+    _get_alert
+)
+
+UNIT_CONFIG = load_config('test/unit/conf/outputs.json')
+
+
+def test_existing_get_output_dispatcher():
+    """Get output dispatcher - existing"""
+    service = 'aws-s3'
+    dispatcher = outputs.get_output_dispatcher(service, REGION, FUNCTION_NAME, UNIT_CONFIG)
+    assert_is_not_none(dispatcher)
+
+def test_nonexistent_get_output_dispatcher():
+    """Get output dispatcher - nonexistent"""
+    nonexistent_service = 'aws-s4'
+    dispatcher = outputs.get_output_dispatcher(nonexistent_service,
+                                               REGION,
+                                               FUNCTION_NAME,
+                                               UNIT_CONFIG)
+    assert_is_none(dispatcher)
+
+@patch('logging.Logger.error')
+def test_get_output_dispatcher_logging(log_mock):
+    """Get output dispatcher - log error"""
+    bad_service = 'bad-output'
+    outputs.get_output_dispatcher(bad_service, REGION, FUNCTION_NAME, UNIT_CONFIG)
+    log_mock.assert_called_with('designated output service [%s] does not exist', bad_service)
+
+
+def test_user_defined_properties():
+    """Get user defined properties"""
+    for output in outputs.STREAM_OUTPUTS.values():
+        props = output(REGION, FUNCTION_NAME, CONFIG).get_user_defined_properties()
+        # The user defined properties should at a minimum contain a descriptor
+        assert_is_not_none(props.get('descriptor'))
+
+
+class TestPagerDutyOutput(object):
+    """Test class for PagerDutyOutput"""
+    __service = 'pagerduty'
+    __dispatcher = None
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         UNIT_CONFIG)
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.__dispatcher = None
+
+    def test_get_default_properties(self):
+        """Get Default Properties - PagerDuty"""
+        props = self.__dispatcher._get_default_properties()
+        assert_equal(len(props), 1)
+        assert_equal(props['url'],
+                     'https://events.pagerduty.com/generic/2010-04-15/create_event.json')
+
+
+class TestSlackOutput(object):
+    """Test class for PagerDutyOutput"""
+    __service = 'slack'
+    __descriptor = 'unit_test_channel'
+    __dispatcher = None
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         UNIT_CONFIG)
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.__dispatcher = None
+
+    @staticmethod
+    def _get_random_alert(key_count, rule_name, omit_rule_desc=False):
+        """This loop generates key/value pairs with a key of length 6 and
+            value of length 148. when formatted, each line should consume
+            160 characters, account for newline and asterisk for bold. For example:
+            '*000001:* 6D829150B0154BF9BAC733FD25C61FA3D8CD3868AC2A92F19EEE119B
+            9CE8D6094966AA7592CE371002F1F7D82617673FCC9A9DB2A8F432AA791D74AB80BBCAD9\n'
+            Therefore, 25*160 = 4000 character message size (exactly the 4000 limit)
+            Anything over 4000 characters will result in multi-part slack messages:
+            55*160 = 8800 & 8800/4000 = ceil(2.2) = 3 messages needed
+        """
+        values = OrderedDict([('{:06}'.format(key),
+                               '{:0148X}'.format(random.randrange(16**128)))
+                              for key in range(key_count)])
+
+        rule_description = ('rule test description', '')[omit_rule_desc]
+        alert = {
+            'record': values,
+            'metadata': {
+                'rule_name': rule_name,
+                'rule_description': rule_description
+            }
+        }
+
+        return alert
+
+    def test_format_message_single(self):
+        """Format Single Message - Slack"""
+        rule_name = 'test_rule_single'
+        alert = self._get_random_alert(25, rule_name)
+        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+
+        # tests
+        assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
+        assert_equal(loaded_message['text'], '*StreamAlert Rule Triggered: test_rule_single*')
+        assert_equal(len(loaded_message['attachments']), 1)
+
+    def test_format_message_mutliple(self):
+        """Format Multi-Message - Slack"""
+        rule_name = 'test_rule_multi-part'
+        alert = self._get_random_alert(30, rule_name)
+        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+
+        # tests
+        assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
+        assert_equal(loaded_message['text'], '*StreamAlert Rule Triggered: test_rule_multi-part*')
+        assert_equal(len(loaded_message['attachments']), 2)
+        assert_equal(loaded_message['attachments'][1]['text'].split('\n')[3][1:7], '000028')
+
+    def test_format_message_default_rule_description(self):
+        """Format Message Default Rule Description - Slack"""
+        rule_name = 'test_empty_rule_description'
+        alert = self._get_random_alert(10, rule_name, True)
+        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+
+        # tests
+        default_rule_description = '*Rule Description:*\nNo rule description provided\n'
+        assert_equal(loaded_message['attachments'][0]['pretext'], default_rule_description)
+
+    def test_json_to_slack_mrkdwn_str(self):
+        """JSON to Slack mrkdwn - simple str"""
+        simple_str = 'value to format'
+        result = self.__dispatcher._json_to_slack_mrkdwn(simple_str, 0)
+
+        assert_equal(len(result), 1)
+        assert_equal(result[0], simple_str)
+
+    def test_json_to_slack_mrkdwn_dict(self):
+        """JSON to Slack mrkdwn - simple dict"""
+        simple_dict = OrderedDict([('test_key_01', 'test_value_01'),
+                                   ('test_key_02', 'test_value_02')])
+        result = self.__dispatcher._json_to_slack_mrkdwn(simple_dict, 0)
+
+        assert_equal(len(result), 2)
+        assert_equal(result[1], '*test_key_02:* test_value_02')
+
+    def test_json_to_slack_mrkdwn_nested_dict(self):
+        """JSON to Slack mrkdwn - nested dict"""
+        nested_dict = OrderedDict([
+            ('root_key_01', 'root_value_01'),
+            ('root_02', 'root_value_02'),
+            ('root_nested_01', OrderedDict([
+                ('nested_key_01', 100),
+                ('nested_key_02', 200),
+                ('nested_nested_01', OrderedDict([
+                    ('nested_nested_key_01', 300)
+                ]))
+            ]))
+        ])
+        result = self.__dispatcher._json_to_slack_mrkdwn(nested_dict, 0)
+        assert_equal(len(result), 7)
+        assert_equal(result[2], '*root_nested_01:*')
+        assert_equal(Counter(result[4])['\t'], 1)
+        assert_equal(Counter(result[6])['\t'], 2)
+
+    def test_json_to_slack_mrkdwn_list(self):
+        """JSON to Slack mrkdwn - simple list"""
+        simple_list = ['test_value_01', 'test_value_02']
+        result = self.__dispatcher._json_to_slack_mrkdwn(simple_list, 0)
+
+        assert_equal(len(result), 2)
+        assert_equal(result[0], '*[1]* test_value_01')
+        assert_equal(result[1], '*[2]* test_value_02')
+
+    def test_json_to_slack_mrkdwn_multi_nested(self):
+        """JSON to Slack mrkdwn - multi type nested"""
+        nested_dict = OrderedDict([
+            ('root_key_01', 'root_value_01'),
+            ('root_02', 'root_value_02'),
+            ('root_nested_01', OrderedDict([
+                ('nested_key_01', 100),
+                ('nested_key_02', 200),
+                ('nested_nested_01', OrderedDict([
+                    ('nested_nested_key_01', [
+                        6161,
+                        1051,
+                        51919
+                    ])
+                ]))
+            ]))
+        ])
+        result = self.__dispatcher._json_to_slack_mrkdwn(nested_dict, 0)
+        assert_equal(len(result), 10)
+        assert_equal(result[2], '*root_nested_01:*')
+        assert_equal(Counter(result[4])['\t'], 1)
+        assert_equal(result[-1], '\t\t\t*[3]* 51919')
+
+    def test_json_list_to_text(self):
+        """JSON list to text"""
+        simple_list = ['test_value_01', 'test_value_02']
+        result = self.__dispatcher._json_list_to_text(simple_list, '\t', 0)
+
+        assert_equal(len(result), 2)
+        assert_equal(result[0], '*[1]* test_value_01')
+        assert_equal(result[1], '*[2]* test_value_02')
+
+    def test_json_map_to_text(self):
+        """JSON map to text"""
+        simple_dict = OrderedDict([('test_key_01', 'test_value_01'),
+                                   ('test_key_02', 'test_value_02')])
+        result = self.__dispatcher._json_map_to_text(simple_dict, '\t', 0)
+
+        assert_equal(len(result), 2)
+        assert_equal(result[1], '*test_key_02:* test_value_02')
+
+
+class TestAWSOutput(object):
+    """Test class for AWSOutput Base"""
+    __abstractmethods_cache = None
+    __dispatcher = None
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__abstractmethods_cache = outputs.AWSOutput.__abstractmethods__
+        outputs.AWSOutput.__abstractmethods__ = frozenset()
+        cls.__dispatcher = outputs.AWSOutput(REGION, FUNCTION_NAME, UNIT_CONFIG)
+        cls.__dispatcher.__service__ = 'aws-s3'
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        outputs.AWSOutput.__abstractmethods__ = cls.__abstractmethods_cache
+        cls.__dispatcher = None
+
+    def test_aws_format_output_config(self):
+        """AWSOutput format output config"""
+
+        props = {'descriptor': OutputProperty('short_descriptor', 'descriptor_value'),
+                 'aws_value': OutputProperty('unique arn value, bucket, etc', 'bucket.value')}
+
+        formatted_config = self.__dispatcher.format_output_config(UNIT_CONFIG, props)
+
+        assert_equal(len(formatted_config), 2)
+        assert_is_not_none(formatted_config.get('descriptor_value'))
+        assert_is_not_none(formatted_config.get('unit_test_bucket'))
+
+    def test_dispatch(self):
+        """AWSOutput dispatch pass"""
+        passed = self.__dispatcher.dispatch()
+        assert_is_none(passed)
+
+
+class TestS3Ouput(object):
+    """Test class for S3Output"""
+    __service = 'aws-s3'
+    __dispatcher = None
+    __descriptor = 'unit_test_bucket'
+    __mocker_s3 = mock_s3()
+    __s3_client = None
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         UNIT_CONFIG)
+
+
+
+        cls.__mocker_s3.start()
+        cls.__s3_client = boto3.client('s3', region_name=REGION)
+        cls.__s3_client.create_bucket(Bucket=UNIT_CONFIG[cls.__service][cls.__descriptor])
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.dispatcher = None
+        cls.__mocker_s3.stop()
+
+    def test_locals(self):
+        """S3Output local variables"""
+        assert_equal(self.__dispatcher.__class__.__name__, 'S3Output')
+        assert_equal(self.__dispatcher.__service__, self.__service)
+
+    @patch('logging.Logger.info')
+    def test_dispatch(self, log_mock):
+        """S3Output dispatch"""
+        alert = _get_alert(0)['default']
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('successfully sent alert to %s', self.__service)
+
+
+class TestLambdaOuput(object):
+    """Test class for LambdaOutput"""
+    __service = 'aws-lambda'
+    __descriptor = 'unit_test_lambda'
+    __dispatcher = None
+    __lambda_client = None
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         UNIT_CONFIG)
+
+        cls.__s3_client = boto3.client('lambda', region_name=REGION)
+
+    @classmethod
+    def _make_lambda_package(cls):
+        """Helper function to create mock lambda package"""
+        mock_lambda_function = """
+def handler(event, context):
+    return event
+"""
+        package_output = StringIO()
+        package = zipfile.ZipFile(package_output, 'w', zipfile.ZIP_DEFLATED)
+        package.writestr('function.zip', mock_lambda_function)
+        package.close()
+        package_output.seek(0)
+
+        return package_output.read()
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.dispatcher = None
+        # cls.__mocker_lambda.stop()
+
+    def test_locals(self):
+        """LambdaOutput local variables"""
+        assert_equal(self.__dispatcher.__class__.__name__, 'LambdaOutput')
+        assert_equal(self.__dispatcher.__service__, self.__service)
+
+    def _create_lambda_function(self):
+        """Helper function to create lambda function"""
+        function_name = UNIT_CONFIG[self.__service][self.__descriptor]
+
+        self.__s3_client.create_function(
+            FunctionName=function_name,
+            Runtime='python2.7',
+            Role='test-iam-role',
+            Handler='function.handler',
+            Description='test lambda function',
+            Timeout=3,
+            MemorySize=128,
+            Publish=True,
+            Code={
+                'ZipFile': self._make_lambda_package()
+            }
+        )
+
+    @mock_lambda
+    @patch('logging.Logger.info')
+    def test_dispatch(self, log_mock):
+        """LambdaOutput dispatch"""
+        self._create_lambda_function()
+        alert = _get_alert(0)['default']
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('successfully sent alert to %s', self.__service)

--- a/test/unit/stream_alert_alert_processor/test_outputs.py
+++ b/test/unit/stream_alert_alert_processor/test_outputs.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+import boto3
+import json
 import random
 import urllib2
 import zipfile
@@ -26,13 +28,11 @@ from nose.tools import (
     assert_equal,
     assert_is_none,
     assert_is_not_none,
-    assert_not_equal,
     assert_set_equal,
     with_setup
 )
 
 from stream_alert.alert_processor import outputs as outputs
-from stream_alert.alert_processor.outputs import *
 
 from stream_alert.alert_processor.main import _load_output_config as load_config
 from stream_alert.alert_processor.output_base import OutputProperty
@@ -45,9 +45,8 @@ from unit.stream_alert_alert_processor import (
 
 from unit.stream_alert_alert_processor.helpers import (
     _get_alert,
-    _encrypt_with_kms,
-    _put_mock_creds,
-    _put_s3_test_object
+    _remove_temp_secrets,
+    _put_mock_creds
 )
 
 UNIT_CONFIG = load_config('test/unit/conf/outputs.json')
@@ -88,10 +87,10 @@ class TestPagerDutyOutput(object):
     """Test class for PagerDutyOutput"""
     @classmethod
     def setup_class(cls):
+        """Setup the class before any methods"""
         cls.__service = 'pagerduty'
         cls.__descriptor = 'unit_test_pagerduty'
         cls.__backup_method = None
-        """Setup the class before any methods"""
         cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
                                                          REGION,
                                                          FUNCTION_NAME,
@@ -110,6 +109,8 @@ class TestPagerDutyOutput(object):
 
     def _setup_dispatch(self):
         """Helper for setting up PagerDutyOutput dispatch"""
+        _remove_temp_secrets()
+
         # Cache the _get_default_properties and set it to return None
         self.__backup_method = self.__dispatcher._get_default_properties
         self.__dispatcher._get_default_properties = lambda: None
@@ -196,6 +197,8 @@ class TestPhantomOutput(object):
 
     def _setup_dispatch(self, url):
         """Helper for setting up PhantomOutput dispatch"""
+        _remove_temp_secrets()
+
         output_name = self.__dispatcher.output_cred_name(self.__descriptor)
 
         creds = {'url': url,
@@ -446,6 +449,8 @@ class TestSlackOutput(object):
 
     def _setup_dispatch(self):
         """Helper for setting up SlackOutput dispatch"""
+        _remove_temp_secrets()
+
         output_name = self.__dispatcher.output_cred_name(self.__descriptor)
 
         creds = {'url': 'https://api.slack.com/web-hook-key'}


### PR DESCRIPTION
to @austinbyers, @jacknagz @mime-frame 
cc @airbnb/streamalert-maintainers 

## changes ##
* Largely, unit tests for the alert processor
* Moving some functions in the alert processor to protected scope.
* Adding the `stream_alert.alert_processor` package to nosetests coverage.
* Alert processor tests are structured according the the corresponding file the tests are for. ie - `test/unit/stream_alert_alert_processor/test_main.py` is for testing the `stream_alert/alert_processor/main.py` file, and so on.
  * The `helpers.py` file contains various helper functions imported from one or multiple `test_` files in the package.