### PR TITLE
[cli][bug] fixing bug related terraform not being installed. resolves #200

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -59,6 +59,9 @@ def run_command(runner_args, **kwargs):
     except subprocess.CalledProcessError as err:
         LOGGER_CLI.error('%s\n%s', error_message, err.cmd)
         return False
+    except OSError as err:
+        LOGGER_CLI.error('%s\n%s (%s)', error_message, err.strerror, runner_args[0])
+        return False
 
     return True
 

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -84,9 +84,9 @@ def lambda_handler(options):
 
 def terraform_check():
     """Verify that Terraform is configured correctly"""
-    prereqs_message = ('Terraform not found! Please install and add to'
+    prereqs_message = ('Terraform not found! Please install and add to '
                        'your $PATH:\n'
-                       '$ export PATH=$PATH:/usr/local/terraform/bin')
+                       '\t$ export PATH=$PATH:/usr/local/terraform/bin')
     run_command(['terraform', 'version'],
                 error_message=prereqs_message,
                 quiet=True)
@@ -95,7 +95,8 @@ def terraform_check():
 def terraform_handler(options):
     """Handle all Terraform CLI operations"""
     # verify terraform is installed
-    terraform_check()
+    if not terraform_check():
+        return
     # use a named tuple to match the 'processor' attribute in the argparse options
     deploy_opts = namedtuple('DeployOptions', ['processor'])
 


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers , @zbuc
resolves: #200
size: small

## fix ##
* Catching `OSError` when trying to run a command that does not exist. Previously, `subprocess.CalledProcessError` would not catch this because commands must exit cleanly with an error code for that exception to be caught. Commands that do not exist do not exit with an error code, and thus this was missed.
* If the `terraform_check` fails to validate a TF install, we will now exit execution of the cli.

## other changes ##
* Fixing formatting issue with prerequisite message printed during terraform check (space missing between "to" and "your").