### PR TITLE
CLI, Athena, CloudWatch Schema fixes

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -751,7 +751,7 @@
       "version": "string",
       "time": "string",
       "id": "string",
-      "resources": {}
+      "resources": []
     },
     "parser": "json"
   },

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -37,7 +37,9 @@ from stream_alert.shared.backoff_handlers import (
 from stream_alert.shared.metrics import MetricLogger
 
 # For Firehose PutRecordBatch backoff
-MAX_BACKOFF_ATTEMPTS = 5
+MAX_BACKOFF_ATTEMPTS = 10
+# Adds a max of 20 seconds more to the Lambda function
+MAX_BACKOFF_FIBO_VALUE = 8
 # Firehose Limits: http://bit.ly/2fw5UY2
 MAX_BATCH_COUNT = 500
 MAX_BATCH_SIZE = 4000 * 1000
@@ -268,8 +270,9 @@ class StreamAlert(object):
 
         @backoff.on_predicate(backoff.fibo,
                               lambda resp: resp['FailedPutCount'] > 0,
-                              jitter=backoff.full_jitter,
                               max_tries=MAX_BACKOFF_ATTEMPTS,
+                              max_value=MAX_BACKOFF_FIBO_VALUE,
+                              jitter=backoff.full_jitter,
                               on_backoff=backoff_handler,
                               on_success=success_handler,
                               on_giveup=giveup_handler)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -157,16 +157,22 @@ def athena_handler(options):
                         special_key = dict
                     elif key_type == []:
                         special_key = list
+                    # Cast nested dict as a string for now
+                    # TODO(jacknagz): support recursive schemas
+                    elif isinstance(key_type, dict):
+                        special_key = 'string'
 
                     # Account for envelope keys
                     if root_key:
-                        if special_key:
+                        if special_key is not None:
                             athena_schema[root_key][key_name] = schema_type_mapping[special_key]
-                        athena_schema[root_key][key_name] = schema_type_mapping[key_type]
+                        else:
+                            athena_schema[root_key][key_name] = schema_type_mapping[key_type]
                     else:
-                        if special_key:
+                        if special_key is not None:
                             athena_schema[key_name] = schema_type_mapping[special_key]
-                        athena_schema[key_name] = schema_type_mapping[key_type]
+                        else:
+                            athena_schema[key_name] = schema_type_mapping[key_type]
 
             add_to_athena_schema(sanitized_schema)
 
@@ -229,7 +235,8 @@ def athena_handler(options):
                 CONFIG['lambda']['athena_partition_refresh_config'] \
                       ['refresh_type'][options.refresh_type][options.bucket] = options.type
                 CONFIG.write()
-                LOGGER_CLI.info('The %s table was successfully created!', options.type)
+                table_name = options.type if options.type == 'alerts' else options.table_name
+                LOGGER_CLI.info('The %s table was successfully created!', table_name)
 
 
 def configure_handler(options):

--- a/stream_alert_cli/terraform/_common.py
+++ b/stream_alert_cli/terraform/_common.py
@@ -56,4 +56,4 @@ def enabled_firehose_logs(config):
 
     # Firehose Delivery Streams cannot have semicolons
     filtered_log_names = [log.replace(':', '_') for log in expanded_logs_with_subtypes]
-    return filtered_log_names
+    return sorted(filtered_log_names)


### PR DESCRIPTION
to: @mime-frame @ryandeivert 
cc:  @airbnb/streamalert-maintainers
size: small

## Background

Several bug fixes identified across CLI and schemas.

## Changes

* Fix a bug in the `cloudwatch:events` schema.  Resources is not a map.
* Add more backoff attempts to the Firehose backoff logic
* Fix bugs in the Athena table creation code
* Sort log types when passing into the Terraform module for Firehose

## Testing

Deployed in a staging account
