### PR TITLE
[lambda][rule] EXPERIMENTAL: schema matching now has better support log patterns

### DIFF
--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -79,7 +79,6 @@ class ParserBase:
     def matched_log_pattern(self, record, log_patterns):
         """Return True if all log patterns of this record match"""
         # Return True immediately if there are no log patterns
-        # or if the data being tested is not a dict
         if not log_patterns:
             return True
 
@@ -104,7 +103,7 @@ class ParserBase:
             pattern_result.append(any(fnmatch(value, pattern)
                                       for pattern in pattern_list))
 
-        all_patterns_result = all(pattern_result)
+        all_patterns_result = bool(pattern_result and all(pattern_result))
         LOGGER.debug('%s log pattern match result: %s', self.type(), all_patterns_result)
 
         # if all pattern group results are True


### PR DESCRIPTION
size: small

## This is *EXPERIMENTAL* for now so please do not merge
* We (and others) should test with a more impactful dataset before deploying this

## Changes 
* Enabling multiple schema matching by default and removing fallback logic that was used before.
* Type conversion now happens during schema matching
  * This change is in place to allow for type conversion to mark a schema as invalid for this log type and continue on to subsequent schemas.
  * Prior to this change, if type conversion failed there would be no way to continue to try other schemas and we would just assume this log was invalid.
* Log pattern matching is also enforced during schema matching now if `log_patterns` are defined for a schema instead of occurring after all matches were determined.

## Testing
* Updating unit tests and ran rule processing tests locally. This will have to be tested in a more realistic setup to determine if it performs well enough (ie - does not impact processing time too much).
