### PR TITLE
Errors statistic should be Sum, not Average

### DIFF
--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_invocation_errors" {
   alarm_name          = "${element(var.lambda_functions, count.index)}_invocation_errors"
   namespace           = "AWS/Lambda"
   metric_name         = "Errors"
-  statistic           = "Average"
+  statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
   threshold           = "0"
   evaluation_periods  = "1"


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers 
size: tiny

Because the CloudWatch alarm for errors computes the `Average`, the alarm looks like this:
`Threshold Crossed: 1 datapoint (1.0135819987837016E-4) was greater than the threshold (0.0).`

It makes more sense to count the total number (`Sum`) of errors instead. This is consistent with how StreamAlert counts Throttles.