### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: trusty
 cache: pip
+sudo: required
 python:
   - 2.7
 before_install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,13 @@ colorama==0.3.3
 coverage==4.3.4
 coveralls==1.1
 decorator==4.0.11
+docopt==0.6.2
 docutils==0.13.1
 extras==1.0.0
 fixtures==3.0.0
 funcsigs==1.0.2
 futures==3.0.5
+google-compute-engine==2.4.0
 httpretty==0.8.10
 hurry.filesize==0.9
 Jinja2==2.9.5


### PR DESCRIPTION
to @ryandeivert 
cc @airbnb/streamalert-maintainers 
size small

The new [Ubuntu image](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch) broke our Travis build, this PR fixes it.

## Changes
* Add `sudo: required` to be more explicit 
* Ran `pip install coveralls` `pip install google-compute-engine` locally, followed by `pip freeze > requirements.txt` to update our dependencies