### PR TITLE
[lambda][rule] removing dependency on gzip json parser

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -678,7 +678,7 @@
       "account": "integer",
       "flowlogstatus": "string"
     },
-    "parser": "gzip-json",
+    "parser": "json",
     "configuration": {
       "json_path": "logEvents[*].extractedFields",
       "envelope_keys": {

--- a/docs/source/conf-schemas-examples.rst
+++ b/docs/source/conf-schemas-examples.rst
@@ -234,8 +234,6 @@ CloudWatch VPC Flow Logs
 
 AWS VPC Flow Logs can be delivered to StreamAlert via CloudWatch.
 
-As they are compressed with deflate, we can use the special ``gzip-json`` for parsing and analysis.
-
 CloudWatch logs are delivered as a nested record, so we will need to pass ``configuration`` options to the parser to find the nested records:
 
 .. code-block:: json
@@ -258,7 +256,7 @@ CloudWatch logs are delivered as a nested record, so we will need to pass ``conf
         "account": "integer",
         "flowlogstatus": "string"
       },
-      "parser": "gzip-json",
+      "parser": "json",
       "configuration": {
         "json_path": "logEvents[*].extractedFields",
         "envelope_keys": {

--- a/docs/source/conf-schemas.rst
+++ b/docs/source/conf-schemas.rst
@@ -52,7 +52,7 @@ Options
 =================  =========  ======================
 Key                Required   Description
 -----------------  ---------  ----------------------
-``parser``         ``true``   The name of the parser to use for a given log's data-type.   Options include ``json, json-gzip, csv, kv, or syslog``
+``parser``         ``true``   The name of the parser to use for a given log's data-type.   Options include ``json, csv, kv, or syslog``
 ``schema``         ``true``   A map of key/value pairs of the name of each field with its type
 ``configuration``  ``false``  Configuration options specific to this log type (see table below for more information)
 =================  =========  ======================
@@ -448,11 +448,6 @@ The resultant parsed records:
       }
     }
   ]
-
-Gzip JSON
-~~~~~~~~~
-
-If incoming records are gzip compressed, use the same options as above but with the ``json-gzip`` parser.
 
 CSV Parsing
 -----------

--- a/docs/source/rule-testing.rst
+++ b/docs/source/rule-testing.rst
@@ -34,7 +34,7 @@ Key                Type                  Required  Description
 ``trigger_count``  ``integer``           No        The amount of alerts that should be generated.  Used for nested data
 ``source``         ``string``            Yes       The name of the Kinesis Stream or S3 bucket where the data originated from.  This value should match a source provided in ``conf/sources.json``
 ``service``        ``string``            Yes       The name of the AWS service which sent the log (Kinesis or S3)
-``compress``       ``boolean``           No        Whether or not to compress records with ``gzip`` prior to testing (used for ``gzip-json`` logs)
+``compress``       ``boolean``           No        Whether or not to compress records with ``gzip`` prior to testing
 =================  ====================  ========  ===========
 
 For more examples, see the provided default rule tests in ``test/integration/rules``

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -17,7 +17,6 @@ import csv
 import json
 import re
 import StringIO
-import zlib
 
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
@@ -254,29 +253,6 @@ class JSONParser(ParserBase):
 
         return json_records
 
-@parser
-class GzipJSONParser(JSONParser):
-    __parserid__ = 'gzip-json'
-
-    def parse(self, schema, data):
-        """Parse a gzipped string into JSON.
-
-        Args:
-            data [str]: Data to be parsed.
-
-        Returns:
-            [list] A list of dictionaries representing parsed records.
-            [boolean] False if the data is not Gzipped JSON or the columns do not match.
-        """
-        try:
-            data = zlib.decompress(data, 47)
-            return super(GzipJSONParser, self).parse(schema, data)
-        except zlib.error:
-            return False
-
-    def type(self):
-        """Return the parserid for the super of this (json, not gzip-json)"""
-        return super(GzipJSONParser, self).__parserid__
 
 @parser
 class CSVParser(ParserBase):

--- a/test/unit/conf/logs.json
+++ b/test/unit/conf/logs.json
@@ -243,7 +243,7 @@
       "account": "integer",
       "flowlogstatus": "string"
     },
-    "parser": "gzip-json",
+    "parser": "json",
     "configuration": {
       "json_path": "logEvents[*].extractedFields",
       "envelope_keys": {


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 
size: small

## Changes
* Removing the `GzipJSONParser` class that was used for decompressing gzipped json data coming from CloudWatch flow logs via Kinesis.
* The decompression of this data will now immediately be attempted during the ingestion of Kinesis data, in: https://github.com/airbnb/streamalert/compare/ryandeivert-gzip-logging-fix?expand=1#diff-3938c84c6d412626570fb7d59e7a86daR317

## Other
* Updating all unit tests to conform to this new workflow.
* Doc updates to reflect changes.