### PR TITLE
[tests] testing fixes

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -581,9 +581,16 @@ class LambdaOutput(AWSOutput):
         alert = kwargs['alert']
         alert_string = json.dumps(alert['record'])
         function_name = self.config[self.__service__][kwargs['descriptor']]
-        parts = function_name.split(':')
 
         # Check to see if there is an optional qualifier included here
+        # Acceptable values for the output configuration are the full ARN,
+        # a function name followed by a qualifier, or just a function name:
+        #   'arn:aws:lambda:aws-region:acct-id:function:function-name:prod'
+        #   'function-name:prod'
+        #   'function-name'
+        # Checking the length of the list for 2 or 8 should account for all
+        # times a qualifier is provided.
+        parts = function_name.split(':')
         if len(parts) == 2 or len(parts) == 8:
             function = parts[-2]
             qualifier = parts[-1]

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -391,6 +391,11 @@ class AlertProcessorTester(object):
                 boto3.client('s3', region_name='us-east-1').create_bucket(Bucket=bucket)
             elif service == 'aws-lambda':
                 function = self.outputs_config[service][descriptor]
+                parts = function.split(':')
+                if len(parts) == 2 or len(parts) == 8:
+                    function = parts[-2]
+                else:
+                    function = parts[-1]
                 helpers.create_lambda_function(function, 'us-east-1')
             elif service == 'pagerduty':
                 output_name = ('/').join([service, descriptor])

--- a/test/unit/stream_alert_cli/test_outputs.py
+++ b/test/unit/stream_alert_cli/test_outputs.py
@@ -70,12 +70,16 @@ def test_write_outputs_config():
         )
 
 
-def test_load_config():
+@patch('stream_alert_cli.outputs.load_outputs_config')
+def test_load_config(method_mock):
     """Load config - check for existing output"""
+    # Patch the return value of the load_outputs_config method to return
+    # the unit testing outputs configuration
+    method_mock.return_value = load_outputs_config(conf_dir="test/unit/conf")
     props = {
         'descriptor': OutputProperty(
             'short description',
-            'sample_lambda')}
+            'unit_test_lambda')}
     loaded = load_config(props, 'aws-lambda')
 
     assert_false(loaded)


### PR DESCRIPTION
to @austinbyers 
cc @airbnb/streamalert-maintainers 
size: small

## changes ##
* Updating the boto3 lambda invocation to utilize a qualifier if one is provided in the output configuration.
* Updating lambda output/alert tests to go with above change.
* Patching a function to load the unit test outputs configuration during tests to avoid breaking tests with production configuration changes.
