### PR TITLE
[lambda][rule] fixing bug that caused rule imports to break in some c…

### DIFF
--- a/stream_alert/rule_processor/main.py
+++ b/stream_alert/rule_processor/main.py
@@ -21,16 +21,12 @@ from stream_alert.rule_processor.handler import StreamAlert
 
 modules_to_import = set()
 # walk the rules directory to dymanically import
-for folder in ('matchers/', 'rules/'):
+for folder in ('matchers', 'rules'):
     for root, dirs, files in os.walk(folder):
         filtered_files = [rule_file for rule_file in files if not (rule_file.startswith((
             '.', '__init__')) or rule_file.endswith('.pyc'))]
+        package_path = root.replace('/', '.')
         for import_file in filtered_files:
-            # Greater than one because that indicates there's only one folder
-            if root.count('/') > 1:
-                package_path = root.replace('/', '.')
-            else:
-                package_path = root.rstrip('/')
             import_module = os.path.splitext(import_file)[0]
             if package_path and import_module:
                 modules_to_import.add('{}.{}'.format(package_path, import_module))


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers, @zbuc

## Fix
* Fixing a bug that caused rule imports to fail when rule files were placed only one level deep in rules:

```
├── rules
│   ├── __init__.py
│   ├── community   # 1st level folder (with no rules)
│   │   ├── __init__.py
│   │   └── cloudtrail   # 2nd level folder [works]
│   │       ├── __init__.py
│   │       └── cloudtrail_root_account.py
│   ├── default
│   │   └── __init__.py
│   └── privaterules   # 1st level folder (with rules) [does not work]
│       ├── __init__.py
│       └── my_rule.py
```

The above example is now supported with this change.