### PR TITLE
[cli][test] live alert testing

### DIFF
--- a/rules/cloudtrail/cloudtrail_critical_api.py
+++ b/rules/cloudtrail/cloudtrail_critical_api.py
@@ -7,7 +7,9 @@ disable = StreamRules.disable()
 
 @rule(logs=['cloudtrail:api_events'],
       matchers=[],
-      outputs=['aws-s3:sample_bucket'])
+      outputs=['aws-s3:sample_bucket', 'aws-lambda:sample_lambda',
+               'pagerduty:sample_integration', 'phantom:sample_integration',
+               'slack:sample_channel'])
 def cloudtrail_critical_api(rec):
     """
     author:           airbnb_csirt

--- a/rules/cloudtrail/cloudtrail_put_bucket_acl.py
+++ b/rules/cloudtrail/cloudtrail_put_bucket_acl.py
@@ -6,7 +6,9 @@ disable = StreamRules.disable()
 
 @rule(logs=['cloudwatch:events'],
       matchers=[],
-      outputs=['aws-s3:sample_bucket'],
+      outputs=['aws-s3:sample_bucket', 'aws-lambda:sample_lambda',
+               'pagerduty:sample_integration', 'phantom:sample_integration',
+               'slack:sample_channel'],
       req_subkeys={'detail': ['requestParameters', 'eventName']})
 def cloudtrail_put_bucket_acl(rec):
     """

--- a/rules/cloudtrail/cloudtrail_put_object_acl.py
+++ b/rules/cloudtrail/cloudtrail_put_object_acl.py
@@ -5,7 +5,9 @@ disable = StreamRules.disable()
 
 @rule(logs=['cloudtrail:events'],
       matchers=[],
-      outputs=['aws-s3:sample_bucket'],
+      outputs=['aws-s3:sample_bucket', 'aws-lambda:sample_lambda',
+               'pagerduty:sample_integration', 'phantom:sample_integration',
+               'slack:sample_channel'],
       req_subkeys={'requestParameters': ['accessControlList']})
 def cloudtrail_put_object_acl(rec):
     """

--- a/rules/cloudtrail/cloudtrail_root_account.py
+++ b/rules/cloudtrail/cloudtrail_root_account.py
@@ -6,7 +6,9 @@ disable = StreamRules.disable()
 
 @rule(logs=['cloudwatch:events'],
       matchers=[],
-      outputs=['aws-s3:sample_bucket'],
+      outputs=['aws-s3:sample_bucket', 'aws-lambda:sample_lambda',
+               'pagerduty:sample_integration', 'phantom:sample_integration',
+               'slack:sample_channel'],
       req_subkeys={'detail': ['userIdentity', 'eventType']})
 def cloudtrail_root_account(rec):
     """

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -120,7 +120,9 @@ class StreamAlert(object):
             LOGGER.debug('Valid data, no alerts')
             return
 
+        # If we want alerts returned to the caller, extend the list. Otherwise
+        # attempt to send them to the alert processor
         if self.return_alerts:
             self.alerts.extend(alerts)
-
-        self.sinker.sink(alerts)
+        else:
+            self.sinker.sink(alerts)

--- a/stream_alert/rule_processor/sink.py
+++ b/stream_alert/rule_processor/sink.py
@@ -120,9 +120,9 @@ class StreamSink(object):
                 Message=message,
                 Subject='StreamAlert Rules Triggered'
             )
-        except ClientError as err:
-            LOGGER.error('An error occurred while publishing alert: %s', err.response)
-            raise err
+        except ClientError:
+            LOGGER.exception('An error occurred while publishing alert to sns')
+            return
 
         if response['ResponseMetadata']['HTTPStatusCode'] != 200:
             LOGGER.error('Failed to publish message to sns topic: %s', self.topic.split(':')[-1])

--- a/stream_alert_cli.py
+++ b/stream_alert_cli.py
@@ -123,6 +123,11 @@ def build_parser():
         help='Names of rules to test, separated by spaces'
     )
 
+    lambda_parser.add_argument(
+        '-l', '--live',
+        help='Run end-to-end tests in the specified cluster'
+    )
+
     # terraform parser and defaults
     tf_parser = subparsers.add_parser(
         'terraform',

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -19,6 +19,9 @@ import logging
 LOGGER_SA = logging.getLogger('StreamAlert')
 LOGGER_SA.setLevel(logging.INFO)
 
+LOGGER_SO = logging.getLogger('StreamAlertOutput')
+LOGGER_SO.setLevel(logging.INFO)
+
 logging.basicConfig(format='%(name)s [%(levelname)s]: %(message)s')
 LOGGER_CLI = logging.getLogger('StreamAlertCLI')
 LOGGER_CLI.setLevel(logging.INFO)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -58,6 +58,9 @@ def cli_runner(options):
     elif options.command == 'lambda':
         lambda_handler(options)
 
+    elif options.command == 'live-test':
+        stream_alert_test(options, CONFIG)
+
     elif options.command == 'terraform':
         terraform_handler(options)
 
@@ -76,7 +79,7 @@ def lambda_handler(options):
         rollback(options)
 
     elif options.subcommand == 'test':
-        stream_alert_test(options, CONFIG)
+        stream_alert_test(options)
 
 
 def terraform_check():

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -76,7 +76,7 @@ def lambda_handler(options):
         rollback(options)
 
     elif options.subcommand == 'test':
-        stream_alert_test(options)
+        stream_alert_test(options, CONFIG)
 
 
 def terraform_check():


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

# we'll do it live #
* Adding a `-l/--live` option to the cli to allow for live alert dispatching to a specified cluster.
  * ie - `$ python stream_alert_cli.py live-test --cluster prod --rule cloudtrail_put_object_acl`
  * ~The "cluster" specified must exist in the `conf/clusters/` directory and should match the name exactly.~
  * The `--cluster/-c` argument is required and must be followed by a "cluster" name.
  * Available "clusters" to use for the `live-test` command are extracted from the `conf/clusters` directory (using the `<cluster>.json` files that exist there) and presented as `choices`.
* The cli package will now dynamically control if calls should be mocked out via a nested decorator, depending on if the `live` option is used.
* If the `--live` option is omitted, the mocking of all calls (boto3=moto and urllib2=patch) will happen.
* If the `--live` option is included, with a cluster, the alert processor with attempt to actually send alerts to the designated outputs for the triggered rule.
* The `CLIConfig` is passed to the cli package to extract values and construct a real context object containing an arn/function_name/etc.

# other updates #
* Changing rule processor to only try to "sink" (aka send to alert processor) only if the alerts are not being returned to the caller.
  * This was the original logic of the rule processor, but I had changed it previously. Now, this allows alerts to be returned to the caller for testing but sent to alert processor when not testing.
* Using `logging.exception` when trying to publish to an sns topic instead of raising the error. This avoids breaking execution.
* Example rules are now configured to send to all example outputs.