### PR TITLE
[core] conditionally log debug messages

### DIFF
--- a/stream_alert/rule_processor/__init__.py
+++ b/stream_alert/rule_processor/__init__.py
@@ -16,3 +16,5 @@ try:
 except (TypeError, ValueError) as err:
     LOGGER.setLevel('INFO')
     LOGGER.error('Defaulting to INFO logging: %s', err)
+
+LOGGER_DEBUG_ENABLED = LOGGER.isEnabledFor(logging.DEBUG)

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -24,7 +24,7 @@ from fnmatch import fnmatch
 
 import jsonpath_rw
 
-from stream_alert.rule_processor import LOGGER
+from stream_alert.rule_processor import LOGGER_DEBUG_ENABLED, LOGGER
 from stream_alert.shared.stats import time_me
 
 PARSERS = {}
@@ -146,9 +146,10 @@ class JSONParser(ParserBase):
                         schema_match = self._key_check(schema[key], [json_records[index][key]])
 
             if not schema_match:
-                LOGGER.debug('Schema: \n%s', json.dumps(schema, indent=2))
-                LOGGER.debug('Key check failure: \n%s', json.dumps(json_records[index], indent=2))
-                LOGGER.debug('Missing keys in record: %s', json.dumps(list(json_keys - schema_keys)))
+                if LOGGER_DEBUG_ENABLED:
+                    LOGGER.debug('Schema: \n%s', json.dumps(schema, indent=2))
+                    LOGGER.debug('Key check failure: \n%s', json.dumps(json_records[index], indent=2))
+                    LOGGER.debug('Missing keys in record: %s', json.dumps(list(json_keys - schema_keys)))
                 del json_records[index]
 
         return bool(json_records)
@@ -360,7 +361,6 @@ class KVParser(ParserBase):
             fields = filter(None, data.split(delimiter))
             # first check the field length matches our # of keys
             if len(fields) != len(schema):
-                LOGGER.debug('KV field length mismatch: %s vs %s', fields, schema)
                 return False
 
             regex = re.compile('.+{}.+'.format(separator))


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

Only run `json.dumps` and `LOGGER` messages when DEBUG is actually enabled.  This saves a lot of unnecessary processing in `info` mode.

Add a try catch when casting to a string for non ascii strings.  This was observed locally while testing.