### PR TITLE
JSON Templates Tests, S3 Events Support, and Moar Unit Tests

### DIFF
--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -18,8 +18,6 @@ import json
 import os
 import sys
 
-from collections import defaultdict
-
 from stream_alert_cli.logger import LOGGER_CLI
 
 

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -30,6 +30,7 @@ from stream_alert_cli.logger import LOGGER_CLI
 
 DIR_TEMPLATES = 'test/integration/templates'
 
+
 def run_command(runner_args, **kwargs):
     """Helper function to run commands with error handling.
 
@@ -56,8 +57,7 @@ def run_command(runner_args, **kwargs):
     try:
         subprocess.check_call(runner_args, stdout=stdout_option, cwd=cwd)
     except subprocess.CalledProcessError as err:
-        LOGGER_CLI.error('%s\n%s', error_message)
-        LOGGER_CLI.error(err.cmd)
+        LOGGER_CLI.error('%s\n%s', error_message, err.cmd)
         return False
 
     return True
@@ -112,7 +112,7 @@ def format_lambda_test_record(test_record):
         template['s3']['bucket']['name'] = source
 
         # Create the mocked s3 object in the designated bucket with the random key
-        _put_mock_s3_object(source, test_record['key'], data, 'us-east-1')
+        put_mock_s3_object(source, test_record['key'], data, 'us-east-1')
 
     elif service == 'kinesis':
         if compress:
@@ -134,7 +134,7 @@ def format_lambda_test_record(test_record):
     return template
 
 
-def _create_lambda_function(function_name, region):
+def create_lambda_function(function_name, region):
     """Helper function to create mock lambda function"""
     boto3.client('lambda', region_name=region).create_function(
         FunctionName=function_name,
@@ -150,7 +150,8 @@ def _create_lambda_function(function_name, region):
         }
     )
 
-def _encrypt_with_kms(data, region, alias):
+
+def encrypt_with_kms(data, region, alias):
     kms_client = boto3.client('kms', region_name=region)
     response = kms_client.encrypt(KeyId=alias,
                                   Plaintext=data)
@@ -173,16 +174,16 @@ return event
     return package_output.read()
 
 
-def _put_mock_creds(output_name, creds, bucket, region, alias):
+def put_mock_creds(output_name, creds, bucket, region, alias):
     """Helper function to mock encrypt creds and put on s3"""
     creds_string = json.dumps(creds)
 
-    enc_creds = _encrypt_with_kms(creds_string, region, alias)
+    enc_creds = encrypt_with_kms(creds_string, region, alias)
 
-    _put_mock_s3_object(bucket, output_name, enc_creds, region)
+    put_mock_s3_object(bucket, output_name, enc_creds, region)
 
 
-def _put_mock_s3_object(bucket, key, data, region):
+def put_mock_s3_object(bucket, key, data, region):
     """Create a mock AWS S3 object for testing
 
     Args:

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -16,8 +16,10 @@ limitations under the License.
 import base64
 import json
 import os
+import random
 import subprocess
 import zipfile
+import zlib
 
 from StringIO import StringIO
 
@@ -28,7 +30,7 @@ from stream_alert_cli.logger import LOGGER_CLI
 
 DIR_TEMPLATES = 'test/integration/templates'
 
-def run_command(cls, runner_args, **kwargs):
+def run_command(runner_args, **kwargs):
     """Helper function to run commands with error handling.
 
     Args:
@@ -53,8 +55,9 @@ def run_command(cls, runner_args, **kwargs):
 
     try:
         subprocess.check_call(runner_args, stdout=stdout_option, cwd=cwd)
-    except subprocess.CalledProcessError as e:
-        LOGGER_CLI.error('Return Code %s - %s', e.returncode, e.cmd)
+    except subprocess.CalledProcessError as err:
+        LOGGER_CLI.error('%s\n%s', error_message)
+        LOGGER_CLI.error(err.cmd)
         return False
 
     return True
@@ -88,7 +91,7 @@ def format_lambda_test_record(test_record):
     elif data_type in (unicode, str):
         data = test_record['data']
     else:
-        LOGGER_CLI.info('Invalid data type: %s', type(test_record['data']))
+        LOGGER_CLI.info('Invalid data type: %s', data_type)
         return
 
     # Get the template file for this particular service

--- a/stream_alert_cli/outputs.py
+++ b/stream_alert_cli/outputs.py
@@ -24,6 +24,7 @@ from stream_alert_cli.logger import LOGGER_CLI
 
 OUTPUTS_CONFIG = 'outputs.json'
 
+
 def load_outputs_config(conf_dir='conf'):
     """Load the outputs configuration file from disk
 
@@ -37,9 +38,12 @@ def load_outputs_config(conf_dir='conf'):
         try:
             values = json.load(outputs)
         except ValueError:
-            LOGGER_CLI.exception('the %s file could not be loaded into json', OUTPUTS_CONFIG)
+            LOGGER_CLI.exception(
+                'the %s file could not be loaded into json',
+                OUTPUTS_CONFIG)
 
     return values
+
 
 def write_outputs_config(data, conf_dir='conf'):
     """Write the outputs configuration file back to disk
@@ -56,6 +60,7 @@ def write_outputs_config(data, conf_dir='conf'):
             sort_keys=True
         ))
 
+
 def load_config(props, service):
     """Gets the outputs config from disk and checks if the output already exists
 
@@ -71,6 +76,7 @@ def load_config(props, service):
         return False
 
     return config
+
 
 def encrypt_and_push_creds_to_s3(region, bucket, key, props):
     """Construct a dictionary of the credentials we want to encrypt and send to s3
@@ -93,6 +99,7 @@ def encrypt_and_push_creds_to_s3(region, bucket, key, props):
     enc_creds = kms_encrypt(region, creds_json)
     return send_creds_to_s3(region, bucket, key, enc_creds)
 
+
 def kms_encrypt(region, data):
     """Encrypt data with AWS KMS.
 
@@ -110,6 +117,7 @@ def kms_encrypt(region, data):
         return response['CiphertextBlob']
     except ClientError:
         LOGGER_CLI.exception('an error occurred during credential encryption')
+
 
 def send_creds_to_s3(region, bucket, key, blob_data):
     """Put the encrypted credential blob for this service and destination in s3
@@ -131,12 +139,14 @@ def send_creds_to_s3(region, bucket, key, blob_data):
 
         return True
     except ClientError as err:
-        LOGGER_CLI.error('An error occurred while sending credentials to S3 for key [%s]: '
-                         '%s [%s]',
-                         key,
-                         err.response['Error']['Message'],
-                         err.response['Error']['BucketName'])
+        LOGGER_CLI.error(
+            'An error occurred while sending credentials to S3 for key [%s]: '
+            '%s [%s]',
+            key,
+            err.response['Error']['Message'],
+            err.response['Error']['BucketName'])
         return False
+
 
 def check_output_exists(config, props, service):
     """Determine if this service and destination combo has already been created
@@ -155,6 +165,7 @@ def check_output_exists(config, props, service):
         return False
 
     return True
+
 
 def update_outputs_config(config, updated_config, service):
     """Updates and writes the outputs config back to disk

--- a/stream_alert_cli/package.py
+++ b/stream_alert_cli/package.py
@@ -172,7 +172,7 @@ class LambdaPackage(object):
         third_party_libs = self.config['lambda'][self.config_key]['third_party_libraries']
         if third_party_libs:
             LOGGER_CLI.info(
-                'Installing third-party libraries: {}'.format(', '.join(third_party_libs)))
+                'Installing third-party libraries: %s', ', '.join(third_party_libs))
             pip_command = ['install']
             pip_command.extend(third_party_libs)
             pip_command.extend(['--upgrade', '--target', temp_package_path])

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -23,7 +23,7 @@ from getpass import getpass
 
 from stream_alert_cli.package import RuleProcessorPackage, AlertProcessorPackage
 from stream_alert_cli.test import stream_alert_test
-from stream_alert_cli.helpers import CLIHelpers
+from stream_alert_cli import helpers
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.version import LambdaVersion
@@ -199,7 +199,7 @@ def terraform_handler(options):
 
 def run_command(args=None, **kwargs):
     """Alias to CLI Helpers.run_command"""
-    return CLIHelpers.run_command(args, **kwargs)
+    return helpers.run_command(args, **kwargs)
 
 
 def continue_prompt():

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -463,13 +463,15 @@ def configure_output(options):
 
     # Encrypt the creds and push them to S3
     # then update the local output configuration with properties
-    if config_outputs.encrypt_and_push_creds_to_s3(region, secrets_bucket, secrets_key, props):
+    if config_outputs.encrypt_and_push_creds_to_s3(
+            region, secrets_bucket, secrets_key, props):
         updated_config = output.format_output_config(config, props)
         config_outputs.update_outputs_config(config, updated_config, service)
 
-        LOGGER_CLI.info('Successfully saved \'%s\' output configuration for service \'%s\'',
-                        props['descriptor'].value,
-                        options.service)
+        LOGGER_CLI.info(
+            'Successfully saved \'%s\' output configuration for service \'%s\'',
+            props['descriptor'].value,
+            options.service)
     else:
         LOGGER_CLI.error('An error occurred while saving \'%s\' '
                          'output configuration for service \'%s\'',

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -353,11 +353,11 @@ def generate_flow_logs(cluster_name, cluster_dict, config):
             'source': 'modules/tf_stream_alert_flow_logs',
             'destination_stream_arn': '${{module.kinesis_{}.arn}}'.format(cluster_name),
             'flow_log_group_name': modules['flow_logs']['log_group_name']}
-        for input in ('vpcs', 'subnets', 'enis'):
-            input_data = modules['flow_logs'].get(input)
+        for flow_log_input in ('vpcs', 'subnets', 'enis'):
+            input_data = modules['flow_logs'].get(flow_log_input)
             if input_data:
                 cluster_dict['module']['flow_logs_{}'.format(
-                    cluster_name)][input] = input_data
+                    cluster_name)][flow_log_input] = input_data
 
 
 def generate_s3_events(cluster_name, cluster_dict, config):

--- a/test/unit/stream_alert_alert_processor/test_output_base.py
+++ b/test/unit/stream_alert_alert_processor/test_output_base.py
@@ -28,9 +28,9 @@ from stream_alert.alert_processor.output_base import (
 )
 
 from stream_alert_cli.helpers import (
-    _encrypt_with_kms,
-    _put_mock_creds,
-    _put_mock_s3_object
+    encrypt_with_kms,
+    put_mock_creds,
+    put_mock_s3_object
 )
 
 from unit.stream_alert_alert_processor import (
@@ -103,7 +103,7 @@ class TestStreamOutputBase(object):
 
         local_cred_location = os.path.join(self.__dispatcher._local_temp_dir(), key)
 
-        _put_mock_s3_object(bucket_name, key, test_data, REGION)
+        put_mock_s3_object(bucket_name, key, test_data, REGION)
 
         self.__dispatcher._get_creds_from_s3(local_cred_location, descriptor)
 
@@ -116,7 +116,7 @@ class TestStreamOutputBase(object):
     def test_kms_decrypt(self):
         """StreamOutputBase KMS Decrypt"""
         test_data = 'data to encrypt'
-        encrypted = _encrypt_with_kms(test_data, REGION, KMS_ALIAS)
+        encrypted = encrypt_with_kms(test_data, REGION, KMS_ALIAS)
         decrypted = self.__dispatcher._kms_decrypt(encrypted)
 
         assert_equal(decrypted, test_data)
@@ -156,7 +156,7 @@ class TestStreamOutputBase(object):
         creds = {'url': 'http://www.foo.bar/test',
                  'token': 'token_to_encrypt'}
 
-        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
+        put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
                         REGION, KMS_ALIAS)
 
         loaded_creds = self.__dispatcher._load_creds(self.__descriptor)

--- a/test/unit/stream_alert_alert_processor/test_outputs.py
+++ b/test/unit/stream_alert_alert_processor/test_outputs.py
@@ -33,8 +33,8 @@ from nose.tools import (
 from stream_alert.alert_processor import outputs
 from stream_alert.alert_processor.output_base import OutputProperty
 from stream_alert_cli.helpers import (
-    _create_lambda_function,
-    _put_mock_creds
+    create_lambda_function,
+    put_mock_creds
 )
 
 from unit.stream_alert_alert_processor import (
@@ -125,7 +125,7 @@ class TestPagerDutyOutput(object):
         creds = {'url': 'http://pagerduty.foo.bar/create_event.json',
                  'service_key': 'mocked_service_key'}
 
-        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
+        put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
                         REGION, KMS_ALIAS)
 
         return _get_sns_message(0)['default']
@@ -211,7 +211,7 @@ class TestPhantomOutput(object):
         creds = {'url': url,
                  'ph_auth_token': 'mocked_auth_token'}
 
-        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
+        put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
                         REGION, KMS_ALIAS)
 
         return _get_sns_message(0)['default']
@@ -448,7 +448,7 @@ class TestSlackOutput(object):
 
         creds = {'url': 'https://api.slack.com/web-hook-key'}
 
-        _put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
+        put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket,
                         REGION, KMS_ALIAS)
 
         return _get_sns_message(0)['default']
@@ -605,7 +605,7 @@ class TestLambdaOuput(object):
     def _setup_dispatch(self):
         """Helper for setting up LambdaOutput dispatch"""
         function_name = CONFIG[self.__service][self.__descriptor]
-        _create_lambda_function(function_name, REGION)
+        create_lambda_function(function_name, REGION)
         return _get_sns_message(0)['default']
 
     @mock_lambda

--- a/test/unit/stream_alert_cli/test_terraform_generate.py
+++ b/test/unit/stream_alert_cli/test_terraform_generate.py
@@ -1,0 +1,384 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import base64
+import json
+
+from nose.tools import assert_equal, assert_not_equal
+
+from stream_alert_cli import terraform_generate
+
+
+class TestTerraformGenerate(object):
+    """Test class for the Terraform Cluster Generating"""
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        pass
+
+    def setup(self):
+        """Setup before each method"""
+        self.cluster_dict = terraform_generate.infinitedict()
+        self.config = {
+            'global': {
+                'account': {
+                    'prefix': 'unit-testing',
+                    'kms_key_alias': 'unit-testing',
+                    'region': 'us-west-1',
+                    'aws_account_id': '12345678910'
+                },
+                'terraform': {
+                    'tfstate_bucket': 'unit-testing.terraform.tfstate'
+                }
+            },
+            'lambda': {
+                'rule_processor_config': {
+                    'source_bucket': 'unit.testing.source.bucket'
+                }
+            },
+            'clusters': {
+                'test': {
+                    'id': 'test',
+                    'modules': {
+                        'cloudwatch_monitoring': {
+                          'enabled': True
+                        },
+                        'kinesis': {
+                            'firehose': {
+                                'enabled': True,
+                                's3_bucket_suffix': 'streamalert.results'
+                            },
+                            'streams': {
+                                'retention': 24,
+                                'shards': 1
+                            }
+                        },
+                        'kinesis_events': {
+                            'enabled': True
+                        },
+                        'stream_alert': {
+                            'alert_processor': {
+                                'current_version': '$LATEST',
+                                'memory': 128,
+                                'timeout': 25
+                            },
+                            'rule_processor': {
+                                'current_version': '$LATEST',
+                                'memory': 128,
+                                'timeout': 25
+                            }
+                        }
+                    },
+                    'outputs': {
+                        'kinesis': [
+                            'username',
+                            'access_key_id',
+                            'secret_key'
+                        ]
+                    },
+                    'region': 'us-west-1'
+                },
+                'advanced': {
+                    'id': 'advanced',
+                    'modules': {
+                        'cloudwatch_monitoring': {
+                          'enabled': True
+                        },
+                        'kinesis': {
+                            'firehose': {
+                                'enabled': True,
+                                's3_bucket_suffix': 'streamalert.results'
+                            },
+                            'streams': {
+                                'retention': 24,
+                                'shards': 1
+                            }
+                        },
+                        'kinesis_events': {
+                            'enabled': True
+                        },
+                        'stream_alert': {
+                            'alert_processor': {
+                                'current_version': '$LATEST',
+                                'memory': 128,
+                                'timeout': 25,
+                                'vpc_config': {
+                                    'subnet_ids': [
+                                        'subnet-id-1'
+                                    ],
+                                    'security_group_ids': [
+                                        'sg-id-1'
+                                    ]
+                                }
+                            },
+                            'rule_processor': {
+                                'current_version': '$LATEST',
+                                'memory': 128,
+                                'timeout': 25
+                            }
+                        },
+                        'cloudtrail': {
+                            'enabled': True
+                        },
+                        'flow_logs': {
+                            'enabled': True,
+                            'vpcs': [
+                                'vpc-id-1',
+                                'vpc-id-2'
+                            ],
+                            'log_group_name': 'unit-test-advanced'
+                        }
+                    },
+                    'outputs': {
+                        'kinesis': [
+                            'username',
+                            'access_key_id',
+                            'secret_key'
+                        ]
+                    },
+                    'region': 'us-west-1'
+                }
+            }
+        }
+
+    def teardown(self):
+        """Teardown after each method"""
+
+    def test_generate_s3_bucket(self):
+        """CLI - Terraform Generate S3 Bucket """
+        bucket = terraform_generate.generate_s3_bucket(
+            bucket='unit.test.bucket',
+            logging='my.s3-logging.bucket',
+            force_destroy=True
+        )
+
+        required_keys = {
+            'bucket',
+            'acl',
+            'force_destroy',
+            'versioning',
+            'logging'
+        }
+
+        assert_equal(type(bucket), dict)
+        assert_equal(bucket['bucket'], 'unit.test.bucket')
+        assert_equal(set(bucket.keys()), required_keys)
+
+    def test_generate_s3_bucket_lifecycle(self):
+        """CLI - Terraform Generate S3 Bucket with Lifecycle"""
+        bucket = terraform_generate.generate_s3_bucket(
+            bucket='unit.test.bucket',
+            logging='my.s3-logging.bucket',
+            force_destroy=False,
+            lifecycle_rule={
+                'prefix': 'logs/',
+                'enabled': True,
+                'transition': {'days': 30, 'storage_class': 'GLACIER'}
+            }
+        )
+
+        assert_equal(bucket['lifecycle_rule']['prefix'], 'logs/')
+        assert_equal(bucket['force_destroy'], False)
+        assert_equal(type(bucket['lifecycle_rule']), dict)
+        assert_equal(type(bucket['versioning']), dict)
+
+    def test_generate_main(self):
+        """CLI - Terraform Generate Main"""
+        init = False
+        config = self.config
+
+        tf_main = terraform_generate.generate_main(
+            config=config,
+            init=init
+        )
+
+        tf_main_expected = {
+            'provider': {
+                'aws': {}
+            },
+            'terraform': {
+                'required_version': '> 0.9.4',
+                'backend': {
+                    's3': {
+                        'bucket': 'unit-testing.streamalert.terraform.state',
+                        'key': 'stream_alert_state/terraform.tfstate',
+                        'region': 'us-west-1',
+                        'encrypt': True,
+                        'acl': 'private',
+                        'kms_key_id': 'alias/unit-testing'
+                    }
+                }
+            },
+            'resource': {
+                'aws_kms_key': {
+                    'stream_alert_secrets': {
+                        'enable_key_rotation': True,
+                        'description': 'StreamAlert secret management'
+                    }
+                },
+                'aws_kms_alias': {
+                    'stream_alert_secrets': {
+                        'name': 'alias/unit-testing',
+                        'target_key_id': '${aws_kms_key.stream_alert_secrets.key_id}'
+                    }
+                },
+                'aws_s3_bucket': {
+                    'lambda_source': {
+                        'bucket': 'unit.testing.source.bucket',
+                        'acl': 'private',
+                        'force_destroy': False,
+                        'versioning': {
+                            'enabled': True
+                        },
+                        'logging': {
+                            'target_bucket': 'unit-testing.streamalert.s3-logging',
+                            'target_prefix': 'unit.testing.source.bucket/'
+                        }
+                    },
+                    'stream_alert_secrets': {
+                        'bucket': 'unit-testing.streamalert.secrets',
+                        'acl': 'private',
+                        'force_destroy': False,
+                        'versioning': {
+                            'enabled': True
+                        },
+                        'logging': {
+                            'target_bucket': 'unit-testing.streamalert.s3-logging',
+                            'target_prefix': 'unit-testing.streamalert.secrets/'
+                        }
+                    },
+                    'terraform_remote_state': {
+                        'bucket': 'unit-testing.terraform.tfstate',
+                        'acl': 'private',
+                        'force_destroy': False,
+                        'versioning': {
+                            'enabled': True
+                        },
+                        'logging': {
+                            'target_bucket': 'unit-testing.streamalert.s3-logging',
+                            'target_prefix': 'unit-testing.terraform.tfstate/'
+                        }
+                    },
+                    'logging_bucket': {
+                        'bucket': 'unit-testing.streamalert.s3-logging',
+                        'acl': 'log-delivery-write',
+                        'force_destroy': False,
+                        'versioning': {
+                            'enabled': True
+                        },
+                        'logging': {
+                            'target_bucket': 'unit-testing.streamalert.s3-logging',
+                            'target_prefix': 'unit-testing.streamalert.s3-logging/'
+                        },
+                        'lifecycle_rule': {
+                            'prefix': '/',
+                            'enabled': True,
+                            'transition': {
+                                'days': 30,
+                                'storage_class': 'GLACIER'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert_equal(tf_main['provider'], tf_main_expected['provider'])
+        assert_equal(tf_main['terraform'], tf_main_expected['terraform'])
+        assert_equal(tf_main['resource'], tf_main_expected['resource'])
+
+    def test_generate_stream_alert(self):
+        """CLI - Terraform Generate stream_alert Module"""
+        pass
+
+    def test_generate_cloudwatch_monitoring(self):
+        """CLI - Terraform Generate cloudwatch_monitoring Module"""
+        cluster_name = 'test'
+        terraform_generate.generate_cloudwatch_monitoring(
+            cluster_name,
+            self.cluster_dict,
+            self.config
+        )
+
+        expected_cloudwatch_tf = {
+            'source': 'modules/tf_stream_alert_monitoring',
+            'sns_topic_arn': '${module.stream_alert_test.sns_topic_arn}',
+            'lambda_functions': [
+                'unit-testing_test_streamalert_rule_processor',
+                'unit-testing_test_streamalert_alert_processor'
+            ],
+            'kinesis_stream': 'unit-testing_test_stream_alert_kinesis'
+        }
+
+        assert_equal(
+            self.cluster_dict['module']['cloudwatch_monitoring_test'],
+            expected_cloudwatch_tf)
+
+    def test_generate_cluster_test(self):
+        """CLI - Terraform Generate 'Test' Cluster"""
+        config = self.config
+
+        tf_cluster = terraform_generate.generate_cluster(
+            config=config,
+            cluster_name='test'
+        )
+
+        cluster_keys = {
+            'module',
+            'output'
+        }
+
+        test_modules = {
+            'stream_alert_test',
+            'cloudwatch_monitoring_test',
+            'kinesis_test',
+            'kinesis_events_test'
+        }
+
+        assert_equal(set(tf_cluster['module'].keys()), test_modules)
+        assert_equal(set(tf_cluster.keys()), cluster_keys)
+
+    def test_generate_cluster_advanced(self):
+        """CLI - Terraform Generate 'Advanced' Cluster"""
+        config = self.config
+
+        tf_cluster = terraform_generate.generate_cluster(
+            config=config,
+            cluster_name='advanced'
+        )
+
+        cluster_keys = {
+            'module',
+            'output'
+        }
+
+        advanced_modules = {
+            'stream_alert_advanced',
+            'cloudwatch_monitoring_advanced',
+            'kinesis_advanced',
+            'kinesis_events_advanced',
+            'flow_logs_advanced',
+            'cloudtrail_advanced'
+        }
+
+        assert_equal(set(tf_cluster['module'].keys()), advanced_modules)
+        assert_equal(set(tf_cluster.keys()), cluster_keys)

--- a/test/unit/stream_alert_cli/test_terraform_generate.py
+++ b/test/unit/stream_alert_cli/test_terraform_generate.py
@@ -17,23 +17,13 @@ limitations under the License.
 import base64
 import json
 
-from nose.tools import assert_equal, assert_not_equal
+from nose.tools import assert_equal
 
 from stream_alert_cli import terraform_generate
 
 
 class TestTerraformGenerate(object):
     """Test class for the Terraform Cluster Generating"""
-
-    @classmethod
-    def setup_class(cls):
-        """Setup the class before any methods"""
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """Teardown the class after all methods"""
-        pass
 
     def setup(self):
         """Setup before each method"""
@@ -204,10 +194,9 @@ class TestTerraformGenerate(object):
     def test_generate_main(self):
         """CLI - Terraform Generate Main"""
         init = False
-        config = self.config
 
         tf_main = terraform_generate.generate_main(
-            config=config,
+            config=self.config,
             init=init
         )
 
@@ -308,6 +297,7 @@ class TestTerraformGenerate(object):
 
     def test_generate_stream_alert(self):
         """CLI - Terraform Generate stream_alert Module"""
+        #TODO(jacknagz): Write this test
         pass
 
     def test_generate_cloudwatch_monitoring(self):
@@ -335,10 +325,9 @@ class TestTerraformGenerate(object):
 
     def test_generate_cluster_test(self):
         """CLI - Terraform Generate 'Test' Cluster"""
-        config = self.config
 
         tf_cluster = terraform_generate.generate_cluster(
-            config=config,
+            config=self.config,
             cluster_name='test'
         )
 
@@ -359,10 +348,9 @@ class TestTerraformGenerate(object):
 
     def test_generate_cluster_advanced(self):
         """CLI - Terraform Generate 'Advanced' Cluster"""
-        config = self.config
 
         tf_cluster = terraform_generate.generate_cluster(
-            config=config,
+            config=self.config,
             cluster_name='advanced'
         )
 

--- a/test/unit/stream_alert_cli/test_terraform_generate.py
+++ b/test/unit/stream_alert_cli/test_terraform_generate.py
@@ -14,16 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-import base64
-import json
+from stream_alert_cli import terraform_generate
 
 from nose.tools import assert_equal
-
-from stream_alert_cli import terraform_generate
 
 
 class TestTerraformGenerate(object):
     """Test class for the Terraform Cluster Generating"""
+
+    def __init__(self):
+        self.cluster_dict = {}
+        self.config = {}
 
     def setup(self):
         """Setup before each method"""
@@ -50,7 +51,7 @@ class TestTerraformGenerate(object):
                     'id': 'test',
                     'modules': {
                         'cloudwatch_monitoring': {
-                          'enabled': True
+                            'enabled': True
                         },
                         'kinesis': {
                             'firehose': {
@@ -91,7 +92,7 @@ class TestTerraformGenerate(object):
                     'id': 'advanced',
                     'modules': {
                         'cloudwatch_monitoring': {
-                          'enabled': True
+                            'enabled': True
                         },
                         'kinesis': {
                             'firehose': {
@@ -152,8 +153,10 @@ class TestTerraformGenerate(object):
 
     def teardown(self):
         """Teardown after each method"""
+        pass
 
-    def test_generate_s3_bucket(self):
+    @staticmethod
+    def test_generate_s3_bucket():
         """CLI - Terraform Generate S3 Bucket """
         bucket = terraform_generate.generate_s3_bucket(
             bucket='unit.test.bucket',
@@ -173,7 +176,8 @@ class TestTerraformGenerate(object):
         assert_equal(bucket['bucket'], 'unit.test.bucket')
         assert_equal(set(bucket.keys()), required_keys)
 
-    def test_generate_s3_bucket_lifecycle(self):
+    @staticmethod
+    def test_generate_s3_bucket_lifecycle():
         """CLI - Terraform Generate S3 Bucket with Lifecycle"""
         bucket = terraform_generate.generate_s3_bucket(
             bucket='unit.test.bucket',
@@ -297,7 +301,7 @@ class TestTerraformGenerate(object):
 
     def test_generate_stream_alert(self):
         """CLI - Terraform Generate stream_alert Module"""
-        #TODO(jacknagz): Write this test
+        # TODO(jacknagz): Write this test
         pass
 
     def test_generate_cloudwatch_monitoring(self):

--- a/test/unit/stream_alert_rule_processor/test_config.py
+++ b/test/unit/stream_alert_rule_processor/test_config.py
@@ -38,7 +38,7 @@ def test_load_config_invalid():
             conf_logs.write('test logs string that will throw an error')
         with open('conf/sources.json', 'w') as conf_sources:
             conf_sources.write('test sources string that will throw an error')
-        config = load_config()
+        load_config()
 
 
 def test_validate_config_valid():

--- a/test/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/test/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -16,7 +16,7 @@ limitations under the License.
 import base64
 import json
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_list_equal
 
 from stream_alert.rule_processor.classifier import StreamPayload, StreamClassifier
 from stream_alert.rule_processor.pre_parsers import StreamPreParsers
@@ -181,7 +181,7 @@ class TestStreamRules(object):
         }
         # doing this because after kinesis_data is read in, types are casted per the schema
         for alert in alerts:
-            assert_equal(set(alert['record'].keys()), set(kinesis_data.keys()))
+            assert_list_equal(alert['record'].keys(), kinesis_data.keys())
             assert_equal(alert['metadata']['outputs'], rule_outputs_map[alert['metadata']['rule_name']])
 
 

--- a/test/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/test/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -174,18 +174,16 @@ class TestStreamRules(object):
 
         # check alert output
         assert_equal(len(alerts), 3)
+        rule_outputs_map = {
+            'chef_logs': ['pagerduty:sample_integration'],
+            'minimal_rule': ['s3:sample_bucket'],
+            'test_nest': ['pagerduty:sample_integration']
+        }
+        # doing this because after kinesis_data is read in, types are casted per the schema
+        for alert in alerts:
+            assert_equal(set(alert['record'].keys()), set(kinesis_data.keys()))
+            assert_equal(alert['metadata']['outputs'], rule_outputs_map[alert['metadata']['rule_name']])
 
-        # alert 2 tests
-        assert_equal(alerts[2]['metadata']['rule_name'], 'chef_logs')
-        assert_equal(alerts[2]['metadata']['outputs'], ['pagerduty:sample_integration'])
-
-        # alert 1 tests
-        assert_equal(alerts[1]['metadata']['rule_name'], 'minimal_rule')
-        assert_equal(alerts[1]['metadata']['outputs'], ['s3:sample_bucket'])
-
-        # alert 0 tests
-        assert_equal(alerts[0]['metadata']['rule_name'], 'test_nest')
-        assert_equal(alerts[0]['metadata']['outputs'], ['pagerduty:sample_integration'])
 
     def test_process_req_subkeys(self):
         """Rule Engine - Req Subkeys"""


### PR DESCRIPTION
to @ryandeivert 
cc @airbnb/streamalert-maintainers 

### Changes
* Move `format_lambda_test_record` into the `cli.helpers` package: This is an effort to share this method across tests (for main/handler, which will come soon).  I also removed the nesting of helper methods within a `CLIHelpers` class since that paradigm wasn't being adopted.
* Modularize terraform_generate: All cluster generation was in one massive method before, this has been broken out into multiple methods for easier management.
* Unit testing: Adds initial unit tests to the terraform_generate code, there are more to add, they will come later.
* Moar unit testing: Get our coverage to 100% for the rule processor `config` module.