### PR TITLE
[lambda][rule] removing a json dump to string in logger output

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -112,7 +112,7 @@ class StreamAlert(object):
         """
         classifier.classify_record(payload, data)
         if not payload.valid:
-            LOGGER.error('Invalid data: %s\n%s', payload, json.dumps(payload.raw_record, indent=4))
+            LOGGER.error('Invalid data: %s\n%s', payload, payload.raw_record)
             return
 
         alerts = StreamRules.process(payload)


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

## change
* Removing a json dump to string of data that is already json. This made it difficult to copy logger output when an "invalid" log was printed, and required replacing a bunch of escape characters that were added during the json dump. The output can now be copied directly from CloudWatch logs for testing/adding new schemas without any manipulation.