### PR TITLE
Lambda to Firehose: Part 3

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -35,7 +35,10 @@ MAX_RECORD_SIZE = 1000 * 1000
 
 class StreamAlert(object):
     """Wrapper class for handling StreamAlert classificaiton and processing"""
-    __config = {}
+    config = {}
+    special_char_regex = re.compile(r'[\`\~\!\@\#\$\%\^\&\*\(\)\-\+\
+                                       \=\[\]\\\{\}\;\'\:\"\,\.\/\<\>\?]')
+    special_char_sub = '_'
 
     def __init__(self, context, enable_alert_processor=True):
         """Initializer
@@ -49,7 +52,7 @@ class StreamAlert(object):
         """
         # Load the config. Validation occurs during load, which will
         # raise exceptions on any ConfigErrors
-        StreamAlert.__config = StreamAlert.__config or load_config()
+        StreamAlert.config = StreamAlert.config or load_config()
 
         # Load the environment from the context arn
         self.env = load_env(context)
@@ -59,7 +62,7 @@ class StreamAlert(object):
         self.sinker = StreamSink(self.env)
 
         # Instantiate a classifier that is used for this run
-        self.classifier = StreamClassifier(config=self.__config)
+        self.classifier = StreamClassifier(config=self.config)
 
         self.enable_alert_processor = enable_alert_processor
         self._failed_record_count = 0
@@ -95,14 +98,14 @@ class StreamAlert(object):
             return False
 
         threat_intel_config = dict()
-        if (self.__config.get('threat_intel')
-                and self.__config.get('threat_intel', {}).get('enabled')):
+        if (self.config.get('threat_intel')
+                and self.config.get('threat_intel', {}).get('enabled')):
             StreamRules.load_intelligence()
-            threat_intel_config = self.__config.get('threat_intel')
+            threat_intel_config = self.config.get('threat_intel')
 
         MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.TOTAL_RECORDS, len(records))
 
-        firehose_config = self.__config['global'].get(
+        firehose_config = self.config['global'].get(
             'infrastructure', {}).get('firehose', {})
         if firehose_config.get('enabled'):
             self.firehose_client = boto3.client('firehose',
@@ -168,119 +171,141 @@ class StreamAlert(object):
         """
         return self._alerts
 
-    def _send_to_firehose(self):
-        """Send all classified records to a respective Firehose Delivery Stream"""
+    @staticmethod
+    def _segment_records_by_count(record_list, max_count):
+        """Segment records by length
 
-        # Setup regex and delivery stream name pattern for functions below
-        special_char_regex = re.compile(r'[\`\~\!\@\#\$\%\^\&\*\(\)\-\+\
-                                           \=\[\]\\\{\}\;\'\:\"\,\.\/\<\>\?]')
-        special_char_sub = '_'
-        delivery_stream_name_pattern = 'streamalert_data_{}'
+        Args:
+            record_list (list): The original records list to be segmented
+            max_count (int): The max amount of records to yield per group
+        """
+        for item in range(0, len(record_list), max_count):
+            yield record_list[item:item + max_count]
 
-        def _segment_records_by_count(record_list, max_count):
-            """Helper function to chunk payloads"""
-            for item in range(0, len(record_list), max_count):
-                yield record_list[item:item + max_count]
+    def _segment_records_by_size(self, record_batch):
+        """Segment record groups by size
 
-        def _segment_records_by_size(record_batch):
-            split_factor = 1
-            len_batch = len(record_batch)
+        Args:
+            record_batch (list): The original record batch to measure and segment
 
-            while True:
-                if len(str(record_batch[:len_batch / split_factor])) > MAX_BATCH_SIZE:
-                    split_factor += 1
-                else:
-                    break
+        Returns:
+            generator: Used to iterate on each newly segmented group
+        """
+        split_factor = 1
+        len_batch = len(record_batch)
 
-            return _segment_records_by_count(record_batch, len_batch / split_factor)
+        while True:
+            if len(str(record_batch[:len_batch / split_factor])) > MAX_BATCH_SIZE:
+                split_factor += 1
+            else:
+                break
 
-        def _limit_record_size(batch):
-            """Helper function to verify record size"""
-            for index, record in enumerate(batch):
-                if len(str(record)) > MAX_RECORD_SIZE:
-                    # Show the first 1k bytes in order to not overload
-                    # CloudWatch logs
-                    LOGGER.error('The following record is too large'
-                                 'be sent to Firehose: %s', str(record)[:1000])
-                    MetricLogger.log_metric(FUNCTION_NAME,
-                                            MetricLogger.FIREHOSE_FAILED_RECORDS,
-                                            1)
-                    batch.pop(index)
+        return self._segment_records_by_count(record_batch, len_batch / split_factor)
 
-        def _sanitize_keys(record):
-            """Remove special characters from parsed record keys
+    @staticmethod
+    def _limit_record_size(batch):
+        """Limit the record size to be sent to Firehose
 
-            This is required when searching in Athena.  Keys can only have
-            a period or underscore
-
-            Returns:
-                dict: A sanitized record
-            """
-            new_record = {}
-            for key, value in record.iteritems():
-                # Set a default value of the original key
-                sanitized_key = key
-                if re.search(special_char_regex, key):
-                    sanitized_key = re.sub(special_char_regex,
-                                           special_char_sub,
-                                           key)
-
-                # Handle nested objects
-                if isinstance(value, dict):
-                    new_record[sanitized_key] = _sanitize_keys(record[key])
-                else:
-                    new_record[sanitized_key] = record[key]
-
-            return new_record
-
-        def _firehose_request(stream_name, record_batch):
-            """Send record batches to Firehose"""
-            LOGGER.debug('Sending %d records to Firehose:%s',
-                         len(record_batch),
-                         stream_name)
-            resp = self.firehose_client.put_record_batch(
-                DeliveryStreamName=stream_name,
-                # The newline at the end is required by Firehose,
-                # otherwise all records will be on a single line and
-                # unsearchable in Athena.
-                Records=[{'Data': json.dumps(_sanitize_keys(record),
-                                             separators=(",", ":")) + '\n'}
-                         for record
-                         in record_batch])
-
-            # Error handle if failures occured
-            # TODO(jack) implement backoff here once the rule processor is split
-            if resp.get('FailedPutCount') > 0:
-                failed_records = [failed
-                                  for failed
-                                  in resp['RequestResponses']
-                                  if failed.get('ErrorCode')]
+        Args:
+            batch (list): Record batch to iterate on
+        """
+        for index, record in enumerate(batch):
+            if len(str(record)) > MAX_RECORD_SIZE:
+                # Show the first 1k bytes in order to not overload
+                # CloudWatch logs
+                LOGGER.error('The following record is too large'
+                             'be sent to Firehose: %s', str(record)[:1000])
                 MetricLogger.log_metric(FUNCTION_NAME,
                                         MetricLogger.FIREHOSE_FAILED_RECORDS,
-                                        resp['FailedPutCount'])
-                # Only print the first 100 failed records to Cloudwatch logs
-                LOGGER.error('The following records failed to Put to the'
-                             'Delivery stream %s: %s',
-                             stream_name,
-                             json.dumps(failed_records[:100], indent=2))
+                                        1)
+                batch.pop(index)
+
+    def _sanitize_keys(self, record):
+        """Remove special characters from parsed record keys
+
+        This is required when searching in Athena.  Keys can only have
+        a period or underscore
+
+        Args:
+            record (dict): Original parsed record
+
+        Returns:
+            dict: A sanitized record
+        """
+        new_record = {}
+        for key, value in record.iteritems():
+            # Set a default value of the original key
+            sanitized_key = key
+            if re.search(self.special_char_regex, key):
+                sanitized_key = re.sub(self.special_char_regex,
+                                       self.special_char_sub,
+                                       key)
+
+            # Handle nested objects
+            if isinstance(value, dict):
+                new_record[sanitized_key] = self._sanitize_keys(record[key])
             else:
-                MetricLogger.log_metric(FUNCTION_NAME,
-                                        MetricLogger.FIREHOSE_RECORDS_SENT,
-                                        len(record_batch))
-                LOGGER.info('Successfully sent %d messages to Firehose:%s',
-                            len(record_batch),
-                            stream_name)
+                new_record[sanitized_key] = record[key]
+
+        return new_record
+
+    def _firehose_request_helper(self, stream_name, record_batch):
+        """Send record batches to Firehose
+
+        Args:
+            stream_name (str): The name of the Delivery Stream to send to
+            record_batch (list): The records to send
+        """
+        LOGGER.debug('Sending %d records to Firehose:%s',
+                     len(record_batch),
+                     stream_name)
+        resp = self.firehose_client.put_record_batch(
+            DeliveryStreamName=stream_name,
+            # The newline at the end is required by Firehose,
+            # otherwise all records will be on a single line and
+            # unsearchable in Athena.
+            Records=[{'Data': json.dumps(self._sanitize_keys(record),
+                                         separators=(",", ":")) + '\n'}
+                     for record
+                     in record_batch])
+
+        # Error handle if failures occured
+        # TODO(jack) implement backoff here once the rule processor is split
+        if resp.get('FailedPutCount') > 0:
+            failed_records = [failed
+                              for failed
+                              in resp['RequestResponses']
+                              if failed.get('ErrorCode')]
+            MetricLogger.log_metric(FUNCTION_NAME,
+                                    MetricLogger.FIREHOSE_FAILED_RECORDS,
+                                    resp['FailedPutCount'])
+            # Only print the first 100 failed records to Cloudwatch logs
+            LOGGER.error('The following records failed to Put to the'
+                         'Delivery stream %s: %s',
+                         stream_name,
+                         json.dumps(failed_records[:100], indent=2))
+        else:
+            MetricLogger.log_metric(FUNCTION_NAME,
+                                    MetricLogger.FIREHOSE_RECORDS_SENT,
+                                    len(record_batch))
+            LOGGER.info('Successfully sent %d messages to Firehose:%s',
+                        len(record_batch),
+                        stream_name)
+
+    def _send_to_firehose(self):
+        """Send all classified records to a respective Firehose Delivery Stream"""
+        delivery_stream_name_pattern = 'streamalert_data_{}'
 
         # Iterate through each payload type
         for log_type, records in self.categorized_payloads.items():
             # This same method is used when naming the Delivery Streams
             formatted_log_type = log_type.replace(':', '_')
 
-            for record_batch in _segment_records_by_count(records, MAX_BATCH_COUNT):
+            for record_batch in self._segment_records_by_count(records, MAX_BATCH_COUNT):
                 stream_name = delivery_stream_name_pattern.format(formatted_log_type)
-                _limit_record_size(record_batch)
-                for sized_batch in _segment_records_by_size(record_batch):
-                    _firehose_request(stream_name, sized_batch)
+                self._limit_record_size(record_batch)
+                for sized_batch in self._segment_records_by_size(record_batch):
+                    self._firehose_request_helper(stream_name, sized_batch)
 
     def _process_alerts(self, payload, threat_intel_config=None):
         """Process records for alerts and send them to the correct places
@@ -315,7 +340,10 @@ class StreamAlert(object):
             # Add all parsed records to the categorized payload dict
             # only if Firehose is enabled
             if self.firehose_client:
-                self.categorized_payloads[payload.log_source].extend(payload.records)
+                # Only send payloads with enabled types
+                if payload.log_source.split(':')[0] not in self.config['global'] \
+                    ['infrastructure'].get('firehose', {}).get('disabled_logs', []):
+                    self.categorized_payloads[payload.log_source].extend(payload.records)
 
             if not record_alerts:
                 continue

--- a/stream_alert_cli/terraform/_common.py
+++ b/stream_alert_cli/terraform/_common.py
@@ -39,6 +39,7 @@ def enabled_firehose_logs(config):
         list: All enabled logs sending to StreamAlert
     """
     config_logs = set(config['logs'])
+    disabled_logs = set(config['global']['infrastructure']['firehose'].get('disabled_logs', []))
     expanded_logs_with_subtypes = set()
     enabled_logs_from_sources = list()
 
@@ -47,8 +48,9 @@ def enabled_firehose_logs(config):
             enabled_logs_from_sources.extend(properties['logs'])
 
     for log in config_logs:
-        for enabled_log in set(enabled_logs_from_sources):
-            if log.split(':')[0] == enabled_log:
+        for enabled_log in set(enabled_logs_from_sources) - disabled_logs:
+            log_type = log.split(':')[0]
+            if log_type == enabled_log:
                 expanded_logs_with_subtypes.add(log)
 
     # Firehose Delivery Streams cannot have semicolons

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -175,7 +175,7 @@ def generate_main(**kwargs):
             'buffer_interval': config['global']['infrastructure'] \
                                      ['firehose'].get('buffer_interval', 300),
             'compression_format': config['global']['infrastructure'] \
-                                        ['firehose'].get('buffer_interval', 'Snappy'),
+                                        ['firehose'].get('compression_format', 'Snappy'),
             's3_logging_bucket': logging_bucket,
             's3_bucket_name': firehose_s3_bucket_name
         }

--- a/tests/unit/stream_alert_cli/terraform/test_common.py
+++ b/tests/unit/stream_alert_cli/terraform/test_common.py
@@ -22,6 +22,9 @@ CONFIG = CLIConfig(config_path='tests/unit/conf')
 
 def test_enabled_firehose_logs():
     """CLI - Terraform Common - Expected Firehose Logs """
+    CONFIG['global']['infrastructure']['firehose'] = {
+        'enabled': True
+    }
     firehose_logs = set(_common.enabled_firehose_logs(CONFIG))
 
     expected_logs = {
@@ -37,6 +40,37 @@ def test_enabled_firehose_logs():
         'test_log_type_json_2',
         'test_log_type_json_nested_osquery',
         'test_log_type_syslog',
+        'test_cloudtrail',
+        'unit_test_simple_log'
+    }
+
+    assert_equal(firehose_logs, expected_logs)
+
+def test_enabled_firehose_logs_disabled():
+    """CLI - Terraform Common - Expected Firehose Logs - Disable"""
+    CONFIG['global']['infrastructure']['firehose'] = {
+        'enabled': True,
+        'disabled_logs': [
+            'test_log_type_json',
+            'test_log_type_csv',
+            'test_log_type_syslog'
+        ]
+    }
+    firehose_logs = set(_common.enabled_firehose_logs(CONFIG))
+
+    expected_logs = {
+        'cloudwatch_test_match_types',
+        # 'test_log_type_csv',
+        'test_log_type_csv_nested',
+        'test_log_type_json_nested',
+        'test_log_type_json_nested_with_data',
+        # 'test_log_type_json',
+        'test_log_type_kv_auditd',
+        'test_multiple_schemas_01',
+        'test_multiple_schemas_02',
+        'test_log_type_json_2',
+        'test_log_type_json_nested_osquery',
+        # 'test_log_type_syslog',
         'test_cloudtrail',
         'unit_test_simple_log'
     }

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -436,3 +436,24 @@ class TestStreamAlert(object):
             self.__sa_handler.run(test_event)
 
             firehose_mock.assert_not_called()
+
+    @patch('stream_alert.rule_processor.handler.LOGGER')
+    @mock_kinesis
+    def test_firehose_record_delivery_client_errorr(self, mock_logging):
+        """StreamAlert Class - Firehose Record Delivery - Client Error"""
+        self.__sa_handler.firehose_client = boto3.client(
+            'firehose', region_name='us-east-1')
+
+        test_events = [
+            # unit_test_simple_log
+            {'unit_key_01': 2, 'unit_key_02': 'testtest'}
+            for _
+            in range(10)]
+
+        self.__sa_handler._firehose_request_helper('invalid_stream',
+                                                   test_events)
+
+        missing_stream_message = 'Client Error ... An error occurred ' \
+        '(ResourceNotFoundException) when calling the PutRecordBatch ' \
+        'operation: Stream invalid_stream under account 123456789012 not found.'
+        assert_true(mock_logging.error.called_with(missing_stream_message))

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -86,11 +86,10 @@ def get_valid_config():
 
 def convert_events_to_kinesis(raw_records):
     """Given a list of pre-defined raw records, make a valid kinesis test event"""
-    return {'Records': [make_kinesis_raw_record('unit_test_default_stream', json.dumps(record))
-                        for
-                        record
-                        in
-                        raw_records]}
+    return {'Records': [make_kinesis_raw_record('unit_test_default_stream',
+                                                json.dumps(record))
+                        for record
+                        in raw_records]}
 
 
 def get_valid_event(count=1, **kwargs):
@@ -127,9 +126,7 @@ def make_kinesis_raw_record(kinesis_stream, kinesis_data):
         'eventSource': 'aws:kinesis',
         'eventSourceARN': 'arn:aws:kinesis:us-east-1:123456789012:stream/{}'.format(kinesis_stream),
         'kinesis': {
-            'data': base64.b64encode(kinesis_data)
-        }
-    }
+            'data': base64.b64encode(kinesis_data)}}
     return raw_record
 
 
@@ -140,9 +137,7 @@ def make_sns_raw_record(topic_name, sns_data):
         'EventSubscriptionArn': 'arn:aws:sns:us-east-1:123456789012:{}'.format(topic_name),
         'Sns': {
             'MessageId': 'unit test message id',
-            'Message': sns_data
-        }
-    }
+            'Message': sns_data}}
     return raw_record
 
 


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers 
size: medium
references: #5, #280, #320 

### Background

Part 3 completes the Lambda and CLI development necessary to send logs directly to Firehose.  At a high level, it accomplishes the following:

* Strip special characters from record keys: This enables records to be compliant with loading data into Hive.
* Payload size checks: Ensure that the max payload size for Firehose is not surpassed.
* Disable log types: For whatever reason, if a user does not want to send a top level log type (`cloudwatch` for example), it can be added to the config.  This will also remove the Firehose Delivery Stream to keep costs down

### Testing

Deployed in a test AWS account to verify end to end workflows