### PR TITLE
[schemas] make osquery decorations an optional key

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -606,7 +606,8 @@
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
-        "log_type"
+        "log_type",
+        "decorations"
       ]
     }
   },


### PR DESCRIPTION
to @mime-frame 
cc @airbnb/streamalert-maintainers 

Osquery decorators are optional, so our `osquery` log schema should also make them optional