### PR TITLE
streamalert - cloudtrail rules - part deux

### DIFF
--- a/rules/cloudtrail/cloudtrail_put_bucket_acl.py
+++ b/rules/cloudtrail/cloudtrail_put_bucket_acl.py
@@ -1,0 +1,48 @@
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+disable = StreamRules.disable()
+
+
+@rule(logs=['cloudwatch:events'],
+      matchers=[],
+      outputs=['aws-s3:sample_bucket'],
+      req_subkeys={'detail': ['requestParameters', 'eventName']})
+def cloudtrail_put_bucket_acl(rec):
+    """
+    author:       airbnb_csirt
+    description:  Identifies a change to an S3 bucket ACL that grants access to AllUsers
+                  (anyone on the internet) or AuthenticatedUsers (any user on any AWS account)
+    reference:    http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+    playbook:     (a) identify who made the change by looking at `userIdentity`
+                  (b) ping that individual to verify the bucket should be accessible to the world
+                  (c) if not, remove the bucket ACL and investigate access logs
+    """
+
+    if rec['detail']['eventName'] != 'PutBucketAcl':
+        return False
+    elif rec['detail']['requestParameters'] == None:
+        # `requestParameters` can be defined with a value of null
+        return False
+
+    insecure_acl_list = {
+        'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',
+        'http://acs.amazonaws.com/groups/global/AllUsers'
+    }
+
+    req_params = rec['detail']['requestParameters']
+    access_control_policy = req_params.get('AccessControlPolicy')
+    if not access_control_policy:
+        return False
+
+    grants = access_control_policy['AccessControlList']['Grant']
+    insecure_buckets = []
+
+    for grant in grants:
+        grantee = grant.get('Grantee', [])
+        if 'URI' in grantee:
+            insecure_buckets.append(grantee['URI'] in insecure_acl_list)
+
+    return (
+        any(insecure_buckets)
+    )

--- a/rules/cloudtrail/cloudtrail_put_object_acl.py
+++ b/rules/cloudtrail/cloudtrail_put_object_acl.py
@@ -1,0 +1,31 @@
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+disable = StreamRules.disable()
+
+@rule(logs=['cloudtrail:events'],
+      matchers=[],
+      outputs=['aws-s3:sample_bucket'],
+      req_subkeys={'requestParameters': ['accessControlList']})
+def cloudtrail_put_object_acl(rec):
+    """
+    author:         airbnb_csirt
+    description:    Identifies a change to an S3 object ACL that grants access to AllUsers
+                    (anyone on the internet) or AuthenticatedUsers (any user with an AWS account)
+    reference:      http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+    playbook:       (a) identify who set the ACL by looking at `userIdentity`
+                    (b) ping that individual to verify the object should be accessible to the world
+                    (c) if not, remove the object ACL and investigate access logs
+    """
+
+    if rec['eventName'] != 'PutObject':
+        return False
+
+    insecure_acl_list = {
+        'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',
+        'http://acs.amazonaws.com/groups/global/AllUsers'
+    }
+
+    acl_entries = {value for value in rec['requestParameters']['accessControlList'].values()}
+
+    return any(blacklist in acl for acl in acl_entries for blacklist in insecure_acl_list)

--- a/rules/cloudtrail/cloudtrail_root_account.py
+++ b/rules/cloudtrail/cloudtrail_root_account.py
@@ -1,0 +1,27 @@
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+disable = StreamRules.disable()
+
+
+@rule(logs=['cloudwatch:events'],
+      matchers=[],
+      outputs=['aws-s3:sample_bucket'],
+      req_subkeys={'detail': ['userIdentity', 'eventType']})
+def cloudtrail_root_account(rec):
+    """
+    author:           airbnb_csirt
+    description:      Root AWS credentials are being used;
+                      This is against best practice and may be an attacker
+    reference_1:      https://aws.amazon.com/premiumsupport/knowledge-center/cloudtrail-root-action-logs/
+    reference_2:      http://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
+    playbook:         (a) identify who is using the Root account
+                      (b) ping the individual to determine if intentional and/or legitimate
+    """
+
+    # see reference_1 for details
+    return (
+        rec['detail']['userIdentity']['type'] == 'Root' and
+        rec['detail']['userIdentity'].get('invokedBy') is None and
+        rec['detail']['eventType']!= 'AwsServiceEvent'
+    )

--- a/test/integration/rules/cloudtrail_put_bucket_acl.json
+++ b/test/integration/rules/cloudtrail_put_bucket_acl.json
@@ -1,0 +1,212 @@
+{
+  "records": [
+    {
+      "data": {
+        "account": 12345,
+        "region": "...",
+        "detail-type": "...",
+        "source": "...",
+        "version": "...",
+        "time": "...",
+        "id": "12345",
+        "resources": {
+          "test": "..."
+        },
+        "detail": {
+          "eventVersion": "...",
+          "userIdentity": {
+            "type": "...",
+            "principalId": "...",
+            "arn": "...",
+            "accountId": "12345",
+            "userName": "...",
+            "sessionContext": {
+              "attributes": {
+                "mfaAuthenticated": "true",
+                "creationDate": "..."
+              }
+            },
+            "invokedBy": "..."
+          },
+          "eventTime": "...",
+          "eventSource": "...",
+          "eventName": "PutBucketAcl",
+          "awsRegion": "...",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "bucketName": "...",
+            "AccessControlPolicy": {
+              "AccessControlList": {
+                "Grant": [
+                  {
+                    "Grantee": {
+                      "xsi:type": "CanonicalUser",
+                      "DisplayName": "...",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "ID": "..."
+                    },
+                    "Permission": "FULL_CONTROL"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                    },
+                    "Permission": "READ"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                    },
+                    "Permission": "READ_ACP"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+                    },
+                    "Permission": "READ"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+                    },
+                    "Permission": "READ_ACP"
+                  }
+                ]
+              },
+              "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+              "Owner": {
+                "DisplayName": "...",
+                "ID": "..."
+              }
+            },
+            "acl": [
+              ""
+            ]
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "12345"
+        }
+      },
+      "description": "CloudTrail - PutBucketAcl - True Positive",
+      "trigger": true,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    },
+    {
+      "data": {
+        "account": 12345,
+        "region": "...",
+        "detail-type": "...",
+        "source": "...",
+        "version": "...",
+        "time": "...",
+        "id": "12345",
+        "resources": {
+          "test": "..."
+        },
+        "detail": {
+          "eventVersion": "...",
+          "userIdentity": {
+            "type": "...",
+            "principalId": "...",
+            "arn": "...",
+            "accountId": "12345",
+            "userName": "...",
+            "sessionContext": {
+              "attributes": {
+                "mfaAuthenticated": "true",
+                "creationDate": "..."
+              }
+            },
+            "invokedBy": "..."
+          },
+          "eventTime": "...",
+          "eventSource": "...",
+          "eventName": "PutBucketAcl",
+          "awsRegion": "...",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "bucketName": "...",
+            "AccessControlPolicy": {
+              "AccessControlList": {
+                "Grant": [
+                  {
+                    "Grantee": {
+                      "xsi:type": "CanonicalUser",
+                      "DisplayName": "...",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "ID": "..."
+                    },
+                    "Permission": "FULL_CONTROL"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    },
+                    "Permission": "READ"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    },
+                    "Permission": "READ_ACP"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    },
+                    "Permission": "READ"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    },
+                    "Permission": "READ_ACP"
+                  }
+                ]
+              },
+              "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+              "Owner": {
+                "DisplayName": "...",
+                "ID": "..."
+              }
+            },
+            "acl": [
+              ""
+            ]
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "12345"
+        }
+      },
+      "description": "CloudTrail - PutBucketAcl - False Positive",
+      "trigger": false,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    }
+  ]
+}

--- a/test/integration/rules/cloudtrail_put_object_acl.json
+++ b/test/integration/rules/cloudtrail_put_object_acl.json
@@ -1,0 +1,124 @@
+{
+    "records": [
+        {
+            "data": {
+                "additionalEventData": {
+                    "x-amz-id-2": "..."
+                },
+                "awsRegion": "...",
+                "eventID": "...",
+                "eventName": "PutObject",
+                "eventSource": "...",
+                "eventTime": "...",
+                "eventType": "AwsApiCall",
+                "eventVersion": "...",
+                "readOnly": false,
+                "recipientAccountId": "12345",
+                "requestID": "...",
+                "requestParameters": {
+                    "X-Amz-Algorithm": "...",
+                    "X-Amz-Date": "...",
+                    "X-Amz-Expires": "12345",
+                    "X-Amz-SignedHeaders": "...",
+                    "accessControlList": {
+                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
+                        "x-amz-grant-read-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
+                        "x-amz-grant-write": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
+                        "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
+                    },
+                    "bucketName": "...",
+                    "key": "...",
+                    "x-amz-storage-class": "..."
+                },
+                "resources": [
+                    {
+                        "ARN": "...",
+                        "type": "..."
+                    },
+                    {
+                        "ARN": "...",
+                        "accountId": "12345",
+                        "type": "..."
+                    }
+                ],
+                "responseElements": {
+                },
+                "sourceIPAddress": "...",
+                "userAgent": "...",
+                "userIdentity": {
+                    "accountId": "12345",
+                    "arn": "...",
+                    "principalId": "12345",
+                    "sessionContext": {
+                        "attributes": {
+                            "creationDate": "...",
+                            "mfaAuthenticated": "false"
+                        }
+                    },
+                    "type": "..."
+                }
+            },
+            "description": "CloudTrail - PutObjectAcl - True Positive",
+            "service": "kinesis",
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "trigger": true
+        },
+        {
+            "data": {
+                "additionalEventData": {
+                    "x-amz-id-2": "..."
+                },
+                "awsRegion": "...",
+                "eventID": "...",
+                "eventName": "PutObject",
+                "eventSource": "...",
+                "eventTime": "...",
+                "eventType": "AwsApiCall",
+                "eventVersion": "...",
+                "readOnly": false,
+                "recipientAccountId": "12345",
+                "requestID": "...",
+                "requestParameters": {
+                    "X-Amz-Algorithm": "...",
+                    "X-Amz-Date": "...",
+                    "X-Amz-Expires": "123",
+                    "X-Amz-SignedHeaders": "...",
+                    "bucketName": "...",
+                    "key": "...",
+                    "x-amz-storage-class": "..."
+                },
+                "resources": [
+                    {
+                        "ARN": "...",
+                        "type": "..."
+                    },
+                    {
+                        "ARN": "...",
+                        "accountId": "12345",
+                        "type": "..."
+                    }
+                ],
+                "responseElements": {
+                },
+                "sourceIPAddress": "...",
+                "userAgent": "...",
+                "userIdentity": {
+                    "accountId": "12345",
+                    "arn": "...",
+                    "principalId": "12345",
+                    "sessionContext": {
+                        "attributes": {
+                            "creationDate": "...",
+                            "mfaAuthenticated": "true"
+                        }
+                    },
+                    "type": "..."
+                }
+            },
+            "description": "CloudTrail - PutObjectAcl - False Positive",
+            "service": "kinesis",
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "trigger": false
+        }
+    ]
+}

--- a/test/integration/rules/cloudtrail_root_account.json
+++ b/test/integration/rules/cloudtrail_root_account.json
@@ -1,0 +1,153 @@
+{
+    "records": [
+        {
+            "data": {
+                "account": 12345,
+                "region": "...",
+                "detail-type": "...",
+                "source": "...",
+                "version": "...",
+                "time": "...",
+                "id": "12345",
+                "resources": {
+                    "test": "..."
+                },
+                "detail": {
+                    "eventVersion": "...",
+                    "userIdentity": {
+                        "type": "Root",
+                        "principalId": "12345",
+                        "arn": "arn:aws:iam::12345:root",
+                        "accountId": "12345"
+                    },
+                    "eventTime": "...",
+                    "eventSource": "...",
+                    "eventName": "ConsoleLogin",
+                    "awsRegion": "...",
+                    "sourceIPAddress": "...",
+                    "userAgent": "...",
+                    "requestParameters": null,
+                    "responseElements": {
+                        "ConsoleLogin": "..."
+                    },
+                    "additionalEventData": {
+                        "LoginTo": "...",
+                        "MobileVersion": "No",
+                        "MFAUsed": "Yes"
+                    },
+                    "eventID": "...",
+                    "eventType": "AwsConsoleSignIn",
+                    "recipientAccountId": "12345"
+                }
+            },
+            "description": "CloudTrail - Root Account Usage - True Positive",
+            "trigger": true,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        },
+        {
+            "data": {
+                "account": 12345,
+                "region": "...",
+                "detail-type": "...",
+                "source": "...",
+                "version": "...",
+                "time": "...",
+                "id": "12345",
+                "resources": {
+                    "test": "..."
+                },
+                "detail": {
+                    "eventVersion": "...",
+                    "userIdentity": {
+                        "type": "Root",
+                        "principalId": "...",
+                        "arn": "...",
+                        "accountId": "12345",
+                        "userName": "...",
+                        "sessionContext": {
+                            "attributes": {
+                                "mfaAuthenticated": "true",
+                                "creationDate": "..."
+                            }
+                        },
+                        "invokedBy": "signin.amazonaws.com"
+                    },
+                    "eventTime": "...",
+                    "eventSource": "...",
+                    "eventName": "...",
+                    "awsRegion": "...",
+                    "sourceIPAddress": "AWS Internal",
+                    "userAgent": "...",
+                    "requestParameters": {
+                        "bucketName": "...",
+                        "AccessControlPolicy": {
+                            "AccessControlList": {
+                                "Grant": [
+                                    {
+                                        "Grantee": {
+                                            "xsi:type": "CanonicalUser",
+                                            "DisplayName": "...",
+                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                                            "ID": "..."
+                                        },
+                                        "Permission": "FULL_CONTROL"
+                                    },
+                                    {
+                                        "Grantee": {
+                                            "xsi:type": "Group",
+                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                                        },
+                                        "Permission": "READ"
+                                    },
+                                    {
+                                        "Grantee": {
+                                            "xsi:type": "Group",
+                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                                        },
+                                        "Permission": "READ_ACP"
+                                    },
+                                    {
+                                        "Grantee": {
+                                            "xsi:type": "Group",
+                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+                                        },
+                                        "Permission": "READ"
+                                    },
+                                    {
+                                        "Grantee": {
+                                            "xsi:type": "Group",
+                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+                                        },
+                                        "Permission": "READ_ACP"
+                                    }
+                                ]
+                            },
+                            "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+                            "Owner": {
+                                "DisplayName": "...",
+                                "ID": "..."
+                            }
+                        },
+                        "acl": [
+                            ""
+                        ]
+                    },
+                    "responseElements": null,
+                    "requestID": "...",
+                    "eventID": "...",
+                    "eventType": "AwsApiCall",
+                    "recipientAccountId": "12345"
+                }
+            },
+            "description": "CloudTrail - Root Account Usage - False Positive",
+            "trigger": false,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        }
+    ]
+}


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers 

**What**

3 new Cloudtrail rules

1. Detect creation of insecure AWS S3 bucket ACLs 
2. Detect creation of insecure AWS S3 object ACLs
3. Detect human use of the `Root` account

See rule docblocks for details :)

**Why**

Real-word production quality rules to help others detect intrusions and insecure configurations!

**Testing**

`./test/scripts/rule_test.sh`
`(14/14)	Tests Passed`