### PR TITLE
CLI Bug Fixes and Terraform CloudTrail/CloudWatch Enhancements

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -520,11 +520,15 @@ def deploy(options):
     if 'all' in processor:
         targets.extend(['module.stream_alert_{}'.format(x)
                         for x in CONFIG.clusters()])
-        targets.append('module.stream_alert_athena')
 
         packages.append(_deploy_rule_processor())
         packages.append(_deploy_alert_processor())
-        packages.append(_deploy_athena_partition_refresh())
+
+        # Only include the Athena function if it exists and is enabled
+        athena_config = CONFIG['lambda'].get('athena_partition_refresh_config')
+        if athena_config and athena_config.get('enabled', False):
+            targets.append('module.stream_alert_athena')
+            packages.append(_deploy_athena_partition_refresh())
 
     # Regenerate the Terraform configuration with the new S3 keys
     if not terraform_generate(config=CONFIG):

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -510,21 +510,24 @@ def generate_s3_events(cluster_name, cluster_dict, config):
     modules = config['clusters'][cluster_name]['modules']
     s3_bucket_id = modules['s3_events'].get('s3_bucket_id')
 
-    if s3_bucket_id:
-        cluster_dict['module']['s3_events_{}'.format(cluster_name)] = {
-            'source': 'modules/tf_stream_alert_s3_events',
-            'lambda_function_arn': '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),
-            'lambda_function_name': '{}_{}_stream_alert_processor'.format(
-                config['global']['account']['prefix'],
-                cluster_name),
-            's3_bucket_id': s3_bucket_id,
-            's3_bucket_arn': 'arn:aws:s3:::{}'.format(s3_bucket_id)}
-        return True
-    else:
+    if not s3_bucket_id:
         LOGGER_CLI.error(
             'Config Error: Missing S3 bucket in %s s3_events module',
             cluster_name)
         return False
+
+    cluster_dict['module']['s3_events_{}'.format(cluster_name)] = {
+        'source': 'modules/tf_stream_alert_s3_events',
+        'lambda_function_arn': '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),
+        'lambda_function_name': '{}_{}_stream_alert_processor'.format(
+            config['global']['account']['prefix'],
+            cluster_name),
+        's3_bucket_id': s3_bucket_id,
+        's3_bucket_arn': 'arn:aws:s3:::{}'.format(s3_bucket_id),
+        'lambda_role_id': '${{module.stream_alert_{}.lambda_role_id}}'.format(cluster_name),
+        'lambda_role_arn': '${{module.stream_alert_{}.lambda_role_arn}}'.format(cluster_name)}
+
+    return True
 
 
 def generate_cluster(**kwargs):

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -132,3 +132,15 @@ resource "aws_lambda_permission" "rule_processor" {
   qualifier     = "production"
   depends_on    = ["aws_lambda_alias.alert_processor_production"]
 }
+
+// Log Retention Policy: Rule Processor
+resource "aws_cloudwatch_log_group" "rule_processor" {
+  name              = "/aws/lambda/${var.prefix}_${var.cluster}_streamalert_rule_processor"
+  retention_in_days = 60
+}
+
+// Log Retention Policy: Alert Processor
+resource "aws_cloudwatch_log_group" "alert_processor" {
+  name              = "/aws/lambda/${var.prefix}_${var.cluster}_streamalert_alert_processor"
+  retention_in_days = 60
+}

--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -3,6 +3,7 @@ resource "aws_cloudtrail" "streamalert" {
   name                          = "${var.prefix}.${var.cluster}.streamalert.cloudtrail"
   s3_bucket_name                = "${aws_s3_bucket.cloudtrail_bucket.id}"
   s3_key_prefix                 = "cloudtrail"
+  enable_log_file_validation    = true
   enable_logging                = "${var.enable_logging}"
   include_global_service_events = true
   is_multi_region_trail         = "${var.is_global_trail}"

--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_iterator_age" {
   metric_name         = "GetRecords.IteratorAgeMilliseconds"
   statistic           = "Maximum"
   comparison_operator = "GreaterThanThreshold"
-  threshold           = "43000000"                                                     // 12 hours
+  threshold           = "1000000"
   evaluation_periods  = "1"
   period              = "300"
   alarm_description   = "StreamAlert Kinesis High Iterator Age: ${var.kinesis_stream}"
@@ -87,7 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_write_exceeded" {
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
   threshold           = "0"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   period              = "300"
   alarm_description   = "StreamAlert Kinesis Write Throughput Exceeded: ${var.kinesis_stream}"
   alarm_actions       = ["${var.sns_topic_arn}"]


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small
resolves #251, resoles #230 

## Changes
* Fix CLI bug related to deploying all Lambda functions when the Athena function is not enabled
* Fix a bug in generating the s3_event Terraform module where input variables were left out
* Adds a retention policy for CloudWatch logs
* Adds CloudTrail log integrity
* Adjusts CloudWatch alarms to reduce FPs and more proactively alert on processing issues

# IMPORTANT NOTE!!
If you are pulling this change in with existing clusters, you have to import the newly added CloudWatch log resource into your statefile.  You must do this for every cluster if you want to retain your old logfiles:

```
$ cd terraform
$ terraform import module.stream_alert_prod.aws_cloudwatch_log_group.alert_processor /aws/lambda/<prefix>_<cluster>_streamalert_alert_processor
$ terraform import module.stream_alert_prod.aws_cloudwatch_log_group.rule_processor /aws/lambda/<prefix>_<cluster>_streamalert_rule_processor
```