### PR TITLE
[core] classifier list/dict type casting fix

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -314,7 +314,7 @@ class StreamClassifier(object):
             elif value == 'integer':
                 try:
                     payload[key] = int(payload[key])
-                except ValueError:
+                except (ValueError, TypeError):
                     LOGGER.error('Invalid schema. Value for key [%s] is not an int: %s',
                                  key, payload[key])
                     return False
@@ -322,7 +322,7 @@ class StreamClassifier(object):
             elif value == 'float':
                 try:
                     payload[key] = float(payload[key])
-                except ValueError:
+                except (ValueError, TypeError):
                     LOGGER.error('Invalid schema. Value for key [%s] is not a float: %s',
                                  key, payload[key])
                     return False

--- a/tests/unit/stream_alert_rule_processor/test_classifier.py
+++ b/tests/unit/stream_alert_rule_processor/test_classifier.py
@@ -126,6 +126,24 @@ class TestStreamClassifier(object):
         # Make sure the list was not modified
         assert_list_equal(payload['key_01'], ['hi', '100'])
 
+    def test_convert_type_type_error(self):
+        """StreamClassifier - Convert Incompatible Types
+
+        This is a bug where a list/dict tries to be casted
+        as an int/float
+        """
+        payload = {'key': ['hi', '100']}
+        schema = {'key': 'integer'}
+
+        payload_2 = {'key': {'hi': '100'}}
+        schema_2 = {'key': 'float'}
+
+        results = []
+        results.append(self.classifier._convert_type(payload, schema))
+        results.append(self.classifier._convert_type(payload_2, schema_2))
+
+        assert_false(all(results))
+
     def test_convert_recursion(self):
         """StreamClassifier - Convert Type, Recursive"""
         payload = {'key_01': {'nested_key_01': '20.1'}}


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

* An issue was identified where lists/dicts trying to cast as float/int would throw TypeErrors

## Changes

* This fixes the issue by catching `TypeError` for `integer` and `float` conversions
* Adds an additional unit test for reproducing the error

## Testing

* Unit tested
* Pylinted
