### PR TITLE
[metrics] initial metrics support

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -102,7 +102,7 @@ class StreamAlert(object):
                 continue
 
             # Create the StreamPayload to use for encapsulating parsed info
-            payload = load_stream_payload(service, entity, raw_record)
+            payload = load_stream_payload(service, entity, raw_record, self.metrics)
             if not payload:
                 continue
 

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -20,10 +20,10 @@ from logging import DEBUG as log_level_debug
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.classifier import StreamClassifier
-from stream_alert.rule_processor.metrics import Metrics
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.rule_processor.rules_engine import StreamRules
 from stream_alert.rule_processor.sink import StreamSink
+from stream_alert.shared.metrics import Metrics
 
 
 class StreamAlert(object):

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -77,7 +77,7 @@ class StreamAlert(object):
         if not records:
             return False
 
-        self.metrics.put_metric_data(
+        self.metrics.add_metric(
             Metrics.Name.TOTAL_RECORDS,
             len(records),
             Metrics.Unit.COUNT)
@@ -110,14 +110,14 @@ class StreamAlert(object):
 
         LOGGER.debug('Invalid record count: %d', self._failed_record_count)
 
-        self.metrics.put_metric_data(
+        self.metrics.add_metric(
             Metrics.Name.FAILED_PARSES,
             self._failed_record_count,
             Metrics.Unit.COUNT)
 
         LOGGER.debug('%s alerts triggered', len(self._alerts))
 
-        self.metrics.put_metric_data(
+        self.metrics.add_metric(
             Metrics.Name.TRIGGERED_ALERTS, len(
                 self._alerts), Metrics.Unit.COUNT)
 
@@ -125,6 +125,9 @@ class StreamAlert(object):
         # this can be time consuming if there are a lot of alerts
         if self._alerts and LOGGER.isEnabledFor(log_level_debug):
             LOGGER.debug('Alerts:\n%s', json.dumps(self._alerts, indent=2))
+
+        # Send any cached metrics to CloudWatch before returning
+        self.metrics.send_metrics()
 
         return self._failed_record_count == 0
 

--- a/stream_alert/rule_processor/metrics.py
+++ b/stream_alert/rule_processor/metrics.py
@@ -1,0 +1,122 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import json
+
+from datetime import datetime
+
+import boto3
+
+from botocore.exceptions import ClientError
+
+from stream_alert.rule_processor import LOGGER
+
+
+class Metrics(object):
+    """Class to hold Rule Processor metric name and unit constants
+    This basically acts as an enum, allowing for the use of dot notation for
+    accessing properties and avoids doing dict lookups a ton.
+    """
+
+    def __init__(self, region):
+        self.boto_cloudwatch = boto3.client('cloudwatch', region_name=region)
+
+    class Name(object):
+        """Constant metric names used in the rule processor"""
+        FAILED_PARSES = 'RuleProcessorFailedParses'
+        S3_DOWNLOAD_TIME = 'RuleProcessorS3DownloadTime'
+        TOTAL_RECORDS = 'RuleProcessorTotalRecords'
+        TOTAL_S3_RECORDS = 'RuleProcessorTotalS3Records'
+        TRIGGERED_ALERTS = 'RuleProcessorTriggeredAlerts'
+
+    class Unit(object):
+        """Unit names for metrics. These are taken from the boto3 CloudWatch page"""
+        SECONDS = 'Seconds'
+        MICROSECONDS = 'Microseconds'
+        MILLISECONDS = 'Milliseconds'
+        BYTES = 'Bytes'
+        KILOBYTES = 'Kilobytes'
+        MEGABYTES = 'Megabytes'
+        GIGABYTES = 'Gigabytes'
+        TERABYTES = 'Terabytes'
+        BITS = 'Bits'
+        KILOBITS = 'Kilobits'
+        MEGABITS = 'Megabits'
+        GIGABITS = 'Gigabits'
+        TERABITS = 'Terabits'
+        PERCENT = 'Percent'
+        COUNT = 'Count'
+        BYTES_PER_SECOND = 'Bytes/Second'
+        KILOBYTES_PER_SECOND = 'Kilobytes/Second'
+        MEGABYTES_PER_SECOND = 'Megabytes/Second'
+        GIGABYTES_PER_SECOND = 'Gigabytes/Second'
+        TERABYTES_PER_SECOND = 'Terabytes/Second'
+        BITS_PER_SECOND = 'Bits/Second'
+        KILOBITS_PER_SECOND = 'Kilobits/Second'
+        MEGABITS_PER_SECOND = 'Megabits/Second'
+        GIGABITS_PER_SECOND = 'Gigabits/Second'
+        TERABITS_PER_SECOND = 'Terabits/Second'
+        COUNT_PER_SECOND = 'Count/Second'
+        NONE = 'None'
+
+    def put_metric_data(self, metric_name, value, unit):
+        """Publish custom metric data to CloudWatch.
+
+        Args:
+            metric_name [string]: Name of metric to publish to. Choices are in
+                `Metrics.Name` above
+            value [number]: Numeric information to post to metric. AWS expects
+                this to be of type 'float' but will accept any numeric value that
+                is not super small (negative) or super large.
+            unit [string]: Unit to use for this metric. Choices are in
+                `Metrics.Unit` above.
+        """
+        if metric_name not in self.Name.__dict__.values():
+            LOGGER.error('Metric name not defined: %s', metric_name)
+            return
+
+        if unit not in self.Unit.__dict__.values():
+            LOGGER.error('Metric unit not defined: %s', unit)
+            return
+
+        LOGGER.debug('Sending metric data to CloudWatch: %s', metric_name)
+        metric_data = [
+            {
+                'MetricName': metric_name,
+                'Timestamp': datetime.utcnow(),
+                'Unit': unit,
+                'Value': value
+            }
+        ]
+
+        self._put_metric(metric_data)
+
+    def _put_metric(self, data):
+        """Helper function to publish custom metric data for StreamAlert to CloudWatch
+
+        Args:
+            data [list<dict>] a list of dictionary items to publish that conforms to
+                the format expected by CloudWatch
+        """
+        try:
+            self.boto_cloudwatch.put_metric_data(Namespace='StreamAlert', MetricData=data)
+        except ClientError as err:
+            LOGGER.exception(
+                'Failed to send metric to CloudWatch. Error: %s\nMetric data:\n%s',
+                err.response,
+                json.dumps(
+                    data,
+                    indent=2,
+                    default=lambda d: d.isoformat()))

--- a/stream_alert/rule_processor/payload.py
+++ b/stream_alert/rule_processor/payload.py
@@ -26,7 +26,7 @@ from urllib import unquote
 import boto3
 
 from stream_alert.rule_processor import LOGGER
-from stream_alert.rule_processor.metrics import Metrics
+from stream_alert.shared.metrics import Metrics
 
 
 def load_stream_payload(service, entity, raw_record, metrics):

--- a/stream_alert/rule_processor/payload.py
+++ b/stream_alert/rule_processor/payload.py
@@ -174,7 +174,7 @@ class S3Payload(StreamPayload):
                         avg_record_size,
                         self.s3_object_size)
 
-        self.metrics.put_metric_data(Metrics.Name.TOTAL_S3_RECORDS, line_num, Metrics.Unit.COUNT)
+        self.metrics.add_metric(Metrics.Name.TOTAL_S3_RECORDS, line_num, Metrics.Unit.COUNT)
 
     def _download_object(self, region, bucket, key):
         """Download an object from S3.
@@ -215,7 +215,7 @@ class S3Payload(StreamPayload):
         LOGGER.info('Completed download in %s seconds', round(total_time, 2))
 
         # Publish a metric on how long this object took to download
-        self.metrics.put_metric_data(
+        self.metrics.add_metric(
             Metrics.Name.S3_DOWNLOAD_TIME, total_time, Metrics.Unit.SECONDS)
 
         return downloaded_s3_object

--- a/stream_alert/rule_processor/payload.py
+++ b/stream_alert/rule_processor/payload.py
@@ -26,9 +26,10 @@ from urllib import unquote
 import boto3
 
 from stream_alert.rule_processor import LOGGER
+from stream_alert.rule_processor.metrics import Metrics
 
 
-def load_stream_payload(service, entity, raw_record):
+def load_stream_payload(service, entity, raw_record, metrics):
     """Returns the right StreamPayload subclass for this service
 
     Args:
@@ -44,7 +45,7 @@ def load_stream_payload(service, entity, raw_record):
         LOGGER.error('Service payload not supported: %s', service)
         return
 
-    return payload_map[service](raw_record=raw_record, entity=entity)
+    return payload_map[service](raw_record=raw_record, entity=entity, metrics=metrics)
 
 
 class StreamPayload(object):
@@ -73,8 +74,9 @@ class StreamPayload(object):
         Keyword Args:
             raw_record (dict): The record to be parsed - in AWS event format
         """
-        self.entity = kwargs['entity']
         self.raw_record = kwargs['raw_record']
+        self.entity = kwargs['entity']
+        self.metrics = kwargs['metrics']
 
         self._refresh_record(None)
 
@@ -172,6 +174,8 @@ class S3Payload(StreamPayload):
                         avg_record_size,
                         self.s3_object_size)
 
+        self.metrics.put_metric_data(Metrics.Name.TOTAL_S3_RECORDS, line_num, Metrics.Unit.COUNT)
+
     def _download_object(self, region, bucket, key):
         """Download an object from S3.
 
@@ -209,6 +213,10 @@ class S3Payload(StreamPayload):
 
         total_time = time.time() - start_time
         LOGGER.info('Completed download in %s seconds', round(total_time, 2))
+
+        # Publish a metric on how long this object took to download
+        self.metrics.put_metric_data(
+            Metrics.Name.S3_DOWNLOAD_TIME, total_time, Metrics.Unit.SECONDS)
 
         return downloaded_s3_object
 

--- a/stream_alert/shared/__init__.py
+++ b/stream_alert/shared/__init__.py
@@ -1,0 +1,8 @@
+import logging
+import os
+
+# Create a package level logger to import
+LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO')
+logging.basicConfig()
+LOGGER = logging.getLogger('StreamAlertShared')
+LOGGER.setLevel(LEVEL.upper())

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -21,7 +21,7 @@ import boto3
 
 from botocore.exceptions import ClientError
 
-from stream_alert.rule_processor import LOGGER
+from stream_alert.shared import LOGGER
 
 
 class Metrics(object):

--- a/stream_alert_cli/package.py
+++ b/stream_alert_cli/package.py
@@ -248,7 +248,10 @@ class RuleProcessorPackage(LambdaPackage):
 
 class AlertProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Alert Processor function"""
-    package_folders = {'stream_alert/alert_processor', 'conf'}
+    package_folders = {
+        'stream_alert/alert_processor',
+        'stream_alert/shared',
+        'conf'}
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'alert_processor'
@@ -257,7 +260,10 @@ class AlertProcessorPackage(LambdaPackage):
 
 class AthenaPackage(LambdaPackage):
     """Create the Athena Partition Refresh Lambda function package"""
-    package_folders = {'stream_alert/athena_partition_refresh', 'conf'}
+    package_folders = {
+        'stream_alert/athena_partition_refresh',
+        'stream_alert/shared',
+        'conf'}
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'athena_partition_refresh'

--- a/stream_alert_cli/package.py
+++ b/stream_alert_cli/package.py
@@ -235,6 +235,7 @@ class RuleProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Rule Processor function"""
     package_folders = {
         'stream_alert/rule_processor',
+        'stream_alert/shared',
         'rules',
         'matchers',
         'helpers',

--- a/test/scripts/unit_tests.sh
+++ b/test/scripts/unit_tests.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
 nosetests test/unit \
 --with-coverage \
---cover-package=stream_alert.rule_processor \
 --cover-package=stream_alert.alert_processor \
---cover-package=stream_alert_cli \
 --cover-package=stream_alert.athena_partition_refresh \
+--cover-package=stream_alert.rule_processor \
+--cover-package=stream_alert.shared \
+--cover-package=stream_alert_cli \
 --cover-min-percentage=80 \
 --cover-html \
 --cover-html-dir=htmlcov

--- a/test/unit/stream_alert_rule_processor/test_classifier.py
+++ b/test/unit/stream_alert_rule_processor/test_classifier.py
@@ -47,7 +47,7 @@ class TestStreamClassifier(object):
 
     def _prepare_and_classify_payload(self, service, entity, raw_record):
         """Helper method to return a preparsed and classified payload"""
-        payload = load_stream_payload(service, entity, raw_record)
+        payload = load_stream_payload(service, entity, raw_record, None)
 
         payload = payload.pre_parse().next()
         self.classifier.load_sources(service, entity)
@@ -256,7 +256,7 @@ class TestStreamClassifier(object):
         })
 
         raw_record = _make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record)
+        payload = load_stream_payload(service, entity, raw_record, None)
         payload = payload.pre_parse().next()
 
         result = self.classifier._parse(payload)
@@ -282,7 +282,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = _make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record)
+        payload = load_stream_payload(service, entity, raw_record, None)
 
         self.classifier.load_sources(service, entity)
 
@@ -311,7 +311,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = _make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record)
+        payload = load_stream_payload(service, entity, raw_record, None)
 
         self.classifier.load_sources(service, entity)
 
@@ -340,7 +340,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = _make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record)
+        payload = load_stream_payload(service, entity, raw_record, None)
 
         self.classifier.load_sources(service, entity)
 

--- a/test/unit/stream_alert_rule_processor/test_classifier.py
+++ b/test/unit/stream_alert_rule_processor/test_classifier.py
@@ -41,7 +41,7 @@ class TestStreamClassifier(object):
         self.classifier = None
 
     def setup(self):
-        """Setup the class before any methods"""
+        """Setup before each method"""
         config = load_config('test/unit/conf')
         self.classifier = sa_classifier.StreamClassifier(config)
 

--- a/test/unit/stream_alert_rule_processor/test_handler.py
+++ b/test/unit/stream_alert_rule_processor/test_handler.py
@@ -38,7 +38,7 @@ from unit.stream_alert_rule_processor.test_helpers import (
 )
 
 
-@patch('stream_alert.rule_processor.metrics.Metrics.put_metric_data', Mock())
+@patch('stream_alert.shared.metrics.Metrics.put_metric_data', Mock())
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
 

--- a/test/unit/stream_alert_rule_processor/test_handler.py
+++ b/test/unit/stream_alert_rule_processor/test_handler.py
@@ -38,6 +38,7 @@ from unit.stream_alert_rule_processor.test_helpers import (
 )
 
 
+@patch('stream_alert.rule_processor.metrics.Metrics.put_metric_data', Mock())
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
 
@@ -57,7 +58,7 @@ class TestStreamAlert(object):
 
     @staticmethod
     @raises(ConfigError)
-    def test_run_config_error():
+    def test_run_config_error(_):
         """StreamAlert Class - Run, Config Error"""
         mock = mock_open(read_data='non-json string that will raise an exception')
         with patch('__builtin__.open', mock):
@@ -120,7 +121,8 @@ class TestStreamAlert(object):
         load_payload_mock.assert_called_with(
             'lambda',
             'entity',
-            'record'
+            'record',
+            self.__sa_handler.metrics
         )
 
     @patch('stream_alert.rule_processor.handler.StreamRules.process')

--- a/test/unit/stream_alert_rule_processor/test_handler.py
+++ b/test/unit/stream_alert_rule_processor/test_handler.py
@@ -38,7 +38,7 @@ from unit.stream_alert_rule_processor.test_helpers import (
 )
 
 
-@patch('stream_alert.shared.metrics.Metrics.put_metric_data', Mock())
+@patch('stream_alert.rule_processor.handler.Metrics.send_metrics', Mock())
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
 
@@ -48,7 +48,7 @@ class TestStreamAlert(object):
     @patch('stream_alert.rule_processor.handler.load_config',
            lambda: load_config('test/unit/conf/'))
     def setup(self):
-        """Setup the class before any methods"""
+        """Setup before each method"""
         self.__sa_handler = StreamAlert(_get_mock_context(), False)
 
     def test_run_no_records(self):
@@ -185,9 +185,10 @@ class TestStreamAlert(object):
         sink_mock.assert_called_with(['success!!'])
 
     @patch('logging.Logger.debug')
+    @patch('stream_alert.shared.metrics.Metrics.send_metrics')
     @patch('stream_alert.rule_processor.handler.StreamRules.process')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
-    def test_run_debug_log_alert(self, extract_mock, rules_mock, log_mock):
+    def test_run_debug_log_alert(self, extract_mock, rules_mock, _, log_mock):
         """StreamAlert Class - Run, Debug Log Alert"""
         extract_mock.return_value = ('kinesis', 'unit_test_default_stream')
         rules_mock.return_value = ['success!!']

--- a/test/unit/stream_alert_rule_processor/test_helpers.py
+++ b/test/unit/stream_alert_rule_processor/test_helpers.py
@@ -88,7 +88,7 @@ def _get_valid_event(count=1):
 def _load_and_classify_payload(config, service, entity, raw_record):
 
     # prepare the payloads
-    payload = load_stream_payload(service, entity, raw_record)
+    payload = load_stream_payload(service, entity, raw_record, None)
 
     payload = payload.pre_parse().next()
     classifier = StreamClassifier(config=config)

--- a/test/unit/stream_alert_rule_processor/test_metrics.py
+++ b/test/unit/stream_alert_rule_processor/test_metrics.py
@@ -1,0 +1,83 @@
+'''
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+from mock import patch
+
+from botocore.exceptions import ClientError
+
+from stream_alert.rule_processor.metrics import Metrics
+
+from unit.stream_alert_rule_processor import REGION
+
+
+class TestMetrics(object):
+    """Test class for Metrics class"""
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__metrics = Metrics(REGION)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.__metrics = None
+
+    @patch('logging.Logger.error')
+    def test_invalid_metric_name(self, log_mock):
+        """Metrics - Invalid Name"""
+        self.__metrics.put_metric_data('bad metric name', 100, 'Seconds')
+
+        log_mock.assert_called_with('Metric name not defined: %s', 'bad metric name')
+
+    @patch('logging.Logger.error')
+    def test_invalid_metric_unit(self, log_mock):
+        """Metrics - Invalid Unit Type"""
+        self.__metrics.put_metric_data('RuleProcessorFailedParses', 100, 'Total')
+
+        log_mock.assert_called_with('Metric unit not defined: %s', 'Total')
+
+    @patch('stream_alert.rule_processor.metrics.Metrics._put_metric')
+    def test_valid_metric(self, metric_mock):
+        """Metrics - Valid Metric"""
+        self.__metrics.put_metric_data('RuleProcessorFailedParses', 100, 'Count')
+
+        metric_mock.assert_called()
+
+    @staticmethod
+    @patch('stream_alert.rule_processor.metrics.boto3')
+    def test_boto_call(boto_mock):
+        """Metrics - Boto Call Params"""
+
+        Metrics(REGION)._put_metric([{'test': 'info'}])
+        boto_mock.client.return_value.put_metric_data.assert_called_with(
+            Namespace='StreamAlert', MetricData=[{'test': 'info'}])
+
+    @staticmethod
+    @patch('stream_alert.rule_processor.metrics.boto3')
+    @patch('logging.Logger.exception')
+    def test_boto_failed(log_mock, boto_mock):
+        """Metrics - Boto Call Failed"""
+        err_response = {'Error': {'Code': 100}}
+
+        # Add ClientError side_effect to mock
+        boto_mock.client.return_value.put_metric_data.side_effect = ClientError(
+            err_response, 'operation')
+
+        Metrics(REGION)._put_metric([{'test': 'info'}])
+
+        log_mock.assert_called_with(
+            'Failed to send metric to CloudWatch. Error: %s\nMetric data:\n%s',
+            err_response,
+            '[\n  {\n    "test": "info"\n  }\n]')

--- a/test/unit/stream_alert_rule_processor/test_payload.py
+++ b/test/unit/stream_alert_rule_processor/test_payload.py
@@ -19,7 +19,7 @@ import logging
 import os
 import tempfile
 
-from mock import call, patch
+from mock import call, Mock, patch
 
 from nose.tools import (
     assert_equal,
@@ -52,7 +52,7 @@ def teardown_s3():
 def test_load_payload_valid():
     """StreamPayload - Loading Stream Payload, Valid"""
 
-    payload = load_stream_payload('s3', 'entity', 'record')
+    payload = load_stream_payload('s3', 'entity', 'record', None)
 
     assert_is_instance(payload, S3Payload)
 
@@ -60,14 +60,14 @@ def test_load_payload_valid():
 @patch('logging.Logger.error')
 def test_load_payload_invalid(log_mock):
     """StreamPayload - Loading Stream Payload, Invalid"""
-    load_stream_payload('blah', 'entity', 'record')
+    load_stream_payload('blah', 'entity', 'record', None)
 
     log_mock.assert_called_with('Service payload not supported: %s', 'blah')
 
 
 def test_repr_string():
     """StreamPayload - String Representation"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record')
+    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
 
     # Set some values that are different than the defaults
     s3_payload.type = 'unit_type'
@@ -83,28 +83,28 @@ def test_repr_string():
 
 def test_get_service_kinesis():
     """StreamPayload - Get Service, Kinesis"""
-    kinesis_payload = load_stream_payload('kinesis', 'entity', 'record')
+    kinesis_payload = load_stream_payload('kinesis', 'entity', 'record', None)
 
     assert_equal(kinesis_payload.service(), 'kinesis')
 
 
 def test_get_service_s3():
     """StreamPayload - Get Service, S3"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record')
+    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
 
     assert_equal(s3_payload.service(), 's3')
 
 
 def test_get_service_sns():
     """StreamPayload - Get Service, SNS"""
-    sns_payload = load_stream_payload('sns', 'entity', 'record')
+    sns_payload = load_stream_payload('sns', 'entity', 'record', None)
 
     assert_equal(sns_payload.service(), 'sns')
 
 
 def test_refresh_record():
     """StreamPayload - Refresh Record"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record')
+    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
 
     # Set some values that are different than the defaults
     s3_payload.type = 'unit_type'
@@ -127,7 +127,7 @@ def test_pre_parse_kinesis(log_mock):
     kinesis_data = json.dumps({'test': 'value'})
     entity = 'unit_test_entity'
     raw_record = _make_kinesis_raw_record(entity, kinesis_data)
-    kinesis_payload = load_stream_payload('kinesis', entity, raw_record)
+    kinesis_payload = load_stream_payload('kinesis', entity, raw_record, Mock())
 
     kinesis_payload = kinesis_payload.pre_parse().next()
 
@@ -145,7 +145,7 @@ def test_pre_parse_sns(log_mock):
     """SNSPayload - Pre Parse"""
     sns_data = json.dumps({'test': 'value'})
     raw_record = _make_sns_raw_record('unit_topic', sns_data)
-    sns_payload = load_stream_payload('sns', 'entity', raw_record)
+    sns_payload = load_stream_payload('sns', 'entity', raw_record, Mock())
 
     sns_payload = sns_payload.pre_parse().next()
 
@@ -159,13 +159,13 @@ def test_pre_parse_sns(log_mock):
 
 @patch('stream_alert.rule_processor.payload.S3Payload._get_object')
 @patch('stream_alert.rule_processor.payload.S3Payload._read_downloaded_s3_object')
-def test_pre_parse_s3(s3_mock, _):
+def test_pre_parse_s3(s3_mock, *_):
     """S3Payload - Pre Parse"""
     records = ['{"record01": "value01"}', '{"record02": "value02"}']
     s3_mock.side_effect = [((0, records[0]), (1, records[1]))]
 
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
 
     for index, record in enumerate(s3_payload.pre_parse()):
         assert_equal(record.pre_parsed_record, records[index])
@@ -189,7 +189,7 @@ def test_pre_parse_s3_debug(s3_mock, log_mock, _):
     s3_mock.side_effect = [((100, records[0]), (200, records[1]))]
 
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
     S3Payload.s3_object_size = 350
 
     _ = [_ for _ in s3_payload.pre_parse()]
@@ -213,7 +213,7 @@ def test_pre_parse_s3_debug(s3_mock, log_mock, _):
 def test_s3_object_too_large():
     """S3Payload - S3ObjectSizeError, Object too Large"""
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, None)
     S3Payload.s3_object_size = (128 * 1024 * 1024) + 10
 
     s3_payload._download_object('region', 'bucket', 'key')
@@ -224,7 +224,7 @@ def test_s3_object_too_large():
 def test_get_object(log_mock, _):
     """S3Payload - Get S3 Info from Raw Record"""
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, None)
 
     s3_payload._get_object()
     log_mock.assert_called_with(
@@ -233,14 +233,13 @@ def test_get_object(log_mock, _):
     )
 
 
-
 @patch('stream_alert.rule_processor.payload.boto3.client')
 @patch('stream_alert.rule_processor.payload.S3Payload._read_downloaded_s3_object')
 @patch('logging.Logger.info')
 def test_s3_download_object(log_mock, *_):
     """S3Payload - Download Object"""
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
     s3_payload._download_object('us-east-1', 'unit_bucket_name', 'unit_key_name')
 
     assert_equal(log_mock.call_args_list[1][0][0], 'Completed download in %s seconds')
@@ -253,7 +252,7 @@ def test_s3_download_object(log_mock, *_):
 def test_s3_download_object_mb(log_mock, *_):
     """S3Payload - Download Object, Size in MB"""
     raw_record = _make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
     S3Payload.s3_object_size = (127.8 * 1024 * 1024)
     s3_payload._download_object('us-east-1', 'unit_bucket_name', 'unit_key_name')
 

--- a/test/unit/stream_alert_shared/test_metrics.py
+++ b/test/unit/stream_alert_shared/test_metrics.py
@@ -17,7 +17,7 @@ from mock import patch
 
 from botocore.exceptions import ClientError
 
-from stream_alert.rule_processor.metrics import Metrics
+from stream_alert.shared.metrics import Metrics
 
 from unit.stream_alert_rule_processor import REGION
 
@@ -48,7 +48,7 @@ class TestMetrics(object):
 
         log_mock.assert_called_with('Metric unit not defined: %s', 'Total')
 
-    @patch('stream_alert.rule_processor.metrics.Metrics._put_metric')
+    @patch('stream_alert.shared.metrics.Metrics._put_metric')
     def test_valid_metric(self, metric_mock):
         """Metrics - Valid Metric"""
         self.__metrics.put_metric_data('RuleProcessorFailedParses', 100, 'Count')
@@ -56,7 +56,7 @@ class TestMetrics(object):
         metric_mock.assert_called()
 
     @staticmethod
-    @patch('stream_alert.rule_processor.metrics.boto3')
+    @patch('stream_alert.shared.metrics.boto3')
     def test_boto_call(boto_mock):
         """Metrics - Boto Call Params"""
 
@@ -65,7 +65,7 @@ class TestMetrics(object):
             Namespace='StreamAlert', MetricData=[{'test': 'info'}])
 
     @staticmethod
-    @patch('stream_alert.rule_processor.metrics.boto3')
+    @patch('stream_alert.shared.metrics.boto3')
     @patch('logging.Logger.exception')
     def test_boto_failed(log_mock, boto_mock):
         """Metrics - Boto Call Failed"""


### PR DESCRIPTION
to @austinbyers , @jacknagz 
cc @airbnb/streamalert-maintainers 

## Changes
* Adding a metrics class to support publishing metrics to cloudwatch
* Including a few metrics for now, which will be added to later. Those include:
  * Total records being processed
  * Number of logs that failed to parse
  * Number of alerts triggered
  * S3 file download time (for latency visibility)
  * Total number of records from S3 files
* Updating tests to cover metrics.