### PR TITLE
[cli tests] mock kinesis on live-test

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -283,6 +283,7 @@ def put_mock_creds(output_name, creds, bucket, region, alias):
     put_mock_s3_object(bucket, output_name, enc_creds, region)
 
 
+@mock_kinesis
 def setup_mock_firehose_delivery_streams(config):
     """Mock Kinesis Firehose Streams for rule testing
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -524,6 +524,7 @@ class AlertProcessorTester(object):
         self.kms_alias = 'alias/stream_alert_secrets_test'
         self.secrets_bucket = 'test.streamalert.secrets'
         self.outputs_config = load_outputs_config()
+        helpers.setup_mock_firehose_delivery_streams(CONFIG)
 
     def test_processor(self, alerts):
         """Perform integration tests for the 'alert' Lambda function. Alerts


### PR DESCRIPTION
to @ryandeivert 
cc @airbnb/streamalert-maintainers 
size small

When running `manage.py live-test`, the firehose mock was not being applied.  This change ensures it's mocked. 