### PR TITLE
[tf] quick fix for a AccessDeniedException introduced by AWS

### DIFF
--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "rule_processor_invoke_alert_proc" {
 
     # Use interpolation because of the different VPC/non vpc resources
     resources = [
-      "arn:aws:lambda:${var.region}:${var.account_id}:function:${var.prefix}_${var.cluster}_streamalert_alert_processor",
+      "arn:aws:lambda:${var.region}:${var.account_id}:function:${var.prefix}_${var.cluster}_streamalert_alert_processor:production",
     ]
   }
 }
@@ -151,8 +151,8 @@ resource "aws_iam_role_policy" "streamalert_alert_processor_lambda" {
         "lambda:InvokeFunction"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${element(
-        split(":", element(var.output_lambda_functions, count.index)), 0)}"
+      "Resource": "arn:aws:lambda:${var.region}:${var.account_id}:function:${
+        element(var.output_lambda_functions, count.index)}"
     }
   ]
 }


### PR DESCRIPTION
to @austinbyers 
cc @airbnb/streamalert-maintainers 

## Change
* Include AWS Lambda function qualifier in InvokeFunction permission to resolve AccessDeniedExceptions seen in CloudWatch when invoking a function without its qualifier.

@austinbyers please add additional context about how you discovered and triaged this issue.