### PR TITLE
[streamalert][app][onelogin] Adding new integration app for OneLogin

### DIFF
--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -1,0 +1,193 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import re
+
+from datetime import datetime
+import requests
+
+from app_integrations import LOGGER
+from app_integrations.apps.app_base import app, AppIntegration
+
+
+class OneLoginApp(AppIntegration):
+    """OneLogin StreamAlert App"""
+    _ONELOGIN_EVENTS_URL = 'https://api.us.onelogin.com/api/1/events'
+    _ONELOGIN_TOKEN_URL = 'https://api.us.onelogin.com/auth/oauth2/v2/token'
+    # OneLogin API returns 50 events per page
+    _MAX_EVENTS_LIMIT = 50
+
+    # Define our authorization headers variable
+    def __init__(self, config):
+        super(OneLoginApp, self).__init__(config)
+        self._auth_headers = None
+        self._next_page_url = None
+
+    @classmethod
+    def _type(cls):
+        return 'events'
+
+    @classmethod
+    def _endpoint(cls):
+        """Class method to return the OneLogin events endpoint
+
+        Returns:
+            str: Path of the events endpoint to query
+        """
+        return cls._ONELOGIN_EVENTS_URL
+
+    @classmethod
+    def service(cls):
+        return 'onelogin'
+
+    def _generate_headers(self, token_url, client_secret, client_id):
+        """Each request will request a new token to call the resources APIs.
+
+        More details to be found here:
+            https://developers.onelogin.com/api-docs/1/oauth20-tokens/generate-tokens-2
+
+        Returns:
+            str: Bearer token to be used to call the OneLogin resource APIs
+        """
+        authorization = 'client_id: %s, client_secret: %s' % (client_id, client_secret)
+        headers_token = {'Authorization': authorization,
+                         'Content-Type': 'application/json'}
+
+        response = requests.post(token_url,
+                                 json={'grant_type':'client_credentials'},
+                                 headers=headers_token)
+
+        if not self._check_http_response(response):
+            return False
+
+        bearer = 'bearer:' % (response.json()['access_token'])
+        self._auth_headers = {'Authorization': bearer}
+
+    def _gather_logs(self):
+        """Gather the authentication log events."""
+
+        if not self._auth_headers:
+            self._auth_headers = self._generate_headers(self._ONELOGIN_TOKEN_URL,
+                                                        self._config['auth']['client_secret'],
+                                                        self._config['auth']['client_id'])
+
+        self._next_page_url = self._ONELOGIN_EVENTS_URL
+        return self._get_onelogin_events()
+
+    def _get_onelogin_events(self):
+        """Get all events from the endpoint for this timeframe
+
+        Returns:
+            [
+                {
+                    'id': <int:id>,
+                    'created_at': <str:created_at>,
+                    'account_id': <int:account_id>,
+                    'user_id': <int:user_id>,
+                    'event_type_id': <int:event_type_id>,
+                    'notes': <str:notes>,
+                    'ipaddr': <str:ipaddr>,
+                    'actor_user_id': <int:actor_user_id>,
+                    'assuming_acting_user_id': null,
+                    'role_id': <int:role_id>,
+                    'app_id': <int:app_id>,
+                    'group_id': <int:group_id>,
+                    'otp_device_id': <int:otp_device_id>,
+                    'policy_id': <int:policy_id>,
+                    'actor_system': <str:actor_system>,
+                    'custom_message': <str:custom_message>,
+                    'role_name': <str:role_name>,
+                    'app_name': <str:app_name>,
+                    'group_name': <str:group_name>,
+                    'actor_user_name': <str:actor_user_name>,
+                    'user_name': <str:user_name>,
+                    'policy_name': <str:policy_name>,
+                    'otp_device_name': <str:otp_device_name>,
+                    'operation_name': <str:operation_name>,
+                    'directory_sync_run_id': <int:directory_sync_run_id>,
+                    'directory_id': <int:directory_id>,
+                    'resolution': <str:resolution>,
+                    'client_id': <int:client_id>,
+                    'resource_type_id': <int:resource_type_id>,
+                    'error_description': <str:error_description>
+                }
+            ]
+        """
+        # OneLogin API expects the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
+        formatted_date = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+        params = {'since': formatted_date}
+
+        # Make sure we have authentication headers
+        if not self._auth_headers:
+            return False
+
+        events = self._get_onelogin_paginated_events(params)
+
+        while self._more_to_poll and self._next_page_url:
+            LOGGER.debug('More events to retrieve for \'%s\': %s', self.type(), self._more_to_poll)
+            pagination = self._get_onelogin_paginated_events(None)
+
+            # Add the events to our results, this is equivalent to using events.extend()
+            events += pagination
+
+        # Return the list of logs to the caller so they can be send to the batcher
+        return events
+
+    def _get_onelogin_paginated_events(self, params):
+        """Get events from the API pagination url
+
+        Returns:
+            The same as the method _get_onelogin_events()
+        """
+        response = requests.get(self._next_page_url, headers=self._auth_headers, params=params)
+        if not self._check_http_response(response):
+            return False
+
+        # Extract events from response
+        events = response.json()['data']
+
+        # Do we have a pagination link to follow?
+        self._more_to_poll = len(events) >= self._MAX_EVENTS_LIMIT
+
+        # If we are already retrieved all the events, then set the value to prevent more requests
+        self._next_page_url = response.json()['pagination']['next_link']
+
+        return events
+
+    def required_auth_info(self):
+        return {
+            'client_secret':
+                {
+                    'description': ('the client secret for the OneLogin API. This '
+                                    'should a string of 57 alphanumeric characters'),
+                    'format': re.compile(r'^[a-zA-Z0-9]{57}$')
+                },
+            'client_id':
+                {
+                    'description': ('the client id for the OneLogin API. This '
+                                    'should a string of 57 alphanumeric characters'),
+                    'format': re.compile(r'^[a-zA-Z0-9]{57}$')
+                }
+            }
+
+    def _sleep_seconds(self):
+        """Return the number of seconds this polling function should sleep for
+        between requests to avoid failed requests. OneLogin tokens allows for 5000 requests
+        every hour, so returning 0 for now.
+
+        Returns:
+            int: Number of seconds that this function shoud sleep for between requests
+        """
+        return 0

--- a/conf/logs.json
+++ b/conf/logs.json
@@ -987,6 +987,41 @@
       ]
     }
   },
+  "onelogin:events": {
+    "schema": {
+      "id": "integer",
+      "created_at": "string",
+      "account_id": "integer",
+      "user_id": "integer",
+      "event_type_id": "integer",
+      "notes": "string",
+      "ipaddr": "string",
+      "actor_user_id": "integer",
+      "assuming_acting_user_id": "integer",
+      "role_id": "integer",
+      "app_id": "integer",
+      "group_id": "integer",
+      "otp_device_id": "integer",
+      "policy_id": "integer",
+      "actor_system": "string",
+      "custom_message": "string",
+      "role_name": "string",
+      "app_name": "string",
+      "group_name": "string",
+      "actor_user_name": "string",
+      "user_name": "string",
+      "policy_name": "string",
+      "otp_device_name": "string",
+      "operation_name": "string",
+      "directory_sync_run_id": "integer",
+      "directory_id": "integer",
+      "resolution": "string",
+      "client_id": "integer",
+      "resource_type_id": "integer",
+      "error_description": "string"
+    },
+    "parser": "json"
+  },
   "osquery:differential": {
     "schema": {
       "action": "string",

--- a/tests/unit/app_integrations/test_apps/test_onelogin.py
+++ b/tests/unit/app_integrations/test_apps/test_onelogin.py
@@ -1,0 +1,211 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=abstract-class-instantiated,protected-access,no-self-use
+from mock import Mock, patch
+
+from nose.tools import assert_equal, assert_false, assert_items_equal
+
+from app_integrations.apps.onelogin import OneLoginApp
+from app_integrations.config import AppConfig
+
+from tests.unit.app_integrations.test_helpers import (
+    get_valid_config_dict,
+    MockSSMClient
+)
+
+
+@patch.object(OneLoginApp, 'type', Mock(return_value='type'))
+@patch.object(OneLoginApp, '_endpoint', Mock(return_value='endpoint'))
+@patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient())
+class TestOneLoginApp(object):
+    """Test class for the OneLoginApp"""
+
+    def __init__(self):
+        self._app = None
+        self._sample_event = {
+            'id': 123,
+            'created_at': '2017-10-05T18:11:32Z',
+            'account_id': 1234,
+            'user_id': 321,
+            'event_type_id': 4321,
+            'notes': 'Notes',
+            'ipaddr': '0.0.0.0',
+            'actor_user_id': 987,
+            'assuming_acting_user_id': 654,
+            'role_id': 456,
+            'app_id': 123456,
+            'group_id': 98765,
+            'otp_device_id': 11111,
+            'policy_id': 22222,
+            'actor_system': 'System',
+            'custom_message': 'Message',
+            'role_name': 'Role',
+            'app_name': 'App Name',
+            'group_name': 'Group Name',
+            'actor_user_name': '',
+            'user_name': 'username',
+            'policy_name': 'Policy Name',
+            'otp_device_name': 'OTP Device Name',
+            'operation_name': 'Operation Name',
+            'directory_sync_run_id': 7777,
+            'directory_id': 6666,
+            'resolution': 'Resolved',
+            'client_id': 11223344,
+            'resource_type_id': 44332211,
+            'error_description': 'ERROR ERROR'
+        }
+
+    # Remove all abstractmethods so we can instantiate DuoApp for testing
+    # Also patch some abstractproperty attributes
+    @patch.object(OneLoginApp, '__abstractmethods__', frozenset())
+    def setup(self):
+        """Setup before each method"""
+        self._app = OneLoginApp(AppConfig(get_valid_config_dict('onelogin')))
+
+    @patch('requests.post')
+    def test_generate_headers(self, requests_mock):
+        """OneLoginApp - Generate Headers, """
+        requests_mock.return_value = Mock(
+            status_code=404,
+            json=Mock(side_effect=[{'message': 'something went wrong'}])
+        )
+        assert_false(self._app._generate_headers(self._app._ONELOGIN_TOKEN_URL,
+                                                 'bad_secret',
+                                                 'bad_id'))
+
+    def test_sleep(self):
+        """OneLoginApp - Sleep Seconds"""
+        self._app._poll_count = 1
+        assert_equal(self._app._sleep_seconds(), 0)
+        self._app._poll_count = 200
+        assert_equal(self._app._sleep_seconds(), 0)
+
+    def test_required_auth_info(self):
+        """OneLoginApp - Required Auth Info"""
+        assert_items_equal(self._app.required_auth_info().keys(),
+                           {'client_secret', 'client_id'})
+
+    @staticmethod
+    def _get_sample_events(count, next_link):
+        """Helper function for returning sample onelogin events"""
+        event = {
+            'id': 123,
+            'created_at': '2017-10-05T18:11:32Z',
+            'account_id': 1234,
+            'user_id': 321,
+            'event_type_id': 4321,
+            'notes': 'Notes',
+            'ipaddr': '0.0.0.0',
+            'actor_user_id': 987,
+            'assuming_acting_user_id': 654,
+            'role_id': 456,
+            'app_id': 123456,
+            'group_id': 98765,
+            'otp_device_id': 11111,
+            'policy_id': 22222,
+            'actor_system': 'System',
+            'custom_message': 'Message',
+            'role_name': 'Role',
+            'app_name': 'App Name',
+            'group_name': 'Group Name',
+            'actor_user_name': '',
+            'user_name': 'username',
+            'policy_name': 'Policy Name',
+            'otp_device_name': 'OTP Device Name',
+            'operation_name': 'Operation Name',
+            'directory_sync_run_id': 7777,
+            'directory_id': 6666,
+            'resolution': 'Resolved',
+            'client_id': 11223344,
+            'resource_type_id': 44332211,
+            'error_description': 'ERROR ERROR'
+        }
+        data = [event] * count
+
+        if not next_link:
+            return {'data': data}
+
+        return {'data': data, 'pagination': {'next_link': next_link}}
+
+    @patch('requests.get')
+    def test_get_onelogin_paginated_events_bad_response(self, requests_mock):
+        """OneLoginApp - Get OneLogin Paginated Events, Bad Response"""
+        requests_mock.return_value = Mock(
+            status_code=404,
+            json=Mock(side_effect=[{'message': 'something went wrong'}])
+        )
+        assert_false(self._app._get_onelogin_paginated_events(None))
+
+    @patch('requests.get')
+    def test_get_onelogin_events_no_headers(self, requests_mock):
+        """OneLoginApp - Get OneLogin Events, No Headers"""
+        assert_false(self._app._get_onelogin_events())
+        requests_mock.assert_not_called()
+
+    @patch('requests.get')
+    def test_get_onelogin_events_bad_response(self, requests_mock):
+        """OneLoginApp - Get OneLogin Events, Bad Response"""
+        self._app._config['auth']['client_secret'] = 'good_secret'
+        self._app._config['auth']['client_id'] = 'client_id'
+        requests_mock.return_value = Mock(
+            status_code=404,
+            json=Mock(side_effect=[{'message': 'something went wrong'}])
+        )
+        assert_false(self._app._get_onelogin_events())
+
+    @patch('requests.get')
+    def test_gather_logs(self, requests_mock):
+        """OneLoginApp - Gather Events Entry Point"""
+        log_count = 3
+        logs = self._get_sample_events(log_count, False)
+        self._app._config['auth']['client_secret'] = 'good_secret'
+        self._app._config['auth']['client_id'] = 'client_id'
+        self._app._auth_headers = True
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(side_effect=[{'response': logs}])
+        )
+
+        assert_equal(len(logs['data']), log_count)
+
+    @patch('requests.get')
+    def test_get_onelogin_paginated_events(self, requests_mock):
+        """OneLoginApp - Get Paginated Events"""
+        log_count = 2
+        next_link = 'https://next_link'
+        logs = self._get_sample_events(log_count, next_link)
+        self._app._config['auth']['client_secret'] = 'good_secret'
+        self._app._config['auth']['client_id'] = 'client_id'
+        self._app._auth_headers = True
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(side_effect=[{'response': logs}])
+        )
+        assert_equal(len(logs['data']), log_count)
+        assert_equal(logs['pagination']['next_link'], next_link)
+
+def test_onelogin_events_endpoint():
+    """OneLoginApp - Verify Events Endpoint"""
+    assert_equal(OneLoginApp._endpoint(), 'https://api.us.onelogin.com/api/1/events')
+
+def test_onelogin_token_endpoint():
+    """OneLoginApp - Verify Token Endpoint"""
+    assert_equal(OneLoginApp._ONELOGIN_TOKEN_URL,
+                 'https://api.us.onelogin.com/auth/oauth2/v2/token')
+
+def test_onelogin_events_type():
+    """OneLoginApp - Verify Events Type"""
+    assert_equal(OneLoginApp._type(), 'events')


### PR DESCRIPTION
to @ryandeivert
cc @mime-frame 

## Change

Adding a new integration application for OneLogin. It will allow the collection of OneLogin events and process them using StreamAlert. Also the schema for the OneLogin events format is added here.
It handles the generation of tokens, using API `client_secret/client_id` pair and pagination of requests to the API, when the number of events returned (using `since`) is over the limit (50). More information here: [https://developers.onelogin.com/api-docs/1/events/get-events](https://developers.onelogin.com/api-docs/1/events/get-events)

## Testing

Unit tests are added for the class:
```
$ ./tests/scripts/unit_tests.sh
...
OneLoginApp - Gather Events Entry Point ... ok
OneLoginApp - Generate Headers, ... ok
OneLoginApp - Get OneLogin Events, Bad Response ... ok
OneLoginApp - Get OneLogin Events, No Headers ... ok
OneLoginApp - Get Paginated Events ... ok
OneLoginApp - Get OneLogin Paginated Events, Bad Response ... ok
OneLoginApp - Required Auth Info ... ok
OneLoginApp - Sleep Seconds ... ok
OneLoginApp - Verify Events Endpoint ... ok
OneLoginApp - Verify Token Endpoint ... ok
OneLoginApp - Verify Events Type ... ok
...
```

FYI: Given that this PR only adds the new application, CI will fail. I will update it accordingly with a new rule so it will address that.