### PR TITLE
Athena Refresh 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   - ./tests/scripts/unit_tests.sh
   - ./manage.py lambda test --processor all
   - sphinx-build -W docs/source docs/build
-  - find . -name '*.py' -not -path './docs/source/*' -exec pylint '{}' +
+  - ./tests/scripts/pylint.sh
 after_success:
   coveralls

--- a/docs/source/account.rst
+++ b/docs/source/account.rst
@@ -67,7 +67,8 @@ First, create the policy to attach to the user:
                 "lambda:*",
                 "logs:*",
                 "s3:*",
-                "sns:*"
+                "sns:*",
+                "sqs:*"
             ],
             "Resource": "*"
         }

--- a/manage.py
+++ b/manage.py
@@ -387,7 +387,7 @@ Examples:
     athena_parser.add_argument(
         '--refresh_type',
         choices=['add_hive_partition', 'repair_hive_table'],
-        help=argparse_suppress
+        help=ARGPARSE_SUPPRESS
     )
 
     athena_parser.add_argument(

--- a/manage.py
+++ b/manage.py
@@ -385,6 +385,12 @@ Examples:
     )
 
     athena_parser.add_argument(
+        '--refresh_type',
+        choices=['add_hive_partition', 'repair_hive_table'],
+        help=argparse_suppress
+    )
+
+    athena_parser.add_argument(
         '--debug',
         action='store_true',
         help=ARGPARSE_SUPPRESS

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -528,10 +528,10 @@ class S3Output(AWSOutput):
 
         # Prefix with alerts to account for generic non-streamalert buckets
         # Produces the following key format:
-        #   alerts/dt=2017-01-25-00-15/kinesis_mystream_myrule_<uuid>.json
+        #   alerts/dt=2017-01-25-00/kinesis_my-stream_my-rule_uuid.json
         # Keys need to be unique to avoid object overwriting
         key = 'alerts/dt={}/{}_{}_{}_{}.json'.format(
-            current_date.strftime('%Y-%m-%d-%H-%M'),
+            current_date.strftime('%Y-%m-%d-%H'),
             service,
             entity,
             alert['rule_name'],

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -16,7 +16,6 @@ limitations under the License.
 from collections import namedtuple
 from getpass import getpass
 import os
-import re
 import shutil
 import sys
 
@@ -156,15 +155,9 @@ def configure_handler(options):
         options (namedtuple): ArgParse command result
     """
     if options.config_key == 'prefix':
-        if not isinstance(options.config_value, (unicode, str)):
-            LOGGER_CLI.error('Invalid prefix type, must be string')
-            return
         CONFIG.set_prefix(options.config_value)
 
     elif options.config_key == 'aws_account_id':
-        if not re.search(r'\A\d{12}\Z', options.config_value):
-            LOGGER_CLI.error('Invalid AWS Account ID, must be 12 digits long')
-            return
         CONFIG.set_aws_account_id(options.config_value)
 
 

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -84,7 +84,7 @@ def athena_handler(options):
 
     elif options.subcommand == 'create-db':
         if athena_client.check_database_exists():
-            LOGGER_CLI.info('The `streamalert` database exists, nothing to do')
+            LOGGER_CLI.info('The \'streamalert\' database already exists, nothing to do')
             return
 
         create_db_success, create_db_result = athena_client.run_athena_query(
@@ -101,7 +101,7 @@ def athena_handler(options):
                 return
 
             if athena_client.check_table_exists(options.type):
-                LOGGER_CLI.info('The `alerts` table already exists.')
+                LOGGER_CLI.info('The \'alerts\' table already exists.')
                 return
 
             query = ('CREATE EXTERNAL TABLE alerts ('
@@ -123,8 +123,8 @@ def athena_handler(options):
             )
 
             if create_table_success:
-                CONFIG['lambda']['athena_partition_refresh_config']['refresh_type'][
-                    'repair_hive_table'][options.bucket] = 'alerts'
+                CONFIG['lambda']['athena_partition_refresh_config'] \
+                    ['refresh_type'][options.refresh_type][options.bucket] = 'alerts'
                 CONFIG.write()
                 LOGGER_CLI.info('The alerts table was successfully created!')
 

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -296,7 +296,6 @@ def generate_cloudwatch_monitoring(cluster_name, cluster_dict, config):
     infrastructure_config = config['global'].get('infrastructure')
     sns_topic_arn = None
 
->>>>>>> [cli] add cloudwatch alarms for athena lambda
     if infrastructure_config and 'monitoring' in infrastructure_config:
         if infrastructure_config['monitoring'].get('create_sns_topic'):
             sns_topic_arn = 'arn:aws:sns:{region}:{account_id}:{topic}'.format(

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -602,9 +602,9 @@ def generate_athena(config):
     enable_metrics = config['global'].get('infrastructure',
                                           {}).get('metrics', {}).get('enabled', False)
 
-    data_buckets = []
+    data_buckets = set()
     for refresh_type in athena_config['refresh_type']:
-        data_buckets.extend(athena_config['refresh_type'][refresh_type].keys())
+        data_buckets.update(set(athena_config['refresh_type'][refresh_type]))
 
     athena_dict['module']['stream_alert_athena'] = {
         'source': 'modules/tf_stream_alert_athena',
@@ -614,7 +614,7 @@ def generate_athena(config):
         'lambda_s3_bucket': athena_config['source_bucket'],
         'lambda_s3_key': athena_config['source_object_key'],
         'lambda_log_level': athena_config.get('log_level', 'info'),
-        'athena_data_buckets': data_buckets,
+        'athena_data_buckets': list(data_buckets),
         'refresh_interval': athena_config.get('refresh_interval', 'rate(10 minutes)'),
         'current_version': athena_config['current_version'],
         'enable_metrics': enable_metrics,

--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_write_exceeded" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = "0"
   evaluation_periods  = "2"
-  period              = "300"
+  period              = "600"
   alarm_description   = "StreamAlert Kinesis Write Throughput Exceeded: ${var.kinesis_stream}"
   alarm_actions       = ["${var.sns_topic_arn}"]
 

--- a/tests/scripts/pylint.sh
+++ b/tests/scripts/pylint.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+find . -name '*.py' -not -path './docs/source/*' -not -path './venv/*' -exec pylint '{}' +

--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -87,13 +87,13 @@ CONFIG_DATA = {
         'athena_partition_refresh_config': {
             "enabled": True,
             "refresh_type": {
-              "repair_hive_table": {
-                "unit-testing.streamalerts": "alerts"
-              },
-              "add_hive_partition": {
-                "unit-testing.streamalerts": "alerts",
-                "test-bucket-with-data": "data-type-1"
-              }
+                "repair_hive_table": {
+                    "unit-testing.streamalerts": "alerts"
+                },
+                "add_hive_partition": {
+                    "unit-testing.streamalerts": "alerts",
+                    "test-bucket-with-data": "data-type-1"
+                }
             },
             'handler': 'main.handler',
             'timeout': '60',
@@ -158,7 +158,8 @@ class TestStreamAlertAthenaGlobals(object):
            return_value=CONFIG_DATA)
     @patch('stream_alert.athena_partition_refresh.main.StreamAlertSQSClient')
     @mock_sqs
-    def test_handler_no_received_messages(self, mock_sqs_client, mock_config, mock_logging):
+    def test_handler_no_received_messages(
+            self, mock_sqs_client, mock_config, mock_logging):
         """Athena - Handler - No Receieved Messages"""
         test_sqs_client = TestStreamAlertSQSClient()
         test_sqs_client.setup()
@@ -172,8 +173,9 @@ class TestStreamAlertAthenaGlobals(object):
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     @patch('stream_alert.athena_partition_refresh.main._load_config',
            return_value=CONFIG_DATA)
-    @patch('stream_alert.athena_partition_refresh.main.StreamAlertSQSClient.unique_s3_buckets_and_keys',
-           return_value={})
+    @patch(
+        'stream_alert.athena_partition_refresh.main.StreamAlertSQSClient.unique_s3_buckets_and_keys',
+        return_value={})
     @mock_sqs
     def test_handler_no_unique_buckets(self, _, mock_config, mock_logging):
         """Athena - Handler - No Unique Buckets"""
@@ -200,76 +202,78 @@ class TestStreamAlertSQSClient(object):
 
         # Create a fake s3 notification message to send
         bucket = 'unit-testing.streamalerts'
-        test_s3_notificaiton = {
-          'Records': [
-            {
-              'eventVersion': '2.0',
-              'eventSource': 'aws:s3',
-              'awsRegion': 'us-east-1',
-              'eventTime': '2017-08-07T18:26:30.956Z',
-              'eventName': 'S3:PutObject',
-              'userIdentity': {
-                'principalId': 'AWS:AAAAAAAAAAAAAAA'
-              },
-              'requestParameters': {
-                'sourceIPAddress': '127.0.0.1'
-              },
-              'responseElements': {
-                'x-amz-request-id': 'FOO',
-                'x-amz-id-2': 'BAR'
-              },
-              's3': {
-                's3SchemaVersion': '1.0',
-                'configurationId': 'queue',
-                'bucket': {
-                  'name': bucket,
-                  'ownerIdentity': {
-                    'principalId': 'AAAAAAAAAAAAAAA'
-                  },
-                  'arn': 'arn:aws:s3:::{}'.format(bucket)
+        test_s3_notification = {
+            'Records': [
+                {
+                    'eventVersion': '2.0',
+                    'eventSource': 'aws:s3',
+                    'awsRegion': 'us-east-1',
+                    'eventTime': '2017-08-07T18:26:30.956Z',
+                    'eventName': 'S3:PutObject',
+                    'userIdentity': {
+                        'principalId': 'AWS:AAAAAAAAAAAAAAA'
+                    },
+                    'requestParameters': {
+                        'sourceIPAddress': '127.0.0.1'
+                    },
+                    'responseElements': {
+                        'x-amz-request-id': 'FOO',
+                        'x-amz-id-2': 'BAR'
+                    },
+                    's3': {
+                        's3SchemaVersion': '1.0',
+                        'configurationId': 'queue',
+                        'bucket': {
+                            'name': bucket,
+                            'ownerIdentity': {
+                                'principalId': 'AAAAAAAAAAAAAAA'
+                            },
+                            'arn': 'arn:aws:s3:::{}'.format(bucket)
+                        },
+                        'object': {
+                            'key': 'alerts/dt=2017-08-26-14-02/rule_name_alerts-1304134918401.json',
+                            'size': 1494,
+                            'eTag': '12214134141431431',
+                            'versionId': 'asdfasdfasdf.dfadCJkj1',
+                            'sequencer': '1212312321312321321'
+                        }
+                    }
                 },
-                'object': {
-                  'key': 'alerts/dt=2017-08-26-14-02/rule_name_alerts-1304134918401.json',
-                  'size': 1494,
-                  'eTag': '12214134141431431',
-                  'versionId': 'asdfasdfasdf.dfadCJkj1',
-                  'sequencer': '1212312321312321321'
-                }
-              }
-            },
-            {
-              'eventVersion': '2.0',
-              'eventSource': 'aws:s3',
-              'awsRegion': 'us-east-1',
-              'eventTime': '2017-08-07T18:26:30.956Z',
-              'eventName': 'S3:GetObject',
-              'userIdentity': {
-                'principalId': 'AWS:AAAAAAAAAAAAAAA'
-              },
-              'requestParameters': {
-                'sourceIPAddress': '127.0.0.1'
-              },
-              'responseElements': {
-                'x-amz-request-id': 'FOO',
-                'x-amz-id-2': 'BAR'
-              },
-              's3': {
-                's3SchemaVersion': '1.0',
-                'configurationId': 'queue',
-                'bucket': {
-                  'name': bucket,
-                  'ownerIdentity': {
-                    'principalId': 'AAAAAAAAAAAAAAA'
-                  },
-                  'arn': 'arn:aws:s3:::{}'.format(bucket)
-                },
-                'object': {
-                  # Different day than the above record
-                  'key': 'alerts/dt=2017-08-27-14-02/rule_name_alerts-1304134918401.json',
-                  'size': 1494,
-                  'eTag': '12214134141431431',
-                  'versionId': 'asdfasdfasdf.dfadCJkj1',
-                  'sequencer': '1212312321312321321'
+                {
+                    'eventVersion': '2.0',
+                    'eventSource': 'aws:s3',
+                    'awsRegion': 'us-east-1',
+                    'eventTime': '2017-08-07T18:26:30.956Z',
+                    'eventName': 'S3:GetObject',
+                    'userIdentity': {
+                        'principalId': 'AWS:AAAAAAAAAAAAAAA'
+                    },
+                    'requestParameters': {
+                        'sourceIPAddress': '127.0.0.1'
+                    },
+                    'responseElements': {
+                        'x-amz-request-id': 'FOO',
+                        'x-amz-id-2': 'BAR'
+                    },
+                    's3': {
+                        's3SchemaVersion': '1.0',
+                        'configurationId': 'queue',
+                        'bucket': {
+                            'name': bucket,
+                            'ownerIdentity': {
+                                'principalId': 'AAAAAAAAAAAAAAA'
+                            },
+                            'arn': 'arn:aws:s3:::{}'.format(bucket)
+                        },
+                        'object': {
+                            # Different day than the above record
+                            'key': 'alerts/dt=2017-08-27-14-02/rule_name_alerts-1304134918401.json',
+                            'size': 1494,
+                            'eTag': '12214134141431431',
+                            'versionId': 'asdfasdfasdf.dfadCJkj1',
+                            'sequencer': '1212312321312321321'
+                        }
+                    }
                 }
             ]
         }
@@ -280,14 +284,12 @@ class TestStreamAlertSQSClient(object):
         self.client.sqs_client.purge_queue(QueueUrl=self.client.athena_sqs_url)
         self.client = None
 
-
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_delete_messages_none_received(self, mock_logging):
         """Athena SQS - Delete Messages - No Receieved Messages"""
         self.client.delete_messages()
 
         assert_true(mock_logging.error.called)
-
 
     # The return value is not being mocked successfully
     @nottest
@@ -296,15 +298,14 @@ class TestStreamAlertSQSClient(object):
     def test_delete_messages_failure(self, mock_logging, mock_sqs_client):
         """Athena SQS - Delete Messages - Failure Response"""
         instance = mock_sqs_client.return_value
-        instance.sqs_client.delete_message_batch.return_value = {'Successful': [{'Id': '2'}],
-                                                                 'Failed': [{'Id': '1'}]}
+        instance.sqs_client.delete_message_batch.return_value = {
+            'Successful': [{'Id': '2'}], 'Failed': [{'Id': '1'}]}
 
         self.client.get_messages()
         self.client.unique_s3_buckets_and_keys()
         self.client.delete_messages()
 
         assert_true(mock_logging.error.called)
-
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_delete_messages_none_processed(self, mock_logging):
@@ -314,7 +315,6 @@ class TestStreamAlertSQSClient(object):
 
         assert_true(mock_logging.error.called)
         assert_false(result)
-
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_delete_messages(self, mock_logging):
@@ -332,7 +332,6 @@ class TestStreamAlertSQSClient(object):
 
         assert_true(mock_logging.error.called)
         assert_is_none(resp)
-
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_get_messages(self, mock_logging):
@@ -378,8 +377,8 @@ class TestStreamAlertSQSClient(object):
         unique_buckets = self.client.unique_s3_buckets_and_keys()
 
         assert_false(unique_buckets)
-        assert_true(mock_logging.debug.called_with('Skipping S3 bucket notification test event'))
-
+        assert_true(mock_logging.debug.called_with(
+            'Skipping S3 bucket notification test event'))
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_unique_s3_buckets_and_keys_invalid_record(self, mock_logging):
@@ -412,6 +411,7 @@ class TestStreamAlertSQSClient(object):
 
 class TestStreamAlertAthenaClient(object):
     """Test class for StreamAlertAthenaClient"""
+
     def setup(self):
         self.client = StreamAlertAthenaClient(CONFIG_DATA,
                                               results_key_prefix='unit-testing')
@@ -439,7 +439,6 @@ class TestStreamAlertAthenaClient(object):
         assert_true(mock_logging.info.called)
         assert_true(result)
 
-
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_add_hive_partition_unknown_bucket(self, mock_logging):
         """Athena - Add Hive Partition - Unknown Bucket"""
@@ -453,7 +452,6 @@ class TestStreamAlertAthenaClient(object):
 
         assert_true(mock_logging.error.called)
         assert_false(result)
-
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_add_hive_partition_unexpected_s3_key(self, mock_logging):
@@ -471,7 +469,6 @@ class TestStreamAlertAthenaClient(object):
         assert_true(mock_logging.error.called)
         assert_false(result)
 
-
     def test_check_table_exists(self):
         """Athena - Check Table Exists"""
         query_result = [{'alerts': True}]
@@ -480,7 +477,8 @@ class TestStreamAlertAthenaClient(object):
         result = self.client.check_table_exists('unit-test')
         assert_true(result)
 
-        generated_results_key = 'unit-testing/{}'.format(datetime.now().strftime('%Y/%m/%d'))
+        generated_results_key = 'unit-testing/{}'.format(
+            datetime.now().strftime('%Y/%m/%d'))
         assert_equal(self.client.athena_results_key, generated_results_key)
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
@@ -533,7 +531,6 @@ class TestStreamAlertAthenaClient(object):
         )
 
         assert_true(query_success)
-
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_run_athena_query_error(self, mock_logging):

--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -173,9 +173,9 @@ class TestStreamAlertAthenaGlobals(object):
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     @patch('stream_alert.athena_partition_refresh.main._load_config',
            return_value=CONFIG_DATA)
-    @patch(
-        'stream_alert.athena_partition_refresh.main.StreamAlertSQSClient.unique_s3_buckets_and_keys',
-        return_value={})
+    @patch('stream_alert.athena_partition_refresh.main.'
+           'StreamAlertSQSClient.unique_s3_buckets_and_keys',
+           return_value={})
     @mock_sqs
     def test_handler_no_unique_buckets(self, _, mock_config, mock_logging):
         """Athena - Handler - No Unique Buckets"""
@@ -281,6 +281,7 @@ class TestStreamAlertSQSClient(object):
                                 QueueUrl=self.client.athena_sqs_url)
 
     def teardown(self):
+        """Purge the Queue and reset the client between runs"""
         self.client.sqs_client.purge_queue(QueueUrl=self.client.athena_sqs_url)
         self.client = None
 
@@ -519,13 +520,12 @@ class TestStreamAlertAthenaClient(object):
         assert_equal(query_results['ResultSet']['Rows'], [])
         assert_true(mock_logging.debug.called)
 
-    @patch('stream_alert.athena_partition_refresh.main.LOGGER')
-    def test_run_athena_query_async(self, mock_logging):
+    def test_run_athena_query_async(self):
         """Athena - Run Athena Query - Async Call"""
         query_result = []
         self.client.athena_client = MockAthenaClient(results=query_result)
 
-        query_success, query_results = self.client.run_athena_query(
+        query_success, _ = self.client.run_athena_query(
             query='SHOW DATABASES;',
             async=True
         )

--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -164,7 +164,7 @@ class TestStreamAlertAthenaGlobals(object):
         handler(None, None)
 
         mock_config.assert_called()
-        mock_logging.info.assert_called_with('No messages recieved, exiting')
+        assert_true(mock_logging.info.called)
 
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     @patch('stream_alert.athena_partition_refresh.main._load_config',
@@ -180,7 +180,7 @@ class TestStreamAlertAthenaGlobals(object):
         handler(None, None)
 
         mock_config.assert_called()
-        mock_logging.error.assert_called_with('No partitions to refresh, exiting')
+        assert_true(mock_logging.error.called)
 
 
 class TestStreamAlertSQSClient(object):

--- a/tests/unit/stream_alert_cli/test_outputs.py
+++ b/tests/unit/stream_alert_cli/test_outputs.py
@@ -88,7 +88,7 @@ def test_encrypt_and_push_creds_to_s3(cli_mock):
             description='short description of info needed',
             value='http://this.url.value')}
 
-    return_value = encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props)
+    return_value = encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props, 'test_alias')
 
     assert_true(return_value)
     cli_mock.assert_not_called()
@@ -101,7 +101,7 @@ def test_encrypt_and_push_creds_to_s3(cli_mock):
     # Create the bucket to hold the mock object being put
     boto3.client('s3', region_name='us-east-1').create_bucket(Bucket='bucket')
 
-    return_value = encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props)
+    return_value = encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props, 'test_alias')
 
     assert_true(return_value)
 
@@ -127,7 +127,7 @@ def test_encrypt_and_push_creds_to_s3_kms_failure(log_mock, boto_mock):
 
     # Add ClientError side_effect to mock
     boto_mock.side_effect = ClientError(err_response, 'operation')
-    encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props)
+    encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props, 'test_alias')
 
     log_mock.assert_called_with('an error occurred during credential encryption')
 

--- a/tests/unit/stream_alert_cli/test_terraform_generate.py
+++ b/tests/unit/stream_alert_cli/test_terraform_generate.py
@@ -598,7 +598,9 @@ class TestTerraformGenerate(object):
                         'repair_hive_table': {
                             'unit-testing.streamalerts': 'alerts'
                         },
-                        'add_hive_partition': {}
+                        'add_hive_partition': {
+                            'unit-testing-2.streamalerts': 'alerts'
+                        }
                     },
                     'handler': 'main.handler',
                     'timeout': '60',
@@ -612,6 +614,7 @@ class TestTerraformGenerate(object):
                 }
             }
         }
+
         expected_athena_config = {
             'module': {
                 'stream_alert_athena': {
@@ -624,7 +627,10 @@ class TestTerraformGenerate(object):
                     'lambda_timeout': '60',
                     'lambda_s3_bucket': 'unit-testing.streamalert.source',
                     'lambda_s3_key': 'lambda/athena/source.zip',
-                    'athena_data_buckets': ['unit-testing.streamalerts'],
+                    'athena_data_buckets': [
+                        'unit-testing.streamalerts',
+                        'unit-testing-2.streamalerts'
+                    ],
                     'prefix': 'unit-testing',
                     'refresh_interval': 'rate(10 minutes)'
                 }
@@ -632,5 +638,12 @@ class TestTerraformGenerate(object):
         }
 
         athena_config = terraform_generate.generate_athena(config=config)
+
+        # List order messes up the comparison between both dictionaries
+        assert_equal(set(athena_config['module']['stream_alert_athena']['athena_data_buckets']),
+                     set(expected_athena_config['module']['stream_alert_athena']['athena_data_buckets']))
+
+        del athena_config['module']['stream_alert_athena']['athena_data_buckets']
+        del expected_athena_config['module']['stream_alert_athena']['athena_data_buckets']
 
         assert_equal(athena_config, expected_athena_config)

--- a/tests/unit/stream_alert_cli/test_terraform_generate.py
+++ b/tests/unit/stream_alert_cli/test_terraform_generate.py
@@ -641,7 +641,8 @@ class TestTerraformGenerate(object):
 
         # List order messes up the comparison between both dictionaries
         assert_equal(set(athena_config['module']['stream_alert_athena']['athena_data_buckets']),
-                     set(expected_athena_config['module']['stream_alert_athena']['athena_data_buckets']))
+                     set(expected_athena_config['module']['stream_alert_athena']\
+                                               ['athena_data_buckets']))
 
         del athena_config['module']['stream_alert_athena']['athena_data_buckets']
         del expected_athena_config['module']['stream_alert_athena']['athena_data_buckets']


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin (both pls review all code)
cc: @airbnb/streamalert-maintainers 
size: medium

## Changes

### Main Changes
* Hive Add Partition support: Instead of searching an entire bucket for new partitions, add them based on S3 event notifications.  This works by parsing the S3 key using a regular expression to extract the YYYY-MM-DD-HH information from the key.  This is specific to Firehose and StreamAlert's S3 Output format
* Add an option for async Athena query execution: I plan on using this option in the future for long running processes.  To maintain state, I plan on using DynamoDB.  This iteration may come sooner if the `ADD PARTITION` command starts taking too long.
* Deduplicate partitions before issuing Athena queries.
* Add clearer log messages.

### CLI Changes
* UX improvements: Moar logger messages indicating things went as expected.  
* Allow for custom KMS alias names (this was previously hardcoded, which is inflexible when a single AWS account has multiple StreamAlert deployments)

### CloudWatch Changes
* Add CloudWatch alarms for the Athena Refresh function via TF generate
* Tune params for WriteThroughputExceeded alarm

## Testing

All Athena and Outputs changes deployed and verified in a side account.  I configured CloudTrail and CloudWatch events to send dummy alerts to S3 with some basic added rules.

![screen shot 2017-08-22 at 5 07 19 pm](https://user-images.githubusercontent.com/11466941/29592994-73892d0e-875c-11e7-9942-d2051472f7bd.png)
