### PR TITLE
[tests] fixing bug in tests that could cause conflicts with user matchers or rules

### DIFF
--- a/test/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/test/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -54,6 +54,12 @@ class TestStreamRules(object):
         cls.env = None
         cls.config = None
 
+    def setup(self):
+        """Setup before each method"""
+        # Clear out the cached matchers and rules to avoid conflicts with production code
+        StreamRules._StreamRules__matchers.clear()
+        StreamRules._StreamRules__rules.clear()
+
     def test_alert_format(self):
         """Rule Engine - Alert Format"""
         @rule(logs=['test_log_type_json_nested_with_data'],


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 
size: small

## Changes
* This fix clears out the private class properties of `__rules` and `__matchers` on `StreamRules` to allow tests to run in a proper state.

## Why
* If a user declared a matcher of `prod`, unit tests would break saying this matcher is already defined. The same would occur for userland rules defined with the same name as a unit test rule.
