### PR TITLE
streamalert - logs - vpc flow - flowlogstatus update

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -764,6 +764,11 @@
         "logGroup": "string",
         "logStream": "string",
         "owner": "integer"
+      },
+      "log_patterns": {
+        "flowlogstatus": [
+          "OK"
+        ]
       }
     }
   },
@@ -795,6 +800,38 @@
       "log_patterns": {
         "flowlogstatus": [
           "NODATA"
+        ]
+      }
+    }
+  },
+  "cloudwatch:flow_logs_skip_data": {
+    "schema": {
+      "protocol": "string",
+      "source": "string",
+      "destination": "string",
+      "srcport": "string",
+      "destport": "string",
+      "action": "string",
+      "packets": "string",
+      "bytes": "string",
+      "windowstart": "integer",
+      "windowend": "integer",
+      "version": "integer",
+      "eni": "string",
+      "account": "integer",
+      "flowlogstatus": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "json_path": "logEvents[*].extractedFields",
+      "envelope_keys": {
+        "logGroup": "string",
+        "logStream": "string",
+        "owner": "integer"
+      },
+      "log_patterns": {
+        "flowlogstatus": [
+          "SKIPDATA"
         ]
       }
     }


### PR DESCRIPTION
to: @ryandeivert 

Details: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html:
- 3 possible values of OK, NODATA or SKIPDATA for `flowlogstatus`
- For the latter 2, the schema accounts for '-' vs. integers

This updates all 3 schemas to use `log_patterns`

**Testing**

```
python manage.py lambda test --processor all
...
python manage.py validate-schemas
```