### PR TITLE
[lambda][alert] fixing bug where metadata for an alert was not being sent to s3

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -515,7 +515,7 @@ class S3Output(AWSOutput):
         service = alert['metadata']['source']['service']
         entity = alert['metadata']['source']['entity']
         current_date = datetime.now()
-        alert_string = json.dumps(alert['record'])
+        alert_string = json.dumps(alert)
         bucket = self.config[self.__service__][kwargs['descriptor']]
         key = '{}/{}/{}/dt={}/streamalerts_{}.json'.format(
             service,


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

## fix
* Fixing bug where `metadata` for a triggered rule was not being sent to s3 for storage along with the alert record itself.