### PR TITLE
[multiproc] EXPERIMENTAL: rule processor multiprocessing proof of concept

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -129,7 +129,7 @@ class StreamAlert(object):
             self._failed_record_count,
             Metrics.Unit.COUNT)
 
-        LOGGER.debug('%s alerts triggered', len(self._alerts))
+        LOGGER.info('%s alerts triggered', len(self._alerts))
 
         self.metrics.add_metric(
             Metrics.Name.TRIGGERED_ALERTS, len(
@@ -210,7 +210,7 @@ class StreamAlert(object):
             record_alerts = StreamRules.process(record)
 
             LOGGER.debug('Processed %d valid record(s) that resulted in %d alert(s).',
-                         len(payload.records),
+                         len(record.records),
                          len(record_alerts))
 
             if not record_alerts:

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -60,7 +60,7 @@ class StreamAlert(object):
 
         self.metrics = Metrics('RuleProcessor', self.env['lambda_region'])
         self.enable_alert_processor = enable_alert_processor
-        self._unmatched_record_count = multiproc.Value('i', 0)
+        self._unmatched_record_count = PROC_MANAGER.Value('i', 0)
         self._alerts = PROC_MANAGER.list()
 
     def run(self, event):
@@ -178,7 +178,7 @@ class StreamAlert(object):
                          for index in range(0, len(payload_records), interval)]
 
         # Create a lock that can be used within spawned processes
-        mutex = multiproc.Lock()
+        mutex = PROC_MANAGER.Lock()
 
         for worker_index, record_group in enumerate(record_groups, start=1):
             offset = (worker_index - 1) * interval
@@ -210,7 +210,7 @@ class StreamAlert(object):
                     LOGGER.error('Record does not match any defined schemas: %s\n%s',
                                  record, record.pre_parsed_record)
 
-                with self._unmatched_record_count.get_lock():
+                with mutex:
                     self._unmatched_record_count.value += 1
                 continue
 

--- a/stream_alert/rule_processor/payload.py
+++ b/stream_alert/rule_processor/payload.py
@@ -21,6 +21,7 @@ import time
 import zlib
 
 from abc import ABCMeta, abstractmethod, abstractproperty
+from copy import copy
 from logging import DEBUG as log_level_debug
 from urllib import unquote
 
@@ -153,7 +154,9 @@ class S3Payload(StreamPayload):
         for line_num, data in self._read_downloaded_s3_object(s3_file):
 
             self._refresh_record(data)
-            yield self
+
+            # Yield a copy of this payload so multiprocessing can be performed
+            yield copy(self)
 
             # Only do the extra calculations below if debug logging is enabled
             if not LOGGER.isEnabledFor(log_level_debug):

--- a/test/unit/stream_alert_rule_processor/test_handler.py
+++ b/test/unit/stream_alert_rule_processor/test_handler.py
@@ -215,10 +215,10 @@ class TestStreamAlert(object):
     @patch('stream_alert.rule_processor.handler.multiproc.Process')
     @patch('stream_alert.rule_processor.payload.StreamPayload')
     @patch('stream_alert.rule_processor.handler.multiproc.cpu_count')
-    @patch('stream_alert.rule_processor.handler.multiproc.Lock')
+    @patch('stream_alert.rule_processor.handler.PROC_MANAGER')
     def test_record_grouping(
             self,
-            mp_lock_mock,
+            mp_manager_mock,
             mp_cpu_mock,
             payload_mock,
             process_mock,
@@ -227,7 +227,7 @@ class TestStreamAlert(object):
         # Set the cpu_count return value to a predetermined value
         mp_cpu_mock.return_value = 2
         # Disable the actual creation of a mutex
-        mp_lock_mock.return_value = None
+        mp_manager_mock.Lock.return_value = None
         # Create a list of predetermined values to compare against
         payload_mock.pre_parse.return_value = range(22)
         # Force copy to return the actual object instead of a copy

--- a/test/unit/stream_alert_rule_processor/test_handler.py
+++ b/test/unit/stream_alert_rule_processor/test_handler.py
@@ -153,7 +153,7 @@ class TestStreamAlert(object):
 
         log_mock.assert_has_calls(calls)
 
-    @patch('stream_alert.rule_processor.handler.multiproc.Process', MultiprocProcessMock)
+    @patch('stream_alert.rule_processor.handler.Process', MultiprocProcessMock)
     @patch('logging.Logger.error')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
     def test_run_invalid_data(self, extract_mock, log_mock):
@@ -171,7 +171,7 @@ class TestStreamAlert(object):
         assert_equal(log_mock.call_args[0][0], 'Record does not match any defined schemas: %s\n%s')
         assert_equal(log_mock.call_args[0][2], '{"bad": "data"}')
 
-    @patch('stream_alert.rule_processor.handler.multiproc.Process', MultiprocProcessMock)
+    @patch('stream_alert.rule_processor.handler.Process', MultiprocProcessMock)
     @patch('stream_alert.rule_processor.sink.StreamSink.sink')
     @patch('stream_alert.rule_processor.handler.StreamRules.process')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')

--- a/test/unit/stream_alert_rule_processor/test_helpers.py
+++ b/test/unit/stream_alert_rule_processor/test_helpers.py
@@ -36,7 +36,7 @@ class MultiprocProcessMock(object):
 
     def start(self):
         """Mock 'start' method"""
-        self.target(self.args[0], self.args[1])
+        self.target(*self.args)
 
     def join(self):
         """Mock 'join' method"""

--- a/test/unit/stream_alert_rule_processor/test_helpers.py
+++ b/test/unit/stream_alert_rule_processor/test_helpers.py
@@ -27,6 +27,22 @@ from unit.stream_alert_rule_processor import (
 )
 
 
+class MultiprocProcessMock(object):
+    """Mock class to house multiprocessing.Process mock methods"""
+
+    def __init__(self, **kwargs):
+        self.target = kwargs.get('target')
+        self.args = kwargs.get('args')
+
+    def start(self):
+        """Mock 'start' method"""
+        self.target(self.args[0], self.args[1])
+
+    def join(self):
+        """Mock 'join' method"""
+        pass
+
+
 def _get_mock_context():
     """Create a fake context object using Mock"""
     arn = 'arn:aws:lambda:{}:123456789012:function:{}:development'


### PR DESCRIPTION
cc @airbnb/streamalert-maintainers

## Changes
* Creating a pool of workers to process records on parallel. This is mostly advantageous for compound files where there is more than one record (such as S3 files).
* The current amount of processes that will be spawned is set to 6 but can be changed.
* Each worker will get an equal portion of the total logs to process (or as close to it as possible)
* This enhacement helps most with compound files that contain many
  records (like those from s3 for instance)
* Each worker appends alerts to the shared alerts list that can be returned to the caller
* This has been tested locally with reading a file of 19993 lines/records.

## Lambda Experimentation
* In a test AWS account, I create a function that has a very simple purpose (putting objects into an S3 bucket) and used it to experiment with various worker/task operations.
* Below are the high level results of those tests with a function configured with 512 MB of memory an a timeout of 5 min.

#### Total of 100 operations (5 tests):
- 1 worker doing 100 operations:
  - Test run 1 in 1.84 sec
  - Test run 2 in 1.62 sec
  - Test run 3 in 1.86 sec
  - Test run 4 in 1.76 sec
  - Test run 5 in 1.76 sec
  - Average time: 1.77 
  - Lambda function ran in 8.85 sec (total execution)

- 10 workers doing 10 operations each: 
  - Test run 1 in 1.64 sec
  - Test run 2 in 2.03 sec
  - Test run 3 in 1.78 sec
  - Test run 4 in 2.07 sec
  - Test run 5 in 1.63 sec
  - Average time: 1.83 sec (0.06 sec diminishment)
  - Lambda function ran in 9.15 sec (total execution)

#### Total of 1000 operations (5 tests):
- 1 worker doing 1000 operations:
  - Test run 1 in 19.42 sec
  - Test run 2 in 21.17 sec
  - Test run 3 in 22.90 sec
  - Test run 4 in 17.67 sec
  - Test run 5 in 18.88 sec
  - Average time: 20.00 sec
  - Lambda function ran in 100.05 sec (total execution)

- 10 workers doing 100 operations each:
  - Test run 1 in 8.46 sec
  - Test run 2 in 8.68 sec
  - Test run 3 in 8.79 sec
  - Test run 4 in 8.63 sec
  - Test run 5 in 8.50 sec
  - Average time: 8.61 sec (11.49 sec improvement)
  - Lambda function ran in 43.06 sec (total execution)

#### Total of 5000 operations (3 tests due to timeout exceeding):
- 1 workers doing 5000 operations:
  - Test run 1 in 98.49 sec
  - Test run 2 in 98.71 sec
  - Test run 3 in 95.76 sec
  - Average time: 97.65 sec
  - Lambda function ran in 292.95 sec (total execution)

- 10 workers doing 500 operations each:
  - Test run 1 in 41.45 sec
  - Test run 2 in 41.92 sec
  - Test run 3 in 42.63 sec
  - Average time: 42.00 sec (55.65 sec improvement)
  - Lambda function ran in 126.01 sec (total execution)


## Performance improvements
* Profiling locally, with code in master processing the 19993 records:
```
Start time 1503108573.75
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 26575.2771ms
End time 1503108600.33
Ran in 26.5756158829 seconds
```
* Notice: **Ran in 26.5756158829 seconds**
* Profiling locally with this multiprocessing code:
```
Start time 1503108143.73
StreamAlert [DEBUG]: [handler._run_batches] Running worker #1 for 1-3333 of 19993 records
StreamAlert [DEBUG]: [handler._run_batches] Running worker #2 for 3334-6666 of 19993 records
StreamAlert [DEBUG]: [handler._run_batches] Running worker #3 for 6667-9999 of 19993 records
StreamAlert [DEBUG]: [handler._run_batches] Running worker #4 for 10000-13332 of 19993 records
StreamAlert [DEBUG]: [handler._run_batches] Running worker #5 for 13333-16665 of 19993 records
StreamAlert [DEBUG]: [handler._run_batches] Running worker #6 for 16666-19993 of 19993 records
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6664.8021ms
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6761.4338ms
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6767.2961ms
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6834.5852ms
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6849.8139ms
StreamAlertShared [INFO]: [stats.timed] (module) stream_alert.rule_processor.handler (method) _process_alerts (time): 6880.0972ms
StreamAlert [INFO]: [handler.run] 1 alerts triggered
End time 1503108151.08
Ran in 7.35581588745 seconds
```
* Notice: **Ran in 7.35581588745 seconds**

#### More than 3.5x improvement in processing speed