### PR TITLE
[tf] tf change to properly configure lambda functions SA can invoke

### DIFF
--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -3,7 +3,7 @@
     "sample_bucket": "sample.bucket.name"
   },
   "aws-lambda": {
-    "sample_lambda": "function-name"
+    "sample_lambda": "function-name:qualifier"
   },
   "pagerduty": [
     "sample_integration"

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -560,10 +560,9 @@ class LambdaOutput(AWSOutput):
              OutputProperty(description='a short and unique descriptor for this Lambda function '
                                         'configuration (ie: abbreviated name)')),
             ('aws_value',
-             OutputProperty(description='the AWS arn, with the optional qualifier, that '
-                                        'represents the Lambda function to use for this '
-                                        'configuration (ie: arn:aws:lambda:aws-region:acct-id:'
-                                        'function:output_function:qualifier)',
+             OutputProperty(description='the AWS Lambda function name, with the optional '
+                                        'qualifier (aka \'alias\'), to use for this '
+                                        'configuration (ie: output_function:qualifier)',
                             input_restrictions={' '})),
         ])
 

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -150,7 +150,7 @@ resource "aws_iam_role_policy" "streamalert_alert_processor_lambda" {
         "lambda:InvokeFunction"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${element(var.output_lambda_functions, count.index)}"
+      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${element(split(":", element(var.output_lambda_functions, count.index)), 0)}"
     }
   ]
 }

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -150,7 +150,8 @@ resource "aws_iam_role_policy" "streamalert_alert_processor_lambda" {
         "lambda:InvokeFunction"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${element(split(":", element(var.output_lambda_functions, count.index)), 0)}"
+      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${element(
+        split(":", element(var.output_lambda_functions, count.index)), 0)}"
     }
   ]
 }


### PR DESCRIPTION
to @austinbyers , @jacknagz 
cc @airbnb/streamalert-maintainers 
size: small

## bug fix ##
* With some updates to properly invoke a lambda function with a designated qualifier, we broke terraform's configuration of said function.
  * Previously, tf was creating a policy using the function name combined with the qualifier.
  * This prevented proper invocation with a specific qualifier using `boto3`
  * The change is to strip off the qualifier, and only use the function name when creating the policy.
* If a qualifier is not provided in the `outputs.json` configuration for this lambda, it does not break this logic. The interpolation will still extract the proper function name.
* Updating the example outputs.json configuration to include a qualifier along with the function name.

## Other change ##
* Updating the message the lambda output configuration prompts with when asking for a function name. It previously requested an ARN, which should not be used now. It is clarified as requiring a function name and optional qualifier (`function_name:qualifier`)