### PR TITLE
[streamalert] logs - update CB and osquery schemas

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -7,7 +7,7 @@
       "md5": "string",
       "node_id": "string",
       "size": "string",
-      "timestamp": "float",
+      "timestamp": "string",
       "type": "string"
     },
     "parser": "json"
@@ -151,13 +151,21 @@
       "alert_resolution": "string",
       "cb_server": "string",
       "feed_name": "string",
+      "ioc_query_index": "string",
+      "ioc_query_string": "string",
       "ioc_type": "string",
       "ioc_value": "string",
       "report_id": [],
       "timestamp": "string",
       "type": "string"
     },
-    "parser": "json"
+    "parser": "json",
+    "configuration": {
+      "optional_top_level_keys": [
+        "ioc_query_index",
+        "ioc_query_string"
+      ]
+    }
   },
   "carbonblack:alert.watchlist.hit.feedsearch.binary": {
     "schema": {
@@ -273,7 +281,7 @@
   },
   "carbonblack:alert.watchlist.hit.query.process": {
     "schema": {
-      "alert_severity": "integer",
+      "alert_severity": "float",
       "alert_type": "string",
       "assigned_to": "string",
       "cb_server": "string",
@@ -290,7 +298,7 @@
       "hostname": "string",
       "interface_ip": "string",
       "ioc_attr": "string",
-      "ioc_confidence": "integer",
+      "ioc_confidence": "float",
       "ioc_type": "string",
       "md5": "string",
       "modload_count": "integer",
@@ -802,6 +810,7 @@
       "hostIdentifier": "string",
       "calendarTime": "string",
       "unixTime": "string",
+      "epoch": "integer",
       "columns": {},
       "action": "string",
       "decorations": {},
@@ -810,8 +819,9 @@
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
-        "log_type",
-        "decorations"
+        "decorations",
+        "epoch",
+        "log_type"
       ]
     }
   },
@@ -825,6 +835,24 @@
       "line": "integer",
       "message": "string",
       "version": "string",
+      "decorations": {},
+      "log_type": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "optional_top_level_keys": [
+        "decorations"
+      ]
+    }
+  },
+  "osquery_snapshot": {
+    "schema": {
+      "snapshot": [],
+      "name": "string",
+      "hostIdentifier": "string",
+      "calendarTime": "string",
+      "unixTime": "string",
+      "action": "string",
       "decorations": {},
       "log_type": "string"
     },


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**What**

Commit schema changes upstream:
- CarbonBlack schema updates
- Support for osquery snapshots

**Testing**

```
python manage.py lambda test --processor all
StreamAlertCLI [INFO]: (14/14) Successful Tests
StreamAlertCLI [INFO]: (30/30) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```