### PR TITLE
[tf][apps] un-commenting `overwrite` option in ssm param

### DIFF
--- a/terraform/modules/tf_stream_alert_app/main.tf
+++ b/terraform/modules/tf_stream_alert_app/main.tf
@@ -38,12 +38,10 @@ resource "aws_lambda_alias" "app_production" {
 
 // SSM Parameter Store value for the base config. Allow this to overwrite existing values
 resource "aws_ssm_parameter" "config" {
-  name  = "${var.function_prefix}_app_config"
-  type  = "SecureString"
-  value = "${var.app_config_parameter}"
-
-  # Not sure if overwrite is required, but it is not supported as of 0.9.*
-  # overwrite = true
+  name      = "${var.function_prefix}_app_config"
+  type      = "SecureString"
+  value     = "${var.app_config_parameter}"
+  overwrite = true
 }
 
 // AWS CloudWatch Event Rule for invoking StreamAlert App lambda on interval


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
* Prior to v0.1.0 of Terraform, there was not support for overwriting an `aws_ssm_parameter` resource with a new value. We now use a newer version that supports this, so this is to enable config overwriting for apps.

## Changes

* Un-commenting the previously commented out `overwrite = true` property for the apps config stored in ssm.
* This is necessary to update the config from the cli with new values (ie: when rate is changed).

## Testing
* Deployed a new rate with this change.