### PR TITLE
[logs] adding an optional key of "epoch" to osquery snapshot logs

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -996,12 +996,14 @@
       "unixTime": "string",
       "action": "string",
       "decorations": {},
-      "log_type": "string"
+      "log_type": "string",
+      "epoch": "integer"
     },
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
-        "decorations"
+        "decorations",
+        "epoch"
       ]
     }
   },


### PR DESCRIPTION
to @mime-frame 
cc @airbnb/streamalert-maintainers 

## Change
* Found that osquery snapshot logs can sometimes contain a top level `"epoch"` key - this change accounts for that.