### PR TITLE
StreamAlert - Rules - Github - Part I

### DIFF
--- a/conf/sources.json
+++ b/conf/sources.json
@@ -2,7 +2,8 @@
   "kinesis": {
     "prefix_cluster1_stream_alert_kinesis": {
       "logs": [
-        "cloudwatch"
+        "cloudwatch",
+        "ghe"
       ]
     }
   },

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from fnmatch import fnmatch
+import json
 import logging
+import re
 import time
 
 from netaddr import IPAddress, IPNetwork
@@ -144,3 +146,27 @@ def is_ioc(rec):
         return True
 
     return False
+
+def ghe_json_message(rec):
+    """Given a GHE log, extract the JSON payload from the message field
+
+    Args:
+        rec [string]: The StreamPayload parsed record
+
+    Returns:
+        [dict]: Parsed JSON GHE message field
+        [NoneType]: If no valid JSON object is found in the message field
+    """
+    json_pattern = re.compile(r'(?P<json_message>\{.*\})')
+    match = re.search(json_pattern, rec['message'])
+
+    if not match:
+        return
+
+    json_message = match.group('json_message')
+    try:
+        message_rec = json.loads(json_message)
+    except ValueError:
+        return
+
+    return message_rec

--- a/matchers/matchers.py
+++ b/matchers/matchers.py
@@ -18,6 +18,5 @@ from stream_alert.rule_processor.rules_engine import StreamRules
 matcher = StreamRules.matcher()
 
 @matcher
-def production_env(rec):
-    """Basic matcher for checking environments based on a key within a record."""
-    return rec['env'] == 'production'
+def github_audit(rec):
+    return rec['program'] == 'github_audit'

--- a/rules/community/github/github_disable_org_two_factor_requirement.py
+++ b/rules/community/github/github_disable_org_two_factor_requirement.py
@@ -13,7 +13,8 @@ def github_disable_org_two_factor_requirement(rec):
     """
     author:       @mimeframe
     description:  Two-factor authentication requirement was disabled.
-    reference:    https://help.github.com/articles/requiring-two-factor-authentication-in-your-organization/
+    reference:    https://help.github.com/
+                  articles/requiring-two-factor-authentication-in-your-organization/
     """
     message_rec = ghe_json_message(rec)
     if not message_rec:

--- a/rules/community/github/github_disable_org_two_factor_requirement.py
+++ b/rules/community/github/github_disable_org_two_factor_requirement.py
@@ -1,0 +1,22 @@
+"""Github two-factor authentication requirement was disabled."""
+from helpers.base import ghe_json_message
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['ghe:general'],
+      matchers=['github_audit'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def github_disable_org_two_factor_requirement(rec):
+    """
+    author:       @mimeframe
+    description:  Two-factor authentication requirement was disabled.
+    reference:    https://help.github.com/articles/requiring-two-factor-authentication-in-your-organization/
+    """
+    message_rec = ghe_json_message(rec)
+    if not message_rec:
+        return False
+
+    return message_rec.get('action') == 'org.disable_two_factor_requirement'

--- a/tests/integration/rules/github_disable_org_two_factor_requirement.json
+++ b/tests/integration/rules/github_disable_org_two_factor_requirement.json
@@ -1,0 +1,46 @@
+{
+    "records": [
+        {
+            "data": {
+                "@timestamp": "2017-09-06T03:49:31.600Z",
+                "@version": 1,
+                "host": "192.168.1.1",
+                "logsource": "...",
+                "message": "<190>Sep 5 20:49:31 ... github_audit: {\"actor_ip\":\"...\",\"from\":\"orgs/two_factor_enforcements#update\",\"actor\":\"...\",\"actor_id\":123,\"created_at\":123,\"org\":\"foobar\",\"org_id\":123,\"action\":\"org.disable_two_factor_requirement\",\"data\":{\"current_tenant_id\":1,\"tenant_fail_safe\":false,\"dbconn\":\"github@foo/github_enterprise\",\"newsies_dbconn\":\"github@foo/github_enterprise\",\"method\":\"PUT\",\"request_id\":\"...\",\"server_id\":\"...\",\"url\":\"...\",\"actor_session\":123,\"areas_of_responsibility\":[\"orgs\",\"identity\"],\"actor_location\":{\"country_code\":\"US\",\"country_name\":\"United States\",\"region\":\"CA\",\"region_name\":\"California\",\"city\":\"San Francisco\",\"postal_code\":\"12345\",\"location\":{\"lat\":11.1111,\"lon\":-111.1111}},\"_document_id\":\"123\"}}",
+                "pid": 0,
+                "port": 123,
+                "program": "github_audit",
+                "received_at": "...",
+                "tags": [
+                  "..."
+                ],
+                "timestamp": "Sep 5 20:49:31"
+            },
+            "description": "Disabling the 2FA requirement on Github should create an alert.",
+            "trigger": true,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        },
+        {
+            "data": {
+                "@timestamp": "2017-09-06T03:49:31.600Z",
+                "@version": 1,
+                "host": "192.168.1.1",
+                "logsource": "...",
+                "message": "<190>Sep 5 20:49:31 ... github_audit: {\"actor_ip\":\"...\",\"from\":\"orgs/two_factor_enforcements#update\",\"actor\":\"...\",\"actor_id\":123,\"created_at\":123,\"org\":\"foobar\",\"org_id\":123,\"action\":\"org.enable_two_factor_requirement\",\"data\":{\"current_tenant_id\":1,\"tenant_fail_safe\":false,\"dbconn\":\"github@foo/github_enterprise\",\"newsies_dbconn\":\"github@foo/github_enterprise\",\"method\":\"PUT\",\"request_id\":\"...\",\"server_id\":\"...\",\"url\":\"...\",\"actor_session\":123,\"areas_of_responsibility\":[\"orgs\",\"identity\"],\"actor_location\":{\"country_code\":\"US\",\"country_name\":\"United States\",\"region\":\"CA\",\"region_name\":\"California\",\"city\":\"San Francisco\",\"postal_code\":\"12345\",\"location\":{\"lat\":11.1111,\"lon\":-111.1111}},\"_document_id\":\"123\"}}",
+                "pid": 0,
+                "port": 123,
+                "program": "github_audit",
+                "received_at": "...",
+                "tags": [
+                  "..."
+                ],
+                "timestamp": "Sep 5 20:49:31"
+            },
+            "description": "Enabling the 2FA requirement on Github should not create an alert.",
+            "trigger": false,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        }
+    ]
+}


### PR DESCRIPTION
to: @ryandeivert 

**Changes**

- Add GHE to `sources.json`
- Add GHE helper functions to `helpers/base.py`
- Rename `matchers/sample.py` → `matchers/matchers.py`,  remove the sample matcher (never used), add the GHE matcher
- Add the first open source rule (disabling 2FA) with it's scrubbed test case

**Testing**

```
StreamAlertCLI [INFO]: (23/23) Successful Tests
StreamAlertCLI [INFO]: (48/48) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

**Followup**

I'll create another PR (non-blocking) with additional rules