### PR TITLE
[logs] adding some additional carbonblack log schemas

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -26,6 +26,7 @@
       "pid": "string",
       "port": "string",
       "process_guid": "string",
+      "process_path": "string",
       "protocol": "string",
       "remote_ip": "string",
       "remote_port": "string",
@@ -38,6 +39,7 @@
       "optional_top_level_keys": [
         "local_ip",
         "local_port",
+        "process_path",
         "remote_ip",
         "remote_port"
       ]
@@ -58,15 +60,19 @@
       "path": "string",
       "pid": "integer",
       "process_guid": "string",
+      "process_path": "string",
       "sensor_id": "integer",
       "timestamp": "integer",
       "type": "string",
+      "uid": "string",
       "username": "string"
     },
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
         "parent_md5",
+        "process_path",
+        "uid",
         "username"
       ]
     }
@@ -140,49 +146,113 @@
       }
     }
   },
+  "carbonblack:alert.status.updated": {
+    "schema": {
+      "alert_resolution": "string",
+      "cb_server": "string",
+      "feed_name": "string",
+      "ioc_type": "string",
+      "ioc_value": "string",
+      "report_id": [],
+      "timestamp": "string",
+      "type": "string"
+    },
+    "parser": "json"
+  },
+  "carbonblack:alert.watchlist.hit.feedsearch.binary": {
+    "schema": {
+      "alert_severity": "float",
+      "alert_type": "string",
+      "assigned_to": "string",
+      "cb_server": "string",
+      "computer_name": "string",
+      "created_time": "string",
+      "digsig_result": "string",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "feed_rating": "integer",
+      "host_count": "integer",
+      "hostname": "string",
+      "ioc_confidence": "float",
+      "ioc_type": "string",
+      "ioc_value": "string",
+      "ioc_value_facet": "string",
+      "md5": "string",
+      "observed_filename": [],
+      "observed_filename_total_count": "integer",
+      "os_type": "string",
+      "other_hostnames": [],
+      "report_score": "integer",
+      "resolved_time": "string",
+      "segment_id": "integer",
+      "sensor_criticality": "integer",
+      "status": "string",
+      "timestamp": "float",
+      "type": "string",
+      "unique_id": "string",
+      "watchlist_id": "string",
+      "watchlist_name": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "log_patterns": {
+        "type": [
+          "alert.watchlist.hit.feedsearch.binary"
+        ]
+      },
+      "optional_top_level_keys": [
+        "assigned_to",
+        "resolved_time"
+      ]
+    }
+  },
   "carbonblack:alert.watchlist.hit.ingress.process": {
     "schema": {
-      "modload_count": "integer",
-      "alert_type": "string",
-      "sensor_criticality": "integer",
-      "report_score": "integer",
-      "watchlist_id": "string",
-      "feed_id": "integer",
-      "sensor_id": "integer",
-      "created_time": "string",
-      "ioc_type": "string",
-      "feed_name": "string",
-      "ioc_confidence": "integer",
       "alert_severity": "integer",
+      "alert_type": "string",
+      "assigned_to": "string",
+      "cb_server": "string",
+      "childproc_count": "integer",
+      "comms_ip": "string",
+      "computer_name": "string",
+      "created_time": "string",
       "crossproc_count": "integer",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "feed_rating": "integer",
+      "filemod_count": "integer",
       "group": "string",
       "hostname": "string",
-      "filemod_count": "integer",
-      "cb_server": "string",
-      "comms_ip": "string",
-      "netconn_count": "integer",
       "interface_ip": "string",
-      "type": "string",
-      "status": "string",
-      "process_path": "string",
-      "timestamp": "float",
-      "process_name": "string",
-      "process_unique_id": "string",
-      "ioc_query_string": "string",
-      "process_id": "string",
-      "computer_name": "string",
-      "process_guid": "string",
-      "watchlist_name": "string",
-      "regmod_count": "integer",
-      "md5": "string",
-      "segment_id": "string",
+      "ioc_attr": "string",
+      "ioc_confidence": "integer",
       "ioc_query_index": "string",
-      "username": "string",
+      "ioc_query_string": "string",
+      "ioc_type": "string",
       "ioc_value": "string",
+      "ioc_value_facet": "string",
+      "md5": "string",
+      "modload_count": "integer",
+      "netconn_count": "integer",
       "os_type": "string",
-      "childproc_count": "integer",
+      "process_guid": "string",
+      "process_id": "string",
+      "process_name": "string",
+      "process_path": "string",
+      "process_unique_id": "string",
+      "regmod_count": "integer",
+      "report_score": "integer",
+      "resolved_time": "string",
+      "segment_id": "string",
+      "sensor_criticality": "integer",
+      "sensor_id": "integer",
+      "status": "string",
+      "timestamp": "float",
+      "type": "string",
       "unique_id": "string",
-      "feed_rating": "integer"
+      "username": "string",
+      "watchlist_id": "string",
+      "watchlist_name": "string"
     },
     "parser": "json",
     "configuration": {
@@ -190,7 +260,72 @@
         "type": [
           "alert.watchlist.hit.ingress.process"
         ]
-      }
+      },
+      "optional_top_level_keys": [
+        "assigned_to",
+        "ioc_attr",
+        "ioc_query_index",
+        "ioc_query_string",
+        "ioc_value_facet",
+        "resolved_time"
+      ]
+    }
+  },
+  "carbonblack:alert.watchlist.hit.query.process": {
+    "schema": {
+      "alert_severity": "integer",
+      "alert_type": "string",
+      "assigned_to": "string",
+      "cb_server": "string",
+      "childproc_count": "integer",
+      "comms_ip": "string",
+      "computer_name": "string",
+      "created_time": "string",
+      "crossproc_count": "integer",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "feed_rating": "integer",
+      "filemod_count": "integer",
+      "group": "string",
+      "hostname": "string",
+      "interface_ip": "string",
+      "ioc_attr": "string",
+      "ioc_confidence": "integer",
+      "ioc_type": "string",
+      "md5": "string",
+      "modload_count": "integer",
+      "netconn_count": "integer",
+      "os_type": "string",
+      "process_guid": "string",
+      "process_id": "string",
+      "process_name": "string",
+      "process_path": "string",
+      "process_unique_id": "string",
+      "regmod_count": "integer",
+      "report_score": "integer",
+      "resolved_time": "string",
+      "segment_id": "string",
+      "sensor_criticality": "integer",
+      "sensor_id": "integer",
+      "status": "string",
+      "timestamp": "float",
+      "type": "string",
+      "unique_id": "string",
+      "username": "string",
+      "watchlist_id": "string",
+      "watchlist_name": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "log_patterns": {
+        "type": [
+          "alert.watchlist.hit.query.process"
+        ]
+      },
+      "optional_top_level_keys": [
+        "assigned_to",
+        "resolved_time"
+      ]
     }
   },
   "carbonblack:watchlist.hit.process": {
@@ -244,6 +379,50 @@
         "type": "string",
         "watchlist_id": "integer",
         "watchlist_name": "string"
+      }
+    }
+  },
+  "carbonblack:watchlist.storage.hit.binary": {
+    "schema": {
+      "cb_server": "string",
+      "cb_version": "string",
+      "docs": [],
+      "md5": "string",
+      "server_name": "string",
+      "timestamp": "float",
+      "type": "string",
+      "watchlist_id": "integer",
+      "watchlist_name": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "log_patterns": {
+        "type": [
+          "watchlist.storage.hit.binary"
+        ]
+      }
+    }
+  },
+  "carbonblack:watchlist.storage.hit.process": {
+    "schema": {
+      "cb_server": "string",
+      "cb_version": "string",
+      "docs": [],
+      "process_guid": "string",
+      "process_id": "string",
+      "segment_id": "string",
+      "server_name": "string",
+      "timestamp": "float",
+      "type": "string",
+      "watchlist_id": "integer",
+      "watchlist_name": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "log_patterns": {
+        "type": [
+          "watchlist.storage.hit.process"
+        ]
       }
     }
   },
@@ -524,23 +703,23 @@
     "parser": "json"
   },
   "cloudtrail:api_events": {
-      "schema": {
-          "awsRegion": "string",
-          "eventID": "string",
-          "eventName": "string",
-          "eventSource": "string",
-          "eventTime": "string",
-          "eventType": "string",
-          "eventVersion": "string",
-          "recipientAccountId": "string",
-          "requestID": "string",
-          "requestParameters": {},
-          "responseElements": {},
-          "sourceIPAddress": "string",
-          "userAgent": "string",
-          "userIdentity": {}
-      },
-      "parser": "json"
+    "schema": {
+      "awsRegion": "string",
+      "eventID": "string",
+      "eventName": "string",
+      "eventSource": "string",
+      "eventTime": "string",
+      "eventType": "string",
+      "eventVersion": "string",
+      "recipientAccountId": "string",
+      "requestID": "string",
+      "requestParameters": {},
+      "responseElements": {},
+      "sourceIPAddress": "string",
+      "userAgent": "string",
+      "userIdentity": {}
+    },
+    "parser": "json"
   },
   "ghe:general": {
     "schema": {
@@ -697,8 +876,10 @@
     "parser": "csv",
     "configuration": {
       "log_patterns": {
-        "type": ["TRAFFIC"]
-        }
+        "type": [
+          "TRAFFIC"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
to @austinbyers , @jacknagz 
cc @airbnb/streamalert-maintainers 

## Updates:
* Adding some additional carbonblack log schemas:
  * `carbonblack:alert.status.updated`
  * `carbonblack:alert.watchlist.hit.feedsearch.binary`
  * `carbonblack:alert.watchlist.hit.ingress.process`
  * `carbonblack:alert.watchlist.hit.query.process`
  * `carbonblack:watchlist.storage.hit.binary`
  * `carbonblack:watchlist.storage.hit.process`
* Updating some existing schemas with optional keys:
  * `carbonblack:ingress.event.netconn`
  * `carbonblack:ingress.event.procstart`
