### PR TITLE
[lambda][output] fixing mocked result for phantom integration tests

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -596,7 +596,8 @@ class AlertProcessorTester(object):
                 # Set the patched urlopen.getcode return value to 200
                 url_mock.return_value.getcode.return_value = 200
                 # Phantom needs a container 'id' value in the http response
-                url_mock.return_value.read.return_value = '{"id": 1948}'
+                url_mock.return_value.read.side_effect = ['{"count": 0, "data": []}',
+                                                          '{"id": 1948}']
             elif service == 'slack':
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'url': 'https://api.slack.com/web-hook-key'}


### PR DESCRIPTION
to @chunyong-lin 
cc @airbnb/streamalert-maintainers 
size: tiny

## Change
* Adding an extra urlopen side effect for Phantom tests to account for the urllib request use for container lookup.