### PR TITLE
[cli] allow a list of lambda functions to be deployed

### DIFF
--- a/stream_alert_cli.py
+++ b/stream_alert_cli.py
@@ -222,6 +222,7 @@ Examples:
         '--processor',
         choices=['alert', 'all', 'athena', 'rule'],
         help=argparse_suppress,
+        action='append',
         required=True
     )
 

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -252,7 +252,7 @@ def terraform_handler(options):
 
         LOGGER_CLI.info('Deploying Lambda Functions')
         # deploy both lambda functions
-        deploy(deploy_opts('all'))
+        deploy(deploy_opts(['rule', 'alert']))
         # create all remainder infrastructure
 
         LOGGER_CLI.info('Building Remainder Infrastructure')
@@ -500,24 +500,24 @@ def deploy(options):
         return athena_package
 
 
-    if processor == 'rule':
+    if 'rule' in processor:
         targets.extend(['module.stream_alert_{}'.format(x)
                    for x in CONFIG.clusters()])
 
         packages.append(_deploy_rule_processor())
 
-    elif processor == 'alert':
+    if 'alert' in processor:
         targets.extend(['module.stream_alert_{}'.format(x)
                    for x in CONFIG.clusters()])
 
         packages.append(_deploy_alert_processor())
 
-    elif processor == 'athena':
+    if 'athena' in processor:
         targets.append('module.stream_alert_athena')
 
         packages.append(_deploy_athena_partition_refresh())
-    
-    elif processor == 'all':
+
+    if 'all' in processor:
         targets.extend(['module.stream_alert_{}'.format(x)
                    for x in CONFIG.clusters()])
         targets.append('module.stream_alert_athena')

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -606,11 +606,11 @@ def stream_alert_test(options, config=None):
             LOGGER_SA.addFilter(TestingSuppressFilter())
 
         # Check if the rule processor should be run for these tests
-        test_rules = (run_options.get('processor') in {'rule', 'all'} or
+        test_rules = (set(run_options.get('processor')).issubset({'rule', 'all'}) or
                       run_options.get('command') == 'live-test')
 
         # Check if the alert processor should be run for these tests
-        test_alerts = (run_options.get('processor') in {'alert', 'all'} or
+        test_alerts = (set(run_options.get('processor')).issubset({'alert', 'all'}) or
                        run_options.get('command') == 'live-test')
 
         rule_proc_tester = RuleProcessorTester(context, test_rules)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers @VVMichaelSawyer 
resolves: #241 
size: small

Convert the `--processor` command line option type from a string to a list, which allows users to cherry pick which Lambda function is deployed.

This fixes a bug identified in #241 where the CLI would try to deploy a Lambda function that is optional (Athena Refresh).

Tested and verified by walking through the `$ python stream_alert_cli.py terraform init` workflow