### PR TITLE
[lambda] add backoff to firehose PutRecordBatch requests

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -12,6 +12,7 @@
     "source_current_hash": "<auto_generated>",
     "source_object_key": "<auto_generated>",
     "third_party_libraries": [
+      "backoff",
       "jsonpath_rw",
       "netaddr"
     ]

--- a/stream_alert/shared/backoff_handlers.py
+++ b/stream_alert/shared/backoff_handlers.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from stream_alert.shared import LOGGER
+
+
+def backoff_handler(details):
+    """Backoff logging handler for when polling occurs.
+
+    Args:
+        details (dict): Backoff context containing the number of tries,
+            target function currently executing, kwargs, args, value,
+            and wait time.
+    """
+    LOGGER.debug('[Backoff]: Trying again in %f seconds after %d tries calling %s',
+                 details['wait'],
+                 details['tries'],
+                 details['target'].__name__)
+
+
+def success_handler(details):
+    """Backoff logging handler for when backoff succeeds.
+
+    Args:
+        details (dict): Backoff context containing the number of tries,
+            target function currently executing, kwargs, args, value,
+            and wait time.
+    """
+    LOGGER.debug('[Backoff]: Completed after %d tries calling %s',
+                 details['tries'],
+                 details['target'].__name__)
+
+
+def giveup_handler(details):
+    """Backoff logging handler for when backoff gives up.
+
+    Args:
+        details (dict): Backoff context containing the number of tries,
+            target function currently executing, kwargs, args, value,
+            and wait time.
+    """
+    LOGGER.debug('[Backoff]: Exiting after %d tries calling %s',
+                 details['tries'],
+                 details['target'].__name__)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

## Changes 

* Add `backoff` as the list of dependencies for the `rule_processor`
* Copies the backoff handlers into shared to be used by the Athena function (soon)
* Wraps the firehose request helper with a backoff decorator

## Testing

Deployed the rule processor in a test account, verified logs are sending via Firehose