### PR TITLE
[bug] output bug fix to prevent using an empty config

### DIFF
--- a/stream_alert_cli/outputs.py
+++ b/stream_alert_cli/outputs.py
@@ -38,10 +38,10 @@ def load_outputs_config(conf_dir='conf'):
         try:
             values = json.load(outputs)
         except ValueError:
-            LOGGER_CLI.exception(
-                'the %s file could not be loaded into json',
+            LOGGER_CLI.error(
+                'The %s file could not be loaded into json',
                 OUTPUTS_CONFIG)
-            return
+            raise
 
     return values
 
@@ -73,7 +73,7 @@ def load_config(props, service):
         [dict] If the output doesn't exist, return the configuration, otherwise return False
     """
     config = load_outputs_config()
-    if not check_output_exists(config, props, service):
+    if output_exists(config, props, service):
         return False
 
     return config
@@ -149,7 +149,7 @@ def send_creds_to_s3(region, bucket, key, blob_data):
         return False
 
 
-def check_output_exists(config, props, service):
+def output_exists(config, props, service):
     """Determine if this service and destination combo has already been created
 
     Args:
@@ -161,11 +161,11 @@ def check_output_exists(config, props, service):
         [boolean] True if the service/destination exists already
     """
     if service in config and props['descriptor'].value in config[service]:
-        LOGGER_CLI.error('this descriptor is already configured for %s. '
-                         'please select a new and unique descriptor', service)
-        return False
+        LOGGER_CLI.error('This descriptor is already configured for %s. '
+                         'Please select a new and unique descriptor', service)
+        return True
 
-    return True
+    return False
 
 
 def update_outputs_config(config, updated_config, service):

--- a/test/unit/stream_alert_cli/test_outputs.py
+++ b/test/unit/stream_alert_cli/test_outputs.py
@@ -20,7 +20,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_kms, mock_s3
 
-from nose.tools import assert_false, assert_list_equal, assert_true
+from nose.tools import assert_false, assert_list_equal, assert_true, raises
 
 from stream_alert.alert_processor.output_base import OutputProperty
 from stream_alert_cli.outputs import (
@@ -42,16 +42,12 @@ def test_load_output_config():
     assert_list_equal(loaded_config_keys, expected_config_keys)
 
 
-@patch('logging.Logger.exception')
-def test_load_output_config_error(log_mock):
+@raises(ValueError)
+def test_load_output_config_error():
     """Load outputs configuration - exception"""
     mock = mock_open(read_data='non-json string that will raise an exception')
     with patch('__builtin__.open', mock):
         load_outputs_config()
-
-    log_mock.assert_called_with(
-        'the %s file could not be loaded into json',
-        'outputs.json')
 
 
 def test_write_outputs_config():


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

## Change
* Fixing a bug that could cause the alert processor to run without a valid config by raising an exception if outputs.json fails to load
* Renaming a function to make its usage more clear (it was very confusing)

### Other
* Updating logger styling and updating unit test to go with above fix