### PR TITLE
streamalert - add osquery 'batch' schema, add counter key, small nits

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1034,13 +1034,38 @@
       "action": "string",
       "decorations": {},
       "log_type": "string",
-      "epoch": "integer"
+      "epoch": "integer",
+      "counter": "integer"
     },
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
         "decorations",
-        "epoch"
+        "epoch",
+        "counter"
+      ]
+    }
+  },
+  "osquery:batch": {
+    "schema": {
+      "diffResults" : {
+        "removed": [],
+        "added": []
+      },
+      "name": "string",
+      "hostIdentifier": "string",
+      "calendarTime": "string",
+      "unixTime": "string",
+      "decorations": {},
+      "epoch": "integer",
+      "counter": "integer"
+    },
+    "parser": "json",
+    "configuration": {
+      "optional_top_level_keys": [
+        "decorations",
+        "epoch",
+        "counter"
       ]
     }
   },

--- a/rules/community/duo_authentication/duo_anonymous_ip_failure.py
+++ b/rules/community/duo_authentication/duo_anonymous_ip_failure.py
@@ -1,8 +1,7 @@
-"""Alert on any Duo authentication logs marked as a failure due to an Anonymous IP."""
+"""Alert on any Duo auth logs marked as a failure due to an Anonymous IP."""
 from stream_alert.rule_processor.rules_engine import StreamRules
 
 rule = StreamRules.rule
-
 
 @rule(logs=['duo:authentication'],
       outputs=['aws-s3:sample-bucket',
@@ -11,8 +10,8 @@ rule = StreamRules.rule
 def duo_anonymous_ip_failure(rec):
     """
     author:       airbnb_csirt
-    description:  Alert on any Duo authentication logs marked as a failure due to an Anonymous IP.
-    reference:    N/A
+    description:  Alert on Duo auth logs marked as a failure due to an Anonymous IP.
+    reference:    https://duo.com/docs/policy#anonymous-networks
     playbook:     N/A
     """
     return rec['result'] == 'FAILURE' and rec['reason'] == 'Anonymous IP'

--- a/rules/community/duo_authentication/duo_fraud.py
+++ b/rules/community/duo_authentication/duo_fraud.py
@@ -1,8 +1,7 @@
-"""Alert on any Duo authentication logs marked as fraud."""
+"""Alert on any Duo auth logs marked as fraud."""
 from stream_alert.rule_processor.rules_engine import StreamRules
 
 rule = StreamRules.rule
-
 
 @rule(logs=['duo:authentication'],
       outputs=['aws-s3:sample-bucket',
@@ -12,7 +11,7 @@ def duo_fraud(rec):
     """
     author:       airbnb_csirt
     description:  Alert on any Duo authentication logs marked as fraud.
-    reference:    N/A
+    reference:    https://duo.com/docs/adminapi#authentication-logs
     playbook:     N/A
     """
     return rec['result'] == 'FRAUD'


### PR DESCRIPTION
to: @jacknagz 
cc: @ashmere 

**Background**

There are 3 osquery result formats, we weren't supporting one of them (`batch`). Now we are

https://github.com/facebook/osquery/blob/master/docs/wiki/deployment/logging.md#schedule-results

**Changes**

- Add osquery's `batch` schema: https://github.com/facebook/osquery/blob/master/docs/wiki/deployment/logging.md#batch-format
- Add optional `counter` key
- Small other fix: Add reference docs for DUO alerts

**Testing**

```
StreamAlertCLI [INFO]: (21/21) Successful Tests
StreamAlertCLI [INFO]: (45/45) Alert Tests Passed
```