### PR TITLE
[Data Normalization][Bug] Insert normalized types to a copy of record

### DIFF
--- a/helpers/base.py
+++ b/helpers/base.py
@@ -103,6 +103,9 @@ def fetch_values_by_datatype(rec, datatype):
         (list) The values of normalized types
     """
     results = []
+    if not rec.get('normalized_types'):
+        return results
+
     if not datatype in rec['normalized_types']:
         return results
 

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -183,7 +183,7 @@ class StreamRules(object):
                     "defined_type2": [[original_key2, sub_key2], [original_key3]]
                 }
         """
-        results = dict()
+        results = None
         if not (datatypes and cls.validate_datatypes(normalized_types, datatypes)):
             return results
 
@@ -387,9 +387,11 @@ class StreamRules(object):
                                                    payload.normalized_types,
                                                    rule.datatypes)
 
-                record_copy = record.copy()
                 if types_result:
+                    record_copy = record.copy()
                     record_copy['normalized_types'] = types_result
+                else:
+                    record_copy = record
                 # rule analysis
                 rule_result = cls.process_rule(record_copy, rule)
                 if rule_result:

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -380,20 +380,24 @@ class StreamRules(object):
                 matcher_result = cls.match_event(record, rule)
                 if not matcher_result:
                     continue
+
+                types_result = None
                 if rule.datatypes:
                     types_result = cls.match_types(record,
                                                    payload.normalized_types,
                                                    rule.datatypes)
-                    record['normalized_types'] = types_result
 
+                record_copy = record.copy()
+                if types_result:
+                    record_copy['normalized_types'] = types_result
                 # rule analysis
-                rule_result = cls.process_rule(record, rule)
+                rule_result = cls.process_rule(record_copy, rule)
                 if rule_result:
                     LOGGER.info('Rule [%s] triggered an alert on log type [%s] from entity \'%s\' '
                                 'in service \'%s\'', rule.rule_name, payload.log_source,
                                 payload.entity, payload.service())
                     alert = {
-                        'record': record,
+                        'record': record_copy,
                         'rule_name': rule.rule_name,
                         'rule_description': rule.rule_function.__doc__ or DEFAULT_RULE_DESCRIPTION,
                         'log_source': str(payload.log_source),


### PR DESCRIPTION
to: @ryandeivert @javuto 
cc: @airbnb/streamalert-maintainers
size: small
solves: #351

## Background

Context for the change

## Changes

* If insert `normalized_types` to the original record, it will prevent other rules which have no datatypes parameters to work correctly.
* Create a local variable to store a copy of the record and pass it to alert if necessary.

## Testing

* Unit Test
  * Create unit test case to reproduce the issue.
  * Apply fix and rerun unit test is passed. 
* Rule Test
  * Create local testing rules and rules test is passed.

