### PR TITLE
[cli][metrics] metric alarms configurable through the cli

### DIFF
--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -25,13 +25,15 @@
         "current_version": "$LATEST",
         "log_level": "info",
         "memory": 128,
-        "timeout": 10
+        "timeout": 10,
+        "enable_metrics": true
       },
       "rule_processor": {
         "current_version": "$LATEST",
         "log_level": "info",
         "memory": 128,
-        "timeout": 10
+        "timeout": 30,
+        "enable_metrics": true
       }
     }
   },

--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -32,7 +32,7 @@
         "enable_metrics": true,
         "log_level": "info",
         "memory": 128,
-        "timeout": 30
+        "timeout": 10
       }
     }
   },

--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -25,15 +25,14 @@
         "current_version": "$LATEST",
         "log_level": "info",
         "memory": 128,
-        "timeout": 10,
-        "enable_metrics": true
+        "timeout": 10
       },
       "rule_processor": {
         "current_version": "$LATEST",
+        "enable_metrics": true,
         "log_level": "info",
         "memory": 128,
-        "timeout": 30,
-        "enable_metrics": true
+        "timeout": 30
       }
     }
   },

--- a/conf/global.json
+++ b/conf/global.json
@@ -6,9 +6,6 @@
     "region": "us-east-1"
   },
   "infrastructure": {
-    "metrics": {
-      "enabled": true
-    },
     "monitoring": {
       "create_sns_topic": true
     }

--- a/docs/source/athena-deploy.rst
+++ b/docs/source/athena-deploy.rst
@@ -55,6 +55,7 @@ Open ``conf/lambda.json``, and fill in the following ``Required`` options:
 Key                                  Required  Default                Description
 -----------------------------------  --------  --------------------   -----------
 ``enabled``                          ``Yes``   ``true``               Enables/Disables the Athena Partition Refresh Lambda function
+``enable_metrics``                   ``No``    ``false``              Enables/Disables logging of metrics for the Athena Partition Refresh Lambda function
 ``log_level``                        ``No``    ``info``               The log level for the Lambda function, can be either ``info`` or ``debug``.  Debug will help with diagnosing errors with polling SQS or sending Athena queries.
 ``memory``                           ``No``    ``128``                The amount of memory (in MB) allocated to the Lambda function
 ``timeout``                          ``No``    ``60``                 The maximum duration of the Lambda function (in seconds)
@@ -70,6 +71,7 @@ Key                                  Required  Default                Descriptio
   {
     "athena_partition_refresh_config": {
       "enabled": true,
+      "enable_metrics": false,
       "log_level": "info",
       "memory": 128,
       "refresh_type": {

--- a/manage.py
+++ b/manage.py
@@ -504,7 +504,8 @@ Resources:
     metric_alarm_parser.add_argument(
         '-ad', '--alarm-description',
         help=ARGPARSE_SUPPRESS,
-        type=_alarm_description_validator
+        type=_alarm_description_validator,
+        default=''
     )
 
     # allow the user to select 0 or more clusters to apply this alarm to
@@ -543,7 +544,8 @@ Resources:
     metric_alarm_parser.add_argument(
         '-s', '--statistic',
         choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum'],
-        help=ARGPARSE_SUPPRESS
+        help=ARGPARSE_SUPPRESS,
+        default=''
     )
 
     # allow verbose output for the CLI with the --debug option

--- a/manage.py
+++ b/manage.py
@@ -249,7 +249,7 @@ Optional Arguemnts:
 {}
 Examples:
 
-    manage.py metrics --enable
+    manage.py metrics --enable --functions rule
 
 """.format(version, cluster_choices_block))
 

--- a/manage.py
+++ b/manage.py
@@ -404,7 +404,7 @@ Resources:
         help=ARGPARSE_SUPPRESS
     )
 
-    # Set the name of this parser to 'validate-schemas'
+    # Set the name of this parser to 'create-alarm'
     metric_alarm_parser.set_defaults(command='create-alarm')
 
     # add all the required parameters

--- a/manage.py
+++ b/manage.py
@@ -221,15 +221,16 @@ Required Arguments:
                                    GreaterThanThreshold
                                    LessThanThreshold
                                    LessThanOrEqualToThreshold
-    -an/--alarm-name             The name for the alarm. This name must be unique within the AWS account
+    -an/--alarm-name             The name for the alarm. This name must be unique within the AWS
+                                   account
     -ep/--evaluation-periods     The number of periods over which data is compared to the specified
                                    threshold. The minimum value for this is 1. Also see the 'Other
                                    Constraints' section below
-    -p/--period                  The period, in seconds, over which the specified statistic is applied.
-                                   Valid values are any multiple of 60. Also see the 'Other Constraints'
-                                   section below
-    -t/--threshold               The value against which the specified statistic is compared. This value
-                                   should be a double.
+    -p/--period                  The period, in seconds, over which the specified statistic is
+                                   applied. Valid values are any multiple of 60. Also see the
+                                   'Other Constraints' section below
+    -t/--threshold               The value against which the specified statistic is compared. This
+                                   value should be a double.
 
 Optional Arguments:
 
@@ -237,8 +238,8 @@ Optional Arguments:
     -c/--clusters                Space delimited list of clusters to apply this metric to. This is
                                    ignored if the --metric-target of 'aggregate' is used.
     -es/--extended-statistic     The percentile statistic for the metric associated with the alarm.
-                                   Specify a value between p0.0 and p100.  Cannot be used in conjunction
-                                   with the --statistic flag.
+                                   Specify a value between p0.0 and p100.  Cannot be used in
+                                   conjunction with the --statistic flag.
     -s/--statistic               The statistic for the metric associated with the alarm, other than
                                    percentile. For percentile statistics, use --extended-statistic.
                                    Cannot be used in conjunction with the --extended-statistic flag

--- a/manage.py
+++ b/manage.py
@@ -25,7 +25,6 @@ terraform <cmd> -var-file=../terraform.tfvars -var-file=../variables.json
 """
 from argparse import Action, ArgumentParser, RawTextHelpFormatter, SUPPRESS as ARGPARSE_SUPPRESS
 import os
-import re
 
 from stream_alert.shared import metrics
 from stream_alert_cli import __version__ as version
@@ -361,12 +360,7 @@ Optional Arguments:
                                    ignored if the --metric-target of 'aggregate' is used.
                                    Choices are:
 {}
-    -es/--extended-statistic     The percentile statistic for the metric associated with the alarm.
-                                   Specify a value between p0.0 and p100.  Cannot be used in
-                                   conjunction with the --statistic flag.
-    -s/--statistic               The statistic for the metric associated with the alarm, other than
-                                   percentile. For percentile statistics, use --extended-statistic.
-                                   Cannot be used in conjunction with the --extended-statistic flag
+    -s/--statistic               The statistic for the metric associated with the alarm.
                                    Choices are:
                                      SampleCount
                                      Average
@@ -418,6 +412,7 @@ Resources:
     metric_alarm_parser.add_argument(
         '-m', '--metric',
         choices=all_metrics,
+        dest='metric_name',
         help=ARGPARSE_SUPPRESS,
         required=True
     )
@@ -522,22 +517,30 @@ Resources:
         default=[]
     )
 
-    # get the extended statistic or statistic value
-    statistic_group = metric_alarm_parser.add_mutually_exclusive_group()
-    def _extended_stat_validator(val):
-        if not re.search(r'p(\d{1,2}(\.\d{0,2})?|100)$', val):
-            raise metric_alarm_parser.error('extended statistic values must start with \'p\' '
-                                            'and be followed by a percentage value (ie: p0.0, '
-                                            'p10, p55.5, p100)')
-        return val
+    ### Commenting out the below until we can support 'extended-statistic' metrics
+    ### alongside 'statistic' metrics. Currently only 'statistic' are supported
+    # # get the extended statistic or statistic value
+    # statistic_group = metric_alarm_parser.add_mutually_exclusive_group()
+    # def _extended_stat_validator(val):
+    #     if not re.search(r'p(\d{1,2}(\.\d{0,2})?|100)$', val):
+    #         raise metric_alarm_parser.error('extended statistic values must start with \'p\' '
+    #                                         'and be followed by a percentage value (ie: p0.0, '
+    #                                         'p10, p55.5, p100)')
+    #     return val
+    #
+    # statistic_group.add_argument(
+    #     '-es', '--extended-statistic',
+    #     help=ARGPARSE_SUPPRESS,
+    #     type=_extended_stat_validator
+    # )
+    #
+    # statistic_group.add_argument(
+    #     '-s', '--statistic',
+    #     choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum'],
+    #     help=ARGPARSE_SUPPRESS
+    # )
 
-    statistic_group.add_argument(
-        '-es', '--extended-statistic',
-        help=ARGPARSE_SUPPRESS,
-        type=_extended_stat_validator
-    )
-
-    statistic_group.add_argument(
+    metric_alarm_parser.add_argument(
         '-s', '--statistic',
         choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum'],
         help=ARGPARSE_SUPPRESS

--- a/manage.py
+++ b/manage.py
@@ -27,12 +27,7 @@ from argparse import Action, ArgumentParser, RawTextHelpFormatter, SUPPRESS as A
 import os
 import re
 
-from stream_alert.shared import (
-    ALERT_PROCESSOR_NAME,
-    ATHENA_PARTITION_REFRESH_NAME,
-    metrics,
-    RULE_PROCESSOR_NAME
-)
+from stream_alert.shared import metrics
 from stream_alert_cli import __version__ as version
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.runner import cli_runner
@@ -52,9 +47,9 @@ class NormalizeFunctionAction(UniqueSetAction):
     def __call__(self, parser, namespace, values, option_string=None):
         super(NormalizeFunctionAction, self).__call__(parser, namespace, values, option_string)
         values = getattr(namespace, self.dest)
-        normalized_map = {'rule': RULE_PROCESSOR_NAME,
-                          'alert': ALERT_PROCESSOR_NAME,
-                          'athena': ATHENA_PARTITION_REFRESH_NAME}
+        normalized_map = {'rule': metrics.RULE_PROCESSOR_NAME,
+                          'alert': metrics.ALERT_PROCESSOR_NAME,
+                          'athena': metrics.ATHENA_PARTITION_REFRESH_NAME}
 
         for func, normalize_func in normalized_map.iteritems():
             if func in values:

--- a/manage.py
+++ b/manage.py
@@ -25,7 +25,9 @@ terraform <cmd> -var-file=../terraform.tfvars -var-file=../variables.json
 """
 from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS as ARGPARSE_SUPPRESS
 import os
+import re
 
+from stream_alert.shared import metrics
 from stream_alert_cli import __version__ as version
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.runner import cli_runner
@@ -113,9 +115,8 @@ Examples:
     live_test_parser.set_defaults(command='live-test')
 
     # get cluster choices from available files
-    clusters = []
-    for _, _, files in os.walk('conf/clusters'):
-        clusters.extend(os.path.splitext(cluster)[0] for cluster in files)
+    clusters = [os.path.splitext(cluster)[0] for _, _, files
+                in os.walk('conf/clusters') for cluster in files]
 
     # add clusters for user to pick from
     live_test_parser.add_argument(
@@ -145,7 +146,8 @@ def _add_validate_schema_subparser(subparsers):
     schema_validation_usage = 'manage.py validate-schemas [options]'
     schema_validation_description = ("""
 StreamAlertCLI v{}
-Run end-to-end tests that will attempt to send alerts
+Run validation of schemas in logs.json using configured integration test files. Validation
+does not actually run the rules engine on test events.
 
 Available Options:
 
@@ -188,6 +190,243 @@ Examples:
         action='store_true',
         help=ARGPARSE_SUPPRESS
     )
+
+
+def _add_metric_alarm_subparser(subparsers):
+    """Add the create-alarm subparser: manage.py create-alarm [options]"""
+    metric_alarm_usage = 'manage.py create-alarm [options]'
+
+    # get the available metrics to be used
+    available_metrics = metrics.MetricLogger.get_available_metrics()
+    all_metrics = [metric for func in available_metrics for metric in available_metrics[func]]
+
+    metric_choices_block = ('\n').join('{:>35}{}'.format('', metric) for metric in all_metrics)
+
+    metric_alarm_description = ("""
+StreamAlertCLI v{}
+Add a CloudWatch alarm for predefined metrics. These are save in the config and
+Terraform is used to create the alarms.
+
+Required Arguments:
+
+    -m/--metric                  The predefined metric to assign this alarm to. Choices are:
+{}
+    -mt/--metric-target          The target of this metric alarm, meaning either the cluster metric
+                                   or the aggrea metric. Choices are:
+                                     cluster
+                                     aggregate
+                                     all
+    -co/--comparison-operator    Comparison operator to use for this metric. Choices are:
+                                   GreaterThanOrEqualToThreshold
+                                   GreaterThanThreshold
+                                   LessThanThreshold
+                                   LessThanOrEqualToThreshold
+    -an/--alarm-name             The name for the alarm. This name must be unique within the AWS account
+    -ep/--evaluation-periods     The number of periods over which data is compared to the specified
+                                   threshold. The minimum value for this is 1. Also see the 'Other
+                                   Constraints' section below
+    -p/--period                  The period, in seconds, over which the specified statistic is applied.
+                                   Valid values are any multiple of 60. Also see the 'Other Constraints'
+                                   section below
+    -t/--threshold               The value against which the specified statistic is compared. This value
+                                   should be a double.
+
+Optional Arguments:
+
+    -ad/--alarm-description      The description for the alarm
+    -c/--clusters                Space delimited list of clusters to apply this metric to. This is
+                                   ignored if the --metric-target of 'aggregate' is used.
+    -es/--extended-statistic     The percentile statistic for the metric associated with the alarm.
+                                   Specify a value between p0.0 and p100.  Cannot be used in conjunction
+                                   with the --statistic flag.
+    -s/--statistic               The statistic for the metric associated with the alarm, other than
+                                   percentile. For percentile statistics, use --extended-statistic.
+                                   Cannot be used in conjunction with the --extended-statistic flag
+                                   Choices are:
+                                     SampleCount
+                                     Average
+                                     Sum
+                                     Minimum
+                                     Maximum
+    --debug                      Enable Debug logger output
+
+Other Constraints:
+
+    The product of the value for period multiplied by the value for evaluation periods cannot
+    exceed 86,400. 86,400 is the number of seconds in one day and an alarm's total current
+    evaluation period can be no longer than one day.
+
+Examples:
+
+    manage.py create-alarm \\
+      --metric FailedParses \\
+      --metric-target cluster \\
+      --comparison-operator GreaterThanOrEqualToThreshold \\
+      --alarm-name FailedParsesAlarm \\
+      --evaluation-periods 1 \\
+      --period 300 \\
+      --threshold 1.0 \\
+      --alarm-description 'Alarm for any failed parses that occur within a 5 minute period in the prod cluster' \\
+      --clusters prod \\
+      --statistic Sum
+
+Resources:
+
+    AWS:        https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
+    Terraform:  https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html
+
+""".format(version, metric_choices_block))
+    metric_alarm_parser = subparsers.add_parser(
+        'create-alarm',
+        description=metric_alarm_description,
+        usage=metric_alarm_usage,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # Set the name of this parser to 'validate-schemas'
+    metric_alarm_parser.set_defaults(command='create-alarm')
+
+    # add all the required parameters
+    # add metrics for user to pick from. Will be mapped to 'metric_name' in terraform
+    metric_alarm_parser.add_argument(
+        '-m', '--metric',
+        choices=all_metrics,
+        help=ARGPARSE_SUPPRESS,
+        required=True
+    )
+
+    # check to see what the user wants to apply this metric to (cluster, aggregate, or both)
+    metric_alarm_parser.add_argument(
+        '-mt', '--metric-target',
+        choices=['cluster', 'aggregate', 'all'],
+        help=ARGPARSE_SUPPRESS,
+        required=True
+    )
+
+    # get the comparison type for this metric
+    metric_alarm_parser.add_argument(
+        '-co', '--comparison-operator',
+        choices=['GreaterThanOrEqualToThreshold', 'GreaterThanThreshold',
+                 'LessThanThreshold', 'LessThanOrEqualToThreshold'],
+        help=ARGPARSE_SUPPRESS,
+        required=True
+    )
+
+    # get the name of the alarm
+    def _alarm_name_validator(val):
+        if not 1 <= len(val) <= 255:
+            raise metric_alarm_parser.error('alarm name length must be between 1 and 255')
+        return val
+
+    metric_alarm_parser.add_argument(
+        '-an', '--alarm-name',
+        help=ARGPARSE_SUPPRESS,
+        required=True,
+        type=_alarm_name_validator
+    )
+
+    # get the evaluation period for this alarm
+    def _alarm_eval_periods_validator(val):
+        error = 'evaluation periods must be an integer greater than 0'
+        try:
+            period = int(val)
+        except ValueError:
+            raise metric_alarm_parser.error(error)
+
+        if period <= 0:
+            raise metric_alarm_parser.error(error)
+        return period
+
+    metric_alarm_parser.add_argument(
+        '-ep', '--evaluation-periods',
+        help=ARGPARSE_SUPPRESS,
+        required=True,
+        type=_alarm_eval_periods_validator
+    )
+
+    # get the period for this alarm
+    def _alarm_period_validator(val):
+        error = 'period must be an integer in multiples of 60'
+        try:
+            period = int(val)
+        except ValueError:
+            raise metric_alarm_parser.error(error)
+
+        if period <= 0 or period % 60 != 0:
+            raise metric_alarm_parser.error(error)
+
+        return period
+
+    metric_alarm_parser.add_argument(
+        '-p', '--period',
+        help=ARGPARSE_SUPPRESS,
+        required=True,
+        type=_alarm_period_validator
+    )
+
+    # get the threshold for this alarm
+    metric_alarm_parser.add_argument(
+        '-t', '--threshold',
+        help=ARGPARSE_SUPPRESS,
+        required=True,
+        type=float
+    )
+
+    # all other optional flags
+    # get the optional alarm description
+    def _alarm_description_validator(val):
+        if len(val) > 1024:
+            raise metric_alarm_parser.error('alarm description length must be less than 1024')
+        return val
+
+    metric_alarm_parser.add_argument(
+        '-ad', '--alarm-description',
+        help=ARGPARSE_SUPPRESS,
+        type=_alarm_description_validator
+    )
+
+    # get cluster choices from available files
+    clusters = [os.path.splitext(cluster)[0] for _, _, files
+                in os.walk('conf/clusters') for cluster in files]
+
+    # allow the user to select 0 or more clusters to apply this alarm to
+    metric_alarm_parser.add_argument(
+        '-c', '--clusters',
+        choices=clusters,
+        help=ARGPARSE_SUPPRESS,
+        nargs='+',
+        default=[]
+    )
+
+    # get the extended statistic or statistic value
+    statistic_group = metric_alarm_parser.add_mutually_exclusive_group()
+    def _extended_stat_validator(val):
+        if not re.search(r'p(\d{1,2}(\.\d{0,2})?|100)$', val):
+            raise metric_alarm_parser.error('extended statistic values must start with \'p\' '
+                                            'and be followed by a percentage value (ie: p0.0, '
+                                            'p10, p55.5, p100)')
+        return val
+
+    statistic_group.add_argument(
+        '-es', '--extended-statistic',
+        help=ARGPARSE_SUPPRESS,
+        type=_extended_stat_validator
+    )
+
+    statistic_group.add_argument(
+        '-s', '--statistic',
+        choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum'],
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # allow verbose output for the CLI with the --debug option
+    metric_alarm_parser.add_argument(
+        '--debug',
+        action='store_true',
+        help=ARGPARSE_SUPPRESS
+    )
+
 
 
 def _add_lambda_subparser(subparsers):
@@ -478,6 +717,7 @@ For additional details on the available commands, try:
     _add_output_subparser(subparsers)
     _add_live_test_subparser(subparsers)
     _add_validate_schema_subparser(subparsers)
+    _add_metric_alarm_subparser(subparsers)
     _add_lambda_subparser(subparsers)
     _add_terraform_subparser(subparsers)
     _add_configure_subparser(subparsers)

--- a/manage.py
+++ b/manage.py
@@ -192,6 +192,60 @@ Examples:
     )
 
 
+def _add_metrics_subparser(subparsers):
+    """Add the metrics subparser: manage.py metrics [options]"""
+    metrics_usage = 'manage.py metrics [options]'
+
+    metrics_description = ("""
+StreamAlertCLI v{}
+Enable or disable metrics for all lambda functions. This toggles the creation of metric filters.
+
+Available Options:
+
+    -e/--enable         Enable CloudWatch metrics through logging and metric filters
+    -d/--disable        Disable CloudWatch metrics through logging and metric filters
+    --debug             Enable Debug logger output
+
+Examples:
+
+    manage.py metrics --enable
+
+""".format(version))
+
+    metrics_parser = subparsers.add_parser(
+        'metrics',
+        description=metrics_description,
+        usage=metrics_usage,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # Set the name of this parser to 'metrics'
+    metrics_parser.set_defaults(command='metrics')
+
+    # get the metric toggle value
+    toggle_group = metrics_parser.add_mutually_exclusive_group(required=True)
+
+    toggle_group.add_argument(
+        '-e', '--enable',
+        dest='enable_metrics',
+        action='store_true'
+    )
+
+    toggle_group.add_argument(
+        '-d', '--disable',
+        dest='enable_metrics',
+        action='store_false'
+    )
+
+    # allow verbose output for the CLI with the --debug option
+    metrics_parser.add_argument(
+        '--debug',
+        action='store_true',
+        help=ARGPARSE_SUPPRESS
+    )
+
+
 def _add_metric_alarm_subparser(subparsers):
     """Add the create-alarm subparser: manage.py create-alarm [options]"""
     metric_alarm_usage = 'manage.py create-alarm [options]'
@@ -277,6 +331,7 @@ Resources:
     Terraform:  https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html
 
 """.format(version, metric_choices_block))
+
     metric_alarm_parser = subparsers.add_parser(
         'create-alarm',
         description=metric_alarm_description,
@@ -718,6 +773,7 @@ For additional details on the available commands, try:
     _add_output_subparser(subparsers)
     _add_live_test_subparser(subparsers)
     _add_validate_schema_subparser(subparsers)
+    _add_metrics_subparser(subparsers)
     _add_metric_alarm_subparser(subparsers)
     _add_lambda_subparser(subparsers)
     _add_terraform_subparser(subparsers)

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -24,6 +24,12 @@ from stream_alert.shared import (
 
 CLUSTER = os.environ.get('CLUSTER', 'unknown_cluster')
 
+# The FUNC_PREFIXES dict acts as a simple map to a human-readable name
+# Add ATHENA_PARTITION_REFRESH_NAME: 'AthenaPartitionRefresh', to the
+# below when metrics are supported there
+FUNC_PREFIXES = {ALERT_PROCESSOR_NAME: 'AlertProcessor',
+                 RULE_PROCESSOR_NAME: 'RuleProcessor'}
+
 try:
     ENABLE_METRICS = bool(int(os.environ.get('ENABLE_METRICS', 0)))
 except ValueError as err:

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -45,6 +45,7 @@ class MetricLogger(object):
     # Constant metric names used for CloudWatch
     FAILED_PARSES = 'FailedParses'
     S3_DOWNLOAD_TIME = 'S3DownloadTime'
+    TOTAL_PROCESSED_SIZE = 'TotalProcessedSize'
     TOTAL_RECORDS = 'TotalRecords'
     TOTAL_S3_RECORDS = 'TotalS3Records'
     TRIGGERED_ALERTS = 'TriggeredAlerts'
@@ -64,6 +65,7 @@ class MetricLogger(object):
         RULE_PROCESSOR_NAME: {
             FAILED_PARSES: (_default_filter.format(FAILED_PARSES), _default_value_lookup),
             S3_DOWNLOAD_TIME: (_default_filter.format(S3_DOWNLOAD_TIME), _default_value_lookup),
+            TOTAL_PROCESSED_SIZE: (_default_filter.format(TOTAL_RECORDS), _default_value_lookup),
             TOTAL_RECORDS: (_default_filter.format(TOTAL_RECORDS), _default_value_lookup),
             TOTAL_S3_RECORDS: (_default_filter.format(TOTAL_S3_RECORDS), _default_value_lookup),
             TRIGGERED_ALERTS: (_default_filter.format(TRIGGERED_ALERTS), _default_value_lookup)

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -19,7 +19,10 @@ import os
 import re
 import sys
 
-from stream_alert.shared import metrics
+from stream_alert.shared import (
+    ATHENA_PARTITION_REFRESH_NAME,
+    metrics
+)
 from stream_alert_cli.helpers import continue_prompt
 from stream_alert_cli.logger import LOGGER_CLI
 
@@ -41,7 +44,6 @@ class CLIConfig(object):
 
     def __setitem__(self, key, new_value):
         self.config.__setitem__(key, new_value)
-        print 'setting', key
         self.write()
 
     def get(self, key):
@@ -139,7 +141,7 @@ class CLIConfig(object):
                 metrics on (rule, alert, or athena)
         """
         for function in lambda_functions:
-            if function == 'athena':
+            if function == ATHENA_PARTITION_REFRESH_NAME:
                 if 'athena_partition_refresh_config' in self.config['lambda']:
                     self.config['lambda']['athena_partition_refresh_config'] \
                         ['enable_metrics'] = enabled
@@ -149,7 +151,7 @@ class CLIConfig(object):
 
             for cluster in clusters:
                 self.config['clusters'][cluster]['modules']['stream_alert'] \
-                    ['{}_processor'.format(function)]['enable_metrics'] = enabled
+                    [function]['enable_metrics'] = enabled
 
         self.write()
 

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -267,7 +267,7 @@ class CLIConfig(object):
 
         # Extract the function name this metric is associated with
         metric_function = {metric: function for function in current_metrics
-                           for metric in current_metrics[function]}[alarm_info['metric']]
+                           for metric in current_metrics[function]}[alarm_info['metric_name']]
 
         # Do not continue if the user is trying to apply a metric alarm for an athena
         # metric to a specific cluster (since the athena function operates on all clusters)

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -128,6 +128,16 @@ class CLIConfig(object):
 
         LOGGER_CLI.info('AWS Account ID successfully configured')
 
+    def toggle_metrics(self, enabled):
+        """Toggle CloudWatch metric logging and filter creation"""
+        metrics = self.config['global']['infrastructure'].get('metrics')
+        if not metrics:
+            self.config['global']['infrastructure']['metrics'] = {}
+
+        metrics['enabled'] = enabled
+
+        self.write()
+
     def add_metric_alarm(self, alarm_info):
         """Add a metric alarm that corresponds to a predefined metrics"""
         metrics = self.config['global']['infrastructure'].get('metrics')

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 
+from stream_alert_cli.helpers import continue_prompt
 from stream_alert_cli.logger import LOGGER_CLI
 
 
@@ -137,17 +138,19 @@ class CLIConfig(object):
         enable_metrics = self.config['global']['infrastructure']['metrics'].get('enabled', False)
 
         if not enable_metrics:
-            LOGGER_CLI.error('Metrics are not currently enabled in \'conf/global.json\'. '
-                             'Metrics must be enabled to create alarms.')
-            return
+            prompt = ('Metrics are not currently enabled in \'conf/global.json\'. Creating a '
+                      'metric alarm will have no effect until metrics are enabled. '
+                      'Would you like to continue anyway?')
+            if not continue_prompt(prompt):
+                return
 
         current_alarms = self.config['global']['infrastructure']['metrics'].get('alarms', {})
 
         if alarm_info['alarm_name'] in current_alarms:
-            LOGGER_CLI.error('Alarm name \'%s\'already defined. Please remove the previous alarm '
-                             'from \'conf/global.json\' or pick a different name.',
-                             alarm_info['alarm_name'])
-            return
+            prompt = ('Alarm name \'{}\' already defined. Would you '
+                      'like to overwrite?').format(alarm_info['alarm_name'])
+            if not continue_prompt(prompt):
+                return
 
         omitted_keys = {'debug', 'alarm_name', 'command'}
 

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -67,6 +67,17 @@ def run_command(runner_args, **kwargs):
     return True
 
 
+def continue_prompt(prompt=''):
+    """Continue prompt used to check user's response"""
+    required_responses = {'yes', 'no'}
+    response = ''
+    while response not in required_responses:
+        prompt = prompt or 'Would you like to continue?'
+        response = raw_input('\n{} (yes or no): '.format(prompt))
+
+    return response == 'yes'
+
+
 def format_lambda_test_record(test_record):
     """Create a properly formatted Kinesis, S3, or SNS record.
 

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -655,7 +655,7 @@ def _toggle_metrics(options):
     Args:
         options (argparser): Contains boolean necessary for toggling metrics
     """
-    CONFIG.toggle_metrics(options.enable_metrics)
+    CONFIG.toggle_metrics(options.enable_metrics, options.clusters, options.functions)
 
 
 def _create_alarm(options):

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -25,6 +25,7 @@ from stream_alert.athena_partition_refresh.main import StreamAlertAthenaClient
 
 from stream_alert_cli import helpers
 from stream_alert_cli.config import CLIConfig
+from stream_alert_cli.helpers import continue_prompt
 from stream_alert_cli.logger import LOGGER_CLI
 import stream_alert_cli.outputs as config_outputs
 from stream_alert_cli.package import AlertProcessorPackage, AthenaPackage, RuleProcessorPackage
@@ -318,16 +319,6 @@ def run_command(args=None, **kwargs):
     return helpers.run_command(args, **kwargs)
 
 
-def continue_prompt():
-    """Continue prompt used before applying Terraform plans"""
-    required_responses = {'yes', 'no'}
-    response = ''
-    while response not in required_responses:
-        response = raw_input('\nWould you like to continue? (yes or no): ')
-    if response == 'no':
-        sys.exit(0)
-
-
 def tf_runner(**kwargs):
     """Terraform wrapper to build StreamAlert infrastructure.
 
@@ -363,7 +354,8 @@ def tf_runner(**kwargs):
     if not run_command(tf_command):
         return False
 
-    continue_prompt()
+    if not continue_prompt():
+        sys.exit(0)
 
     if action == 'destroy':
         LOGGER_CLI.info('Destroying infrastructure')

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -74,6 +74,9 @@ def cli_runner(options):
     elif options.command == 'athena':
         athena_handler(options)
 
+    elif options.command == 'metrics':
+        _toggle_metrics(options)
+
     elif options.command == 'create-alarm':
         _create_alarm(options)
 
@@ -644,6 +647,16 @@ def configure_output(options):
                          'output configuration for service \'%s\'',
                          props['descriptor'].value,
                          options.service)
+
+
+def _toggle_metrics(options):
+    """Enable or disable logging CloudWatch metrics
+
+    Args:
+        options (argparser): Contains boolean necessary for toggling metrics
+    """
+    CONFIG.toggle_metrics(options.enable_metrics)
+
 
 def _create_alarm(options):
     """Create a new CloudWatch alarm for the given metric

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -432,6 +432,8 @@ def generate_cloudwatch_metric_alarms(cluster_name, cluster_dict, config):
         if 'metric_alarms' not in func_config:
             continue
 
+        # TODO: update this logic to simply use a list of maps once Terraform fixes
+        # their support for this, instead of the comma-separated string this creates
         metric_alarms = func_config['metric_alarms']
         for name, alarm_info in metric_alarms.iteritems():
             formatted_alarms.append(

--- a/stream_alert_cli/terraform_generate.py
+++ b/stream_alert_cli/terraform_generate.py
@@ -228,7 +228,7 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
         'cluster': cluster_name,
         'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
         'rule_processor_enable_metrics': modules['stream_alert'] \
-            ['rule_processor']['enable_metrics'],
+            ['rule_processor'].get('enable_metrics', False),
         'rule_processor_log_level': modules['stream_alert'] \
             ['rule_processor'].get('log_level', 'info'),
         'rule_processor_memory': modules['stream_alert']['rule_processor']['memory'],
@@ -237,7 +237,7 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
         'rule_processor_config': '${var.rule_processor_config}',
         'alert_processor_config': '${var.alert_processor_config}',
         'alert_processor_enable_metrics': modules['stream_alert'] \
-            ['alert_processor']['enable_metrics'],
+            ['alert_processor'].get('enable_metrics', False),
         'alert_processor_log_level': modules['stream_alert'] \
             ['alert_processor'].get('log_level', 'info'),
         'alert_processor_memory': modules['stream_alert']['alert_processor']['memory'],
@@ -283,15 +283,12 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
     return True
 
 def generate_cloudwatch_log_metrics(cluster_name, cluster_dict, config):
-    """Add the CloudWatch Metric Filters module to the Terraform cluster dict.
+    """Add the CloudWatch Metric Filters information to the Terraform cluster dict.
 
     Args:
         cluster_name (str): The name of the currently generating cluster
         cluster_dict (defaultdict): The dict containing all Terraform config for a given cluster.
         config (dict): The loaded config from the 'conf/' directory
-
-    Returns:
-        bool: Result of applying the cloudwatch metric filters to the stream_alert module
     """
     stream_alert_config = config['clusters'][cluster_name]['modules']['stream_alert']
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -191,7 +191,7 @@ class RuleProcessorTester(object):
 
         # Print rule name for section header, but only if we get
         # to a point where there is a record to actually be tested.
-        # This avoids potentialy blank sections
+        # This avoids potentially blank sections
         if print_header_line and (alerts or self.print_output):
             print '\n{}'.format(rule_name)
 

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -180,3 +180,21 @@ resource "aws_cloudwatch_log_metric_filter" "alert_processor_cw_metric_filters" 
     value     = "${element(split(",", var.alert_processor_metric_filters[count.index]), 2)}"
   }
 }
+
+// CloudWatch metric alarms that are created per-cluster
+// The split list is our way around poor tf support for lists of maps and is made up of:
+// <alarm_name>, <alarm_description>, <comparison_operator>, <evaluation_periods>,
+// <metric>, <period>, <statistic>, <threshold>
+resource "aws_cloudwatch_metric_alarm" "cw_metric_alarms" {
+  count               = "${length(var.metric_alarms)}"
+  alarm_name          = "${element(split(",", var.metric_alarms[count.index]), 0)}"
+  alarm_description   = "${element(split(",", var.metric_alarms[count.index]), 1)}"
+  comparison_operator = "${element(split(",", var.metric_alarms[count.index]), 2)}"
+  evaluation_periods  = "${element(split(",", var.metric_alarms[count.index]), 3)}"
+  metric_name         = "${element(split(",", var.metric_alarms[count.index]), 4)}"
+  period              = "${element(split(",", var.metric_alarms[count.index]), 5)}"
+  statistic           = "${element(split(",", var.metric_alarms[count.index]), 6)}"
+  threshold           = "${element(split(",", var.metric_alarms[count.index]), 7)}"
+  namespace           = "${var.namespace}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+}

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -185,6 +185,7 @@ resource "aws_cloudwatch_log_metric_filter" "alert_processor_cw_metric_filters" 
 // The split list is our way around poor tf support for lists of maps and is made up of:
 // <alarm_name>, <alarm_description>, <comparison_operator>, <evaluation_periods>,
 // <metric>, <period>, <statistic>, <threshold>
+// TODO: update this logic to simply use a variable that is a list of maps once Terraform fixes this
 resource "aws_cloudwatch_metric_alarm" "cw_metric_alarms" {
   count               = "${length(var.metric_alarms)}"
   alarm_name          = "${element(split(",", var.metric_alarms[count.index]), 0)}"

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -97,7 +97,14 @@ variable "alert_processor_metric_filters" {
   default = []
 }
 
+variable "metric_alarms" {
+  type    = "list"
+  default = []
+}
+
 variable "namespace" {
   type    = "string"
   default = "StreamAlert"
 }
+
+variable "sns_topic_arn" {}

--- a/tests/unit/stream_alert_cli/test_terraform_generate.py
+++ b/tests/unit/stream_alert_cli/test_terraform_generate.py
@@ -585,14 +585,15 @@ class TestTerraformGenerate(object):
                     'prefix': 'unit-testing'
                 },
                 'infrastructure': {
-                    'metrics': {
-                        'enabled': True
+                    'monitoring': {
+                        'create_sns_topic': True
                     }
                 }
             },
             'lambda': {
                 'athena_partition_refresh_config': {
                     'enabled': True,
+                    'enable_metrics': True,
                     'current_version': '$LATEST',
                     'refresh_type': {
                         'repair_hive_table': {


### PR DESCRIPTION
to @austinbyers or @chunyong-lin 
cc @airbnb/streamalert-maintainers 
size: large

### Background & Why
* Context on recent developments:
  * StreamAlert now has support for metric logging with the merge of https://github.com/airbnb/streamalert/pull/282 ([metrics] v2 of metrics support using metric filters).
  * The usage of filter patterns for metrics allows us to cheaply track whatever sort of metric we want to by simply logging certain messages to logger.
  * Adding a new metric to be tracked involves adding it to the `stream_alert/shared/metrics.py` package to be used throughout the project.
* Any predefined metric can now have alarms associated with it to allow for notifications if something unexpected is occurring.
* For instance, if the number of `FailedParses` (aka incoming logs that do not match a defined schema) rises above a certain threshold, CloudWatch can fire an alarm that then notifies any service connected to the alarm.
  * The alarm currently sends to an SNS topic that is either designated by the user or chose by default by StreamAlert.

### Changes
* CloudWatch alarms for all predefined metrics we use are now configurable through the `manage.py` cli.
* A alarm that operates against a specific cluster's metric is configurable like so (note the use of `--metric-target cluster`):
```
    python manage.py create-alarm \
      --metric FailedParses \
      --metric-target cluster \
      --comparison-operator GreaterThanOrEqualToThreshold \
      --alarm-name 'Prod - Failed Parses Alarm' \
      --evaluation-periods 1 \
      --period 300 \
      --threshold 1.0 \
      --alarm-description 'Alarm for any failed parses that occur within a 5 minute period in the prod cluster' \
      --clusters prod \
      --statistic Sum
```
* A alarm that operates against the aggregate metric (across all clusters) is configurable like so (note the use of `--metric-target aggregate`):
```
    python manage.py create-alarm \
      --metric FailedParses \
      --metric-target aggregate \
      --comparison-operator GreaterThanOrEqualToThreshold \
      --alarm-name 'Aggregate - Failed Parses Alarm' \
      --evaluation-periods 1 \
      --period 300 \
      --threshold 1.0 \
      --alarm-description 'Aggregate alarm for any failed parses that occur within a 5 minute period in any cluster' \
      --statistic Sum
```
* Alarms current support one action, and that is sending to the SNS topic defined in `conf/global.json` (or the default SNS topic of `stream_alert_monitoring` if one is not defined).

### Other changes
* Adding a metric for `TOTAL_PROCESSED_SIZE` that will log the processed bytes for each rule processor invocation.
* The `manage.py` cli also now supports turning on or off metrics for a given cluster/function:
`manage.py metrics --enable --functions rule`
  * An optional list of `--clusters` can be added to only enable for specific clusters. By default without `--clusters` this will enable metrics for all clusters for the given function

### Testing
* There are no big changes to the core library/functions, but these changes have been deployed in a test AWS account to ensure the alarms get properly created:
```
+ aws_cloudwatch_metric_alarm.metric_alarm_AggregateFailedParsesAlarm
    actions_enabled:                       "true"
    alarm_actions.#:                       "1"
    alarm_actions.1304590987:              "arn:aws:sns:us-east-1:454267907943:stream_alert_monitoring"
    alarm_description:                     "Aggregate alarm for any failed parses that occur within a 5 minute period in any cluster"
    alarm_name:                            "Aggregate - Failed Parses Alarm"
    comparison_operator:                   "GreaterThanOrEqualToThreshold"
    evaluate_low_sample_count_percentiles: "<computed>"
    evaluation_periods:                    "1"
    metric_name:                           "RuleProcessor-FailedParses"
    namespace:                             "StreamAlert"
    period:                                "300"
    statistic:                             "Sum"
    threshold:                             "1"
    treat_missing_data:                    "missing"

+ module.stream_alert_prod.aws_cloudwatch_metric_alarm.cw_metric_alarms
    actions_enabled:                       "true"
    alarm_actions.#:                       "1"
    alarm_actions.1304590987:              "arn:aws:sns:us-east-1:454267907943:stream_alert_monitoring"
    alarm_description:                     "Alarm for any failed parses that occur within a 5 minute period in the prod cluster"
    alarm_name:                            "Prod - Failed Parses Alarm"
    comparison_operator:                   "GreaterThanOrEqualToThreshold"
    evaluate_low_sample_count_percentiles: "<computed>"
    evaluation_periods:                    "1"
    metric_name:                           "RuleProcessor-FailedParses-PROD"
    namespace:                             "StreamAlert"
    period:                                "300"
    statistic:                             "Sum"
    threshold:                             "1"
    treat_missing_data:                    "missing"
```
