### PR TITLE
[apps] adding method to mask authentication info before logging to output

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -274,6 +274,7 @@ class AppIntegration(object):
             return
 
         while self._gather() + self._sleep_seconds() < self._config.remaining_ms() / 1000.0:
+            LOGGER.debug('Lambda remaining seconds: %.2f', self._config.remaining_ms() / 1000.0)
             if not self._more_to_poll:
                 break
 

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -133,6 +133,8 @@ class DuoApp(AppIntegration):
         # Setting _more_to_poll to true here will allow the caller to try to poll again
         self._more_to_poll = len(logs) >= self._MAX_RESPONSE_LOGS
 
+        LOGGER.debug('More logs to poll for \'%s\': %s', self.type(), self._more_to_poll)
+
         # Return the list of logs to the caller so they can be send to the batcher
         return logs
 

--- a/app_integrations/batcher.py
+++ b/app_integrations/batcher.py
@@ -55,7 +55,9 @@ class Batcher(object):
 
         # Fall back on segmenting the list of logs into multiple requests
         # if they could not be sent at once
-        return self._segment_and_send(source_function, logs)
+        self._segment_and_send(source_function, logs)
+
+        LOGGER.info('Finished batch send of %d logs to the rule processor', len(logs))
 
     def _segment_and_send(self, source_function, logs):
         """Protected method for segmenting a list of logs into smaller lists

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -196,7 +196,8 @@ class TestAppIntegration(object):
 
     @patch('app_integrations.apps.app_base.AppIntegration._gather')
     @patch('app_integrations.apps.app_base.AppIntegration._sleep_seconds', Mock(return_value=1))
-    @patch('app_integrations.config.AppConfig.remaining_ms', Mock(side_effect=[5000, 2000]))
+    @patch('app_integrations.config.AppConfig.remaining_ms',
+           Mock(side_effect=[5000, 5000, 2000, 2000]))
     def test_gather_multiple(self, gather_mock):
         """App Integration - Gather, Entry Point, Multiple Calls"""
         # 3 == number of 'seconds' this ran for. This is compared against the remaining_ms mock

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 # pylint: disable=no-self-use,protected-access
 from mock import patch
-from nose.tools import assert_equal, assert_items_equal, raises
+from nose.tools import assert_equal, assert_false, assert_items_equal, raises
 
 from app_integrations.config import AppConfig
 from app_integrations.exceptions import AppIntegrationConfigError
@@ -121,3 +121,19 @@ class TestAppIntegrationConfig(object):
         """AppIntegrationConfig - Mark Failure"""
         self._config.mark_failure()
         assert_equal(self._config['current_state'], 'failed')
+
+    def test_is_failing(self):
+        """AppIntegrationConfig - Check If Failing"""
+        assert_false(self._config.is_failing)
+
+    def test_scrub_auth_info(self):
+        """AppIntegrationConfig - Scrub Auth Info"""
+        auth_key = '{}_auth'.format(FUNCTION_NAME)
+        param_dict = {auth_key: self._config['auth']}
+        scrubbed_config = self._config._scrub_auth_info(param_dict, auth_key)
+        assert_equal(scrubbed_config[auth_key]['api_hostname'],
+                     '*' * len(self._config['auth']['api_hostname']))
+        assert_equal(scrubbed_config[auth_key]['integration_key'],
+                     '*' * len(self._config['auth']['integration_key']))
+        assert_equal(scrubbed_config[auth_key]['secret_key'],
+                     '*' * len(self._config['auth']['secret_key']))


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers , @javuto 
size: small

### Changes
* In order to prevent sensitive auth info from making its way into the log output when `debug` mode is enabled, I've added a method for masking the sensitive information with `*` values before it gets printed.
* This is only used in one place and returns a copy of the origin dict to avoid altering the values needed by the function.
* Adding debug log statement that will periodically log how much time (in ms) the Lambda function has remaining. This could be useful for troubleshooting future issues (ie: timeouts).
* Adding info log statement to print when batch sending of logs is finished.
* Adding debug log statement to print if there are more logs to poll for duo_(auth|admin).
* Updating unit tests to verify the masking occurs.