### PR TITLE
[logs] updating `carbonblack:feed.query.hit.process` schema

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -653,6 +653,7 @@
       "filemod_count": "integer",
       "filtering_known_dlls": "boolean",
       "host_type": "string",
+      "interface_ip": "string",
       "last_server_update": "integer",
       "last_update": "string",
       "modload_count": "integer",
@@ -686,7 +687,8 @@
         "alliance_score_srstrust",
         "alliance_score_virustotal",
         "alliance_updated_srstrust",
-        "alliance_updated_virustotal"
+        "alliance_updated_virustotal",
+        "interface_ip"
       ],
       "envelope_keys": {
         "cb_server": "string",


### PR DESCRIPTION
to @mime-frame 
cc @airbnb/streamalert-maintainers 
size: small

## Changes
* After seeing an incoming `feed.query.hit.process` log that has a `interface_ip` key within `docs` entries, I've updated the `carbonblack:feed.query.hit.process` schema to have `interface_ip` as an optional top level key