### PR TITLE
streamalert - schema - carbonblack - fixes

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -186,7 +186,7 @@
       "ioc_value": "string",
       "ioc_value_facet": "string",
       "md5": "string",
-      "observed_filename": [],
+      "observed_filename": "string",
       "observed_filename_total_count": "integer",
       "os_type": "string",
       "other_hostnames": [],
@@ -210,7 +210,8 @@
       },
       "optional_top_level_keys": [
         "assigned_to",
-        "resolved_time"
+        "resolved_time",
+        "segment_id"
       ]
     }
   },
@@ -281,6 +282,14 @@
   },
   "carbonblack:alert.watchlist.hit.query.process": {
     "schema": {
+      "alliance_data_srstrust": [],
+      "alliance_data_virustotal": [],
+      "alliance_link_srstrust": "string",
+      "alliance_link_virustotal": "string",
+      "alliance_score_srstrust": "integer",
+      "alliance_score_virustotal": "integer",
+      "alliance_updated_srstrust": "string",
+      "alliance_updated_virustotal": "string",
       "alert_severity": "float",
       "alert_type": "string",
       "assigned_to": "string",
@@ -331,13 +340,30 @@
         ]
       },
       "optional_top_level_keys": [
+        "alliance_data_srstrust",
+        "alliance_data_virustotal",
+        "alliance_link_srstrust",
+        "alliance_link_virustotal",
+        "alliance_score_srstrust",
+        "alliance_score_virustotal",
+        "alliance_updated_srstrust",
+        "alliance_updated_virustotal",
         "assigned_to",
+        "ioc_attr",
         "resolved_time"
       ]
     }
   },
   "carbonblack:watchlist.hit.process": {
     "schema": {
+      "alliance_data_srstrust": [],
+      "alliance_data_virustotal": [],
+      "alliance_link_srstrust": "string",
+      "alliance_link_virustotal": "string",
+      "alliance_score_srstrust": "integer",
+      "alliance_score_virustotal": "integer",
+      "alliance_updated_srstrust": "string",
+      "alliance_updated_virustotal": "string",
       "childproc_count": "integer",
       "cmdline": "string",
       "comms_ip": "string",
@@ -378,6 +404,16 @@
     "parser": "json",
     "configuration": {
       "json_path": "docs[*]",
+      "optional_top_level_keys": [
+        "alliance_data_srstrust",
+        "alliance_data_virustotal",
+        "alliance_link_srstrust",
+        "alliance_link_virustotal",
+        "alliance_score_srstrust",
+        "alliance_score_virustotal",
+        "alliance_updated_srstrust",
+        "alliance_updated_virustotal"
+      ],
       "envelope_keys": {
         "cb_server": "string",
         "cb_version": "string",
@@ -481,6 +517,39 @@
         "watchlist_name": "string"
       }
     }
+  },
+  "carbonblack:watchlist.hit.ingress.binary": {
+    "schema": {
+      "alert_severity": "float",
+      "alert_type": "string",
+      "cb_server": "string",
+      "computer_name": "string",
+      "created_time": "string",
+      "digsig_result": "string",
+      "feed_id": "integer",
+      "feed_name": "string",
+      "feed_rating": "integer",
+      "host_count": "integer",
+      "hostname": "string",
+      "ioc_confidence": "float",
+      "ioc_type": "string",
+      "ioc_value": "string",
+      "ioc_value_facet": "string",
+      "md5": "string",
+      "observed_filename": [],
+      "observed_filename_total_count": "integer",
+      "os_type": "string",
+      "other_hostnames": [],
+      "report_score": "integer",
+      "sensor_criticality": "integer",
+      "status": "string",
+      "timestamp": "float",
+      "type": "string",
+      "unique_id": "string",
+      "watchlist_id": "string",
+      "watchlist_name": "string"
+    },
+    "parser": "json"
   },
   "carbonblack:feed.storage.hit.binary": {
     "schema": {
@@ -636,7 +705,7 @@
         "process_id": "string",
         "report_id": "string",
         "report_score": "integer",
-        "segment_id": "integer",
+        "segment_id": "string",
         "sensor_id": "integer",
         "timestamp": "float",
         "type": "string"


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**Overview**

CarbonBlack has one of the most complicated, dynamic schemas 🥇 

This addresses known `Record does not match any defined schemas` ERRORs.

**Testing**

1) `python manage.py validate-schemas`
2) `python manage.py lambda test --processor all`
3) My eyes 👀 
