### PR TITLE
Athena Data Bucket Support

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1079,7 +1079,17 @@ Available Subcommands:
 Examples:
 
     manage.py athena create-db
-    manage.py athena create-table --type alerts --bucket s3.bucket.name
+
+    manage.py athena create-table \
+    --type alerts \
+    --bucket s3.bucket.name \
+    --refresh-type add_hive_partition
+
+    manage.py athena create-table \
+    --type data \
+    --bucket s3.bucket.name \
+    --refresh-type add_hive_partition \
+    --table_name my_athena_table
 
 """.format(version))
     athena_parser = subparsers.add_parser(
@@ -1101,12 +1111,17 @@ Examples:
     # TODO(jacknagz): Create a second choice for data tables, and accept a log name argument.
     athena_parser.add_argument(
         '--type',
-        choices=['alerts'],
+        choices=['alerts', 'data'],
         help=ARGPARSE_SUPPRESS
     )
 
     athena_parser.add_argument(
         '--bucket',
+        help=ARGPARSE_SUPPRESS
+    )
+
+    athena_parser.add_argument(
+        '--table_name',
         help=ARGPARSE_SUPPRESS
     )
 

--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -347,8 +347,8 @@ class StreamAlertAthenaClient(object):
                 # This logic extracts out the name of the table from the
                 # first element in the S3 path, as that's how log types
                 # are configured to send to Firehose.
-                athena_table = path.split('/')[0] if athena_table != 'alerts' \
-                    else athena_table
+                if athena_table != 'alerts':
+                    athena_table = path.split('/')[0]
 
                 # Example:
                 # PARTITION (dt = '2017-01-01-01') LOCATION 's3://bucket/path/'
@@ -362,7 +362,7 @@ class StreamAlertAthenaClient(object):
                     path=path)
                 # By using the partition as the dict key, this ensures that
                 # Athena will not try to add the same partition twice.
-                # TODO(jacknagz): Write this dictionary to Dyanmodb
+                # TODO(jacknagz): Write this dictionary to SSM/DynamoDb
                 # to increase idempotence of this Lambda function
                 partitions[athena_table][partition] = location
 
@@ -390,7 +390,7 @@ class StreamAlertAthenaClient(object):
                 return False
 
             LOGGER.info('Successfully added the following partitions:\n%s',
-                        json.dumps(partitions[athena_table], indent=4))
+                        json.dumps({athena_table: partitions[athena_table]}, indent=4))
         return True
 
 

--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -95,7 +95,7 @@ CONFIG_DATA = {
                 },
                 "add_hive_partition": {
                     "unit-testing.streamalerts": "alerts",
-                    "test-bucket-with-data": "data-type-1"
+                    "unit-testing.streamalert.data": "data"
                 }
             },
             'handler': 'main.handler',
@@ -431,12 +431,20 @@ class TestStreamAlertAthenaClient(object):
         result = self.client.add_hive_partition({
             'unit-testing.streamalerts': set([
                 'alerts/dt=2017-08-26-14/rule_name_alerts-1304134918401.json',
-                'alerts/dt=2017-08-27-14/rule_name_alerts-1304134918401.json',
+                'alerts/dt=2017-08-27-14/rule_name_alerts-1304134918401.json'
+            ]),
+            'unit-testing.streamalert.data': set([
+                'log_type_1/2017/08/26/14/test-data-11111-22222-33333.snappy',
+                'log_type_2/2017/08/26/14/test-data-11111-22222-33333.snappy',
+                'log_type_2/2017/08/26/15/test-data-11111-22222-33333.snappy',
+                'log_type_2/2017/08/26/16/test-data-11111-22222-33333.snappy',
+                'log_type_3/2017/08/26/14/test-data-11111-22222-33333.snappy',
+                'log_type_1/2017/08/26/11/test-data-11111-22222-33333.snappy'
             ]),
             'test-bucket-with-data': set([
                 '2017/08/26/14/rule_name_alerts-1304134918401.json',
                 '2017/08/28/14/rule_name_alerts-1304134918401.json',
-                '2017/07/30/14/rule_name_alerts-1304134918401.json',
+                '2017/07/30/14/rule_name_alerts-1304134918401.json'
             ])
         })
 

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -346,7 +346,7 @@ class TestStreamAlert(object):
         self.__sa_handler = StreamAlert(get_mock_context(), False)
         load_intelligence_mock.assert_called()
 
-    def test_firehose_sanitize_keys(self):
+    def test_firehosesanitize_keys(self):
         """StreamAlert Class - Firehose - Sanitize Keys"""
         # test_log_type_json_nested
         test_event = {
@@ -375,7 +375,7 @@ class TestStreamAlert(object):
             }
         }
 
-        sanitized_event = self.__sa_handler._sanitize_keys(test_event)
+        sanitized_event = self.__sa_handler.sanitize_keys(test_event)
         assert_equal(sanitized_event, expected_sanitized_event)
 
     def test_firehose_segment_records_by_size(self):

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -346,7 +346,7 @@ class TestStreamAlert(object):
         self.__sa_handler = StreamAlert(get_mock_context(), False)
         load_intelligence_mock.assert_called()
 
-    def test_firehosesanitize_keys(self):
+    def test_firehose_sanitize_keys(self):
         """StreamAlert Class - Firehose - Sanitize Keys"""
         # test_log_type_json_nested
         test_event = {


### PR DESCRIPTION
to: @austinbyers @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium
resolves: #5 

## Background

StreamAlert currently supports historical searching of `alerts` buckets only.  This PR adds support for historical search of data sent via Kinesis Firehose.

## Changes

* Automatically add partitions for Athena data tables
* Support data Athena table creation from the CLI
* Convert StreamAlert schemas into Hive schemas

## Testing

* All testing done in a side AWS account