### PR TITLE
streamalert - types - wrong command value for CB

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -1,6 +1,6 @@
 {
   "carbonblack":{
-    "command": ["cmdline"],
+    "command": ["command_line"],
     "destinationAddress": ["remote_ip"],
     "destinationDomain": ["domain"],
     "destinationPort": ["remote_port"],

--- a/conf/types.json
+++ b/conf/types.json
@@ -1,6 +1,6 @@
 {
   "carbonblack":{
-    "command": ["command_line"],
+    "command": ["cmdline", "command_line"],
     "destinationAddress": ["remote_ip"],
     "destinationDomain": ["domain"],
     "destinationPort": ["remote_port"],


### PR DESCRIPTION
to: @chunyong-lin 

**What**

CB supports both `cmdline` and `command_line`

`carbonblack:feed.query.hit.process` -> `cmdline`

& 

`carbonblack:ingress.event.procstart` -> `command_line`