### PR TITLE
[cli][bug] Add a condition to include `threat_intel` directory

### DIFF
--- a/stream_alert_cli/package.py
+++ b/stream_alert_cli/package.py
@@ -228,13 +228,14 @@ class LambdaPackage(object):
 class RuleProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Rule Processor function"""
     package_folders = {
-        'threat_intel',
         'stream_alert/rule_processor',
         'stream_alert/shared',
         'rules',
         'matchers',
         'helpers',
         'conf'}
+    if os.path.exists('threat_intel'):
+        package_folders.add('threat_intel')
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'rule_processor'


### PR DESCRIPTION
to: @jacknagz
cc: @airbnb/streamalert-maintainers 
size: tiny

## Background
This bug will break when uploading lambda function to lambda function if user has no `threat_intel` directory created even Threat Intel feature is disabled.
Add a condition to include `threat_intel` directory in `RuleProcessorPackage`.

## Testing
Deploy rule processor and alert processor in AWS testing account. It was passed.

