### PR TITLE
fixing the osquery:differential schema

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -983,9 +983,11 @@
   },
   "osquery:differential": {
     "schema": {
-      "action": "string",
       "calendarTime": "string",
-      "columns": {},
+      "diffResults": {
+        "removed": [],
+        "added": []
+      },
       "counter": "integer",
       "decorations": {},
       "epoch": "integer",


### PR DESCRIPTION
confirmed working with 2.7.0 & 2.8.0 osquery outputs