### PR TITLE
[ci] adding sphinx-build to CI to check for doc errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ cache: pip
 sudo: required
 python:
   - 2.7
-before_install:
- - sudo apt-get install -qq python-numpy python-scipy
 install:
   - pip install -r requirements.txt
 script:
   - ./test/scripts/unit_tests.sh
   - ./stream_alert_cli.py lambda test --processor all
+  - sphinx-build -W docs/source docs/build
 after_success:
   coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,8 @@ requests==2.13.0
 rsa==3.3
 s3transfer==0.1.10
 six==1.10.0
+Sphinx==1.6.3
+sphinx-rtd-theme==0.2.4
 testtools==2.2.0
 traceback2==1.4.0
 unittest2==1.1.0


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

## Change
* Adding `sphinx-build` to travis so CI will fail if there are any warnings or errors when trying to build docs. This should help us avoid having to make massive fixes to docs in the future when updates are added.