### PR TITLE
[streamalert] - rule tests - make descriptions clearer

### DIFF
--- a/tests/integration/rules/cloudtrail_critical_api_calls.json
+++ b/tests/integration/rules/cloudtrail_critical_api_calls.json
@@ -33,7 +33,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - DeleteSubnet",
+            "description": "Deleting an AWS subnet (DeleteSubnet) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -71,7 +71,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - DeleteVpc",
+            "description": "Deleting an AWS VPC (DeleteVpc) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -121,7 +121,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - UpdateTrail",
+            "description": "Updating an AWS CloudTrail trail (UpdateTrail) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -157,7 +157,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - StopLogging",
+            "description": "Suspending the recording of AWS API calls and log file delivery for a trail will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -248,7 +248,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - DeleteDBCluster",
+            "description": "Deleting a database cluster (DeleteDBCluster) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -284,7 +284,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - StopConfigurationRecorder",
+            "description": "Suspending recording of resource changes through AWS Config (StopConfigurationRecorder) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -326,7 +326,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - DeleteFlowLogs",
+            "description": "Deleting AWS network flow logs (DeleteFlowLogs) will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": true
@@ -335,7 +335,7 @@
             "data": {
                 "awsRegion": "us-west-2",
                 "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DeleteFalsePositiveCase",
+                "eventName": "DescribeFlowLogs",
                 "eventSource": "ec2.amazonaws.com",
                 "eventTime": "2017-01-01T00:20:50Z",
                 "eventType": "AwsApiCall",
@@ -368,7 +368,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - Critical API - False Positive Case",
+            "description": "Describing AWS network flog logs will not create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": false

--- a/tests/integration/rules/cloudtrail_put_bucket_acl.json
+++ b/tests/integration/rules/cloudtrail_put_bucket_acl.json
@@ -52,22 +52,6 @@
                     "Grantee": {
                       "xsi:type": "Group",
                       "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
-                    },
-                    "Permission": "READ"
-                  },
-                  {
-                    "Grantee": {
-                      "xsi:type": "Group",
-                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
-                    },
-                    "Permission": "READ_ACP"
-                  },
-                  {
-                    "Grantee": {
-                      "xsi:type": "Group",
-                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
                       "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
                     },
                     "Permission": "READ"
@@ -99,7 +83,95 @@
           "recipientAccountId": "12345"
         }
       },
-      "description": "CloudTrail - PutBucketAcl - True Positive",
+      "description": "An AWS S3 bucket with 'AllUsers' permission(s) will create an alert.",
+      "trigger": true,
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "service": "kinesis"
+    },
+    {
+      "data": {
+        "account": 12345,
+        "region": "...",
+        "detail-type": "...",
+        "source": "...",
+        "version": "...",
+        "time": "...",
+        "id": "12345",
+        "resources": {
+          "test": "..."
+        },
+        "detail": {
+          "eventVersion": "...",
+          "userIdentity": {
+            "type": "...",
+            "principalId": "...",
+            "arn": "...",
+            "accountId": "12345",
+            "userName": "...",
+            "sessionContext": {
+              "attributes": {
+                "mfaAuthenticated": "true",
+                "creationDate": "..."
+              }
+            },
+            "invokedBy": "..."
+          },
+          "eventTime": "...",
+          "eventSource": "...",
+          "eventName": "PutBucketAcl",
+          "awsRegion": "...",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "bucketName": "...",
+            "AccessControlPolicy": {
+              "AccessControlList": {
+                "Grant": [
+                  {
+                    "Grantee": {
+                      "xsi:type": "CanonicalUser",
+                      "DisplayName": "...",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "ID": "..."
+                    },
+                    "Permission": "FULL_CONTROL"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                    },
+                    "Permission": "READ"
+                  },
+                  {
+                    "Grantee": {
+                      "xsi:type": "Group",
+                      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                      "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+                    },
+                    "Permission": "READ_ACP"
+                  }
+                ]
+              },
+              "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+              "Owner": {
+                "DisplayName": "...",
+                "ID": "..."
+              }
+            },
+            "acl": [
+              ""
+            ]
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "12345"
+        }
+      },
+      "description": "An AWS S3 bucket with 'AuthenticatedUsers' permission(s) will create an alert.",
       "trigger": true,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"
@@ -203,7 +275,7 @@
           "recipientAccountId": "12345"
         }
       },
-      "description": "CloudTrail - PutBucketAcl - False Positive",
+      "description": "An AWS PutBucketAcl call without 'AuthenticatedUsers' & 'AllUsers' will not create an alert.",
       "trigger": false,
       "source": "prefix_cluster1_stream_alert_kinesis",
       "service": "kinesis"

--- a/tests/integration/rules/cloudtrail_put_object_acl.json
+++ b/tests/integration/rules/cloudtrail_put_object_acl.json
@@ -21,9 +21,131 @@
                     "X-Amz-Expires": "12345",
                     "X-Amz-SignedHeaders": "...",
                     "accessControlList": {
-                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
-                        "x-amz-grant-read-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
-                        "x-amz-grant-write": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\"",
+                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                        "x-amz-grant-read-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                        "x-amz-grant-write": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                        "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\""
+                    },
+                    "bucketName": "...",
+                    "key": "...",
+                    "x-amz-storage-class": "..."
+                },
+                "resources": [
+                    {
+                        "ARN": "...",
+                        "type": "..."
+                    },
+                    {
+                        "ARN": "...",
+                        "accountId": "12345",
+                        "type": "..."
+                    }
+                ],
+                "responseElements": {
+                },
+                "sourceIPAddress": "...",
+                "userAgent": "...",
+                "userIdentity": {
+                    "accountId": "12345",
+                    "arn": "...",
+                    "principalId": "12345",
+                    "sessionContext": {
+                        "attributes": {
+                            "creationDate": "...",
+                            "mfaAuthenticated": "false"
+                        }
+                    },
+                    "type": "..."
+                }
+            },
+            "description": "Storing an S3 object with an `AuthenticatedUsers` permission will create an alert.",
+            "service": "s3",
+            "source": "prefix.cluster.sample.bucket",
+            "trigger_count": 1,
+            "trigger": true
+        },
+        {
+            "data": {
+                "additionalEventData": {
+                    "x-amz-id-2": "..."
+                },
+                "awsRegion": "...",
+                "eventID": "...",
+                "eventName": "PutObject",
+                "eventSource": "...",
+                "eventTime": "...",
+                "eventType": "AwsApiCall",
+                "eventVersion": "...",
+                "readOnly": false,
+                "recipientAccountId": "12345",
+                "requestID": "...",
+                "requestParameters": {
+                    "X-Amz-Algorithm": "...",
+                    "X-Amz-Date": "...",
+                    "X-Amz-Expires": "12345",
+                    "X-Amz-SignedHeaders": "...",
+                    "accessControlList": {
+                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
+                    },
+                    "bucketName": "...",
+                    "key": "...",
+                    "x-amz-storage-class": "..."
+                },
+                "resources": [
+                    {
+                        "ARN": "...",
+                        "type": "..."
+                    },
+                    {
+                        "ARN": "...",
+                        "accountId": "12345",
+                        "type": "..."
+                    }
+                ],
+                "responseElements": {
+                },
+                "sourceIPAddress": "...",
+                "userAgent": "...",
+                "userIdentity": {
+                    "accountId": "12345",
+                    "arn": "...",
+                    "principalId": "12345",
+                    "sessionContext": {
+                        "attributes": {
+                            "creationDate": "...",
+                            "mfaAuthenticated": "false"
+                        }
+                    },
+                    "type": "..."
+                }
+            },
+            "description": "Storing an S3 object with an `AllUsers` permission will create an alert.",
+            "service": "s3",
+            "source": "prefix.cluster.sample.bucket",
+            "trigger_count": 1,
+            "trigger": true
+        },
+        {
+            "data": {
+                "additionalEventData": {
+                    "x-amz-id-2": "..."
+                },
+                "awsRegion": "...",
+                "eventID": "...",
+                "eventName": "PutObject",
+                "eventSource": "...",
+                "eventTime": "...",
+                "eventType": "AwsApiCall",
+                "eventVersion": "...",
+                "readOnly": false,
+                "recipientAccountId": "12345",
+                "requestID": "...",
+                "requestParameters": {
+                    "X-Amz-Algorithm": "...",
+                    "X-Amz-Date": "...",
+                    "X-Amz-Expires": "12345",
+                    "X-Amz-SignedHeaders": "...",
+                    "accessControlList": {
                         "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
                     },
                     "bucketName": "...",
@@ -58,7 +180,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - PutObjectAcl - True Positive",
+            "description": "Storing an S3 object with an `AllUsers` and `AuthenticatedUsers` permission will create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger_count": 1,
@@ -116,7 +238,7 @@
                     "type": "..."
                 }
             },
-            "description": "CloudTrail - PutObjectAcl - False Positive",
+            "description": "Storing an S3 object without an `AllUsers` or `AuthenticatedUsers` permission will not create an alert.",
             "service": "s3",
             "source": "prefix.cluster.sample.bucket",
             "trigger": false

--- a/tests/integration/rules/cloudtrail_root_account_usage.json
+++ b/tests/integration/rules/cloudtrail_root_account_usage.json
@@ -40,7 +40,7 @@
                     "recipientAccountId": "12345"
                 }
             },
-            "description": "CloudTrail - Root Account Usage - True Positive",
+            "description": "Use of the AWS 'Root' account will create an alert.",
             "trigger": true,
             "source": "prefix_cluster1_stream_alert_kinesis",
             "service": "kinesis"
@@ -80,62 +80,6 @@
                     "sourceIPAddress": "AWS Internal",
                     "userAgent": "...",
                     "requestParameters": {
-                        "bucketName": "...",
-                        "AccessControlPolicy": {
-                            "AccessControlList": {
-                                "Grant": [
-                                    {
-                                        "Grantee": {
-                                            "xsi:type": "CanonicalUser",
-                                            "DisplayName": "...",
-                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                                            "ID": "..."
-                                        },
-                                        "Permission": "FULL_CONTROL"
-                                    },
-                                    {
-                                        "Grantee": {
-                                            "xsi:type": "Group",
-                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
-                                        },
-                                        "Permission": "READ"
-                                    },
-                                    {
-                                        "Grantee": {
-                                            "xsi:type": "Group",
-                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
-                                        },
-                                        "Permission": "READ_ACP"
-                                    },
-                                    {
-                                        "Grantee": {
-                                            "xsi:type": "Group",
-                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
-                                        },
-                                        "Permission": "READ"
-                                    },
-                                    {
-                                        "Grantee": {
-                                            "xsi:type": "Group",
-                                            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
-                                        },
-                                        "Permission": "READ_ACP"
-                                    }
-                                ]
-                            },
-                            "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
-                            "Owner": {
-                                "DisplayName": "...",
-                                "ID": "..."
-                            }
-                        },
-                        "acl": [
-                            ""
-                        ]
                     },
                     "responseElements": null,
                     "requestID": "...",
@@ -144,7 +88,7 @@
                     "recipientAccountId": "12345"
                 }
             },
-            "description": "CloudTrail - Root Account Usage - False Positive",
+            "description": "AWS 'Root' account activity initiated automatically by an AWS service on your behalf will not create an alert.",
             "trigger": false,
             "source": "prefix_cluster1_stream_alert_kinesis",
             "service": "kinesis"


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 
cc: @0xdabbad00

**Changes**

This updates the rule test descriptions to a Ruby-style test description instead of the confusing TP/FP pattern we initially started with.

This addresses https://github.com/airbnb/streamalert/issues/290

I also added some additional tests for existing rules.

**Testing**

```
python manage.py lambda test --processor all

StreamAlertCLI [INFO]: (17/17) Successful Tests
StreamAlertCLI [INFO]: (39/39) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```