### PR TITLE
Increase Kinesis write throughput exceeded alarm threshold

### DIFF
--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -88,9 +88,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_write_exceeded" {
   metric_name         = "WriteProvisionedThroughputExceeded"
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
-  threshold           = "0"
+  threshold           = "3"
   evaluation_periods  = "2"
-  period              = "600"
+  period              = "60"
   alarm_description   = "StreamAlert Kinesis Write Throughput Exceeded: ${var.kinesis_stream}"
   alarm_actions       = ["${var.sns_topic_arn}"]
 


### PR DESCRIPTION
size: tiny
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

Under normal operation, there may be occasional small spikes in Kinesis `WriteProvisionedThroughputExceeded` errors. We don't need to alarm for only one or two sporadic errors; these will be retried.

The new settings mean: "Alert if there are more than 3 errors per minute for 2 minutes in a row"