### PR TITLE
[streamalert][bug] Fix to allow nested structured data and normalization

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -167,8 +167,8 @@ class StreamRules(object):
             datatypes (list): defined in rule options, normalized_types users
                 interested in.
 
-        Returns:
-            (dict): A dict of normalized_types with original key names
+        Sets:
+            It sets the dict of normalized_types with original key names
 
         Example 1:
             datatypes=['defined_type1', 'defined_type2', 'not_defined_type']
@@ -183,11 +183,13 @@ class StreamRules(object):
                     "defined_type2": [[original_key2, sub_key2], [original_key3]]
                 }
         """
-        results = dict()
-        if not (datatypes and cls.validate_datatypes(normalized_types, datatypes)):
-            return results
+        if 'normalized_types' not in record:
+            record['normalized_types'] = dict()
 
-        return cls.match_types_helper(record, normalized_types, datatypes)
+        if not (datatypes and cls.validate_datatypes(normalized_types, datatypes)):
+            return
+
+        record['normalized_types'] = cls.match_types_helper(record, normalized_types, datatypes)
 
     @classmethod
     def match_types_helper(cls, record, normalized_types, datatypes):
@@ -381,10 +383,7 @@ class StreamRules(object):
                 if not matcher_result:
                     continue
                 if rule.datatypes:
-                    types_result = cls.match_types(record,
-                                                   payload.normalized_types,
-                                                   rule.datatypes)
-                    record['normalized_types'] = types_result
+                    cls.match_types(record, payload.normalized_types, rule.datatypes)
 
                 # rule analysis
                 rule_result = cls.process_rule(record, rule)

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -615,14 +615,18 @@ class TestStreamRules(object):
                 'awsRegion': 'region_name',
                 'source': '1.1.1.2'
             },
+            'columns': {
+                'cmdline': 'hostname'
+            },
             'sourceIPAddress': '1.1.1.2'
         }
         normalized_types = {
             'account': ['account'],
             'region': ['region', 'awsRegion'],
-            'ipv4': ['destination', 'source', 'sourceIPAddress']
+            'ipv4': ['destination', 'source', 'sourceIPAddress'],
+            'command': ['cmdline']
         }
-        datatypes = ['account', 'ipv4', 'region']
+        datatypes = ['account', 'ipv4', 'region', 'command']
         results = StreamRules.match_types_helper(
             record,
             normalized_types,
@@ -631,7 +635,8 @@ class TestStreamRules(object):
         expected_results = {
             'account': [['account']],
             'ipv4': [['sourceIPAddress'], ['detail', 'source']],
-            'region': [['region'], ['detail', 'awsRegion']]
+            'region': [['region'], ['detail', 'awsRegion']],
+            'command': [['columns', 'cmdline']]
         }
         assert_equal(results, expected_results)
 


### PR DESCRIPTION
to @ryandeivert 
cc @mime-frame 

This code fixes the problem of having nested data in normalized fields and not be detected by the rules as datatype. Resolves: https://github.com/airbnb/streamalert/issues/333

## Change

The method `match_types` now sets the value of `record['normalized_types']` instead of returning it. Given that the method was being invoked recursively, the impacted field was not updated correctly and the nested normalized fields that we were interested on, they were not set. With this fix the existing rules work as expected while other new rules can be implemented and the normalization can be used with nested fields.

## Testing

Tested for existing rules using `python manage.py lambda test --processor all`
Added coverage for this in the existing test `tests/unit/stream_alert_rule_processor/test_rules_engine.py` and checked with the following command:
```
$ ./tests/scripts/unit_tests.sh
...
Rules Engine - Match normalized types against record ... ok
Rules Engine - Recursively walk though all nested keys and update ... ok
...
```
