### PR TITLE
streamalert - threat intel - duo

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -210,5 +210,13 @@
       "srcuser",
       "dstuser"
     ]
+  },
+  "duo": {
+    "sourceAddress": [
+      "ip"
+    ],
+    "userName": [
+      "username"
+    ]
   }
 }

--- a/conf/types.json
+++ b/conf/types.json
@@ -120,6 +120,14 @@
       "invokedBy"
     ]
   },
+  "duo": {
+    "sourceAddress": [
+      "ip"
+    ],
+    "userName": [
+      "username"
+    ]
+  },
   "ghe": {
     "destinationAddress": [
       "remote_address"
@@ -209,14 +217,6 @@
     "userName": [
       "srcuser",
       "dstuser"
-    ]
-  },
-  "duo": {
-    "sourceAddress": [
-      "ip"
-    ],
-    "userName": [
-      "username"
     ]
   }
 }


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

**Changes**

This adds the fields from the DUO schemas that map to CEF fields that are compared against threat intelligence.

**Testing**

```
python manage.py lambda test --processor all

StreamAlertCLI [INFO]: (21/21) Successful Tests
StreamAlertCLI [INFO]: (45/45) Alert Tests Passed
```

**Things to reason about as the reviewer**

1) Can/should I just specifically reference `duo:authentication` vs. `duo`, since `duo:administrator` doesn't contain either of the fields that map to threat intel?
2) What's the best way to test changes to this conf file? I'm not sure what I did for testing is good enough.