### PR TITLE
[cli] update CLI descriptions

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -96,22 +96,23 @@ def terraform_check():
 
 def terraform_handler(options):
     """Handle all Terraform CLI operations"""
-    # verify terraform is installed
+    # Verify terraform is installed
     if not terraform_check():
         return
-    # use a named tuple to match the 'processor' attribute in the argparse options
+    # Use a named tuple to match the 'processor' attribute in the argparse options
     deploy_opts = namedtuple('DeployOptions', ['processor'])
 
-    # plan/apply our streamalert infrastructure
+    # Plan and Apply our streamalert infrastructure
     if options.subcommand == 'build':
-        # Make sure the Terraform is completely up to date
+        # Generate Terraform files
         if not terraform_generate(config=CONFIG):
             return
-        # --target is for terraforming a specific streamalert module
+        # Target is for terraforming a specific streamalert module.
+        # This value is passed as a list
         if options.target:
-            target = options.target
             targets = ['module.{}_{}'.format(target, cluster)
-                       for cluster in CONFIG.clusters()]
+                       for cluster in CONFIG.clusters()
+                       for target in options.target]
             tf_runner(targets=targets)
         else:
             tf_runner()


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium

Refactor the StreamAlert CLI help messages for clarity and updated usage:

General help: 
```
$ python stream_alert_cli.py --help
usage: stream_alert_cli.py [command] [subcommand] [options]

StreamAlertCLI v0.2.1
Build, Deploy, Configure, and Test StreamAlert Infrastructure

Available Commands:

    stream_alert_cli.py terraform               Manage StreamAlert infrastructure
    stream_alert_cli.py output                  Configure new StreamAlert outputs
    stream_alert_cli.py lambda                  Deploy, test, and rollback StreamAlert AWS Lambda functions

For additional details on the available commands, try:

    stream_alert_cli.py [command] --help

positional arguments:
  {output,live-test,lambda,terraform}
    output              Define a new output to send alerts to
    live-test           ==SUPPRESS==
    lambda              ==SUPPRESS==
    terraform           ==SUPPRESS==

optional arguments:
  -h, --help            show this help message and exit
```

Lambda help:
```
$ python stream_alert_cli.py lambda --help
usage: stream_alert_cli.py lambda [subcommand] [options]

StreamAlertCLI v0.2.1
Deploy, Rollback, and Test StreamAlert Lambda functions

Available Subcommands:

    stream_alert_cli.py lambda deploy [options]         Deploy Lambda functions
    stream_alert_cli.py lambda rollback [options]       Rollback Lambda functions
    stream_alert_cli.py lambda test [options]           Run rule tests

Available Options:

    --processor                                         The name of the Lambda function to manage.
                                                        Valid options include: rule, alert, or all.
    --debug                                             Enable Debug logger output.
    --rules                                             List of rules to test, separated by spaces.

Examples:

    stream_alert_cli.py lambda deploy --processor all
    stream_alert_cli.py lambda rollback --processor all
    stream_alert_cli.py lambda test --processor rule --rules lateral_movement root_logins

optional arguments:
  -h, --help  show this help message and exit
```

Terraform help:
```
$ python stream_alert_cli.py terraform --help
usage: stream_alert_cli.py terraform [subcommand] [options]

StreamAlertCLI v0.2.1
Plan and Apply StreamAlert Infrastructure with Terraform

Available Subcommands:

    stream_alert_cli.py terraform init                      Initialize StreamAlert infrastructure
    stream_alert_cli.py terraform init-backend              Initialize the Terraform backend
    stream_alert_cli.py terraform build [options]           Run Terraform on all StreamAlert modules
    stream_alert_cli.py terraform clean                     Remove Terraform files (only use this when destroying all infrastructure)
    stream_alert_cli.py terraform destroy [options]         Destroy StreamAlert infrastructure
    stream_alert_cli.py terraform generate                  Generate Terraform files from JSON cluster files
    stream_alert_cli.py terraform status                    Show cluster health, and other currently configured infrastructure information

Available Options:

    --target                                                The Terraform module name to apply.
                                                            Valid options: stream_alert, kinesis, kinesis_events,
                                                            cloudtrail, monitoring, and s3_events.
Examples:

    stream_alert_cli.py terraform init
    stream_alert_cli.py terraform init-backend
    stream_alert_cli.py terraform generate

    stream_alert_cli.py terraform build
    stream_alert_cli.py terraform build --target kinesis
    stream_alert_cli.py terraform build --target stream_alert

    stream_alert_cli.py terraform destroy
    stream_alert_cli.py terraform destroy -target cloudtrail

optional arguments:
  -h, --help  show this help message and exit
```

Output help:
```
$ python stream_alert_cli.py output --help
usage: stream_alert_cli.py output [subcommand] [options]

StreamAlertCLI v0.2.1
Define new StreamAlert outputs to send alerts to

Available Subcommands:

    stream_alert_cli.py output new [options]    Create a new StreamAlert output

Examples:

    stream_alert_cli.py output new --service <service_name>
    stream_alert_cli.py output new --service aws-s3
    stream_alert_cli.py output new --service pagerduty
    stream_alert_cli.py output new --service slack

optional arguments:
  -h, --help  show this help message and exit
```

Live-test help:
```
$ python stream_alert_cli.py live-test --help
usage: stream_alert_cli.py live-test [options]

StreamAlertCLI v0.2.1
Run end-to-end tests that will attempt to send alerts

Available Options:

    --cluster               The cluster name to use for live testing
    --rules                 Name of rules to test, separated by spaces
    --debug                 Enable Debug logger output

Examples:

    stream_alert_cli.py live-test --cluster prod
    stream_alert_cli.py live-test --rules

optional arguments:
  -h, --help  show this help message and exit
```