### PR TITLE
[shared][stats] adding timing decorator to log stats on methods

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -18,7 +18,7 @@ from collections import namedtuple, OrderedDict
 
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.parsers import get_parser
-from stream_alert.shared.stats import timeme
+from stream_alert.shared.stats import time_me
 
 # Set the below to True when we want to support matching on multiple schemas
 # and then log_patterns will be used as a fall back for key/value matching
@@ -125,7 +125,7 @@ class StreamClassifier(object):
         return OrderedDict((source, logs[source]) for source in logs.keys()
                            if source.split(':')[0] in self._entity_log_sources)
 
-    @timeme
+    @time_me
     def classify_record(self, payload):
         """Classify and type raw record passed into StreamAlert.
 
@@ -192,7 +192,7 @@ class StreamClassifier(object):
 
         return schema_matches[0]
 
-    @timeme
+    @time_me
     def _process_log_schemas(self, payload):
         """Get any log schemas that matched this log format
 

--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -18,6 +18,7 @@ from collections import namedtuple, OrderedDict
 
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.parsers import get_parser
+from stream_alert.shared.stats import timeme
 
 # Set the below to True when we want to support matching on multiple schemas
 # and then log_patterns will be used as a fall back for key/value matching
@@ -124,6 +125,7 @@ class StreamClassifier(object):
         return OrderedDict((source, logs[source]) for source in logs.keys()
                            if source.split(':')[0] in self._entity_log_sources)
 
+    @timeme
     def classify_record(self, payload):
         """Classify and type raw record passed into StreamAlert.
 
@@ -190,6 +192,7 @@ class StreamClassifier(object):
 
         return schema_matches[0]
 
+    @timeme
     def _process_log_schemas(self, payload):
         """Get any log schemas that matched this log format
 

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -25,6 +25,7 @@ from fnmatch import fnmatch
 import jsonpath_rw
 
 from stream_alert.rule_processor import LOGGER
+from stream_alert.shared.stats import timeme
 
 PARSERS = {}
 
@@ -240,6 +241,7 @@ class JSONParser(ParserBase):
 
         return json_records
 
+    @timeme
     def parse(self, schema, data):
         """Parse a string into a list of JSON payloads.
 

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -25,7 +25,7 @@ from fnmatch import fnmatch
 import jsonpath_rw
 
 from stream_alert.rule_processor import LOGGER
-from stream_alert.shared.stats import timeme
+from stream_alert.shared.stats import time_me
 
 PARSERS = {}
 
@@ -192,6 +192,7 @@ class JSONParser(ParserBase):
                     # Set default value
                     record[key_name] = _default_optional_values(schema[key_name])
 
+    @time_me
     def _parse_records(self, schema, json_payload):
         """Identify and extract nested payloads from parsed JSON records.
 
@@ -241,7 +242,7 @@ class JSONParser(ParserBase):
 
         return json_records
 
-    @timeme
+    @time_me
     def parse(self, schema, data):
         """Parse a string into a list of JSON payloads.
 

--- a/stream_alert/shared/stats.py
+++ b/stream_alert/shared/stats.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import time
+
+from stream_alert.shared import LOGGER
+
+
+def timeme(func):
+    """Timing decorator for wrapping a function"""
+
+    def timed(*args, **kw):
+        """Wrapping function"""
+        time_start = time.time()
+        result = func(*args, **kw)
+        time_end = time.time()
+
+        message = '(module) {} (method) {} (time): {:>.4f}ms'.format(
+            func.__module__, func.__name__, (time_end - time_start) * 1000
+        )
+
+        LOGGER.debug(message)
+
+        return result
+
+    return timed

--- a/stream_alert/shared/stats.py
+++ b/stream_alert/shared/stats.py
@@ -18,7 +18,7 @@ import time
 from stream_alert.shared import LOGGER
 
 
-def timeme(func):
+def time_me(func):
     """Timing decorator for wrapping a function"""
 
     def timed(*args, **kw):

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -22,6 +22,9 @@ LOGGER_SA.setLevel(logging.INFO)
 LOGGER_SO = logging.getLogger('StreamAlertOutput')
 LOGGER_SO.setLevel(logging.INFO)
 
+LOGGER_SH = logging.getLogger('StreamAlertShared')
+LOGGER_SH.setLevel(logging.INFO)
+
 logging.basicConfig(format='%(name)s [%(levelname)s]: %(message)s')
 LOGGER_CLI = logging.getLogger('StreamAlertCLI')
 LOGGER_CLI.setLevel(logging.INFO)

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -33,7 +33,7 @@ from stream_alert.rule_processor.config import load_config
 from stream_alert.rule_processor.handler import StreamAlert
 from stream_alert.rule_processor.rules_engine import StreamRules
 from stream_alert_cli import helpers
-from stream_alert_cli.logger import LOGGER_CLI, LOGGER_SA, LOGGER_SO
+from stream_alert_cli.logger import LOGGER_CLI, LOGGER_SA, LOGGER_SH, LOGGER_SO
 from stream_alert_cli.outputs import load_outputs_config
 
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -606,7 +606,7 @@ def stream_alert_test(options, config=None):
             #   call .shutdown() on the existing logger
             #   debug_formatter = logging.Formatter('%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s')
             #   set the new logger to the formatter above
-            for streamalert_logger in (LOGGER_SA, LOGGER_SO, LOGGER_CLI):
+            for streamalert_logger in (LOGGER_SA, LOGGER_SH, LOGGER_SO, LOGGER_CLI):
                 streamalert_logger.setLevel(logging.DEBUG)
         else:
             # Add a filter to suppress a few noisy log messages


### PR DESCRIPTION
to @austinbyers, @jacknagz 
cc @airbnb/streamalert-maintainers 

## Changes
* Adding new `stats` module within shared to hold a timing decorator (and potentially more internal statistic related stuff in the future).
* classifier.classify_record, classifier._process_log_schemas now provide timing info
* JSON parser's parse_records now provides timing info
* This is enabled in debug mode only

## Example output
`StreamAlertShared [DEBUG]: (module) stream_alert.rule_processor.classifier (method) _process_log_schemas (time): 0.7188ms`

## Caveat
* The decorator has no way to determine the **class** a function being timed is tied to. I even investigated hacky ways to try to determine this using the `inspect` package but came up short. I'm open to suggestions, but logging the module may be enough for our purposes for now.