### PR TITLE
Fix 'stream_alert_cli.py configure prefix'

### DIFF
--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -159,7 +159,7 @@ def configure_handler(options):
         options [named_tuple]: ArgParse command result
     """
     if options.config_key == 'prefix':
-        if isinstance(options.config_key, (unicode, str)):
+        if not isinstance(options.config_value, (unicode, str)):
             LOGGER_CLI.error('Invalid prefix type, must be string')
             return
         CONFIG.set_prefix(options.config_value)


### PR DESCRIPTION
Fixes `stream_alert_cli.py configure prefix` to error only if the argument is *not* a string (and to check the config value)

Resolves: #256 

to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

## Tested
### Before
```
$ python stream_alert_cli.py configure prefix hello_world
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues
StreamAlertCLI [ERROR]: Invalid prefix type, must be string
StreamAlertCLI [INFO]: Completed
```
and `conf/global.json` is not modified.

### After
```
$ python stream_alert_cli.py configure prefix hello_world
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues
StreamAlertCLI [INFO]: Completed
```
and `conf/global.json` is updated with the new prefix