### PR TITLE
[apps][duo_auth] adding duo auth example rules and updating tests

### DIFF
--- a/rules/community/duo_authentication/duo_anonymous_ip_failure.py
+++ b/rules/community/duo_authentication/duo_anonymous_ip_failure.py
@@ -1,0 +1,18 @@
+"""Alert on any Duo authentication logs marked as a failure due to an Anonymous IP."""
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+
+@rule(logs=['duo:authentication'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def duo_anonymous_ip_failure(rec):
+    """
+    author:       airbnb_csirt
+    description:  Alert on any Duo authentication logs marked as a failure due to an Anonymous IP.
+    reference:    N/A
+    playbook:     N/A
+    """
+    return rec['result'] == 'FAILURE' and rec['reason'] == 'Anonymous IP'

--- a/rules/community/duo_authentication/duo_fraud.py
+++ b/rules/community/duo_authentication/duo_fraud.py
@@ -1,0 +1,18 @@
+"""Alert on any Duo authentication logs marked as fraud."""
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+
+@rule(logs=['duo:authentication'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def duo_fraud(rec):
+    """
+    author:       airbnb_csirt
+    description:  Alert on any Duo authentication logs marked as fraud.
+    reference:    N/A
+    playbook:     N/A
+    """
+    return rec['result'] == 'FRAUD'

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -220,6 +220,10 @@ def format_lambda_test_record(test_record):
         template['Sns']['Message'] = data
         template['EventSubscriptionArn'] = 'arn:aws:sns:us-east-1:111222333:{}'.format(
             source)
+
+    elif service == 'stream_alert_app':
+        template['stream_alert_app'] = source
+        template['logs'] = [data]
     else:
         LOGGER_CLI.info('Invalid service %s', service)
 

--- a/tests/integration/rules/duo_anonymous_ip_failure.json
+++ b/tests/integration/rules/duo_anonymous_ip_failure.json
@@ -1,0 +1,66 @@
+{
+  "records": [
+    {
+      "data": {
+        "username": "user.name@email.com",
+        "access_device": {
+          "flash_version": "27.0.0.0",
+          "java_version": "uninstalled",
+          "os_version": "10.12.6",
+          "browser_version": "60.0.0000.80",
+          "trusted_endpoint_status": "not trusted",
+          "os": "Mac OS X",
+          "browser": "Chrome"
+        },
+        "timestamp": 1505316499,
+        "new_enrollment": false,
+        "ip": "12.123.123.12",
+        "integration": "Test Integration",
+        "reason": "Anonymous IP",
+        "location": {
+          "city": "Place",
+          "state": "State",
+          "country": "US"
+        },
+        "factor": "Duo Push",
+        "device": "555-123-4567",
+        "result": "FAILURE"
+      },
+      "description": "Duo authentication log marked as failure as a result of 'Anonymous IP' that will create an alert",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger": true
+    },
+    {
+      "data": {
+        "username": "user.name@email.com",
+        "access_device": {
+          "flash_version": "27.0.0.0",
+          "java_version": "uninstalled",
+          "os_version": "10.12.6",
+          "browser_version": "60.0.0000.80",
+          "trusted_endpoint_status": "not trusted",
+          "os": "Mac OS X",
+          "browser": "Chrome"
+        },
+        "timestamp": 1505316499,
+        "new_enrollment": false,
+        "ip": "12.123.123.12",
+        "integration": "Test Integration",
+        "reason": "Location restricted",
+        "location": {
+          "city": "Place",
+          "state": "State",
+          "country": "US"
+        },
+        "factor": "Duo Push",
+        "device": "555-123-5678",
+        "result": "FAILURE"
+      },
+      "description": "Duo authentication log marked as failure as a result of 'Location restricted' that will not create an alert",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger": false
+    }
+  ]
+}

--- a/tests/integration/rules/duo_fraud.json
+++ b/tests/integration/rules/duo_fraud.json
@@ -1,0 +1,66 @@
+{
+  "records": [
+    {
+      "data": {
+        "username": "user.name@email.com",
+        "access_device": {
+          "flash_version": "27.0.0.0",
+          "java_version": "uninstalled",
+          "os_version": "10.12.6",
+          "browser_version": "60.0.0000.80",
+          "trusted_endpoint_status": "not trusted",
+          "os": "Mac OS X",
+          "browser": "Chrome"
+        },
+        "timestamp": 1505316499,
+        "new_enrollment": false,
+        "ip": "12.123.123.12",
+        "integration": "Test Integration",
+        "reason": "",
+        "location": {
+          "city": "Place",
+          "state": "State",
+          "country": "US"
+        },
+        "factor": "Duo Push",
+        "device": "555-123-4567",
+        "result": "FRAUD"
+      },
+      "description": "Duo authentication log marked as fraud that will create an alert",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger": true
+    },
+    {
+      "data": {
+        "username": "user.name@email.com",
+        "access_device": {
+          "flash_version": "27.0.0.0",
+          "java_version": "uninstalled",
+          "os_version": "10.12.6",
+          "browser_version": "60.0.0000.80",
+          "trusted_endpoint_status": "not trusted",
+          "os": "Mac OS X",
+          "browser": "Chrome"
+        },
+        "timestamp": 1505316499,
+        "new_enrollment": false,
+        "ip": "12.123.123.12",
+        "integration": "Test Integration",
+        "reason": "",
+        "location": {
+          "city": "Place",
+          "state": "State",
+          "country": "US"
+        },
+        "factor": "Duo Push",
+        "device": "555-123-5678",
+        "result": "SUCCESS"
+      },
+      "description": "Duo authentication log marked as success that will not create an alert",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger": false
+    }
+  ]
+}

--- a/tests/integration/templates/stream_alert_app.json
+++ b/tests/integration/templates/stream_alert_app.json
@@ -1,0 +1,4 @@
+{
+  "stream_alert_app": "",
+  "logs": []
+}


### PR DESCRIPTION
to @jacknagz , @fusionrace 
cc @airbnb/streamalert-maintainers 

### Changes
* Adding two new example rules for Duo:
  * `duo_anonymous_ip_failure`: Alerts on duo auth logs that are marked as failure due to anonymous IP
  * `duo_fraud`: Alerts on duo auth logs that are marked as fraudulent by the end user
* Updating the testing framework to have support for the new `stream_alert_app` test records.