### PR TITLE
[Data Normalization] Make `logs` optional when `datatypes` is defined

### DIFF
--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -133,6 +133,8 @@ def _sort_dict(unordered_dict):
     """
     result = OrderedDict()
     for key, value in sorted(unordered_dict.items(), key=lambda t: t[0]):
+        if key == 'normalized_types':
+            continue
         if isinstance(value, dict):
             result[key] = _sort_dict(value)
             continue

--- a/stream_alert/rule_processor/payload.py
+++ b/stream_alert/rule_processor/payload.py
@@ -82,12 +82,11 @@ class StreamPayload(object):
     def __repr__(self):
         repr_str = (
             '<{} valid:{} log_source:{} entity:{} '
-            'type:{} record:{} normalized_types:{}>'
+            'type:{} record:{}>'
             ).format(
                 self.__class__.__name__, self.valid,
                 self.log_source, self.entity,
-                self.type, self.records,
-                self.normalized_types
+                self.type, self.records
                 )
 
         return repr_str
@@ -127,7 +126,6 @@ class StreamPayload(object):
         self.records = None
         self.type = None
         self.valid = False
-        self.normalized_types = None
 
 
 class S3ObjectSizeError(Exception):

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -380,7 +380,7 @@ class StreamRules(object):
                 matcher_result = cls.match_event(record, rule)
                 if not matcher_result:
                     continue
-                if rule.datatypes is not None:
+                if rule.datatypes:
                     types_result = cls.match_types(record,
                                                    payload.normalized_types,
                                                    rule.datatypes)

--- a/tests/unit/stream_alert_rule_processor/test_payload.py
+++ b/tests/unit/stream_alert_rule_processor/test_payload.py
@@ -69,8 +69,7 @@ def test_repr_string():
     s3_payload.records = ['rec1', 'rec2']
     print_value = ('<S3Payload valid:False log_source:unit_source '
                    'entity:entity type:unit_type '
-                   'record:[\'rec1\', \'rec2\'] '
-                   'normalized_types:None>')
+                   'record:[\'rec1\', \'rec2\']>')
 
     output_print = s3_payload.__repr__()
     assert_equal(output_print, print_value)

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -186,9 +186,9 @@ class TestStreamRules(object):
         # doing this because after kinesis_data is read in, types are casted per
         # the schema
         for alert in alerts:
-            record_keys = alert['record'].keys()
-            record_keys.remove('normalized_types')
-            assert_items_equal(record_keys, kinesis_data.keys())
+            if 'normalized_types' in alert['record'].keys():
+                alert['record'].remove('normalized_types')
+            assert_items_equal(alert['record'].keys(), kinesis_data.keys())
             assert_items_equal(alert['outputs'], rule_outputs_map[alert['rule_name']])
 
     def test_process_subkeys_nested_records(self):


### PR DESCRIPTION
to @ryandeivert @mime-frame 
cc @airbnb/streamalert-maintainers 
size: tiny
contributes to: #304 

## Summary
Remove `log_source` constrain which means `logs` keyword is optional when we define a rule if `datatypes` keyword present. Otherwise `logs` keyword is required. 
Apply Data Normalization feature to a rule, we can define a rule in this format
```
from helpers.base import fetch_values_by_datatype

@rule(datatypes=['command'])
def alert_suspicious_wget(rec):
    results = fetch_values_by_datatype(rec, 'command')
    for result in results:
        if fnmatch(result, "wget *"):
            return true
    return false
```

## Changes

## Testing
* Integration test is passed, it covers three cases
  * `logs` is present, `datatypes` is not
  * `logs` is present, `datatypes` is
  * `logs` is not present, `datatypes` is
* Unit test is passed, and it covers four cases
  * `logs` is present, `datatypes` is not - working as expected
  * `logs` is present, `datatypes` is - working as expected
  * `logs` is not present, `datatypes` is not - log an ERROR
  * `logs` is not present, `datatypes` is - working as expected.
* Testing in AWS testing account is passed