### PR TITLE
[cli] raising exception if output creds could not be encrypted

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -35,7 +35,7 @@ For example:
  - ``python manage.py output new --service slack``
 
 .. note:: If this is the first time you have configured new outputs via the cli, you may see this error for certain services:
- `An error occurred while sending credentials to S3 for key [<SERVICE>/<KEY>]: The specified bucket does not exist [<PREFIX>.streamalert.secrets]`.
+ `An error occurred while sending credentials to S3 for key '<SERVICE>/<KEY>' in bucket '<PREFIX>.streamalert.secrets': The specified bucket does not exist`.
  If you encounter this error, first make sure you've followed the `Quick Start <getting-started.html#quick-start>`_ steps.
  If you've already configured StreamAlert in the past, you may just have to run `python manage.py terraform build`.
  This ensures the S3 bucket used for storing encrypted secrets is created and only needs to be run once.

--- a/stream_alert_cli/outputs.py
+++ b/stream_alert_cli/outputs.py
@@ -118,8 +118,8 @@ def kms_encrypt(region, data, kms_key_alias):
                                   Plaintext=data)
         return response['CiphertextBlob']
     except ClientError:
-        LOGGER_CLI.exception('an error occurred during credential encryption')
-
+        LOGGER_CLI.error('An error occurred during credential encryption')
+        raise
 
 def send_creds_to_s3(region, bucket, key, blob_data):
     """Put the encrypted credential blob for this service and destination in s3
@@ -142,11 +142,11 @@ def send_creds_to_s3(region, bucket, key, blob_data):
         return True
     except ClientError as err:
         LOGGER_CLI.error(
-            'An error occurred while sending credentials to S3 for key [%s]: '
-            '%s [%s]',
+            'An error occurred while sending credentials to S3 for key \'%s\' '
+            'in bucket \'%s\': %s',
             key,
-            err.response['Error']['Message'],
-            err.response['Error']['BucketName'])
+            bucket,
+            err.response['Error']['Message'])
         return False
 
 

--- a/tests/unit/stream_alert_cli/test_outputs.py
+++ b/tests/unit/stream_alert_cli/test_outputs.py
@@ -106,8 +106,9 @@ def test_encrypt_and_push_creds_to_s3(cli_mock):
     assert_true(return_value)
 
 
+@raises(ClientError)
 @patch('boto3.client')
-@patch('logging.Logger.exception')
+@patch('logging.Logger.error')
 def test_encrypt_and_push_creds_to_s3_kms_failure(log_mock, boto_mock):
     """Encrypt and push creds to s3 - kms failure"""
     props = {
@@ -129,7 +130,7 @@ def test_encrypt_and_push_creds_to_s3_kms_failure(log_mock, boto_mock):
     boto_mock.side_effect = ClientError(err_response, 'operation')
     encrypt_and_push_creds_to_s3('us-east-1', 'bucket', 'key', props, 'test_alias')
 
-    log_mock.assert_called_with('an error occurred during credential encryption')
+    log_mock.assert_called_with('An error occurred during credential encryption')
 
 
 def test_update_outputs_config():


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 

### Fix
* Raising an exception if credentials fail to encrypt with KMS. This used to allow execution to continue to the point of trying to upload an empty blob to S3, and then would fail with a different error. This helps differentiate failures.
* Updating unit tests for new exceptions being raised.