### PR TITLE
Consolidate StreamAlerts Buckets

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -144,6 +144,7 @@ def terraform_handler(options):
             'aws_s3_bucket.logging_bucket',
             'aws_s3_bucket.stream_alert_secrets',
             'aws_s3_bucket.terraform_remote_state',
+            'aws_s3_bucket.streamalerts',
             'aws_kms_key.stream_alert_secrets',
             'aws_kms_alias.stream_alert_secrets'
         ]

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "alert_processor_s3" {
     ]
 
     resources = [
-      "${aws_s3_bucket.streamalerts.arn}/*",
+      "arn:aws:s3:::${var.prefix}.streamalerts/*",
     ]
   }
 

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -122,19 +122,3 @@ resource "aws_lambda_permission" "with_sns" {
   qualifier     = "production"
   depends_on    = ["aws_lambda_alias.alert_processor_production"]
 }
-
-// S3 bucket for S3 outputs
-resource "aws_s3_bucket" "streamalerts" {
-  bucket        = "${replace("${var.prefix}.${var.cluster}.streamalerts", "_", ".")}"
-  acl           = "private"
-  force_destroy = false
-
-  versioning {
-    enabled = true
-  }
-
-  logging {
-    target_bucket = "${var.s3_logging_bucket}"
-    target_prefix = "${replace("${var.prefix}.${var.cluster}.streamalerts", "_", ".")}/"
-  }
-}

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -68,7 +68,3 @@ variable "alert_processor_vpc_security_group_ids" {
   type    = "list"
   default = []
 }
-
-variable "s3_logging_bucket" {
-  type = "string"
-}


### PR DESCRIPTION
to @ryandeivert 
cc @airbnb/streamalert-maintainers 

## Background
A current issue with per-cluster S3 Alert buckets is that a rule acting across multiple environments will throw a permissions error.  The reason is that a given Lambda function will try to send to another cluster's bucket, and no permission exists to allow that.

## Change
Move the creation of StreamAlerts buckets out of each cluster and into a single bucket per StreamAlert setup.

Also update unit tests accordingly.

## Tested
Verified in a side account with two clusters.  Alerts were sending to the same bucket from multiple Lambda functions.

## Important!
Before pulling this update and migrating to a unified bucket scheme, perform the following:

1. Copy all existing StreamAlerts to a temporary bucket.
2. Empty bucket/clear out old alerts.
3. Run `python stream_alert_cli.py terraform build` after pulling updates from this repo.
4. S3 sync temp bucket to new unified bucket `<prefix>.streamalerts`.