### PR TITLE
[bug][config] removing kinesis outputs from default cluster config

### DIFF
--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -36,12 +36,5 @@
       }
     }
   },
-  "outputs": {
-    "kinesis": [
-      "username",
-      "access_key_id",
-      "secret_key"
-    ]
-  },
   "region": "us-east-1"
 }


### PR DESCRIPTION
to @jacknagz 
cc @airbnb/streamalert-maintainers 
size: small

### Change
* Removing the `outputs` from the default cluster config since it breaks new deploys and is tech debt left over from a TF refactor.