### PR TITLE
[tests] alert processor testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
  - sudo apt-get install -qq python-numpy python-scipy
 install:
   - pip install -r requirements.txt
-script: 
+script:
   - ./test/scripts/unit_tests.sh
-  - ./test/scripts/rule_test.sh
+  - ./stream_alert_cli.py lambda test --processor rule
+  - ./stream_alert_cli.py lambda test --processor alert
+  - ./stream_alert_cli.py lambda test --processor all

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ install:
   - pip install -r requirements.txt
 script:
   - ./test/scripts/unit_tests.sh
-  - ./stream_alert_cli.py lambda test --processor rule
-  - ./stream_alert_cli.py lambda test --processor alert
   - ./stream_alert_cli.py lambda test --processor all

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from stream_alert.alert_processor.outputs import get_output_dispatcher
 
 logging.basicConfig()
-LOGGER = logging.getLogger('StreamOutput')
+LOGGER = logging.getLogger('StreamAlertOutput')
 LOGGER.setLevel(logging.DEBUG)
 
 def handler(event, context):
@@ -129,8 +129,9 @@ def run(loaded_sns_message, region, function_name, config):
                                        rule_name=rule_name,
                                        alert=alert)
         except Exception as err:
-            LOGGER.error('An error occurred while sending alert to %s:%s: %s. alert:\n%s',
-                         service, descriptor, err, json.dumps(alert, indent=4))
+            LOGGER.exception('An error occurred while sending alert '
+                             'to %s:%s: %s. alert:\n%s', service, descriptor,
+                             err, json.dumps(alert, indent=2))
 
 def _sort_dict(unordered_dict):
     """Recursively sort a dictionary

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -33,6 +33,9 @@ def handler(event, context):
             contains a 'Message' key pointing to the alert payload that
             has been sent from the main StreamAlert Rule processor function
         context [AWSLambdaContext]: basically a namedtuple of properties from AWS
+
+    Returns:
+        [generator] yields back the current status to the caller
     """
     records = event.get('Records', [])
     LOGGER.info('Running alert processor for %d records', len(records))
@@ -58,11 +61,14 @@ def handler(event, context):
             continue
 
         if not 'default' in loaded_sns_message:
-            if not 'AlarmName' in loaded_sns_message:  # do not log for messages related to alarms
+            # do not log for messages related to alarms
+            if not 'AlarmName' in loaded_sns_message:
                 LOGGER.error('Malformed SNS: %s', loaded_sns_message)
             continue
 
-        run(loaded_sns_message, region, function_name, config)
+        # Yield back the current status to the caller
+        for status in run(loaded_sns_message, region, function_name, config):
+            yield status
 
 def run(loaded_sns_message, region, function_name, config):
     """Send an Alert to its described outputs.
@@ -94,6 +100,9 @@ def run(loaded_sns_message, region, function_name, config):
         region [string]: the AWS region being used
         function_name [string]: the name of the lambda function
         config [dict]: the loaded configuration for outputs from conf/outputs.json
+
+    Returns:
+        [generator] yields back dispatch status and name of the output to the handler
     """
     LOGGER.debug(loaded_sns_message)
     alert = loaded_sns_message['default']
@@ -124,14 +133,19 @@ def run(loaded_sns_message, region, function_name, config):
 
         LOGGER.debug('Sending alert to %s:%s', service, descriptor)
 
+        sent = False
         try:
-            output_dispatcher.dispatch(descriptor=descriptor,
-                                       rule_name=rule_name,
-                                       alert=alert)
+            sent = output_dispatcher.dispatch(descriptor=descriptor,
+                                              rule_name=rule_name,
+                                              alert=alert)
+
         except Exception as err:
             LOGGER.exception('An error occurred while sending alert '
                              'to %s:%s: %s. alert:\n%s', service, descriptor,
                              err, json.dumps(alert, indent=2))
+
+        # Yield back the result to the handler
+        yield sent, output
 
 def _sort_dict(unordered_dict):
     """Recursively sort a dictionary

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -28,7 +28,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 logging.basicConfig()
-LOGGER = logging.getLogger('StreamOutput')
+LOGGER = logging.getLogger('StreamAlertOutput')
 
 OutputProperty = namedtuple('OutputProperty',
                             'description, value, input_restrictions, mask_input, cred_requirement')

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -177,9 +177,11 @@ class StreamOutputBase(object):
             success [boolean]: Indicates if the dispatching of alerts was successful
         """
         if success:
-            LOGGER.info('successfully sent alert to %s', self.__service__)
+            LOGGER.info('Successfully sent alert to %s', self.__service__)
         else:
-            LOGGER.error('failed to send alert to %s', self.__service__)
+            LOGGER.error('Failed to send alert to %s', self.__service__)
+
+        return bool(success)
 
     @staticmethod
     def _request_helper(url, data, headers=None, verify=True):

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -101,8 +101,7 @@ class PagerDutyOutput(StreamOutputBase):
         """
         creds = self._load_creds(kwargs['descriptor'])
         if not creds:
-            self._log_status(False)
-            return
+            return self._log_status(False)
 
         message = 'StreamAlert Rule Triggered - {}'.format(kwargs['rule_name'])
         rule_desc = kwargs['alert']['metadata']['rule_description'] or DEFAULT_RULE_DESCRIPTION
@@ -129,7 +128,7 @@ class PagerDutyOutput(StreamOutputBase):
                          error_message,
                          '\n'.join(detailed_errors))
 
-        self._log_status(success)
+        return self._log_status(success)
 
 
 @output
@@ -189,7 +188,6 @@ class PhantomOutput(StreamOutputBase):
         resp = self._request_helper(container_url, container_string, headers, False)
 
         if not self._check_http_response(resp):
-            self._log_status(False)
             return False
 
         try:
@@ -211,8 +209,7 @@ class PhantomOutput(StreamOutputBase):
         """
         creds = self._load_creds(kwargs['descriptor'])
         if not creds:
-            self._log_status(False)
-            return
+            return self._log_status(False)
 
         headers = {"ph-auth-token": creds['ph_auth_token']}
         rule_desc = kwargs['alert']['metadata']['rule_description'] or DEFAULT_RULE_DESCRIPTION
@@ -234,7 +231,7 @@ class PhantomOutput(StreamOutputBase):
 
             success = self._check_http_response(resp)
 
-        self._log_status(success)
+        return self._log_status(success)
 
 
 @output
@@ -432,8 +429,7 @@ class SlackOutput(StreamOutputBase):
         """
         creds = self._load_creds(kwargs['descriptor'])
         if not creds:
-            self._log_status(False)
-            return
+            return self._log_status(False)
 
         slack_message = self._format_message(kwargs['rule_name'], kwargs['alert'])
 
@@ -444,7 +440,7 @@ class SlackOutput(StreamOutputBase):
             LOGGER.error('Encountered an error while sending to Slack: %s',
                          resp.read())
 
-        self._log_status(success)
+        return self._log_status(success)
 
 class AWSOutput(StreamOutputBase):
     """Subclass to be inherited from for all AWS service outputs"""
@@ -536,7 +532,7 @@ class S3Output(AWSOutput):
                                  Bucket=bucket,
                                  Key=key)
 
-        self._log_status(resp)
+        return self._log_status(resp)
 
 @output
 class LambdaOutput(AWSOutput):
@@ -593,4 +589,4 @@ class LambdaOutput(AWSOutput):
                              InvocationType='Event',
                              Payload=alert_string)
 
-        self._log_status(resp)
+        return self._log_status(resp)

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -435,11 +435,9 @@ class SlackOutput(StreamOutputBase):
             self._log_status(False)
             return
 
-        url = os.path.join(creds['url'])
-
         slack_message = self._format_message(kwargs['rule_name'], kwargs['alert'])
 
-        resp = self._request_helper(url, slack_message)
+        resp = self._request_helper(creds['url'], slack_message)
         success = self._check_http_response(resp)
 
         if not success:

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -27,7 +27,7 @@ import boto3
 from stream_alert.alert_processor.output_base import StreamOutputBase, OutputProperty
 
 logging.basicConfig()
-LOGGER = logging.getLogger('StreamOutput')
+LOGGER = logging.getLogger('StreamAlertOutput')
 
 # STREAM_OUTPUTS will contain each subclass of the StreamOutputBase
 # All included subclasses are designated using the '@output' class decorator

--- a/stream_alert_cli.py
+++ b/stream_alert_cli.py
@@ -80,7 +80,7 @@ def build_parser():
         choices=['new'],
         help=('new: create a new output to send alerts to\n')
     )
-    #
+    # output service options
     output_parser.add_argument(
         '--service',
         choices=['aws-lambda', 'aws-s3', 'pagerduty', 'phantom', 'slack'],
@@ -115,6 +115,13 @@ def build_parser():
         '--debug',
         action='store_true',
         help='Enable DEBUG logger output'
+    )
+
+    lambda_parser.add_argument(
+        '-r', '--rules',
+        type=str,
+        default='',
+        help='Comma separated names of rules to test'
     )
 
     # terraform parser and defaults

--- a/stream_alert_cli.py
+++ b/stream_alert_cli.py
@@ -119,9 +119,8 @@ def build_parser():
 
     lambda_parser.add_argument(
         '-r', '--rules',
-        type=str,
-        default='',
-        help='Comma separated names of rules to test'
+        nargs='+',
+        help='Names of rules to test, separated by spaces'
     )
 
     # terraform parser and defaults

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -13,10 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-
 import json
 import os
 import subprocess
+import zipfile
+
+from StringIO import StringIO
+
+import boto3
 
 from stream_alert_cli.logger import LOGGER_CLI
 
@@ -54,3 +58,62 @@ class CLIHelpers(object):
             return False
 
         return True
+
+
+def _create_lambda_function(function_name, region):
+    """Helper function to create mock lambda function"""
+    boto3.client('lambda', region_name=region).create_function(
+        FunctionName=function_name,
+        Runtime='python2.7',
+        Role='test-iam-role',
+        Handler='function.handler',
+        Description='test lambda function',
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+        Code={
+            'ZipFile': _make_lambda_package()
+        }
+    )
+
+def _encrypt_with_kms(data, region, alias):
+    kms_client = boto3.client('kms', region_name=region)
+    response = kms_client.encrypt(KeyId=alias,
+                                  Plaintext=data)
+
+    return response['CiphertextBlob']
+
+
+def _make_lambda_package():
+    """Helper function to create mock lambda package"""
+    mock_lambda_function = """
+def handler(event, context):
+return event
+"""
+    package_output = StringIO()
+    package = zipfile.ZipFile(package_output, 'w', zipfile.ZIP_DEFLATED)
+    package.writestr('function.zip', mock_lambda_function)
+    package.close()
+    package_output.seek(0)
+
+    return package_output.read()
+
+
+def _put_mock_creds(output_name, creds, bucket, region, alias):
+    """Helper function to mock encrypt creds and put on s3"""
+    creds_string = json.dumps(creds)
+
+    enc_creds = _encrypt_with_kms(creds_string, region, alias)
+
+    _put_s3_test_object(bucket, output_name, enc_creds, region)
+
+
+def _put_s3_test_object(bucket, key, data, region):
+    s3_client = boto3.client('s3', region_name=region)
+    s3_client.create_bucket(Bucket=bucket)
+    s3_client.put_object(
+        Body=data,
+        Bucket=bucket,
+        Key=key,
+        ServerSideEncryption='AES256'
+    )

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -105,10 +105,18 @@ def _put_mock_creds(output_name, creds, bucket, region, alias):
 
     enc_creds = _encrypt_with_kms(creds_string, region, alias)
 
-    _put_s3_test_object(bucket, output_name, enc_creds, region)
+    _put_mock_s3_object(bucket, output_name, enc_creds, region)
 
 
-def _put_s3_test_object(bucket, key, data, region):
+def _put_mock_s3_object(bucket, key, data, region):
+    """Create a mock AWS S3 object for testing
+
+    Args:
+        bucket: the bucket in which to place the object (string)
+        key: the key to use for the S3 object (string)
+        data: the actual value to use for the object (string)
+        region: the aws region to use for this boto3 client
+    """
     s3_client = boto3.client('s3', region_name=region)
     s3_client.create_bucket(Bucket=bucket)
     s3_client.put_object(

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -150,8 +150,7 @@ class RuleProcessorTester(object):
                     (rule_name, 'Rule failure: {}'.format(test_record['description'])))
 
         # Report on the final test results
-        if self.print_output:
-            self.report_output_summary()
+        self.report_output_summary()
 
     def check_keys(self, rule_name, test_record):
         """Check the test_record contains the required keys
@@ -225,9 +224,17 @@ class RuleProcessorTester(object):
         passed_tests = len(self.rules_fail_pass_warn[1])
         total_tests = failed_tests + passed_tests
 
-        # Print a message indicating how many of the total tests passed
-        print '\n\n{}({}/{})\tRule Tests Passed{}'.format(
-            COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
+        # Print some lines at the bottom of output to make it more readable
+        # This occurs here so there is always space and not only when the
+        # successful test info prints
+        print '\n\n'
+
+        # Only print success info if we explicitly want to print output
+        # but always print any errors or warnings below
+        if self.print_output:
+            # Print a message indicating how many of the total tests passed
+            print '{}({}/{})\tRule Tests Passed{}'.format(
+                COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
 
         # Check if there were failed tests and report on them appropriately
         if self.rules_fail_pass_warn[0]:
@@ -410,7 +417,7 @@ class AlertProcessorTester(object):
         total_tests = failed_tests + passed_tests
 
         # Print a message indicating how many of the total tests passed
-        print '\n{}({}/{})\tAlert Tests Passed{}'.format(
+        print '{}({}/{})\tAlert Tests Passed{}'.format(
             COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
 
         # Check if there were failed tests and report on them appropriately

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -23,18 +23,26 @@ import re
 import time
 import zlib
 
-import boto3
-from moto import mock_s3, mock_sns
+from mock import Mock, patch
 
+import boto3
+from moto import mock_lambda, mock_kms, mock_s3, mock_sns
+
+from stream_alert.alert_processor import main as StreamOutput
 from stream_alert.rule_processor.handler import StreamAlert
+from stream_alert_cli.helpers import (
+    _create_lambda_function,
+    _put_mock_creds,
+    _put_mock_s3_object
+)
+
+from stream_alert_cli.outputs import load_outputs_config
 from stream_alert_cli.logger import LOGGER_CLI, LOGGER_SA
+
 # import all rules loaded from the main handler
 # pylint: disable=unused-import
 import stream_alert.rule_processor.main
 # pylint: enable=unused-import
-
-BOTO_MOCKER_S3 = mock_s3()
-BOTO_MOCKER_SNS = mock_sns()
 
 DIR_RULES = 'test/integration/rules'
 DIR_TEMPLATES = 'test/integration/templates'
@@ -48,6 +56,7 @@ class TestingSuppressFilter(logging.Filter):
     """Simple logging filter for suppressing specific log messagses that we
     do not want to print during testing. Add any suppressions to the tuple.
     """
+
     def filter(self, record):
         suppress_starts_with = (
             'Starting download from S3',
@@ -55,331 +64,478 @@ class TestingSuppressFilter(logging.Filter):
         )
         return not record.getMessage().startswith(suppress_starts_with)
 
-def report_output(cols, failed):
-    """Helper function to pretty print columns
-    Args:
-        cols: A list of columns to print (service, test description)
-        failed: Boolean indicating if this rule failed
-    """
 
-    status = ('{}[Pass]{}'.format(COLOR_GREEN, COLOR_RESET),
-              '{}[Fail]{}'.format(COLOR_RED, COLOR_RESET))[failed]
+class RuleProcessorTester(object):
+    """Class to encapsulate testing the rule processor"""
 
-    print '\t{}\ttest ({}): {}'.format(status, *cols)
+    def __init__(self, print_output):
+        super(self.__class__, self).__init__()
+        # Create the topic used for the mocking of alert sending
+        # This is used in stream_alert/rule_processor/sink.py to 'send' alerts
+        sns_client = boto3.client('sns', region_name='us-east-1')
+        sns_client.create_topic(Name='test_streamalerts')
+        # Create a list for pass/fails. The first value in the list is a
+        # list of tuples for failures, and the second is list of tuples for
+        # passes. Tuple is (rule_name, rule_description)
+        self.rules_fail_pass_warn = ([], [], [])
+        self.print_output = print_output
 
-def report_output_summary(rules_fail_pass):
-    """Helper function to print the summary results of all tests
-    Args:
-        rules_fail_pass [list]: A list containing two lists for failed and passed
-            rule tests. The sublists contain tuples made up of: (rule_name, rule_description)
-    """
-    failed_tests = len(rules_fail_pass[0])
-    passed_tests = len(rules_fail_pass[1])
-    total_tests = failed_tests + passed_tests
+    def test_processor(self, rules):
+        """Perform integration tests for the 'rule' Lambda function
 
-    # Print a message indicating how many of the total tests passed
-    print '\n\n{}({}/{})\tTests Passed{}'.format(
-        COLOR_GREEN,
-        passed_tests,
-        total_tests,
-        COLOR_RESET
-    )
+        Returns:
+            [generator] yields a tuple containig a boolean of test status and
+                a list of alerts to run through the alert processor
+        """
+        all_tests_passed = True
 
-    # Check if there were failed tests and report on them appropriately
-    if rules_fail_pass[0]:
-        color = COLOR_RED
-        # Print a message indicating how many of the total tests failed
-        print '{}({}/{})\tTests Failed'.format(color, failed_tests, total_tests)
-
-        # Iterate over the rule_name values in the failed list and report on them
-        for index, failure in enumerate(rules_fail_pass[0]):
-            if index == failed_tests-1:
-                # Change the color back so std out is not red
-                color = COLOR_RESET
-            print '\t({}/{}) test failed for rule: {} [{}]{}'.format(index+1, failed_tests,
-                                                                     failure[0], failure[1],
-                                                                     color)
-
-    # Check if there were any warnings and report on them
-    if rules_fail_pass[2]:
-        color = COLOR_YELLOW
-        warning_count = len(rules_fail_pass[2])
-        print '{}{} \tWarning{}'.format(color, warning_count, ('', 's')[warning_count > 1])
-
-        for index, failure in enumerate(rules_fail_pass[2]):
-            if index == warning_count-1:
-                # Change the color back so std out is not yellow
-                color = COLOR_RESET
-            print '\t({}/{}) {} [{}]{}'.format(index+1, warning_count, failure[1],
-                                               failure[0], color)
-
-def test_rule(rule_name, test_record, formatted_record):
-    """Feed formatted records into StreamAlert and check for alerts
-    Args:
-        rule_name: The rule name being tested
-        test_record: A single record to test
-        formatted_record: A properly formatted version of record for the service to be tested
-
-    Returns:
-        boolean indicating if this rule passed
-    """
-    event = {'Records': [formatted_record]}
-
-    trigger_count = test_record.get('trigger_count')
-    if trigger_count:
-        expected_alert_count = trigger_count
-    else:
-        expected_alert_count = (0, 1)[test_record['trigger']]
-
-    # Start mocked sns
-    BOTO_MOCKER_SNS.start()
-
-    # Create the topic used for the mocking of alert sending
-    boto3.client('sns', region_name='us-east-1').create_topic(Name='test_streamalerts')
-
-    # Run the rule processor. Passing 'None' for context will load a mocked object later
-    alerts = StreamAlert(None, True).run(event)
-
-    # Stop mocked sns
-    BOTO_MOCKER_SNS.stop()
-
-    # we only want alerts for the specific rule passed in
-    matched_alert_count = len([x for x in alerts if x['metadata']['rule_name'] == rule_name])
-
-    report_output([test_record['service'], test_record['description']],
-                  matched_alert_count != expected_alert_count)
-
-    return matched_alert_count == expected_alert_count
-
-def format_record(test_record):
-    """Create a properly formatted Kinesis, S3, or SNS record.
-
-    Supports a dictionary or string based data record.  Reads in
-    event templates from the test/integration/templates folder.
-
-    Args:
-        test_record: Test record metadata dict with the following structure:
-            data - string or dict of the raw data
-            description - a string describing the test that is being performed
-            trigger - bool of if the record should produce an alert
-            source - which stream/s3 bucket originated the data
-            service - which aws service originated the data
-            compress (optional) - if the payload needs to be gzip compressed or not
-
-    Returns:
-        dict in the format of the specific service
-    """
-    service = test_record['service']
-    source = test_record['source']
-    compress = test_record.get('compress')
-
-    data_type = type(test_record['data'])
-    if data_type == dict:
-        data = json.dumps(test_record['data'])
-    elif data_type in (unicode, str):
-        data = test_record['data']
-    else:
-        LOGGER_CLI.info('Invalid data type: %s', type(test_record['data']))
-        return
-
-    # Get the template file for this particular service
-    template_path = os.path.join(DIR_TEMPLATES, '{}.json'.format(service))
-    with open(template_path, 'r') as service_template:
-        try:
-            template = json.load(service_template)
-        except ValueError as err:
-            LOGGER_CLI.error('Error loading %s.json: %s', service, err)
-            return
-
-    if service == 's3':
-        # Set the S3 object key to a random value for testing
-        test_record['key'] = ('{:032X}'.format(random.randrange(16**32)))
-        template['s3']['object']['key'] = test_record['key']
-        template['s3']['object']['size'] = len(data)
-        template['s3']['bucket']['arn'] = 'arn:aws:s3:::{}'.format(source)
-        template['s3']['bucket']['name'] = source
-
-        # Create the mocked s3 object in the designated bucket with the random key
-        put_mocked_s3_object(source, test_record['key'], data)
-
-    elif service == 'kinesis':
-        if compress:
-            kinesis_data = base64.b64encode(zlib.compress(data))
-        else:
-            kinesis_data = base64.b64encode(data)
-
-        template['kinesis']['data'] = kinesis_data
-        template['eventSourceARN'] = 'arn:aws:kinesis:us-east-1:111222333:stream/{}'.format(source)
-
-    elif service == 'sns':
-        template['Sns']['Message'] = data
-        template['EventSubscriptionArn'] = 'arn:aws:sns:us-east-1:111222333:{}'.format(source)
-    else:
-        LOGGER_CLI.info('Invalid service %s', service)
-
-    return template
-
-def check_keys(test_record):
-    """Check the test_record contains the required keys
-
-    Args:
-        test_record: Test record metadata dict
-
-    Returns:
-        boolean result of key set comparison
-    """
-    req_keys = {
-        'data',
-        'description',
-        'service',
-        'source',
-        'trigger'
-    }
-
-    optional_keys = {
-        'trigger_count',
-        'compress'
-    }
-
-    record_keys = set(test_record.keys())
-    return (
-        req_keys == record_keys or
-        any(x in test_record for x in optional_keys)
-    )
-
-def apply_helpers(test_record):
-    """Detect and apply helper functions to test fixtures
-    Helpers are declared in test fixtures via the following keyword:
-    "<helpers:helper_name>"
-
-    Supported helper functions:
-        last_hour: return the current epoch time minus 60 seconds to pass the
-                   last_hour rule helper.
-    Args:
-        test_record: loaded fixture file JSON as a dict.
-    """
-    # declare all helper functions here, they should always return a string
-    helpers = {
-        'last_hour': lambda: str(int(time.time()) - 60)
-    }
-    helper_regex = re.compile(r'\<helper:(?P<helper>\w+)\>')
-
-    def find_and_apply_helpers(test_record):
-        for key, value in test_record.iteritems():
-            if isinstance(value, str) or isinstance(value, unicode):
-                test_record[key] = re.sub(
-                    helper_regex,
-                    lambda match: helpers[match.group('helper')](),
-                    test_record[key]
-                )
-            elif isinstance(value, dict):
-                find_and_apply_helpers(test_record[key])
-
-    find_and_apply_helpers(test_record)
-
-def test_alert_rules():
-    """Integration test the 'Alert' Lambda function with various record types
-
-    Returns:
-        boolean indicating if all tests passed
-    """
-    # Start the mock_s3 instance here so we can test with mocked objects project-wide
-    BOTO_MOCKER_S3.start()
-    all_tests_passed = True
-
-    # Create a list for pass/fails. The first value in the list is a list of tuples for failures,
-    # and the second is list of tuples for passes. Tuple is (rule_name, rule_description)
-    rules_fail_pass = [[], [], []]
-
-    for root, _, rule_files in os.walk(DIR_RULES):
-        for rule_file in rule_files:
-            rule_name = rule_file.split('.')[0]
-            rule_file_path = os.path.join(root, rule_file)
-
-            with open(rule_file_path, 'r') as rule_file_handle:
+        for rule_file, rule_name in get_rule_test_files(rules):
+            with open(os.path.join(DIR_RULES, rule_file), 'r') as rule_file_handle:
                 try:
                     contents = json.load(rule_file_handle)
-                    test_records = contents['records']
                 except Exception as err:
                     all_tests_passed = False
-                    message = 'improperly formatted file - {}: {}'.format(type(err).__name__, err)
-                    rules_fail_pass[2].append((rule_file, message))
+                    message = 'Improperly formatted file - {}: {}'.format(
+                        type(err).__name__, err)
+                    self.rules_fail_pass_warn[2].append((rule_name, message))
                     continue
 
-            if len(test_records) == 0:
+            test_records = contents.get('records')
+            if not test_records:
                 all_tests_passed = False
-                rules_fail_pass[2].append((rule_file, 'no records to test in file'))
+                self.rules_fail_pass_warn[2].append(
+                    (rule_name, 'No records to test in file'))
                 continue
 
             print_header = True
             # Go over the records and test the applicable rule
             for test_record in test_records:
-                if not check_keys(test_record):
+                if not self.check_keys(rule_name, test_record):
                     all_tests_passed = False
-                    message = 'improperly formatted record: {}'.format(test_record)
-                    rules_fail_pass[2].append((rule_file, message))
                     continue
 
-                if print_header:
-                    # Print rule name for section header, but only if we get to a point
-                    # where there is a record to actually be tested. this avoid blank sections
-                    print '\n{}'.format(rule_name)
-                    print_header = not print_header
+                self.apply_helpers(test_record)
 
-                apply_helpers(test_record)
-                formatted_record = format_record(test_record)
-                current_test_passed = test_rule(rule_name, test_record, formatted_record)
+                # Run tests on the formatted record
+                alerts, expected_alerts = self.test_rule(
+                    rule_name,
+                    test_record,
+                    self.format_record(test_record))
+
+                current_test_passed = len(alerts) == expected_alerts
+
+                # Print rule name for section header, but only if we get
+                # to a point where there is a record to actually be tested.
+                # This avoids potentialy blank sections
+                if print_header:
+                    if alerts or self.print_output:
+                        print '\n{}'.format(rule_name)
+                        print_header = not print_header
+
+                if self.print_output:
+                    report_output([
+                        current_test_passed,
+                        'rule',
+                        test_record['service'],
+                        '{} [trigger={}]'.format(test_record['description'],
+                                                 expected_alerts)])
+
                 all_tests_passed = current_test_passed and all_tests_passed
 
+                # yield the result and alerts back to caller
+                yield all_tests_passed, alerts
+
                 # Add the name of the rule to the applicable pass or fail list
-                rules_fail_pass[current_test_passed].append((rule_name, test_record['description']))
+                self.rules_fail_pass_warn[current_test_passed].append(
+                    (rule_name, 'Rule failure: {}'.format(test_record['description'])))
 
-    # Report on the final test results
-    report_output_summary(rules_fail_pass)
+        # Report on the final test results
+        if self.print_output:
+            self.report_output_summary()
 
-    BOTO_MOCKER_S3.stop()
+    def check_keys(self, rule_name, test_record):
+        """Check the test_record contains the required keys
 
-    return all_tests_passed
+        Args:
+            test_record [dict]: Test record metadata dict
 
-def put_mocked_s3_object(bucket_name, key_name, body_value):
-    """Create a mock AWS S3 object for testing
+        Returns:
+            [bool] boolean result indicating if the proper keys are present
+        """
+        required_keys = {'data', 'description', 'service', 'source', 'trigger'}
+
+        record_keys = set(test_record.keys())
+        if not required_keys.issubset(record_keys):
+            req_key_diff = required_keys.difference(record_keys)
+            missing_keys = ','.join('\'{}\''.format(key) for key in req_key_diff)
+            message = 'Missing required key(s) in log: {}'.format(missing_keys)
+            self.rules_fail_pass_warn[0].append((rule_name, message))
+            return False
+
+        optional_keys = {'trigger_count', 'compress'}
+
+        key_diff = record_keys.difference(required_keys | optional_keys)
+
+        # Log a warning if there are extra keys declared in the test log
+        if key_diff:
+            extra_keys = ','.join('\'{}\''.format(key) for key in key_diff)
+            message = 'Additional unnecessary keys in log: {}'.format(extra_keys)
+            # Remove the key(s) and just warn the user that they are extra
+            record_keys.difference_update(key_diff)
+            self.rules_fail_pass_warn[2].append((rule_name, message))
+
+
+        return record_keys.issubset(required_keys | optional_keys)
+
+    @staticmethod
+    def apply_helpers(test_record):
+        """Detect and apply helper functions to test fixtures
+        Helpers are declared in test fixtures via the following keyword:
+        "<helpers:helper_name>"
+
+        Supported helper functions:
+            last_hour: return the current epoch time minus 60 seconds to pass the
+                       last_hour rule helper.
+        Args:
+            test_record: loaded fixture file JSON as a dict.
+        """
+        # declare all helper functions here, they should always return a string
+        helpers = {
+            'last_hour': lambda: str(int(time.time()) - 60)
+        }
+        helper_regex = re.compile(r'\<helper:(?P<helper>\w+)\>')
+
+        def find_and_apply_helpers(test_record):
+            """Apply any helpers to the passed in test_record"""
+            for key, value in test_record.iteritems():
+                if isinstance(value, str) or isinstance(value, unicode):
+                    test_record[key] = re.sub(
+                        helper_regex,
+                        lambda match: helpers[match.group('helper')](),
+                        test_record[key]
+                    )
+                elif isinstance(value, dict):
+                    find_and_apply_helpers(test_record[key])
+
+        find_and_apply_helpers(test_record)
+
+    def report_output_summary(self):
+        """Helper function to print the summary results of all rule tests"""
+        failed_tests = len(self.rules_fail_pass_warn[0])
+        passed_tests = len(self.rules_fail_pass_warn[1])
+        total_tests = failed_tests + passed_tests
+
+        # Print a message indicating how many of the total tests passed
+        print '\n\n{}({}/{})\tRule Tests Passed{}'.format(
+            COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
+
+        # Check if there were failed tests and report on them appropriately
+        if self.rules_fail_pass_warn[0]:
+            color = COLOR_RED
+            # Print a message indicating how many of the total tests failed
+            print '{}({}/{})\tRule Tests Failed'.format(color, failed_tests, total_tests)
+
+            # Iterate over the rule_name values in the failed list and report on them
+            for index, failure in enumerate(self.rules_fail_pass_warn[0]):
+                if index == failed_tests - 1:
+                    # Change the color back so std out is not red
+                    color = COLOR_RESET
+                print '\t({}/{}) [{}] {}{}'.format(
+                    index + 1, failed_tests, failure[0], failure[1], color)
+
+        # Check if there were any warnings and report on them
+        if self.rules_fail_pass_warn[2]:
+            color = COLOR_YELLOW
+            warning_count = len(self.rules_fail_pass_warn[2])
+            print '{}{} \tRule Warning{}'.format(color, warning_count, ('', 's')[warning_count > 1])
+
+            for index, failure in enumerate(self.rules_fail_pass_warn[2]):
+                if index == warning_count - 1:
+                    # Change the color back so std out is not yellow
+                    color = COLOR_RESET
+                print '\t({}/{}) [{}] {}{}'.format(index + 1, warning_count, failure[0],
+                                                   failure[1], color)
+
+    def test_rule(self, rule_name, test_record, formatted_record):
+        """Feed formatted records into StreamAlert and check for alerts
+        Args:
+            rule_name [str]: The rule name being tested
+            test_record [dict]: A single record to test
+            formatted_record [dict]: A properly formatted version of
+                record for the service to be tested
+
+        Returns:
+            [bool] boolean indicating if this rule passed
+        """
+        event = {'Records': [formatted_record]}
+
+        expected_alert_count = test_record.get('trigger_count')
+        if not expected_alert_count:
+            expected_alert_count = (0, 1)[test_record['trigger']]
+
+        # Run the rule processor. Passing 'None' for context
+        # will load a mocked object later
+        alerts = StreamAlert(None, True).run(event)
+
+        # we only want alerts for the specific rule being tested
+        alerts = [alert for alert in alerts
+                  if alert['metadata']['rule_name'] == rule_name]
+
+        return alerts, expected_alert_count
+
+    def format_record(self, test_record):
+        """Create a properly formatted Kinesis, S3, or SNS record.
+
+        Supports a dictionary or string based data record.  Reads in
+        event templates from the test/integration/templates folder.
+
+        Args:
+            test_record: Test record metadata dict with the following structure:
+                data - string or dict of the raw data
+                description - a string describing the test that is being performed
+                trigger - bool of if the record should produce an alert
+                source - which stream/s3 bucket originated the data
+                service - which aws service originated the data
+                compress (optional) - if the payload needs to be gzip compressed or not
+
+        Returns:
+            dict in the format of the specific service
+        """
+        service = test_record['service']
+        source = test_record['source']
+        compress = test_record.get('compress')
+
+        data_type = type(test_record['data'])
+        if data_type == dict:
+            data = json.dumps(test_record['data'])
+        elif data_type in (unicode, str):
+            data = test_record['data']
+        else:
+            LOGGER_CLI.info('Invalid data type: %s', type(test_record['data']))
+            return
+
+        # Get the template file for this particular service
+        template_path = os.path.join(DIR_TEMPLATES, '{}.json'.format(service))
+        with open(template_path, 'r') as service_template:
+            try:
+                template = json.load(service_template)
+            except ValueError as err:
+                LOGGER_CLI.error('Error loading %s.json: %s', service, err)
+                return
+
+        if service == 's3':
+            # Set the S3 object key to a random value for testing
+            test_record['key'] = ('{:032X}'.format(random.randrange(16**32)))
+            template['s3']['object']['key'] = test_record['key']
+            template['s3']['object']['size'] = len(data)
+            template['s3']['bucket']['arn'] = 'arn:aws:s3:::{}'.format(source)
+            template['s3']['bucket']['name'] = source
+
+            # Create the mocked s3 object in the designated bucket with the random key
+            _put_mock_s3_object(source, test_record['key'], data, 'us-east-1')
+
+        elif service == 'kinesis':
+            if compress:
+                kinesis_data = base64.b64encode(zlib.compress(data))
+            else:
+                kinesis_data = base64.b64encode(data)
+
+            template['kinesis']['data'] = kinesis_data
+            template['eventSourceARN'] = 'arn:aws:kinesis:us-east-1:111222333:stream/{}'.format(
+                source)
+
+        elif service == 'sns':
+            template['Sns']['Message'] = data
+            template['EventSubscriptionArn'] = 'arn:aws:sns:us-east-1:111222333:{}'.format(
+                source)
+        else:
+            LOGGER_CLI.info('Invalid service %s', service)
+
+        return template
+
+
+class AlertProcessorTester(object):
+    """Class to encapsulate testing the alert processor"""
+    _alert_fail_pass = [0, 0]
+
+    def __init__(self):
+        super(self.__class__, self).__init__()
+        self.kms_alias = 'alias/stream_alert_secrets_test'
+        self.secrets_bucket = 'test.streamalert.secrets'
+        self.outputs_config = load_outputs_config()
+
+    @patch('urllib2.urlopen')
+    def test_processor(self, alerts, url_mock):
+        """Perform integration tests for the 'alert' Lambda function
+
+        Args:
+            alerts [list]: list of alerts to be processed
+            url_mock [mock.patch]: patch to mock out urlopen calls
+
+        Return:
+            [bool] boolean indicating the status of the alert processor dispatching
+        """
+        status = True
+        # Set the logger level to info so its not too noisy
+        StreamOutput.LOGGER.setLevel(logging.ERROR)
+        for alert in alerts:
+            outputs = alert['metadata'].get('outputs', [])
+            self.setup_outputs(outputs, url_mock)
+            event = {'Records': [{'Sns': {'Message': json.dumps({'default': alert})}}]}
+            context = Mock()
+            context.invoked_function_arn = (
+                'arn:aws:lambda:us-east-1:0123456789012:'
+                'function:streamalert_alert_processor:production')
+            context.function_name = 'test_streamalert_alert_processor'
+            for passed, output in StreamOutput.handler(event, context):
+                status = status and passed
+                service, descriptor = output.split(':')
+                message = 'sending alert to \'{}\''.format(descriptor)
+                report_output([
+                    passed,
+                    'alert',
+                    service,
+                    message
+                ])
+
+                self._alert_fail_pass[passed] += 1
+
+        return status
+
+    @classmethod
+    def report_output_summary(cls):
+        """Helper function to print the summary results of all alert tests"""
+        failed_tests = cls._alert_fail_pass[0]
+        passed_tests = cls._alert_fail_pass[1]
+        total_tests = failed_tests + passed_tests
+
+        # Print a message indicating how many of the total tests passed
+        print '\n{}({}/{})\tAlert Tests Passed{}'.format(
+            COLOR_GREEN, passed_tests, total_tests, COLOR_RESET)
+
+        # Check if there were failed tests and report on them appropriately
+        if failed_tests:
+            # Print a message indicating how many of the total tests failed
+            print '{}({}/{})\tAlert Tests Failed{}'.format(
+                COLOR_RED, failed_tests, total_tests, COLOR_RESET)
+
+    def setup_outputs(self, outputs, url_mock):
+        """Helper function to handler any output setup"""
+        for output in outputs:
+            try:
+                service, descriptor = output.split(':')
+            except ValueError:
+                continue
+
+            if service == 'aws-s3':
+                bucket = self.outputs_config[service][descriptor]
+                boto3.client('s3', region_name='us-east-1').create_bucket(Bucket=bucket)
+            elif service == 'aws-lambda':
+                function = self.outputs_config[service][descriptor]
+                _create_lambda_function(function, 'us-east-1')
+            elif service == 'pagerduty':
+                output_name = ('/').join([service, descriptor])
+                creds = {'service_key': '247b97499078a015cc6c586bc0a92de6'}
+                _put_mock_creds(output_name, creds, self.secrets_bucket,
+                                'us-east-1', self.kms_alias)
+
+                # Set the patched urlopen.getcode return value to 200
+                url_mock.return_value.getcode.return_value = 200
+            elif service == 'phantom':
+                output_name = ('/').join([service, descriptor])
+                creds = {'ph_auth_token': '6c586bc047b9749a92de29078a015cc6',
+                         'url': 'phantom.foo.bar'}
+                _put_mock_creds(output_name, creds, self.secrets_bucket,
+                                'us-east-1', self.kms_alias)
+
+                # Set the patched urlopen.getcode return value to 200
+                url_mock.return_value.getcode.return_value = 200
+                # Phantom needs a container 'id' value in the http response
+                url_mock.return_value.read.return_value = '{"id": 1948}'
+            elif service == 'slack':
+                output_name = ('/').join([service, descriptor])
+                creds = {'url': 'https://api.slack.com/web-hook-key'}
+                _put_mock_creds(output_name, creds, self.secrets_bucket,
+                                'us-east-1', self.kms_alias)
+
+                # Set the patched urlopen.getcode return value to 200
+                url_mock.return_value.getcode.return_value = 200
+
+
+def report_output(cols):
+    """Helper function to pretty print columns for reporting results
+    Args:
+        cols [list]: A list of columns to print as output
+    """
+
+    status = ('{}[Fail]{}'.format(COLOR_RED, COLOR_RESET),
+              '{}[Pass]{}'.format(COLOR_GREEN, COLOR_RESET))[cols[0]]
+
+    print '\t{}\t{}\t({}): {}'.format(status, *cols[1:])
+
+
+def get_rule_test_files(filter_rules):
+    """Helper to get rule files to be tested
 
     Args:
-        bucket_name: the bucket in which to place the object (string)
-        key_name: the key to use for the S3 object (string)
-        body_value: the actual value to use for the object (string)
+        filter_rules [str]: Comma separated list of rules to run tests against
+
+    Returns:
+        [generator] Yields back the rule file path and rule name
     """
-    s3_resource = boto3.resource('s3', region_name='us-east-1')
-    s3_resource.create_bucket(Bucket=bucket_name)
-    obj = s3_resource.Object(bucket_name, key_name)
-    response = obj.put(Body=body_value)
+    rules_to_test = ([], filter_rules.split(','))[bool(filter_rules)]
 
-    # Log if this was not a success (this should not fail for mocked objects)
-    if response['ResponseMetadata']['HTTPStatusCode'] != 200:
-        LOGGER_CLI.error('Could not put mock object with key %s in s3 bucket with name %s',
-                         key_name,
-                         bucket_name)
+    for _, _, test_rule_files in os.walk(DIR_RULES):
+        for rule_file in test_rule_files:
+            rule_name = rule_file.split('.')[0]
 
+            # If specific rules are being tested, skip files
+            # that do not match those rules
+            if rules_to_test and rule_name not in rules_to_test:
+                continue
+
+            yield rule_file, rule_name
+
+
+@mock_lambda
+@mock_sns
+@mock_s3
+@mock_kms
 def stream_alert_test(options):
     """Integration testing handler
 
     Args:
         options: dict of CLI options: (func, env, source)
     """
-    # Add the filter to suppress specific messages from testing output
-    LOGGER_SA.addFilter(TestingSuppressFilter())
+    # Instantiate two status items - one for the rule processor
+    # and one for the alert processor
+    rp_status, ap_status = True, True
 
     if options.debug:
         LOGGER_SA.setLevel(logging.DEBUG)
+        LOGGER_CLI.setLevel(logging.DEBUG)
     else:
-        LOGGER_SA.setLevel(logging.INFO)
+        # Add a filter to suppress a few noisy log messages
+        LOGGER_SA.addFilter(TestingSuppressFilter())
 
-    if options.processor == 'rule':
-        passed = test_alert_rules()
+    test_alerts = options.processor == 'alert'
+    # See if the alert processor should be run for these tests
+    run_ap = test_alerts or options.processor == 'all'
+    rule_proc_tester = RuleProcessorTester(not test_alerts)
+    # Run the rule processor for all rules or designated rule set
+    for status, alerts in rule_proc_tester.test_processor(options.rules):
+        # If the alert processor should be tested, pass any alerts to it
+        # and store the status over time
+        if run_ap:
+            # Update the overall alert processor status with the ongoing status
+            ap_status = AlertProcessorTester().test_processor(alerts) and ap_status
 
-    elif options.processor == 'alert':
-        # TODO(jack) test output
-        raise NotImplementedError
+        # Update the overall rule processor status with the ongoing status
+        rp_status = status and rp_status
 
-    if not passed:
+    # Report summary information for the alert processor if it was ran
+    if run_ap:
+        AlertProcessorTester.report_output_summary()
+
+    if not (rp_status and ap_status):
         os._exit(1)

--- a/test/integration/context
+++ b/test/integration/context
@@ -1,3 +1,0 @@
-{
-  "invoked_function_arn": "arn:aws:lambda:us-east-1:555555555555:function:streamalert_testing"
-}

--- a/test/unit/stream_alert_alert_processor/__init__.py
+++ b/test/unit/stream_alert_alert_processor/__init__.py
@@ -18,3 +18,4 @@ from stream_alert.alert_processor.main import _load_output_config
 REGION = 'us-east-1'
 FUNCTION_NAME = 'corp-prefix_prod_streamalert_alert_processor'
 CONFIG = _load_output_config('test/unit/conf/outputs.json')
+KMS_ALIAS = 'alias/stream_alert_secrets_test'

--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -46,7 +46,8 @@ def test_handler_malformed_message(log_mock):
     context = _get_mock_context()
     message = {'not_default': {'record': {'size': '9982'}}}
     event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
-    handler(event, context)
+    for _ in handler(event, context):
+        pass
     log_mock.assert_called_with('Malformed SNS: %s', message)
 
 
@@ -55,7 +56,8 @@ def test_handler_bad_message(log_mock):
     """Main handler decode failure logging"""
     context = _get_mock_context()
     event = {'Records': [{'Sns': {'Message': 'this\nvalue\nshould\nfail\nto\ndecode'}}]}
-    handler(event, context)
+    for _ in handler(event, context):
+        pass
     assert_equal(str(log_mock.call_args_list[0]),
                  str(call('An error occurred while decoding message to JSON: %s',
                           ValueError('No JSON object could be decoded',))))
@@ -67,7 +69,8 @@ def test_handler_run(run_mock):
     context = _get_mock_context()
     message = {'default': {'record': {'size': '9982'}}}
     event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
-    handler(event, context)
+    for _ in handler(event, context):
+        pass
 
     # This test will load the actual config, so we should compare the
     # function call against the same config here.

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -27,18 +27,20 @@ from stream_alert.alert_processor.output_base import (
     StreamOutputBase
 )
 
-from unit.stream_alert_alert_processor import (
-    REGION,
-    FUNCTION_NAME,
-    CONFIG
-)
-
-from unit.stream_alert_alert_processor.helpers import (
+from stream_alert_cli.helpers import (
     _encrypt_with_kms,
-    _remove_temp_secrets,
     _put_mock_creds,
     _put_s3_test_object
 )
+
+from unit.stream_alert_alert_processor import (
+    CONFIG,
+    FUNCTION_NAME,
+    KMS_ALIAS,
+    REGION
+)
+
+from unit.stream_alert_alert_processor.helpers import _remove_temp_secrets
 
 # Remove all abstractmethods from __abstractmethods__ so we can
 # instantiate StreamOutputBase for testing
@@ -101,8 +103,7 @@ class TestStreamOutputBase(object):
 
         local_cred_location = os.path.join(self.__dispatcher._local_temp_dir(), key)
 
-        client = boto3.client('s3', region_name=REGION)
-        _put_s3_test_object(client, bucket_name, key, test_data)
+        _put_s3_test_object(bucket_name, key, test_data, REGION)
 
         self.__dispatcher._get_creds_from_s3(local_cred_location, descriptor)
 
@@ -115,9 +116,7 @@ class TestStreamOutputBase(object):
     def test_kms_decrypt(self):
         """StreamOutputBase KMS Decrypt"""
         test_data = 'data to encrypt'
-        client = boto3.client('kms', region_name=REGION)
-
-        encrypted = _encrypt_with_kms(client, test_data)
+        encrypted = _encrypt_with_kms(test_data, REGION, KMS_ALIAS)
         decrypted = self.__dispatcher._kms_decrypt(encrypted)
 
         assert_equal(decrypted, test_data)
@@ -157,7 +156,8 @@ class TestStreamOutputBase(object):
         creds = {'url': 'http://www.foo.bar/test',
                  'token': 'token_to_encrypt'}
 
-        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket)
+        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
+                        REGION, KMS_ALIAS)
 
         loaded_creds = self.__dispatcher._load_creds(self.__descriptor)
 

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -125,13 +125,13 @@ class TestStreamOutputBase(object):
     def test_log_status_success(self, log_mock):
         """StreamOutputBase Log status success"""
         self.__dispatcher._log_status(True)
-        log_mock.assert_called_with('successfully sent alert to %s', 'test_service')
+        log_mock.assert_called_with('Successfully sent alert to %s', 'test_service')
 
     @patch('logging.Logger.error')
     def test_log_status_failed(self, log_mock):
         """StreamOutputBase Log status failed"""
         self.__dispatcher._log_status(False)
-        log_mock.assert_called_with('failed to send alert to %s', 'test_service')
+        log_mock.assert_called_with('Failed to send alert to %s', 'test_service')
 
     @patch('urllib2.urlopen')
     def test_check_http_response(self, mock_getcode):

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -30,7 +30,7 @@ from stream_alert.alert_processor.output_base import (
 from stream_alert_cli.helpers import (
     _encrypt_with_kms,
     _put_mock_creds,
-    _put_s3_test_object
+    _put_mock_s3_object
 )
 
 from unit.stream_alert_alert_processor import (
@@ -103,7 +103,7 @@ class TestStreamOutputBase(object):
 
         local_cred_location = os.path.join(self.__dispatcher._local_temp_dir(), key)
 
-        _put_s3_test_object(bucket_name, key, test_data, REGION)
+        _put_mock_s3_object(bucket_name, key, test_data, REGION)
 
         self.__dispatcher._get_creds_from_s3(local_cred_location, descriptor)
 

--- a/test/unit/stream_alert_alert_processor/test_outputs.py
+++ b/test/unit/stream_alert_alert_processor/test_outputs.py
@@ -149,7 +149,7 @@ class TestPagerDutyOutput(object):
 
         self._teardown_dispatch()
 
-        log_info_mock.assert_called_with('successfully sent alert to %s', self.__service)
+        log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @patch('urllib2.urlopen')
@@ -168,7 +168,7 @@ class TestPagerDutyOutput(object):
 
         self._teardown_dispatch()
 
-        log_error_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @mock_s3
@@ -182,7 +182,7 @@ class TestPagerDutyOutput(object):
 
         self._teardown_dispatch()
 
-        log_error_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
 
 class TestPhantomOutput(object):
@@ -230,7 +230,7 @@ class TestPhantomOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_mock.assert_called_with('successfully sent alert to %s', self.__service)
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @patch('urllib2.urlopen')
@@ -244,7 +244,7 @@ class TestPhantomOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @patch('urllib2.urlopen')
@@ -282,7 +282,7 @@ class TestPhantomOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @mock_s3
@@ -294,7 +294,7 @@ class TestPhantomOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_error_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
 
 class TestSlackOutput(object):
@@ -466,7 +466,7 @@ class TestSlackOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_info_mock.assert_called_with('successfully sent alert to %s', self.__service)
+        log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @patch('urllib2.urlopen')
@@ -485,7 +485,7 @@ class TestSlackOutput(object):
 
         log_error_mock.assert_any_call('Encountered an error while sending to Slack: %s',
                                        error_message)
-        log_error_mock.assert_any_call('failed to send alert to %s', self.__service)
+        log_error_mock.assert_any_call('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @mock_s3
@@ -497,7 +497,7 @@ class TestSlackOutput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_error_mock.assert_called_with('failed to send alert to %s', self.__service)
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
 
 class TestAWSOutput(object):
@@ -577,7 +577,7 @@ class TestS3Ouput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_mock.assert_called_with('successfully sent alert to %s', self.__service)
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
 
 class TestLambdaOuput(object):
@@ -617,4 +617,4 @@ class TestLambdaOuput(object):
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_mock.assert_called_with('successfully sent alert to %s', self.__service)
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)

--- a/test/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/test/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -84,7 +84,7 @@ class TestStreamRules(object):
     def test_alert_format(self):
         """Rule Engine - Alert Format"""
         @rule(logs=['test_log_type_json_nested_with_data'],
-              outputs=['s3:sample.bucket'])
+              outputs=['s3:sample_bucket'])
         def alert_format_test(rec):
             """'alert_format_test' docstring for testing rule_description"""
             return rec['application'] == 'web-app'
@@ -136,7 +136,7 @@ class TestStreamRules(object):
             return True
 
         @rule(logs=['test_log_type_json_nested_with_data'],
-              outputs=['s3:sample.bucket'])
+              outputs=['s3:sample_bucket'])
         def minimal_rule(rec):
             return rec['unixtime'] == 1483139547
 
@@ -181,7 +181,7 @@ class TestStreamRules(object):
 
         # alert 1 tests
         assert_equal(alerts[1]['metadata']['rule_name'], 'minimal_rule')
-        assert_equal(alerts[1]['metadata']['outputs'], ['s3:sample.bucket'])
+        assert_equal(alerts[1]['metadata']['outputs'], ['s3:sample_bucket'])
 
         # alert 0 tests
         assert_equal(alerts[0]['metadata']['rule_name'], 'test_nest')
@@ -190,13 +190,13 @@ class TestStreamRules(object):
     def test_process_req_subkeys(self):
         """Rule Engine - Req Subkeys"""
         @rule(logs=['test_log_type_json_nested'],
-              outputs=['s3:sample.bucket'],
+              outputs=['s3:sample_bucket'],
               req_subkeys={'data': ['location']})
         def data_location(rec):
             return rec['data']['location'].startswith('us')
 
         @rule(logs=['test_log_type_json_nested'],
-              outputs=['s3:sample.bucket'],
+              outputs=['s3:sample_bucket'],
               req_subkeys={'data': ['category']})
         def web_server(rec):
             return rec['data']['category'] == 'web-server'
@@ -244,7 +244,7 @@ class TestStreamRules(object):
     def test_syslog_rule(self):
         """Rule Engine - Syslog Rule"""
         @rule(logs=['test_log_type_syslog'],
-              outputs=['s3:sample.bucket'])
+              outputs=['s3:sample_bucket'])
         def syslog_sudo(rec):
             return (
                 rec['application'] == 'sudo' and


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

## changes  ##
* Adding option to `cli` to run rule test on a comma separated list of rules.
  * New options is used like so: `python stream_alert_cli.py lambda test --processor rule --rule cloudtrail_put_bucket_acl,cloudtrail_put_object_acl`
* Updating the alert processor so it can yield back status results to the calling handler. Would like to make this more granular in the future.
* Removing an unused file (`context`)
* Migrating some helper functions from the unit testing framework to the cli package so they can be utilized across tests.
* The cli now supports running tests for the `alert` processor via: `python stream_alert_cli.py lambda test --processor alert`
  * End-to-end testing is also available via: `python stream_alert_cli.py lambda test --processor all`
  * Either of the above commands can be used in conjunction with the new `--rule/-r` flag to specify rules to test against.

Testing output will now look similar to:
```
$ python stream_alert_cli.py lambda test --processor all --rule cloudtrail_critical_api
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

cloudtrail_critical_api
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - DeleteSubnet
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - DeleteVpc
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - UpdateTrail
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - StopLogging
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - DeleteDBCluster
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - StopConfigurationRecorder
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=1]	rule	(kinesis): CloudTrail - Critical API - DeleteFlowLogs
	[Pass]              	alert	(aws-s3): sending alert to 'sample_bucket'
	[Pass]   [trigger=0]	rule	(kinesis): CloudTrail - Critical API - False Positive Case



(8/8)	Rule Tests Passed
(7/7)	Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

Incoming PR for doc updates.