### PR TITLE
streamalert - schemas - vpc flow logs - address NODATA case

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -765,6 +765,38 @@
       }
     }
   },
+  "cloudwatch:flow_logs_no_data": {
+    "schema": {
+      "protocol": "string",
+      "source": "string",
+      "destination": "string",
+      "srcport": "string",
+      "destport": "string",
+      "action": "string",
+      "packets": "string",
+      "bytes": "string",
+      "windowstart": "integer",
+      "windowend": "integer",
+      "version": "integer",
+      "eni": "string",
+      "account": "integer",
+      "flowlogstatus": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "json_path": "logEvents[*].extractedFields",
+      "envelope_keys": {
+        "logGroup": "string",
+        "logStream": "string",
+        "owner": "integer"
+      },
+      "log_patterns": {
+        "flowlogstatus": [
+          "NODATA"
+        ]
+      }
+    }
+  },
   "cloudtrail:events": {
     "schema": {
       "additionalEventData": {},


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**Overview**

This PR addresses the fact that AWS has VPC flow logs that aren't strongly typed and can result in `Record does not match any defined schemas` ERRORs.

In most instances, `protocol`, `srcport`, etc are integers.

However, for the `NODATA` case (see http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html), this doesn't hold true:

```
{
    "messageType": "DATA_MESSAGE",
    "owner": "...",
    "logGroup": "...",
    "logStream": "...",
    "subscriptionFilters": [
        "..."
    ],
    "logEvents": [
        {
            "id": "...",
            "timestamp": 123,
            "message": "...",
            "extractedFields": {
                "eni": "...",
                "destination": "-",
                "windowstart": "12345",
                "source": "-",
                "flowlogstatus": "NODATA",
                "version": "2",
                "packets": "-",
                "protocol": "-",
                "bytes": "-",
                "srcport": "-",
                "action": "-",
                "windowend": "45678",
                "destport": "-",
                "account": "..."
            }
        }
    ]
}
```

Note the `"-"` as a placeholder for empty data.

We address the issue by defining a schema that specifically matches this log type via  `log_patterns` and `string` vs. `integer` types.

**Testing**

`python manage.py validate-schemas`

AND

`python manage.py lambda test --processor all`