### PR TITLE
[metrics] v2 of metrics support using metric filters

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -6,11 +6,11 @@
     "region": "us-east-1"
   },
   "infrastructure": {
+    "metrics": {
+      "enabled": true
+    },
     "monitoring": {
       "create_sns_topic": true
-    },
-    "metrics": {
-      "enabled": false
     }
   },
   "terraform": {

--- a/stream_alert/alert_processor/__init__.py
+++ b/stream_alert/alert_processor/__init__.py
@@ -1,0 +1,21 @@
+"""Initialize logging for the alert processor."""
+import logging
+import os
+
+FUNCTION_NAME = 'alert_processor'
+
+# Create a package level logger to import
+LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()
+
+# Cast integer levels to avoid a ValueError
+if LEVEL.isdigit():
+    LEVEL = int(LEVEL)
+
+logging.basicConfig(format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s')
+
+LOGGER = logging.getLogger('StreamAlertOutput')
+try:
+    LOGGER.setLevel(LEVEL)
+except (TypeError, ValueError) as err:
+    LOGGER.setLevel('INFO')
+    LOGGER.error('Defaulting to INFO logging: %s', err)

--- a/stream_alert/alert_processor/__init__.py
+++ b/stream_alert/alert_processor/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-FUNCTION_NAME = 'alert_processor'
+from stream_alert.shared import ALERT_PROCESSOR_NAME as FUNCTION_NAME
 
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()

--- a/stream_alert/alert_processor/helpers.py
+++ b/stream_alert/alert_processor/helpers.py
@@ -13,11 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import logging
-
-logging.basicConfig()
-LOGGER = logging.getLogger('StreamAlertOutput')
-LOGGER.setLevel(logging.DEBUG)
+from stream_alert.alert_processor import LOGGER
 
 
 def validate_alert(alert):

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -17,12 +17,9 @@ from collections import OrderedDict
 import json
 import logging
 
+from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.helpers import validate_alert
 from stream_alert.alert_processor.outputs import get_output_dispatcher
-
-logging.basicConfig()
-LOGGER = logging.getLogger('StreamAlertOutput')
-LOGGER.setLevel(logging.DEBUG)
 
 
 def handler(event, context):

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 from collections import OrderedDict
 import json
-import logging
 
 from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.helpers import validate_alert

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -272,7 +272,6 @@ class StreamOutputBase(object):
         Returns:
             OrderedDict: Contains various OutputProperty items
         """
-        pass
 
     @abstractmethod
     def dispatch(self, **kwargs):
@@ -285,4 +284,3 @@ class StreamOutputBase(object):
                 rule_name (str): Name of the triggered rule
                 alert (dict): Alert relevant to the triggered rule
         """
-        pass

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -16,7 +16,6 @@ limitations under the License.
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 import json
-import logging
 import os
 import ssl
 import tempfile
@@ -25,8 +24,7 @@ import urllib2
 import boto3
 from botocore.exceptions import ClientError
 
-logging.basicConfig()
-LOGGER = logging.getLogger('StreamAlertOutput')
+from stream_alert.alert_processor import LOGGER
 
 OutputProperty = namedtuple('OutputProperty',
                             'description, value, input_restrictions, mask_input, cred_requirement')

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -18,16 +18,13 @@ import cgi
 from collections import OrderedDict
 from datetime import datetime
 import json
-import logging
 import os
 import uuid
 
 import boto3
 
+from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.output_base import OutputProperty, StreamOutputBase
-
-logging.basicConfig()
-LOGGER = logging.getLogger('StreamAlertOutput')
 
 # STREAM_OUTPUTS will contain each subclass of the StreamOutputBase
 # All included subclasses are designated using the '@output' class decorator

--- a/stream_alert/athena_partition_refresh/__init__.py
+++ b/stream_alert/athena_partition_refresh/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-FUNCTION_NAME = 'athena_partition_refresh'
+from stream_alert.shared import ATHENA_PARTITION_REFRESH_NAME as FUNCTION_NAME
 
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()

--- a/stream_alert/athena_partition_refresh/__init__.py
+++ b/stream_alert/athena_partition_refresh/__init__.py
@@ -1,0 +1,21 @@
+"""Initialize logging for the athena partition refresh function."""
+import logging
+import os
+
+FUNCTION_NAME = 'athena_partition_refresh'
+
+# Create a package level logger to import
+LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()
+
+# Cast integer levels to avoid a ValueError
+if LEVEL.isdigit():
+    LEVEL = int(LEVEL)
+
+logging.basicConfig(format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s')
+
+LOGGER = logging.getLogger('StreamAlertAthena')
+try:
+    LOGGER.setLevel(LEVEL)
+except (TypeError, ValueError) as err:
+    LOGGER.setLevel('INFO')
+    LOGGER.error('Defaulting to INFO logging: %s', err)

--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -16,7 +16,6 @@ limitations under the License.
 from collections import defaultdict
 from datetime import datetime
 import json
-import logging
 import os
 import re
 import urllib
@@ -24,11 +23,7 @@ import urllib
 import backoff
 import boto3
 
-logging.basicConfig(
-    format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s')
-LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO')
-LOGGER = logging.getLogger('StreamAlertAthena')
-LOGGER.setLevel(LEVEL.upper())
+from stream_alert.athena_partition_refresh import LOGGER
 
 
 def _backoff_handler(details):

--- a/stream_alert/rule_processor/__init__.py
+++ b/stream_alert/rule_processor/__init__.py
@@ -2,6 +2,8 @@
 import logging
 import os
 
+FUNCTION_NAME = 'rule_processor'
+
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()
 

--- a/stream_alert/rule_processor/__init__.py
+++ b/stream_alert/rule_processor/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-FUNCTION_NAME = 'rule_processor'
+from stream_alert.shared import RULE_PROCESSOR_NAME as FUNCTION_NAME
 
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -16,13 +16,13 @@ limitations under the License.
 from logging import DEBUG as LOG_LEVEL_DEBUG
 import json
 
-from stream_alert.rule_processor import LOGGER
+from stream_alert.rule_processor import FUNCTION_NAME, LOGGER
 from stream_alert.rule_processor.classifier import StreamClassifier
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.rule_processor.rules_engine import StreamRules
 from stream_alert.rule_processor.sink import StreamSink
-from stream_alert.shared.metrics import Metrics
+from stream_alert.shared.metrics import MetricLogger
 
 
 class StreamAlert(object):
@@ -51,7 +51,6 @@ class StreamAlert(object):
         # Instantiate a classifier that is used for this run
         self.classifier = StreamClassifier(config=config)
 
-        self.metrics = Metrics('RuleProcessor', self.env['lambda_region'])
         self.enable_alert_processor = enable_alert_processor
         self._failed_record_count = 0
         self._alerts = []
@@ -76,10 +75,7 @@ class StreamAlert(object):
         if not records:
             return False
 
-        self.metrics.add_metric(
-            Metrics.Name.TOTAL_RECORDS,
-            len(records),
-            Metrics.Unit.COUNT)
+        MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.TOTAL_RECORDS, len(records))
 
         for raw_record in records:
             # Get the service and entity from the payload. If the service/entity
@@ -101,7 +97,7 @@ class StreamAlert(object):
                 continue
 
             # Create the StreamPayload to use for encapsulating parsed info
-            payload = load_stream_payload(service, entity, raw_record, self.metrics)
+            payload = load_stream_payload(service, entity, raw_record)
             if not payload:
                 continue
 
@@ -109,24 +105,18 @@ class StreamAlert(object):
 
         LOGGER.debug('Invalid record count: %d', self._failed_record_count)
 
-        self.metrics.add_metric(
-            Metrics.Name.FAILED_PARSES,
-            self._failed_record_count,
-            Metrics.Unit.COUNT)
+        MetricLogger.log_metric(FUNCTION_NAME,
+                                MetricLogger.FAILED_PARSES,
+                                self._failed_record_count)
 
         LOGGER.debug('%s alerts triggered', len(self._alerts))
 
-        self.metrics.add_metric(
-            Metrics.Name.TRIGGERED_ALERTS, len(
-                self._alerts), Metrics.Unit.COUNT)
+        MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.TRIGGERED_ALERTS, len(self._alerts))
 
         # Check if debugging logging is on before json dumping alerts since
         # this can be time consuming if there are a lot of alerts
         if self._alerts and LOGGER.isEnabledFor(LOG_LEVEL_DEBUG):
             LOGGER.debug('Alerts:\n%s', json.dumps(self._alerts, indent=2))
-
-        # Send any cached metrics to CloudWatch before returning
-        self.metrics.send_metrics()
 
         return self._failed_record_count == 0
 

--- a/stream_alert/shared/__init__.py
+++ b/stream_alert/shared/__init__.py
@@ -1,6 +1,11 @@
-"""Define logger for shared functionality."""
+"""Define some shared resources."""
 import logging
 import os
+
+
+ALERT_PROCESSOR_NAME = 'alert_processor'
+ATHENA_PARTITION_REFRESH_NAME = 'athena_partition_refresh'
+RULE_PROCESSOR_NAME = 'rule_processor'
 
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -13,14 +13,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from datetime import datetime
 import json
 import os
 
-import boto3
-from botocore.exceptions import ClientError
-
 from stream_alert.shared import LOGGER
+# Since this is a shared package, try to import the relevant processor name
+try:
+    from stream_alert.alert_processor import FUNCTION_NAME as ALERT_PROCESSOR
+except ImportError:
+    ALERT_PROCESSOR = 'alert_processor'
+
+try:
+    from stream_alert.athena_partition_refresh import FUNCTION_NAME as ATHENA_PROCESSOR
+except ImportError:
+    ATHENA_PROCESSOR = 'athena_partition_refresh'
+
+try:
+    from stream_alert.rule_processor import FUNCTION_NAME as RULE_PROCESSOR
+except ImportError:
+    RULE_PROCESSOR = 'rule_processor'
 
 CLUSTER = os.environ.get('CLUSTER', 'unknown_cluster')
 
@@ -32,120 +43,74 @@ except ValueError as err:
                  err.message)
 
 
-class Metrics(object):
-    """Class to hold metric names and unit constants.
+class MetricLogger(object):
+    """Class to hold metric logging to be picked up by log metric filters.
 
     This basically acts as an enum, allowing for the use of dot notation for
     accessing properties and avoids doing dict lookups a ton.
     """
 
-    def __init__(self, lambda_function, region):
-        self.boto_cloudwatch = boto3.client('cloudwatch', region_name=region)
-        self._metric_data = []
-        self._dimensions = [
-            {
-                'Name': 'Cluster',
-                'Value': CLUSTER
-            },
-            {
-                'Name': 'Function',
-                'Value': lambda_function
-            }
-        ]
+    # Constant metric names used for CloudWatch
+    FAILED_PARSES = 'FailedParses'
+    S3_DOWNLOAD_TIME = 'S3DownloadTime'
+    TOTAL_RECORDS = 'TotalRecords'
+    TOTAL_S3_RECORDS = 'TotalS3Records'
+    TRIGGERED_ALERTS = 'TriggeredAlerts'
 
-    class Name(object):
-        """Constant metric names used for CloudWatch"""
-        FAILED_PARSES = 'FailedParses'
-        S3_DOWNLOAD_TIME = 'S3DownloadTime'
-        TOTAL_RECORDS = 'TotalRecords'
-        TOTAL_S3_RECORDS = 'TotalS3Records'
-        TRIGGERED_ALERTS = 'TriggeredAlerts'
+    _default_filter = '{{ $.metric_name = "{}" }}'
+    _default_value_lookup = '$.metric_value'
 
-    class Unit(object):
-        """Unit names for metrics. These are taken from the boto3 CloudWatch page"""
-        SECONDS = 'Seconds'
-        MICROSECONDS = 'Microseconds'
-        MILLISECONDS = 'Milliseconds'
-        BYTES = 'Bytes'
-        KILOBYTES = 'Kilobytes'
-        MEGABYTES = 'Megabytes'
-        GIGABYTES = 'Gigabytes'
-        TERABYTES = 'Terabytes'
-        BITS = 'Bits'
-        KILOBITS = 'Kilobits'
-        MEGABITS = 'Megabits'
-        GIGABITS = 'Gigabits'
-        TERABITS = 'Terabits'
-        PERCENT = 'Percent'
-        COUNT = 'Count'
-        BYTES_PER_SECOND = 'Bytes/Second'
-        KILOBYTES_PER_SECOND = 'Kilobytes/Second'
-        MEGABYTES_PER_SECOND = 'Megabytes/Second'
-        GIGABYTES_PER_SECOND = 'Gigabytes/Second'
-        TERABYTES_PER_SECOND = 'Terabytes/Second'
-        BITS_PER_SECOND = 'Bits/Second'
-        KILOBITS_PER_SECOND = 'Kilobits/Second'
-        MEGABITS_PER_SECOND = 'Megabits/Second'
-        GIGABITS_PER_SECOND = 'Gigabits/Second'
-        TERABITS_PER_SECOND = 'Terabits/Second'
-        COUNT_PER_SECOND = 'Count/Second'
-        NONE = 'None'
+    # Establish all the of available metrics for each processor. These use default
+    # values for the filter pattern and value lookup, created above, but can be
+    # overridden in special cases. The terraform generate code uses these values to
+    # create the actual CloudWatch metric filters that will be used for each function.
+    # If additional metric logging is added that does not conform to this default
+    # configuration, new filters & lookups should be created to handle them as well.
+    _available_metrics = {
+        ALERT_PROCESSOR: {},   # Placeholder for future alert processor metrics
+        ATHENA_PROCESSOR: {},  # Placeholder for future athena processor metrics
+        RULE_PROCESSOR: {
+            FAILED_PARSES: (_default_filter.format(FAILED_PARSES), _default_value_lookup),
+            S3_DOWNLOAD_TIME: (_default_filter.format(S3_DOWNLOAD_TIME), _default_value_lookup),
+            TOTAL_RECORDS: (_default_filter.format(TOTAL_RECORDS), _default_value_lookup),
+            TOTAL_S3_RECORDS: (_default_filter.format(TOTAL_S3_RECORDS), _default_value_lookup),
+            TRIGGERED_ALERTS: (_default_filter.format(TRIGGERED_ALERTS), _default_value_lookup)
+        }
+    }
 
-    def add_metric(self, metric_name, value, unit):
-        """Add a metric to the list of metrics to be sent to CloudWatch
+    @classmethod
+    def log_metric(cls, lambda_function, metric_name, value):
+        """Log a metric using the logger the list of metrics to be sent to CloudWatch
 
         Args:
             metric_name (str): Name of metric to publish to. Choices are in `Metrics.Name` above
             value (num): Numeric information to post to metric. AWS expects
                 this to be of type 'float' but will accept any numeric value that
                 is not super small (negative) or super large.
-            unit (str): Unit to use for this metric. Choices are in `Metrics.Unit` above.
         """
-        if metric_name not in self.Name.__dict__.values():
-            LOGGER.error('Metric name not defined: %s', metric_name)
-            return
-
-        if unit not in self.Unit.__dict__.values():
-            LOGGER.error('Metric unit not defined: %s', unit)
-            return
-
-        self._metric_data.append(
-            {
-                'MetricName': metric_name,
-                'Timestamp': datetime.utcnow(),
-                'Unit': unit,
-                'Value': value,
-                "Dimensions": self._dimensions
-            }
-        )
-
-    def send_metrics(self):
-        """Public method for publishing custom metric data to CloudWatch."""
         if not ENABLE_METRICS:
-            LOGGER.debug('Sending of metric data is currently disabled.')
+            LOGGER.debug('Logging of metric data is currently disabled.')
             return
 
-        if not self._metric_data:
-            LOGGER.debug('No metric data to send to CloudWatch.')
+        if lambda_function not in cls._available_metrics:
+            LOGGER.error('Function \'%s\' not defined in available metrics. Options are: %s',
+                         lambda_function,
+                         ', '.join('\'{}\''.format(key) for key in cls._available_metrics
+                                   if cls._available_metrics[key]))
             return
 
-        for metric in self._metric_data:
-            LOGGER.debug('Sending metric data to CloudWatch: %s', metric['MetricName'])
+        if metric_name not in cls._available_metrics[lambda_function]:
+            LOGGER.error('Metric name (\'%s\') not defined for \'%s\' function. Options are: %s',
+                         metric_name,
+                         lambda_function,
+                         ', '.join('\'{}\''.format(value)
+                                   for value in cls._available_metrics[lambda_function]))
+            return
 
-        self._put_metrics()
+        # Use a default format for logging this metric that will get picked up by the filters
+        LOGGER.info('%s', json.dumps({'metric_name': metric_name, 'metric_value': value}))
 
-    def _put_metrics(self):
-        """Protected method for publishing custom metric data to CloudWatch that
-        handles all of the boto3 calls and error handling.
-        """
-        try:
-            self.boto_cloudwatch.put_metric_data(
-                Namespace='StreamAlert', MetricData=self._metric_data)
-        except ClientError as err:
-            LOGGER.exception(
-                'Failed to send metric to CloudWatch. Error: %s\nMetric data:\n%s',
-                err.response,
-                json.dumps(
-                    self._metric_data,
-                    indent=2,
-                    default=lambda d: d.isoformat()))
+    @classmethod
+    def get_available_metrics(cls):
+        """Return the protected dictionary of metrics for all functions"""
+        return cls._available_metrics

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -138,8 +138,11 @@ def format_lambda_test_record(test_record):
     return template
 
 
-def create_lambda_function(function_name, region):
+def  create_lambda_function(function_name, region):
     """Helper function to create mock lambda function"""
+    if function_name.find(':') != -1:
+        function_name = function_name.split(':')[0]
+
     boto3.client('lambda', region_name=region).create_function(
         FunctionName=function_name,
         Runtime='python2.7',
@@ -153,7 +156,6 @@ def create_lambda_function(function_name, region):
             'ZipFile': _make_lambda_package()
         }
     )
-
 
 def encrypt_with_kms(data, region, alias):
     """Encrypt the given data with KMS."""

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -139,7 +139,7 @@ class RuleProcessorTester(object):
             return
 
         # Create the StreamPayload to use for encapsulating parsed info
-        payload = load_stream_payload(service, entity, formatted_record, Mock())
+        payload = load_stream_payload(service, entity, formatted_record)
         if not payload:
             self.all_tests_passed = False
             return

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -42,37 +42,6 @@ data "aws_iam_policy_document" "rule_processor_invoke_alert_proc" {
   }
 }
 
-// IAM Role Policy: Allow the Rule Processor to publish CloudWatch metrics
-resource "aws_iam_role_policy" "streamalert_rule_processor_cloudwatch_put_metric_data" {
-  name = "${var.prefix}_${var.cluster}_streamalert_rule_processor_put_metric_data"
-  role = "${aws_iam_role.streamalert_rule_processor_role.id}"
-
-  policy = "${data.aws_iam_policy_document.put_metric_data.json}"
-}
-
-// IAM Role Policy: Allow the Alert Processor to publish CloudWatch metrics
-resource "aws_iam_role_policy" "streamalert_alert_processor_cloudwatch_put_metric_data" {
-  name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_put_metric_data"
-  role = "${aws_iam_role.streamalert_alert_processor_role.id}"
-
-  policy = "${data.aws_iam_policy_document.put_metric_data.json}"
-}
-
-// IAM Policy Doc: Allow the Lambda Functions to publish CloudWatch metrics
-data "aws_iam_policy_document" "put_metric_data" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "cloudwatch:PutMetricData",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
-}
-
 // IAM Role: Alert Processor Execution Role
 resource "aws_iam_role" "streamalert_alert_processor_role" {
   name = "${var.prefix}_${var.cluster}_streamalert_alert_processor_role"

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -150,3 +150,33 @@ resource "aws_cloudwatch_log_group" "alert_processor" {
   name              = "/aws/lambda/${var.prefix}_${var.cluster}_streamalert_alert_processor"
   retention_in_days = 60
 }
+
+// CloudWatch metric filters for the rule processor
+// The split list is made up of: <filter_name>, <filter_pattern>, <value>
+resource "aws_cloudwatch_log_metric_filter" "rule_processor_cw_metric_filters" {
+  count          = "${length(var.rule_processor_metric_filters)}"
+  name           = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
+  pattern        = "${element(split(",", var.rule_processor_metric_filters[count.index]), 1)}"
+  log_group_name = "${aws_cloudwatch_log_group.rule_processor.name}"
+
+  metric_transformation {
+    name      = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
+    namespace = "${var.namespace}"
+    value     = "${element(split(",", var.rule_processor_metric_filters[count.index]), 2)}"
+  }
+}
+
+// CloudWatch metric filters for the alert processor
+// The split list is made up of: <filter_name>, <filter_pattern>, <value>
+resource "aws_cloudwatch_log_metric_filter" "alert_processor_cw_metric_filters" {
+  count          = "${length(var.alert_processor_metric_filters)}"
+  name           = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
+  pattern        = "${element(split(",", var.alert_processor_metric_filters[count.index]), 1)}"
+  log_group_name = "${aws_cloudwatch_log_group.alert_processor.name}"
+
+  metric_transformation {
+    name      = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
+    namespace = "${var.namespace}"
+    value     = "${element(split(",", var.alert_processor_metric_filters[count.index]), 2)}"
+  }
+}

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -86,3 +86,18 @@ variable "alert_processor_vpc_security_group_ids" {
   type    = "list"
   default = []
 }
+
+variable "rule_processor_metric_filters" {
+  type    = "list"
+  default = []
+}
+
+variable "alert_processor_metric_filters" {
+  type    = "list"
+  default = []
+}
+
+variable "namespace" {
+  type    = "string"
+  default = "StreamAlert"
+}

--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -97,3 +97,18 @@ resource "aws_cloudwatch_log_group" "athena" {
   name              = "/aws/lambda/${var.prefix}_streamalert_athena_partition_refresh"
   retention_in_days = 60
 }
+
+// CloudWatch metric filters for the athena partition refresh function
+// The split list is made up of: <filter_name>, <filter_pattern>, <value>
+resource "aws_cloudwatch_log_metric_filter" "athena_partition_refresh_cw_metric_filters" {
+  count          = "${length(var.athena_metric_filters)}"
+  name           = "${element(split(",", var.athena_metric_filters[count.index]), 0)}"
+  pattern        = "${element(split(",", var.athena_metric_filters[count.index]), 1)}"
+  log_group_name = "${aws_cloudwatch_log_group.athena.name}"
+
+  metric_transformation {
+    name      = "${element(split(",", var.athena_metric_filters[count.index]), 0)}"
+    namespace = "${var.namespace}"
+    value     = "${element(split(",", var.athena_metric_filters[count.index]), 2)}"
+  }
+}

--- a/terraform/modules/tf_stream_alert_athena/variables.tf
+++ b/terraform/modules/tf_stream_alert_athena/variables.tf
@@ -46,3 +46,13 @@ variable "refresh_interval" {
 variable "enable_metrics" {
   default = false
 }
+
+variable "athena_metric_filters" {
+  type    = "list"
+  default = []
+}
+
+variable "namespace" {
+  type    = "string"
+  default = "StreamAlert"
+}

--- a/tests/unit/conf/outputs.json
+++ b/tests/unit/conf/outputs.json
@@ -3,7 +3,8 @@
     "unit_test_bucket": "unit.test.bucket.name"
   },
   "aws-lambda": {
-    "unit_test_lambda": "unit_test_function"
+    "unit_test_lambda": "unit_test_function",
+    "unit_test_lambda_qual": "unit_test_function:production"
   },
   "pagerduty": [
     "unit_test_pagerduty"

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -587,9 +587,9 @@ class TestLambdaOuput(object):
         assert_equal(self.__dispatcher.__class__.__name__, 'LambdaOutput')
         assert_equal(self.__dispatcher.__service__, self.__service)
 
-    def _setup_dispatch(self):
+    def _setup_dispatch(self, alt_descriptor=''):
         """Helper for setting up LambdaOutput dispatch"""
-        function_name = CONFIG[self.__service][self.__descriptor]
+        function_name = CONFIG[self.__service][alt_descriptor or self.__descriptor]
         create_lambda_function(function_name, REGION)
         return get_alert()
 
@@ -599,6 +599,18 @@ class TestLambdaOuput(object):
         """LambdaOutput dispatch"""
         alert = self._setup_dispatch()
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+    @mock_lambda
+    @patch('logging.Logger.info')
+    def test_dispatch_with_qualifier(self, log_mock):
+        """LambdaOutput dispatch with qualifier"""
+        alt_descriptor = '{}_qual'.format(self.__descriptor)
+        alert = self._setup_dispatch(alt_descriptor)
+        self.__dispatcher.dispatch(descriptor=alt_descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
 

--- a/tests/unit/stream_alert_cli/test_terraform_generate.py
+++ b/tests/unit/stream_alert_cli/test_terraform_generate.py
@@ -632,7 +632,8 @@ class TestTerraformGenerate(object):
                         'unit-testing-2.streamalerts'
                     ],
                     'prefix': 'unit-testing',
-                    'refresh_interval': 'rate(10 minutes)'
+                    'refresh_interval': 'rate(10 minutes)',
+                    'athena_metric_filters': []
                 }
             }
         }

--- a/tests/unit/stream_alert_rule_processor/test_classifier.py
+++ b/tests/unit/stream_alert_rule_processor/test_classifier.py
@@ -44,7 +44,7 @@ class TestStreamClassifier(object):
 
     def _prepare_and_classify_payload(self, service, entity, raw_record):
         """Helper method to return a preparsed and classified payload"""
-        payload = load_stream_payload(service, entity, raw_record, None)
+        payload = load_stream_payload(service, entity, raw_record)
 
         payload = payload.pre_parse().next()
         self.classifier.load_sources(service, entity)
@@ -253,7 +253,7 @@ class TestStreamClassifier(object):
         })
 
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record, None)
+        payload = load_stream_payload(service, entity, raw_record)
         payload = payload.pre_parse().next()
 
         result = self.classifier._parse(payload)
@@ -279,7 +279,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record, None)
+        payload = load_stream_payload(service, entity, raw_record)
 
         self.classifier.load_sources(service, entity)
 
@@ -308,7 +308,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record, None)
+        payload = load_stream_payload(service, entity, raw_record)
 
         self.classifier.load_sources(service, entity)
 
@@ -337,7 +337,7 @@ class TestStreamClassifier(object):
 
         service, entity = 'kinesis', 'test_stream_2'
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
-        payload = load_stream_payload(service, entity, raw_record, None)
+        payload = load_stream_payload(service, entity, raw_record)
 
         self.classifier.load_sources(service, entity)
 

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import base64
 import logging
 
-from mock import call, Mock, mock_open, patch
+from mock import call, mock_open, patch
 from nose.tools import (
     assert_equal,
     assert_false,

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -137,9 +137,7 @@ class TestStreamAlert(object):
 
         calls = [call('Processed %d valid record(s) that resulted in %d alert(s).', 1, 0),
                  call('Invalid record count: %d', 0),
-                 call('Logging of metric data is currently disabled.'),
-                 call('%s alerts triggered', 0),
-                 call('Logging of metric data is currently disabled.')]
+                 call('%s alerts triggered', 0)]
 
         log_mock.assert_has_calls(calls)
 

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -32,7 +32,6 @@ from stream_alert.rule_processor.handler import load_config, StreamAlert
 from tests.unit.stream_alert_rule_processor.test_helpers import get_mock_context, get_valid_event
 
 
-@patch('stream_alert.rule_processor.handler.Metrics.send_metrics', Mock())
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
 
@@ -52,7 +51,7 @@ class TestStreamAlert(object):
 
     @staticmethod
     @raises(ConfigError)
-    def test_run_config_error(_):
+    def test_run_config_error():
         """StreamAlert Class - Run, Config Error"""
         mock = mock_open(read_data='non-json string that will raise an exception')
         with patch('__builtin__.open', mock):
@@ -115,8 +114,7 @@ class TestStreamAlert(object):
         load_payload_mock.assert_called_with(
             'lambda',
             'entity',
-            'record',
-            self.__sa_handler.metrics
+            'record'
         )
 
     @patch('stream_alert.rule_processor.handler.StreamRules.process')
@@ -139,7 +137,9 @@ class TestStreamAlert(object):
 
         calls = [call('Processed %d valid record(s) that resulted in %d alert(s).', 1, 0),
                  call('Invalid record count: %d', 0),
-                 call('%s alerts triggered', 0)]
+                 call('Logging of metric data is currently disabled.'),
+                 call('%s alerts triggered', 0),
+                 call('Logging of metric data is currently disabled.')]
 
         log_mock.assert_has_calls(calls)
 
@@ -179,10 +179,9 @@ class TestStreamAlert(object):
         sink_mock.assert_called_with(['success!!'])
 
     @patch('logging.Logger.debug')
-    @patch('stream_alert.shared.metrics.Metrics.send_metrics')
     @patch('stream_alert.rule_processor.handler.StreamRules.process')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
-    def test_run_debug_log_alert(self, extract_mock, rules_mock, _, log_mock):
+    def test_run_debug_log_alert(self, extract_mock, rules_mock, log_mock):
         """StreamAlert Class - Run, Debug Log Alert"""
         extract_mock.return_value = ('kinesis', 'unit_test_default_stream')
         rules_mock.return_value = ['success!!']

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -85,7 +85,7 @@ def get_valid_event(count=1):
 def load_and_classify_payload(config, service, entity, raw_record):
     """Return a loaded and classified payload."""
     # prepare the payloads
-    payload = load_stream_payload(service, entity, raw_record, None)
+    payload = load_stream_payload(service, entity, raw_record)
 
     payload = payload.pre_parse().next()
     classifier = StreamClassifier(config=config)

--- a/tests/unit/stream_alert_rule_processor/test_payload.py
+++ b/tests/unit/stream_alert_rule_processor/test_payload.py
@@ -46,7 +46,7 @@ def teardown_s3():
 
 def test_load_payload_valid():
     """StreamPayload - Loading Stream Payload, Valid"""
-    payload = load_stream_payload('s3', 'entity', 'record', None)
+    payload = load_stream_payload('s3', 'entity', 'record')
 
     assert_is_instance(payload, S3Payload)
 
@@ -54,14 +54,14 @@ def test_load_payload_valid():
 @patch('logging.Logger.error')
 def test_load_payload_invalid(log_mock):
     """StreamPayload - Loading Stream Payload, Invalid"""
-    load_stream_payload('blah', 'entity', 'record', None)
+    load_stream_payload('blah', 'entity', 'record')
 
     log_mock.assert_called_with('Service payload not supported: %s', 'blah')
 
 
 def test_repr_string():
     """StreamPayload - String Representation"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
+    s3_payload = load_stream_payload('s3', 'entity', 'record')
 
     # Set some values that are different than the defaults
     s3_payload.type = 'unit_type'
@@ -77,28 +77,28 @@ def test_repr_string():
 
 def test_get_service_kinesis():
     """StreamPayload - Get Service, Kinesis"""
-    kinesis_payload = load_stream_payload('kinesis', 'entity', 'record', None)
+    kinesis_payload = load_stream_payload('kinesis', 'entity', 'record')
 
     assert_equal(kinesis_payload.service(), 'kinesis')
 
 
 def test_get_service_s3():
     """StreamPayload - Get Service, S3"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
+    s3_payload = load_stream_payload('s3', 'entity', 'record')
 
     assert_equal(s3_payload.service(), 's3')
 
 
 def test_get_service_sns():
     """StreamPayload - Get Service, SNS"""
-    sns_payload = load_stream_payload('sns', 'entity', 'record', None)
+    sns_payload = load_stream_payload('sns', 'entity', 'record')
 
     assert_equal(sns_payload.service(), 'sns')
 
 
 def test_refresh_record():
     """StreamPayload - Refresh Record"""
-    s3_payload = load_stream_payload('s3', 'entity', 'record', None)
+    s3_payload = load_stream_payload('s3', 'entity', 'record')
 
     # Set some values that are different than the defaults
     s3_payload.type = 'unit_type'
@@ -121,7 +121,7 @@ def test_pre_parse_kinesis(log_mock):
     kinesis_data = json.dumps({'test': 'value'})
     entity = 'unit_test_entity'
     raw_record = make_kinesis_raw_record(entity, kinesis_data)
-    kinesis_payload = load_stream_payload('kinesis', entity, raw_record, Mock())
+    kinesis_payload = load_stream_payload('kinesis', entity, raw_record)
 
     kinesis_payload = kinesis_payload.pre_parse().next()
 
@@ -139,7 +139,7 @@ def test_pre_parse_sns(log_mock):
     """SNSPayload - Pre Parse"""
     sns_data = json.dumps({'test': 'value'})
     raw_record = make_sns_raw_record('unit_topic', sns_data)
-    sns_payload = load_stream_payload('sns', 'entity', raw_record, Mock())
+    sns_payload = load_stream_payload('sns', 'entity', raw_record)
 
     sns_payload = sns_payload.pre_parse().next()
 
@@ -159,7 +159,7 @@ def test_pre_parse_s3(s3_mock, *_):
     s3_mock.side_effect = [((0, records[0]), (1, records[1]))]
 
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
 
     for index, record in enumerate(s3_payload.pre_parse()):
         assert_equal(record.pre_parsed_record, records[index])
@@ -183,7 +183,7 @@ def test_pre_parse_s3_debug(s3_mock, log_mock, _):
     s3_mock.side_effect = [((100, records[0]), (200, records[1]))]
 
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
     S3Payload.s3_object_size = 350
 
     _ = [_ for _ in s3_payload.pre_parse()]
@@ -208,7 +208,7 @@ def test_pre_parse_s3_debug(s3_mock, log_mock, _):
 def test_s3_object_too_large():
     """S3Payload - S3ObjectSizeError, Object too Large"""
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, None)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
     S3Payload.s3_object_size = (128 * 1024 * 1024) + 10
 
     s3_payload._download_object('region', 'bucket', 'key')
@@ -219,7 +219,7 @@ def test_s3_object_too_large():
 def test_get_object(log_mock, _):
     """S3Payload - Get S3 Info from Raw Record"""
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, None)
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
 
     s3_payload._get_object()
     log_mock.assert_called_with(
@@ -234,7 +234,7 @@ def test_get_object(log_mock, _):
 def test_s3_download_object(log_mock, *_):
     """S3Payload - Download Object"""
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
     s3_payload._download_object('us-east-1', 'unit_bucket_name', 'unit_key_name')
 
     assert_equal(log_mock.call_args_list[1][0][0], 'Completed download in %s seconds')
@@ -247,7 +247,7 @@ def test_s3_download_object(log_mock, *_):
 def test_s3_download_object_mb(log_mock, *_):
     """S3Payload - Download Object, Size in MB"""
     raw_record = make_s3_raw_record('unit_bucket_name', 'unit_key_name')
-    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record, Mock())
+    s3_payload = load_stream_payload('s3', 'unit_key_name', raw_record)
     S3Payload.s3_object_size = (127.8 * 1024 * 1024)
     s3_payload._download_object('us-east-1', 'unit_bucket_name', 'unit_key_name')
 

--- a/tests/unit/stream_alert_rule_processor/test_payload.py
+++ b/tests/unit/stream_alert_rule_processor/test_payload.py
@@ -20,7 +20,7 @@ import logging
 import os
 import tempfile
 
-from mock import call, Mock, patch
+from mock import call, patch
 from nose.tools import (
     assert_equal,
     assert_false,

--- a/tests/unit/stream_alert_shared/test_metrics.py
+++ b/tests/unit/stream_alert_shared/test_metrics.py
@@ -63,8 +63,8 @@ class TestMetrics(object):
         """Metrics - Valid Metric"""
         shared.metrics.MetricLogger.log_metric('rule_processor', 'FailedParses', 100)
 
-        log_mock.assert_called_with(
-            '%s', '{"metric_name": "FailedParses", "metric_value": 100}')
+        log_mock.assert_called_with('{"metric_name": "%s", "metric_value": %s}',
+                                    'FailedParses', 100)
 
     @patch('logging.Logger.debug')
     def test_disabled_metrics(self, log_mock):
@@ -73,8 +73,6 @@ class TestMetrics(object):
 
         # Force reload the metrics package to trigger constant loading
         reload(shared.metrics)
-
-        shared.metrics.MetricLogger.log_metric('', '', '')
 
         log_mock.assert_called_with('Logging of metric data is currently disabled.')
 


### PR DESCRIPTION
to @austinbyers or @jacknagz 
cc @airbnb/streamalert-maintainers & @mime-frame 
size: medium
contributes to: #157 

## Background
* After a v1 attempt in https://github.com/airbnb/streamalert/pull/247, it was discovered that the implementation had a major set back:
  * We quickly discovered that we were exceeding the 150 transactions-per-second allowed by [CloudWatch's PutMetricData limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html) and thus were being throttled practically immediately.
  * This is more speculative, but the latency of calling boto3 with the metric data (exacerbated by being throttled) may also cause a slight increase in the rule processor invocation time.

## Changes
* Migrate to utilizing CloudWatch Metric Filters to allow for filtering CloudWatch logs for specific terms and extracting values from those log entries.
* Metrics will now be compiled per-cluster and also sent to an aggregate metric that encompasses all clusters. For instance, the metric for `S3DownloadTime` will appear as:
  * `RuleProcessor-S3DownloadTime` (aggregate)
  * `RuleProcessor-S3DownloadTime-PROD` (prod cluster)
  * `RuleProcessor-S3DownloadTime-CORP` (corp cluster)
* Logs with metrics will default to logging json using: `json.dumps({'metric_name': metric_name, 'metric_value': value})`, resulting in lines like:
 ```
[INFO]	2017-08-29T06:12:52.56Z	89bd8174-cc61-4e64-862b-4b084de2281f
{
    "metric_name": "TriggeredAlerts",
    "metric_value": 2
}
```
* The new `MetricLogger` class can be extended to use non-default logging formats and specify different filter patterns/value lookup - but the defaults should cover most of our use cases for now.
* Example of the new metrics, namespaced under `StreamAlert` in CloudWatch metrics:
![image](https://user-images.githubusercontent.com/13773789/29807225-dfc492b6-8c47-11e7-8486-d590faf61999.png)
* Graph showing failed log parsing from data coming into 2 rule processors in different clusters:
![image](https://user-images.githubusercontent.com/13773789/29807328-50f4f5b6-8c48-11e7-904a-6ee060d50dde.png)



### Caveat(s)
* We lose the ability to assign 'dimensions' to our CloudWatch metrics being posted, which allows for better segmentation of metric data in dashboard. For instance, we could break out metrics by functions name and cluster using dimensions.
  * The band-aid approach to make up for the lack of dimensions is prefixing metric names with the function name and adding a suffix for the cluster. We now will have metric names similar to: `RuleProcessor-FailedParses-PROD`

### Testing
* Deployed these changes in a test AWS account, utilizing a multiple cluster configuration to ensure all the metrics played well together. 

### Other
* Migrating some logging instantiation to within init - this is most in preparation of moving all logging into the `shared` package in the near future

### Upcoming
* Doc changes to demonstrate how to enabled/disable metrics
* CloudWatch alarm creation through the cli for any available metric filter.
