### PR TITLE
[lambda] add a second layer of backoff to firehose

### DIFF
--- a/stream_alert/shared/backoff_handlers.py
+++ b/stream_alert/shared/backoff_handlers.py
@@ -25,10 +25,10 @@ def backoff_handler(details):
             target function currently executing, kwargs, args, value,
             and wait time.
     """
-    LOGGER.debug('[Backoff]: Trying again in %f seconds after %d tries calling %s',
-                 details['wait'],
-                 details['tries'],
-                 details['target'].__name__)
+    LOGGER.info('[Backoff]: Trying again in %f seconds after %d tries calling %s',
+                details['wait'],
+                details['tries'],
+                details['target'].__name__)
 
 
 def success_handler(details):
@@ -52,6 +52,6 @@ def giveup_handler(details):
             target function currently executing, kwargs, args, value,
             and wait time.
     """
-    LOGGER.debug('[Backoff]: Exiting after %d tries calling %s',
-                 details['tries'],
-                 details['target'].__name__)
+    LOGGER.info('[Backoff]: Exiting after %d tries calling %s',
+                details['tries'],
+                details['target'].__name__)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium

## Changes

Currently, Firehose will not throw an exception if any of the records fail in the [PutRecordBatch](http://boto3.readthedocs.io/en/latest/reference/services/firehose.html#Firehose.Client.put_record_batch) request.

It will however return details in the response of the number of failed records.  This change allows for clearer diagnosis of Firehose operations.

I also modified the Firehose logger messages for clarity/consistency/usefulness

## Testing

All tests performed in a StreamAlert cluster in a staging AWS account