### PR TITLE
[apps] migrating requests logic to base class

### DIFF
--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -116,6 +116,8 @@ class DuoApp(AppIntegration):
 
         # Make the request to the api, resulting in a bool or dict
         response = self._make_request(full_url, headers=headers, params=params)
+        if not response:
+            return False
 
         # Duo stores the list of logs in the 'response' key of the response
         logs = response['response']

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -20,8 +20,6 @@ import hmac
 import re
 import urllib
 
-import requests
-
 from app_integrations import LOGGER
 from app_integrations.apps.app_base import app, AppIntegration
 
@@ -116,13 +114,11 @@ class DuoApp(AppIntegration):
         if not headers:
             return False
 
-        # Perform the request and get the list of logs
-        response = requests.get(full_url, headers=headers, params=params)
+        # Make the request to the api, resulting in a bool or dict
+        response = self._make_request(full_url, headers=headers, params=params)
 
-        if not self._check_http_response(response):
-            return False
-
-        logs = response.json()['response']
+        # Duo stores the list of logs in the 'response' key of the response
+        logs = response['response']
 
         # Get the timestamp from the latest event. Duo produces these sequentially
         # so we can just extract the timestamp from the last item in the list

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -92,6 +92,21 @@ class TestDuoApp(object):
         requests_mock.assert_not_called()
 
     @patch('requests.get')
+    def test_get_duo_logs_bad_response(self, requests_mock):
+        """DuoApp - Get Duo Logs, Bad Response"""
+        requests_mock.return_value = Mock(
+            status_code=404,
+            json=Mock(side_effect=[{'message': 'something went wrong'}])
+        )
+
+        assert_false(self._app._get_duo_logs('hostname', 'full_url'))
+
+        # The .json should be called on the response once, to get the error message
+        # If it was called twice, it means `logs = response.json()['response']`
+        # is being called and should not be
+        assert_equal(requests_mock.return_value.json.call_count, 1)
+
+    @patch('requests.get')
     def test_gather_logs(self, requests_mock):
         """DuoApp - Gather Logs Entry Point"""
         log_count = 3

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -92,21 +92,6 @@ class TestDuoApp(object):
         requests_mock.assert_not_called()
 
     @patch('requests.get')
-    def test_get_duo_logs_bad_response(self, requests_mock):
-        """DuoApp - Get Duo Logs, Bad Response"""
-        requests_mock.return_value = Mock(
-            status_code=404,
-            json=Mock(side_effect=[{'message': 'something went wrong'}])
-        )
-
-        assert_false(self._app._get_duo_logs('hostname', 'full_url'))
-
-        # The .json should be called on the response once, to get the error message
-        # If it was called twice, it means `logs = response.json()['response']`
-        # is being called and should not be
-        assert_equal(requests_mock.return_value.json.call_count, 1)
-
-    @patch('requests.get')
     def test_gather_logs(self, requests_mock):
         """DuoApp - Gather Logs Entry Point"""
         log_count = 3


### PR DESCRIPTION
to @austinbyers 
cc @airbnb/streamalert-maintainers 
size: small

### Changes
* To make the app class interface easier to subclass/utilize, I've moved the functionality
  for performing GET requests against an endpoint to within the base app class.
* Updating tests to account for the migrated code.
* Adding debug statement to log when a request occurs.