### PR TITLE
streamalert - osquery prefix - plus outdated docs

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -806,7 +806,7 @@
       ]
     }
   },
-  "osquery": {
+  "osquery:differential": {
     "schema": {
       "name": "string",
       "hostIdentifier": "string",
@@ -827,7 +827,7 @@
       ]
     }
   },
-  "osquery_status": {
+  "osquery:status": {
     "schema": {
       "hostIdentifier": "string",
       "calendarTime": "string",
@@ -847,7 +847,7 @@
       ]
     }
   },
-  "osquery_snapshot": {
+  "osquery:snapshot": {
     "schema": {
       "snapshot": [],
       "name": "string",

--- a/docs/source/conf-schemas-examples.rst
+++ b/docs/source/conf-schemas-examples.rst
@@ -314,7 +314,7 @@ This approach promotes Rule safety, but requires additional time to define the s
 .. code-block:: json
 
   {
-    "osquery": {
+    "osquery:differential": {
       "parser": "json",
       "schema": {
         "name": "string",
@@ -416,4 +416,3 @@ Syslog Example
 --------------
 
 See `Schemas <conf-schemas.html>`_
-

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -63,7 +63,7 @@ Here’s an example rule that alerts on the use of sudo in a PCI environment:
 
     from fnmatch import fnmatch
 
-    @rule(logs=['osquery'],                           # applicable datasource(s)
+    @rule(logs=['osquery:differential'],              # applicable datasource(s)
           matchers=['pci'],                           # matcher(s) to evaluate
           outputs=['pagerduty:cirt', 'slack:cirt'])   # where to send alerts
     def production_sudo(record):                      # incoming record/log
@@ -140,7 +140,7 @@ Examples:
   # The 'columns' key must contain
   # sub-keys of 'address' and 'hostnames'
 
-  @rule(logs=['osquery'],
+  @rule(logs=['osquery:differential'],
         outputs=['pagerduty', 'aws-s3'],
         req_subkeys={'columns':['address', 'hostnames']})
         ...
@@ -148,7 +148,7 @@ Examples:
   # The 'columns' key must contain
   # sub-keys of 'port' and 'protocol'
 
-  @rule(logs=['osquery'],
+  @rule(logs=['osquery:differential'],
         outputs=['pagerduty', 'aws-s3'],
         req_subkeys={'columns':['port', 'protocol']})
         ...

--- a/matchers/sample.py
+++ b/matchers/sample.py
@@ -4,19 +4,18 @@ multiple rules.  For example, if we write an osquery rule that
 is specific for the `prod` environment, we can define a matcher
 and add it to our rules' `match` keyword argument:
 
-    @rule('root_logins', data_source=['osquery'], matchers=['prod'],
-          sink=['csirt-pagerduty'])
+@rule('root_logins', logs=['osquery:differential'], matchers=['prod'],
+      outputs=['pagerduty:sample-integration'])
 
 You can also supply multiple matchers for many common scenarios:
 
-    @rule('root_logins', data_source=['osquery'],
-          matchers=['prod', 'itx_corp'], sink=['csirt-pagerduty'])
+@rule('root_logins', logs=['osquery:differential'],
+      matchers=['prod', 'pci'], outputs=['pagerduty:sample-integration'])
 """
 # from helpers.base import in_set, last_hour
 from stream_alert.rule_processor.rules_engine import StreamRules
 
 matcher = StreamRules.matcher()
-
 
 @matcher
 def production_env(rec):


### PR DESCRIPTION
to: @ryandeivert or @austinbyers or @chunyong-lin 

**Details**
- Prefix osquery logs with `osquery:`, as we did with CB
- Fix outdated code comments in `matchers/sample.py`

**Testing**

```
StreamAlertCLI [INFO]: (17/17) Successful Tests
StreamAlertCLI [INFO]: (39/39) Alert Tests Passed
```