### PR TITLE
[cli] package in the new helpers and matchers folders

### DIFF
--- a/stream_alert_cli/package.py
+++ b/stream_alert_cli/package.py
@@ -221,7 +221,12 @@ class LambdaPackage(object):
 
 class RuleProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Rule Processor function"""
-    package_folders = {'stream_alert/rule_processor', 'rules', 'conf'}
+    package_folders = {
+        'stream_alert/rule_processor',
+        'rules',
+        'matchers',
+        'helpers',
+        'conf'}
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'rule_processor'


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

With the updated folder structure in #210, we need to package in the folders to the `rule_processor` deployment package.