### PR TITLE
[cli][test] validation of schemas without writing a rule

### DIFF
--- a/docs/source/rule-testing.rst
+++ b/docs/source/rule-testing.rst
@@ -76,17 +76,17 @@ For example, to replace a time based field with ``last_hour``:
   }
 
 
-Validating Log Schemas
-~~~~~~~~~~~~~~~~~~~~~~
+Validate Log Schemas
+~~~~~~~~~~~~~~~~~~~~
 
-In some cases, there may be logs coming into StreamAlert that are of a known type, but you do not have a current need to apply rule
-logic to them. However, it is still advantageous to add schemas for these logs and *test* to ensure your new schemas are valid.
+In some cases, there may be incoming logs to StreamAlert with a known type, but without specific rules that apply to them.
+However, it is best practice to write schemas for these logs and *verify* that they are valid.
 
-This is possible through the addition of log schema(s) to ``conf/logs.json`` and creation of test record(s) in ``tests/integration/rules/``
-using known samples of logs (without actually adding a corresponding rule). Running the ``manage.py`` script with the ``validate-schemas``
-option will iterate over all json test files and attempt to match records within them to a defined log schema.
+This is possible by first adding the new schema(s) to ``conf/logs.json`` along with creation of test record(s) in ``tests/integration/rules/``
+containing samples of real logs (without actually adding a corresponding rule). Running the ``manage.py`` script with the ``validate-schemas``
+option will iterate over all json test files and attempt to classify each record.
 
-To simply run schema validation on all test files:
+To run schema validation on all test files:
 
 .. code-block:: bash
 
@@ -106,7 +106,7 @@ Or:
   $ python manage.py validate-schemas --test-files <test_rule_file>
 
 
-Example of running schema validation on two valid test files:
+Schema validation on two valid test files:
 
 .. code-block:: bash
 
@@ -134,7 +134,7 @@ This will produce output similar to the following::
   StreamAlertCLI [INFO]: Completed
 
 
-Example of running schema validation on a test file that contains one valid record and one invalid record:
+Schema validation failure on a test file containing one valid record and one invalid record:
 
 .. code-block:: bash
 

--- a/manage.py
+++ b/manage.py
@@ -153,7 +153,7 @@ Available Options:
 
 Examples:
 
-    stream_alert_cli.py validate-schemas --files
+    manage.py validate-schemas --files
 
 """.format(version))
     schema_validation_parser = subparsers.add_parser(

--- a/manage.py
+++ b/manage.py
@@ -140,6 +140,48 @@ Examples:
     )
 
 
+def _add_validate_schema_subparser(subparsers):
+    schema_validation_usage = 'manage.py validate-schemas [options]'
+    schema_validation_description = ("""
+StreamAlertCLI v{}
+Run end-to-end tests that will attempt to send alerts
+
+Available Options:
+
+    --files                 Name (not full path) of test file(s) to validate, separated by spaces
+    --debug                 Enable Debug logger output
+
+Examples:
+
+    stream_alert_cli.py validate-schemas --files
+
+""".format(version))
+    schema_validation_parser = subparsers.add_parser(
+        'validate-schemas',
+        description=schema_validation_description,
+        usage=schema_validation_usage,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # Set the name of this parser to 'validate-schemas'
+    schema_validation_parser.set_defaults(command='validate-schemas')
+
+    # add the optional ability to test against specific files
+    schema_validation_parser.add_argument(
+        '-f', '--files',
+        nargs='+',
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # allow verbose output for the CLI with te --debug option
+    schema_validation_parser.add_argument(
+        '--debug',
+        action='store_true',
+        help=ARGPARSE_SUPPRESS
+    )
+
+
 def _add_lambda_subparser(subparsers):
     """Add the Lambda subparser: manage.py lambda [subcommand] [options]"""
     lambda_usage = 'manage.py lambda [subcommand] [options]'
@@ -427,6 +469,7 @@ For additional details on the available commands, try:
     subparsers = parser.add_subparsers()
     _add_output_subparser(subparsers)
     _add_live_test_subparser(subparsers)
+    _add_validate_schema_subparser(subparsers)
     _add_lambda_subparser(subparsers)
     _add_terraform_subparser(subparsers)
     _add_configure_subparser(subparsers)

--- a/manage.py
+++ b/manage.py
@@ -141,6 +141,7 @@ Examples:
 
 
 def _add_validate_schema_subparser(subparsers):
+    """Add the validate-schemas subparser: manage.py validate-schemas [options]"""
     schema_validation_usage = 'manage.py validate-schemas [options]'
     schema_validation_description = ("""
 StreamAlertCLI v{}
@@ -148,12 +149,19 @@ Run end-to-end tests that will attempt to send alerts
 
 Available Options:
 
-    --files                 Name (not full path) of test file(s) to validate, separated by spaces
-    --debug                 Enable Debug logger output
+    --test-files         Name(s) of test files to validate, separated by spaces (not full path)
+                           These files should be located within 'tests/integration/rules/' and each
+                           should be named according to the rule they are meant to test. The
+                           contents should be json, in the form of `{{"records": [ <records as maps> ]}}`.
+                           See the sample test files in 'tests/integration/rules/' for an example.
+                           The '--test-files' flag will accept the full file name, with extension,
+                           or the base file name, without extension (ie: test_file_name.json or
+                           test_file_name are both acceptable arguments)
+    --debug              Enable Debug logger output
 
 Examples:
 
-    manage.py validate-schemas --files
+    manage.py validate-schemas --test-files <test_file_name_01.json> <test_file_name_02.json>
 
 """.format(version))
     schema_validation_parser = subparsers.add_parser(
@@ -169,7 +177,7 @@ Examples:
 
     # add the optional ability to test against specific files
     schema_validation_parser.add_argument(
-        '-f', '--files',
+        '-f', '--test-files',
         nargs='+',
         help=ARGPARSE_SUPPRESS
     )

--- a/manage.py
+++ b/manage.py
@@ -132,7 +132,7 @@ Examples:
         help=ARGPARSE_SUPPRESS
     )
 
-    # allow verbose output for the CLI with te --debug option
+    # allow verbose output for the CLI with the --debug option
     live_test_parser.add_argument(
         '--debug',
         action='store_true',
@@ -182,7 +182,7 @@ Examples:
         help=ARGPARSE_SUPPRESS
     )
 
-    # allow verbose output for the CLI with te --debug option
+    # allow verbose output for the CLI with the --debug option
     schema_validation_parser.add_argument(
         '--debug',
         action='store_true',

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -24,7 +24,6 @@ import zipfile
 import zlib
 
 import boto3
-
 from moto import mock_cloudwatch, mock_lambda, mock_kms, mock_s3
 
 from stream_alert_cli.logger import LOGGER_CLI

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -24,7 +24,7 @@ import zipfile
 import zlib
 
 import boto3
-from moto import mock_cloudwatch, mock_lambda, mock_kms, mock_s3
+from moto import mock_cloudwatch, mock_kms, mock_lambda, mock_s3
 
 from stream_alert_cli.logger import LOGGER_CLI
 

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import base64
+from collections import namedtuple
 import json
 import os
 import random
@@ -23,6 +24,8 @@ import zipfile
 import zlib
 
 import boto3
+
+from moto import mock_cloudwatch, mock_lambda, mock_kms, mock_s3
 
 from stream_alert_cli.logger import LOGGER_CLI
 
@@ -203,3 +206,68 @@ def put_mock_s3_object(bucket, key, data, region):
         Key=key,
         ServerSideEncryption='AES256'
     )
+
+
+def mock_me(context):
+    """Decorator function for wrapping framework in mock calls
+    for running local tests, and omitting mocks if testing live
+
+    Args:
+        context (namedtuple): A constructed aws context object
+    """
+    def wrap(func):
+        """Wrap the returned function with or without mocks"""
+        if context.mocked:
+            @mock_cloudwatch
+            @mock_lambda
+            @mock_s3
+            @mock_kms
+            def mocked(options, context):
+                """This function is now mocked using moto mock decorators to
+                override any boto3 calls. Wrapping this function here allows
+                us to mock out all calls that happen below this scope."""
+                return func(options, context)
+            return mocked
+
+        def unmocked(options, context):
+            """This function will remain unmocked and operate normally"""
+            return func(options, context)
+        return unmocked
+
+    return wrap
+
+
+def get_context_from_config(cluster, config):
+    """Return a constructed context to be used for testing
+
+    Args:
+        cluster (str): Name of the cluster to be used for live testing
+        config (CLIConfig): Configuration for this StreamAlert setup that
+            includes cluster info, etc that can be used for constructing
+            an aws context object
+    """
+    context = namedtuple('aws_context', ['invoked_function_arn',
+                                         'function_name'
+                                         'mocked'])
+
+    # Return a mocked context if the cluster is not provided
+    # Otherwise construct the context from the config using the cluster
+    if not cluster:
+        context.invoked_function_arn = (
+            'arn:aws:lambda:us-east-1:123456789012:'
+            'function:test_streamalert_processor:development')
+        context.function_name = 'test_streamalert_alert_processor'
+        context.mocked = True
+    else:
+        prefix = config['global']['account']['prefix']
+        account = config['global']['account']['aws_account_id']
+        region = config['global']['account']['region']
+        function_name = '{}_{}_streamalert_alert_processor'.format(prefix, cluster)
+        arn = 'arn:aws:lambda:{}:{}:function:{}:testing'.format(
+            region, account, function_name)
+
+        context.invoked_function_arn = arn
+        context.function_name = function_name
+        context.mocked = False
+
+    return context

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -14,6 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import logging
+import logging.handlers
+
+
+class SuppressNonErrors(logging.Filter):
+    """Simple logging filter to allow only caching error messages to a MemoryHandler"""
+    def filter(self, record):
+        return record.levelno == logging.ERROR
+
+
+class SuppressNoise(logging.Filter):
+    """Simple logging filter for suppressing specific log messagses that we
+    do not want to print during testing. Add any suppressions to the tuple.
+    """
+
+    def filter(self, record):
+        suppress_starts_with = (
+            'Starting download from S3',
+            'Completed download in'
+        )
+        return not record.getMessage().startswith(suppress_starts_with)
+
 
 LOGGER_SA = logging.getLogger('StreamAlert')
 LOGGER_SA.setLevel(logging.INFO)
@@ -33,3 +54,14 @@ for logger in logging.Logger.manager.loggerDict:
     if logger.startswith('StreamAlert'):
         continue
     logging.getLogger(logger).setLevel(logging.CRITICAL)
+
+# Get a logging MemoryHandler with a default buffer size of 1000
+# We don't care about assigning a target to this handler since these logs
+# will not actually be written out to disk, etc
+LOG_ERROR_HANDLER = logging.handlers.MemoryHandler(1000)
+
+# Add a filter to suppress everything that is not an error
+LOG_ERROR_HANDLER.addFilter(SuppressNonErrors())
+
+# Add the MemoryHandler to the root logger to capture all logs in all loggers
+logging.getLogger().addHandler(LOG_ERROR_HANDLER)

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -55,13 +55,21 @@ for logger in logging.Logger.manager.loggerDict:
         continue
     logging.getLogger(logger).setLevel(logging.CRITICAL)
 
-# Get a logging MemoryHandler with a default buffer size of 1000
-# We don't care about assigning a target to this handler since these logs
-# will not actually be written out to disk, etc
-LOG_ERROR_HANDLER = logging.handlers.MemoryHandler(1000)
+def get_log_memory_hanlder():
+    """Get a logging MemoryHandler with a default buffer size of 1000
+    We don't care about assigning a target to this handler since these logs
+    will not actually be written out to disk, etc
 
-# Add a filter to suppress everything that is not an error
-LOG_ERROR_HANDLER.addFilter(SuppressNonErrors())
+    Returns:
+        logging.handlers.MemoryHandler: In memory logging handler that caches
+            all messages going through the root logger to a buffer
+    """
+    log_mem_hanlder = logging.handlers.MemoryHandler(1000)
 
-# Add the MemoryHandler to the root logger to capture all logs in all loggers
-logging.getLogger().addHandler(LOG_ERROR_HANDLER)
+    # Add a filter to suppress everything that is not an error
+    log_mem_hanlder.addFilter(SuppressNonErrors())
+
+    # Add the MemoryHandler to the root logger to capture all logs in all loggers
+    logging.getLogger().addHandler(log_mem_hanlder)
+
+    return log_mem_hanlder

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -61,6 +61,9 @@ def cli_runner(options):
     elif options.command == 'live-test':
         stream_alert_test(options, CONFIG)
 
+    elif options.command == 'validate-schemas':
+        stream_alert_test(options)
+
     elif options.command == 'terraform':
         terraform_handler(options)
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -75,10 +75,6 @@ class RuleProcessorTester(object):
         """
         self.all_tests_passed = True
         self.context = context
-        # Create the topic used for the mocking of alert sending
-        # This is used in stream_alert/rule_processor/sink.py to 'send' alerts
-        sns_client = boto3.client('sns', region_name='us-east-1')
-        sns_client.create_topic(Name='test_streamalerts')
         # Create a list for pass/fails. The first value in the list is a
         # list of tuples for failures, and the second is list of tuples for
         # passes. Tuple is (rule_name, rule_description)
@@ -556,7 +552,6 @@ def mock_me(context):
         if context.mocked:
             @mock_cloudwatch
             @mock_lambda
-            @mock_sns
             @mock_s3
             @mock_kms
             def mocked(options, context):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -600,6 +600,22 @@ def report_output(passed, cols):
     print '\t{}{:>14}\t{}\t({}): {}'.format(status, *cols)
 
 
+def check_untested_rules():
+    """Function that prints warning log messages for rules that exist but do
+    not have proper integration tests configured.
+    """
+    all_test_files = {os.path.splitext(test_file)[0] for _, _, test_rule_files
+                      in os.walk(DIR_RULES) for test_file in test_rule_files}
+
+    untested_rules = set(StreamRules.get_rules()).difference(all_test_files)
+
+    for rule in untested_rules:
+        LOGGER_CLI.warn('%sNo tests configured for rule: \'%s\'. Please add a '
+                        'corresponding test file for this rule in \'%s\' with the '
+                        'name \'%s.json\' to avoid seeing this warning%s', COLOR_YELLOW,
+                        rule, DIR_RULES, rule, COLOR_RESET)
+
+
 def stream_alert_test(options, config=None):
     """High level function to wrap the integration testing entry point.
     This encapsulates the testing function and is used to specify if calls
@@ -668,6 +684,8 @@ def stream_alert_test(options, config=None):
         if test_alerts:
             AlertProcessorTester.report_output_summary()
 
+        # Check all of the rule files to make sure they have tests configured
+        check_untested_rules()
 
         if not (rule_proc_tester.all_tests_passed and
                 alert_proc_tester.all_tests_passed):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -710,7 +710,7 @@ def stream_alert_test(options, config=None):
 
         validate_schemas = options.command == 'validate-schemas'
 
-        filters = options.files if validate_schemas else options.rules
+        filters = options.test_files if validate_schemas else options.rules
 
         # Run the rule processor for all rules or designated rule set
         for alerts in rule_proc_tester.test_processor(filters, validate_schemas):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -84,7 +84,7 @@ class RuleProcessorTester(object):
         """Perform integration tests for the 'rule' Lambda function
 
         Args:
-            filter_rules [list or None]: Specific rule names (or None) to restrict
+            filter_rules (list|None): Specific rule names (or None) to restrict
                 testing to. This is passed in from the CLI using the --rules option.
             validate_only [bool=False]: If true, validation of test records will occur
                 without the rules engine being applied to events.
@@ -123,9 +123,9 @@ class RuleProcessorTester(object):
         """Function to validate test records and log any errors
 
         Args:
-            rule_name [str]: The rule name being tested
-            test_record [dict]: A single record to test
-            formatted_record [dict]: A dictionary that includes the 'data' from the
+            rule_name (str): The rule name being tested
+            test_record (dict): A single record to test
+            formatted_record (dict): A dictionary that includes the 'data' from the
                 test record, formatted into a structure that is resemblant of how
                 an incoming record from a service would format it.
                 See test/integration/templates for example of how each service
@@ -154,18 +154,18 @@ class RuleProcessorTester(object):
         """Run tests on a test record for a given rule
 
         Args:
-            rule_name [str]: The name of the rule being tested.
-            test_record [dict]: The loaded test event from json
-            formatted_record [dict]: A dictionary that includes the 'data' from the
+            rule_name (str): The name of the rule being tested.
+            test_record (dict): The loaded test event from json
+            formatted_record (dict): A dictionary that includes the 'data' from the
                 test record, formatted into a structure that is resemblant of how
                 an incoming record from a service would format it.
                 See test/integration/templates for example of how each service
                 formats records.
-            print_header_line [bool]: Indicates if this is the first record from
+            print_header_line (bool): Indicates if this is the first record from
                 a test file, and therefore we should print some header information
 
         Returns:
-            [list] alerts that were generated from this test event
+            list: alerts that were generated from this test event
         """
         event = {'Records': [formatted_record]}
         # Run tests on the formatted record
@@ -206,12 +206,12 @@ class RuleProcessorTester(object):
         """Helper to get rule files to be tested
 
         Args:
-            filter_rules [list or None]: List of specific rule names or file names
+            filter_rules (list|None): List of specific rule names or file names
                 (or None) that has been fed in from the CLI to restrict testing to
 
-        Returns:
-            [generator] Yields back the rule name and the json loaded contents of
-                the respective test event file.
+        Yields:
+            str: rule name
+            dict: loaded json contents of the respective test event file
         """
         # Since filter_rules can be either a list of rule names or rule files,
         # we should check to see if there is a '.json' extension and just use the
@@ -399,6 +399,7 @@ class RuleProcessorTester(object):
             bool: False if errors occurred during processing
         """
         # Clear out any old alerts or errors from the previous test run
+        # pylint: disable=protected-access
         del self.processor._alerts[:]
         self.processor._failed_record_count = 0
 
@@ -534,7 +535,11 @@ class AlertProcessorTester(object):
                              failed_tests, total_tests, COLOR_RESET)
 
     def setup_outputs(self, alert):
-        """Helper function to handler any output setup"""
+        """Helper function to handler any output setup
+
+        Args:
+            alert (dict): The alert dictionary containing outputs the need mocking out
+        """
         outputs = alert.get('outputs', [])
         # Patch the urllib2.urlopen event to override HTTPStatusCode, etc
         url_mock = Mock()
@@ -590,8 +595,8 @@ def report_output(passed, cols):
     """Helper function to pretty print columns for reporting results
 
     Args:
-        passed [bool]: The pass status of the current test case
-        cols [list]: A list of columns to print as output
+        passed (bool): The pass status of the current test case
+        cols (list): A list of columns to print as output
     """
 
     status = ('{}[Pass]{}'.format(COLOR_GREEN, COLOR_RESET) if passed else

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -646,11 +646,14 @@ def stream_alert_test(options, config=None):
             LOGGER_SA.addFilter(TestingSuppressFilter())
 
         # Check if the rule processor should be run for these tests
-        test_rules = (set(run_options.get('processor')).issubset({'rule', 'all'}) or
-                      run_options.get('command') == 'live-test')
+        test_rules = (set(run_options.get('processor')).issubset({'rule', 'all'})
+                      if run_options.get('processor') else
+                      run_options.get('command') == 'live-test' or
+                      run_options.get('command') == 'validate-schemas')
 
         # Check if the alert processor should be run for these tests
-        test_alerts = (set(run_options.get('processor')).issubset({'alert', 'all'}) or
+        test_alerts = (set(run_options.get('processor')).issubset({'alert', 'all'})
+                       if run_options.get('processor') else
                        run_options.get('command') == 'live-test')
 
         rule_proc_tester = RuleProcessorTester(context, test_rules)

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -161,9 +161,18 @@ class RuleProcessorTester(object):
             [generator] Yields back the rule name and the json loaded contents of
                 the respective test event file.
         """
+        if filter_rules:
+            for index, rule in enumerate(filter_rules):
+                parts = os.path.splitext(rule)
+                if parts[1] == '.json':
+                    filter_rules[index] = parts[0]
+
+            # Create a copy of the filtered rules that can be altered
+            filter_rules_copy = filter_rules[:]
+
         for _, _, test_rule_files in os.walk(DIR_RULES):
             for rule_file in test_rule_files:
-                rule_name = rule_file.split('.')[0]
+                rule_name = os.path.splitext(rule_file)[0]
 
                 # If only specific rules are being tested,
                 # skip files that do not match those rules
@@ -195,8 +204,9 @@ class RuleProcessorTester(object):
 
                 yield rule_name, contents
 
-        # Print any of the filtered rules that do not have tests configured
-        if filter_rules:
+        # Print any of the filtered rules that remain in the list
+        # This means that there are not tests configured for them
+        if filter_rules and filter_rules_copy:
             self.all_tests_passed = False
             for filter_rule in filter_rules:
                 message = 'No test events configured for designated rule.'

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -86,7 +86,7 @@ class RuleProcessorTester(object):
         Args:
             filter_rules (list|None): Specific rule names (or None) to restrict
                 testing to. This is passed in from the CLI using the --rules option.
-            validate_only [bool=False]: If true, validation of test records will occur
+            validate_only (bool): If true, validation of test records will occur
                 without the rules engine being applied to events.
 
         Yields:


### PR DESCRIPTION
to @austinbyers for manage.py updates and various logging changes
to @jacknagz and @chunyong-lin for cli refactor
to @mime-frame: please confirm that log output examples below are sensible
size: medium
resolves: #149 
resolves: #154 
resolves: #245
contributes to: #276 

### Changes
* Testing via `manage.py` now supports a `validate-schemas` command.
  * An optional argument for this command is `--test-files` which accepts a space separated list of files (or, alternatively, rule names) to validate.
  * For example: `python manage.py validate-schemas --test-files cloudtrail_put_bucket_acl`
  * This command does not perform any actual rule engine operations and will simply attempt to 'classify' the record against the defined log schemas.
* All summary output is now printed through the logging object with their respective levels (ie: warning, error, info) instead of through print statements.

### Examples
#### Running the following command with all valid records:
##### `$ python manage.py validate-schemas --test-files cloudtrail_put_object_acl.json`
```
$ python manage.py validate-schemas --test-files cloudtrail_put_object_acl.json
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

cloudtrail_put_object_acl
       [Pass]  [log='cloudtrail:events']     validation  (s3): CloudTrail - PutObjectAcl - True Positive
       [Pass]  [log='cloudtrail:events']     validation  (s3): CloudTrail - PutObjectAcl - False Positive

StreamAlertCLI [INFO]: (2/2) Successful Tests
StreamAlertCLI [INFO]: Completed
```

#### Running the following command with 1 invalid record:
##### `$ python manage.py validate-schemas --test-files cloudtrail_put_object_acl.json`
```
$ python manage.py validate-schemas --test-files cloudtrail_put_object_acl.json
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

cloudtrail_put_object_acl
       [Pass]  [log='cloudtrail:events']     validation  (s3): CloudTrail - PutObjectAcl - True Positive
       [Fail]  [log='unknown']               validation  (s3): CloudTrail - PutObjectAcl - False Positive

StreamAlertCLI [INFO]: (1/2) Successful Tests
StreamAlertCLI [ERROR]: (1/2) Failures
StreamAlertCLI [ERROR]: (1/1) [cloudtrail_put_object_acl] Data is invalid due to missing key(s) in test record: 'eventVersion'. Rule: 'cloudtrail_put_object_acl'. Description: 'CloudTrail - PutObjectAcl - False Positive'
```

### Other updates
* Adding the ability to detect any error messages that are logged during execution
  * By adding a MemoryHandler to the root logger and filtering out all messages that are not of level 'error', we can store any errors that occur during test runs in a buffer.
  * The number of errors that occurred will be reported at the end, and the errors themselves will be logged so they can be addressed.
* We will now log warnings to stdout for any rule that exists without a corresponding integration test, like so:
```
StreamAlertCLI [WARNING]: No tests configured for rule: 'rule_without_a_test'. Please add a corresponding test file for this rule in 'tests/integration/rules' with the name 'rule_without_a_test.json' to avoid seeing this warning
```
* A similar warning like the one above will be logged if a integration test file exists, but there is no rule for said file. However, this will **only** occur if the command is `lambda test` and not with `validate-schemas`. The output is like so:
```
StreamAlertCLI [WARNING]: No rules configured for test file: 'test_without_rule.json'. Please add a corresponding rule for this test file in 'rules/' with the name 'test_without_rule.py' to avoid seeing this warning and any associated errors above
```
* Significantly changing how status messages are stored and output during a test run.

### Bug fixes
* Resolving bug with improper set logic that could cause the alert processor to get ran inadvertently. See [this commit](https://github.com/airbnb/streamalert/commit/817d9e348300fd718498ab0adb67cfed0070fde6).
* Resolving bug that could cause the `analyze_record_delta` function to report that keys defined as `optional_top_level_keys` in a log's schema were in fact required. See [this commit](https://github.com/airbnb/streamalert/commit/c9c493579403108a31bf6292143fcab81c41c741).