### PR TITLE
streamalert - carbonblack - feed.synchronized

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -448,6 +448,18 @@
       }
     }
   },
+  "carbonblack:feed.synchronized": {
+    "schema": {
+      "cb_server": "string",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "feed_update_time": "string",
+      "scan_start_time": "string",
+      "timestamp": "float",
+      "type": "string"
+    },
+    "parser": "json"
+  },
   "cloudwatch:events": {
     "schema": {
       "account": "integer",


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**What**

Support the log type `feed.synchronized` for CarbonBlack.

Example log:

```
{
  "cb_server": "...",
  "feed_id": 123,
  "feed_name": "...",
  "feed_update_time": "2017-06-21T08:18:03Z",
  "scan_start_time": null,
  "timestamp": 1498033084.509223,
  "type": "feed.synchronized"
}
```

**Testing**

`python stream_alert_cli.py lambda test --processor all`

```
(14/14)	Rule Tests Passed
(50/50)	Alert Tests Passed
```