### PR TITLE
[logs] adding some optional top level keys to "carbonblack:watchlist.hit.process"

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -356,13 +356,17 @@
   },
   "carbonblack:watchlist.hit.process": {
     "schema": {
+      "alliance_data_srsthreat": [],
       "alliance_data_srstrust": [],
       "alliance_data_virustotal": [],
       "alliance_link_srstrust": "string",
+      "alliance_link_srsthreat": "string",
       "alliance_link_virustotal": "string",
       "alliance_score_srstrust": "integer",
+      "alliance_score_srsthreat": "integer",
       "alliance_score_virustotal": "integer",
       "alliance_updated_srstrust": "string",
+      "alliance_updated_srsthreat": "string",
       "alliance_updated_virustotal": "string",
       "childproc_count": "integer",
       "cmdline": "string",
@@ -406,12 +410,16 @@
       "json_path": "docs[*]",
       "optional_top_level_keys": [
         "alliance_data_srstrust",
+        "alliance_data_srsthreat",
         "alliance_data_virustotal",
         "alliance_link_srstrust",
+        "alliance_link_srsthreat",
         "alliance_link_virustotal",
         "alliance_score_srstrust",
+        "alliance_score_srsthreat",
         "alliance_score_virustotal",
         "alliance_updated_srstrust",
+        "alliance_updated_srsthreat",
         "alliance_updated_virustotal"
       ],
       "envelope_keys": {


### PR DESCRIPTION
to @mime-frame 
cc @airbnb/streamalert-maintainers 

## Change
* Updating the `carbonblack:watchlist.hit.process` to contain some additional optional top level keys for known feeds.