### PR TITLE
[lambda][alert] fixing bug that caused logging to break with pagerduty

### DIFF
--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -117,8 +117,9 @@ def run(loaded_sns_message, region, function_name, config):
         try:
             service, descriptor = output.split(':')
         except ValueError:
-            LOGGER.error('Outputs for rules must be declared with both a service and a '
-                         'descriptor for the integration (ie: \'slack:my_channel\')')
+            LOGGER.error('Improperly formatted output [%s]. Outputs for rules must '
+                         'be declared with both a service and a descriptor for the '
+                         'integration (ie: \'slack:my_channel\')', output)
             continue
 
         if not service in config or not descriptor in config[service]:

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -150,9 +150,9 @@ class StreamOutputBase(object):
 
             return True
         except ClientError as err:
-            LOGGER.error('credentials for %s could not be downloaded from S3: %s',
-                         self.output_cred_name(descriptor),
-                         err.response)
+            LOGGER.exception('credentials for \'%s\' could not be downloaded '
+                             'from S3: %s', self.output_cred_name(descriptor),
+                             err.response)
 
     def _kms_decrypt(self, data):
         """Decrypt data with AWS KMS.
@@ -205,9 +205,8 @@ class StreamOutputBase(object):
             resp = urllib2.urlopen(request, context=context)
             return resp
         except urllib2.HTTPError as err:
-            raise OutputRequestFailure('Failed to send to {} - [{}] {}'.format(err.url,
-                                                                               err.code,
-                                                                               err.read()))
+            raise OutputRequestFailure('Failed to send to {} - [{}]'.format(err.url,
+                                                                            err.code))
 
     @staticmethod
     def _check_http_response(resp):


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 
size: small

## fixes ##
* Bug that caused logging to break with high throughput to PagerDuty
* The error occurs when attempting to send a large amount of consecutive alerts to PD.
* How the issue/fix was discovered
  * PagerDuty would begin to return a 403 Forbidden Request error
  * The HTTP response fp for the exception would return a weird 121 byte blob of binary data that could not be printed well.
  * AWS's logging choked on printing this, throwing the following error: `'utf8' codec can't decode byte 0x8b in position 93: invalid start byte: UnicodeDecodeError`
* The change that fixes this is not reading/printing the error response data and instead just printing the url and error code being returned. It is still unclear why the response returned by PagerDuty is _seemingly_ garbage.

## other changes ##
* Switching another place to use `logging.exception` so we have more insight into where errors occur.
* If an improperly formatted `output` is provided in a rule, we will now log the actual value of the output.