### PR TITLE
[logs] fixing small bug in log schema

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -278,7 +278,7 @@
       "product_version": "string",
       "server_added_timestamp": "string",
       "signed": "string",
-      "timestamp": "float"
+      "timestamp": "string"
     },
     "parser": "json",
     "configuration": {


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

### bug fix
* Fixing small bug in `carbonblack:watchlist.hit.binary` declared schema. It turns out the `timestamp` stored at the root of the log is a `float`, but the `timestamp` stored within each entry of the `docs` list (inside the 'envelope') is a `string` value (ie: `2017-01-01T20:55:57.828Z`).
* Example:
```
{
  "cb_server": "cbserver",
  "cb_version": "6.1.0.170309.1140",
  "docs": [
    {
      "cb_version": "524",
      "comments": "comment",
      "company_name": "Foobar Corp",
      "copied_mod_len": "284904",
      "digsig_issuer": "Foobar Inc",
      "digsig_result": "Untrusted",
      "digsig_result_code": "123123123123",
      "digsig_subject": "Internal",
      "endpoint": [
        "1LAKDJ-F93J1"
      ],
      "event_partition_id": [
        "111111111111"
      ],
      "facet_id": "0",
      "file_desc": "Foobar Tech",
      "file_version": "1.0.0",
      "group": [
        "FooBar"
      ],
      "host_count": 1,
      "internal_name": "foobar-2-0",
      "is_64bit": "false",
      "is_executable_image": "false",
      "last_seen": "2017-03-01T00:00:50.635Z",
      "legal_copyright": "Copyright (C) 2011 Foobar Corporation",
      "md5": "0000000000000000000000000000",
      "observed_filename": [
        "c:\\program files (x86)\\foobar\\lolevildawg.dll"
      ],
      "orig_mod_len": "222222",
      "original_filename": "asdfasdfasdfasdf",
      "os_type": "Windows",
      "product_name": "Foobar Technology",
      "product_version": "1.0.0",
      "server_added_timestamp": "2017-01-00T20:55:57.828Z",
      "signed": "Untrusted Root",
      "timestamp": "2017-01-01T20:55:57.828Z"
    }
  ],
  "highlights_by_doc": {},
  "server_name": "foobar.my.carbonblack.io",
  "timestamp": "1491264681.15",
  "type": "watchlist.hit.binary",
  "watchlist_id": "593",
  "watchlist_name": "tmp-delete-me-bad-signature"
}
```
