### PR TITLE
streamalert - flow logs - one schema

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -760,38 +760,6 @@
       "protocol": "string",
       "source": "string",
       "destination": "string",
-      "srcport": "integer",
-      "destport": "integer",
-      "action": "string",
-      "packets": "integer",
-      "bytes": "integer",
-      "windowstart": "integer",
-      "windowend": "integer",
-      "version": "integer",
-      "eni": "string",
-      "account": "string",
-      "flowlogstatus": "string"
-    },
-    "parser": "json",
-    "configuration": {
-      "json_path": "logEvents[*].extractedFields",
-      "envelope_keys": {
-        "logGroup": "string",
-        "logStream": "string",
-        "owner": "integer"
-      },
-      "log_patterns": {
-        "flowlogstatus": [
-          "OK"
-        ]
-      }
-    }
-  },
-  "cloudwatch:flow_logs_no_data": {
-    "schema": {
-      "protocol": "string",
-      "source": "string",
-      "destination": "string",
       "srcport": "string",
       "destport": "string",
       "action": "string",
@@ -811,43 +779,6 @@
         "logGroup": "string",
         "logStream": "string",
         "owner": "integer"
-      },
-      "log_patterns": {
-        "flowlogstatus": [
-          "NODATA"
-        ]
-      }
-    }
-  },
-  "cloudwatch:flow_logs_skip_data": {
-    "schema": {
-      "protocol": "string",
-      "source": "string",
-      "destination": "string",
-      "srcport": "string",
-      "destport": "string",
-      "action": "string",
-      "packets": "string",
-      "bytes": "string",
-      "windowstart": "integer",
-      "windowend": "integer",
-      "version": "integer",
-      "eni": "string",
-      "account": "string",
-      "flowlogstatus": "string"
-    },
-    "parser": "json",
-    "configuration": {
-      "json_path": "logEvents[*].extractedFields",
-      "envelope_keys": {
-        "logGroup": "string",
-        "logStream": "string",
-        "owner": "integer"
-      },
-      "log_patterns": {
-        "flowlogstatus": [
-          "SKIPDATA"
-        ]
       }
     }
   },


### PR DESCRIPTION
to: @jacknagz 

**What**

This is a stop gap solution while we address the issue/bug of type-checking being performed after a schema has been chosen (https://github.com/airbnb/streamalert/issues/353).

This issue was reported by Scott: https://streamalert.slack.com/archives/C3BHE2Z0S/p1507134986000135

I merged the 3 schemas into 1 by removing `log_patterns` and making keys that could be an integer or a string, a string.

**Note**

The PR looks like garbage, so I suggest viewing in Raw or just knowing that the final schema is the following:

```
  "cloudwatch:flow_logs": {
    "schema": {
      "protocol": "string",
      "source": "string",
      "destination": "string",
      "srcport": "string",
      "destport": "string",
      "action": "string",
      "packets": "string",
      "bytes": "string",
      "windowstart": "integer",
      "windowend": "integer",
      "version": "integer",
      "eni": "string",
      "account": "string",
      "flowlogstatus": "string"
    },
    "parser": "json",
    "configuration": {
      "json_path": "logEvents[*].extractedFields",
      "envelope_keys": {
        "logGroup": "string",
        "logStream": "string",
        "owner": "integer"
      }
    }
  }
```

**Testing**

```
StreamAlertCLI [INFO]: (25/25) Successful Tests
StreamAlertCLI [INFO]: (51/51) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

