### PR TITLE
streamalert - local testing - remove INFO of triggers

### DIFF
--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -24,7 +24,7 @@ class SuppressNonErrors(logging.Filter):
 
 
 class SuppressNoise(logging.Filter):
-    """Simple logging filter for suppressing specific log messagses that we
+    """Simple logging filter for suppressing specific log messages that we
     do not want to print during testing. Add any suppressions to the tuple.
     """
 
@@ -33,7 +33,10 @@ class SuppressNoise(logging.Filter):
             'Starting download from S3',
             'Completed download in'
         )
-        return not record.getMessage().startswith(suppress_starts_with)
+        return (
+            not record.getMessage().startswith(suppress_starts_with) and
+            'triggered an alert on log type' not in record.getMessage()
+        )
 
 
 LOGGER_SA = logging.getLogger('StreamAlert')


### PR DESCRIPTION
to: @ryandeivert 

**What**

- Remove the annoying `StreamAlert [INFO]: Rule [...] triggered an alert on log type [...] from entity '..' in service '..'` output when doing local testing of rules.
- This information is already captured in the `[trigger=...]` output

**Result**

```
cloudtrail_put_object_acl
       [Pass]  [trigger=1]                   rule      (s3): Storing an S3 object with an `AuthenticatedUsers` permission will create an alert.
       [Pass]                                alert     (pagerduty): sending alert to 'sample-integration'
       [Pass]                                alert     (aws-s3): sending alert to 'sample-bucket'
       [Pass]                                alert     (slack): sending alert to 'sample-channel'
       [Pass]  [trigger=1]                   rule      (s3): Storing an S3 object with an `AllUsers` permission will create an alert.
       [Pass]                                alert     (pagerduty): sending alert to 'sample-integration'
       [Pass]                                alert     (aws-s3): sending alert to 'sample-bucket'
       [Pass]                                alert     (slack): sending alert to 'sample-channel'
       [Pass]  [trigger=1]                   rule      (s3): Storing an S3 object with an `AllUsers` and `AuthenticatedUsers` permission will create an alert.
       [Pass]                                alert     (pagerduty): sending alert to 'sample-integration'
       [Pass]                                alert     (aws-s3): sending alert to 'sample-bucket'
       [Pass]                                alert     (slack): sending alert to 'sample-channel'
       [Pass]  [trigger=0]                   rule      (s3): Storing an S3 object without an `AllUsers` or `AuthenticatedUsers` permission will not create an alert.

cloudtrail_root_account_usage
       [Pass]  [trigger=1]                   rule      (kinesis): Use of the AWS 'Root' account will create an alert.
       [Pass]                                alert     (pagerduty): sending alert to 'sample-integration'
       [Pass]                                alert     (aws-s3): sending alert to 'sample-bucket'
       [Pass]                                alert     (slack): sending alert to 'sample-channel'
       [Pass]  [trigger=0]                   rule      (kinesis): AWS 'Root' account activity initiated automatically by an AWS service on your behalf will not create an alert.
```

![image](https://user-images.githubusercontent.com/25284506/30190837-c7eaa3ae-93f1-11e7-950b-96f43772a9b6.png)

**Testing**

`python manage.py lambda test --processor all`