### PR TITLE
[tests] Show missing lines in unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [report]
 omit =
     stream_alert_cli/*
+
+show_missing = True


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 

## Changes

The code coverage plugin `coverage` fixed an issue after the version `4.1` and it no longer shows the lines that are missing from unit tests by default. This information is rather helpful when writing unit tests because shows which parts of your code still need some testing. The parameter `show_missing` brings back the missing column, for code coverage.

## Testing

Running the unit tests it shows a new column with the actual missing lines from the tests:
```
$ ./tests/scripts/unit_tests.sh
...
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
app_integrations.py                                13      0   100%
app_integrations/apps.py                            7      0   100%
app_integrations/apps/app_base.py                 108      0   100%
app_integrations/apps/duo.py                       59      1    98%   42
app_integrations/batcher.py                        41      0   100%
app_integrations/config.py                        139      6    96%   121, 209-211, 291-292
...
```


