### PR TITLE
streamalert - carbonblack schema changes - round 1

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -7,7 +7,7 @@
       "md5": "string",
       "node_id": "string",
       "size": "string",
-      "timestamp": "string",
+      "timestamp": "float",
       "type": "string"
     },
     "parser": "json"
@@ -30,12 +30,14 @@
       "remote_ip": "string",
       "remote_port": "string",
       "sensor_id": "string",
-      "timestamp": "string",
+      "timestamp": "float",
       "type": "string"
     },
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
+        "local_ip",
+        "local_port",
         "remote_ip",
         "remote_port"
       ]
@@ -94,7 +96,7 @@
       "segment_id": "integer",
       "sensor_id": "integer",
       "server_name": "string",
-      "timestamp": "string",
+      "timestamp": "float",
       "type": "string"
     },
     "parser": "json",
@@ -276,7 +278,7 @@
       "product_version": "string",
       "server_added_timestamp": "string",
       "signed": "string",
-      "timestamp": "string"
+      "timestamp": "float"
     },
     "parser": "json",
     "configuration": {
@@ -308,6 +310,30 @@
       "ioc_type": "string",
       "ioc_value": "string",
       "md5": "string",
+      "report_id": "string",
+      "report_score": "integer",
+      "sensor_id": "integer",
+      "server_name": "string",
+      "timestamp": "float",
+      "type": "string"
+    },
+    "parser": "json"
+  },
+  "carbonblack:feed.ingress.hit.binary": {
+    "schema": {
+      "cb_server": "string",
+      "cb_version": "string",
+      "computer_name": "string",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "from_feed_search": "boolean",
+      "group": "string",
+      "hostname": "string",
+      "ioc_attr": {},
+      "ioc_type": "string",
+      "ioc_value": "string",
+      "md5": "string",
+      "os_type": "string",
       "report_id": "string",
       "report_score": "integer",
       "sensor_id": "integer",


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**What**

1) Fixed Carbonblack schemas that were denoting `timestamp` as a string, when in fact it's a float.

Example:

```
{
  "cb_server": "...",
  "cb_version": "...",
  "computer_name": "...",
  "feed_id": 123,
  "feed_name": "...",
  "from_feed_search": false,
  "group": "...",
  "hostname": "...",
  "ioc_attr": {},
  "ioc_type": "...",
  "ioc_value": "...",
  "md5": "...",
  "os_type": "...",
  "report_id": "...",
  "report_score": 123,
  "sensor_id": 123,
  "server_name": "...",
  "timestamp": 1497997455.021,
  "type": "feed.ingress.hit.binary"
}
```

2) Fixed `carbonblack:ingress.event.netconn`, which occasionally does not have the `local_ip` and `local_port` keys 

3) Added the `feed.ingress.hit.binary` schema

**Testing**

`python stream_alert_cli.py lambda test --processor all`

```
(14/14)	Rule Tests Passed
(50/50)	Alert Tests Passed
```