### PR TITLE
[lambda][alert] fixing bug in alert processor that cause lambda invocations to fail

### DIFF
--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -46,8 +46,8 @@ def test_handler_malformed_message(log_mock):
     context = _get_mock_context()
     message = {'not_default': {'record': {'size': '9982'}}}
     event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
-    for _ in handler(event, context):
-        pass
+    handler(event, context)
+
     log_mock.assert_called_with('Malformed SNS: %s', message)
 
 
@@ -56,8 +56,8 @@ def test_handler_bad_message(log_mock):
     """Main handler decode failure logging"""
     context = _get_mock_context()
     event = {'Records': [{'Sns': {'Message': 'this\nvalue\nshould\nfail\nto\ndecode'}}]}
-    for _ in handler(event, context):
-        pass
+    handler(event, context)
+
     assert_equal(str(log_mock.call_args_list[0]),
                  str(call('An error occurred while decoding message to JSON: %s',
                           ValueError('No JSON object could be decoded',))))
@@ -69,8 +69,7 @@ def test_handler_run(run_mock):
     context = _get_mock_context()
     message = {'default': {'record': {'size': '9982'}}}
     event = {'Records': [{'Sns': {'Message': json.dumps(message)}}]}
-    for _ in handler(event, context):
-        pass
+    handler(event, context)
 
     # This test will load the actual config, so we should compare the
     # function call against the same config here.

--- a/test/unit/stream_alert_alert_processor/test_main.py
+++ b/test/unit/stream_alert_alert_processor/test_main.py
@@ -18,7 +18,7 @@ import json
 from collections import OrderedDict
 from mock import patch, call
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_is_instance
 
 from stream_alert.alert_processor.main import (
     _load_output_config,
@@ -74,6 +74,15 @@ def test_handler_run(run_mock):
     # This test will load the actual config, so we should compare the
     # function call against the same config here.
     run_mock.assert_called_with(message, REGION, FUNCTION_NAME, _load_output_config())
+
+
+def test_handler_return():
+    """Main handler return value"""
+    context = _get_mock_context()
+    event = {'Records': []}
+    value = handler(event, context)
+
+    assert_is_instance(value, list)
 
 
 def test_load_output_config():


### PR DESCRIPTION
to @austinbyers 
cc @airbnb/streamalert-maintainers 

## bug fix ##
* Resolving an issue where lambda invocations of the alert processor function would fail because the return value of the main handler function is a `generator` object.

## context ##
* It appears that AWS lambda expects a return value from the functions main handler that is json serializable. Using a `generator` to yield results to the caller function breaks serialization, and thus breaks invoking of the lambda function.
* This change will create a list that is instead extended with the results of the `run` function, which is then returned to the caller. `list` objects are, in fact, serializable into json 😂 
