### PR TITLE
"other_hostnames" optional in "carbonblack:alert.watchlist.hit.feedsearch.binary"

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -210,6 +210,7 @@
       },
       "optional_top_level_keys": [
         "assigned_to",
+        "other_hostnames",
         "resolved_time",
         "segment_id"
       ]


### PR DESCRIPTION
to @mime-frame 
cc @airbnb/streamalert-maintainers 

## Changes
* Observed an optional top level key for log type `carbonblack:alert.watchlist.hit.feedsearch.binary` of `other_hostnames`. Updating schema to make this key optional.
