### PR TITLE
streamalert - cloudtrail - security groups - ingress

### DIFF
--- a/helpers/base.py
+++ b/helpers/base.py
@@ -172,13 +172,17 @@ def ghe_json_message(rec):
     return message_rec
 
 def select_key(data, search_key, results):
-    """
+    """ Recursively search for a given key and return all values
     Args:
         data (dict, list)
         search_key (string)
+        results (array)
+
+    Returns:
+        (list) all values
     """
     if not hasattr(data, 'items'):
-        return
+        return []
     if search_key in data:
         results.append(data[search_key])
     for key, val in data.iteritems():

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -181,14 +181,23 @@ def select_key(data, search_key, results):
     Returns:
         (list) all values
     """
-    if not isinstance(data, (dict, list)):
-        return []
-    if search_key in data:
-        results.append(data[search_key])
+    # Check for lists - this will handle lists of lists, etc
+    if isinstance(data, list):
+        for item in data:
+            select_key(item, search_key, results)
+    # Only dictionaries can have keys, so return here if this is not one
+    if not isinstance(data, dict):
+        return
+    # Iterate over all of the key/values
     for key, val in data.iteritems():
+        # Handle nested dictionaries
         if isinstance(val, dict):
-            select_key(data[key], search_key, results)
+            select_key(val, search_key, results)
+        # Handle lists within a dictonary - the safety check at the top will handle nesting
         elif isinstance(val, list):
-            for item in val:
-                select_key(item, search_key, results)
+            select_key(val, search_key, results)
+        elif key == search_key:
+            # Finally, if this key is in the dictionary, extract the value for
+            # it and append to the results list that is passed by reference
+            results.append(val)
     return results

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -171,7 +171,7 @@ def ghe_json_message(rec):
 
     return message_rec
 
-def select_key(data, search_key, results):
+def select_key(data, search_key, results=None):
     """Recursively search for a given key and return all values
     Args:
         data (dict, list)
@@ -181,6 +181,8 @@ def select_key(data, search_key, results):
     Returns:
         (list) all values
     """
+    if results is None:
+        results = []
     # Check for lists - this will handle lists of lists, etc
     if isinstance(data, list):
         for item in data:

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -170,3 +170,21 @@ def ghe_json_message(rec):
         return
 
     return message_rec
+
+def select_key(data, search_key, results):
+    """
+    Args:
+        data (dict, list)
+        search_key (string)
+    """
+    if not hasattr(data, 'items'):
+        return
+    if search_key in data:
+        results.append(data[search_key])
+    for key, val in data.iteritems():
+        if isinstance(val, dict):
+            select_key(data[key], search_key, results)
+        elif isinstance(val, list):
+            for item in val:
+                select_key(item, search_key, results)
+    return results

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -181,7 +181,7 @@ def select_key(data, search_key, results):
     Returns:
         (list) all values
     """
-    if not hasattr(data, 'items'):
+    if not isinstance(data, (dict, list)):
         return []
     if search_key in data:
         results.append(data[search_key])

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -172,7 +172,7 @@ def ghe_json_message(rec):
     return message_rec
 
 def select_key(data, search_key, results):
-    """ Recursively search for a given key and return all values
+    """Recursively search for a given key and return all values
     Args:
         data (dict, list)
         search_key (string)

--- a/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
@@ -12,7 +12,7 @@ rule = StreamRules.rule
       req_subkeys={'detail': ['eventName', 'requestParameters']})
 def cloudtrail_security_group_ingress_anywhere(rec):
     """
-    author:         @mimeframe
+    author:         @mimeframe, @ryandeivert
     description:    Alert on AWS Security Groups that allow ingress from anywhere.
                     This rule accounts for both IPv4 and IPv6.
     reference:      http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/

--- a/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
@@ -1,0 +1,33 @@
+"""Alert on AWS Security Groups that allow ingress from anywhere."""
+from helpers.base import select_key
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['cloudwatch:events'],
+      matchers=[],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'],
+      req_subkeys={'detail': ['eventName', 'requestParameters']})
+def cloudtrail_security_group_ingress_anywhere(rec):
+    """
+    author:         @mimeframe
+    description:    Alert on AWS Security Groups that allow ingress from anywhere.
+                    This rule accounts for both IPv4 and IPv6.
+    reference:      http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/
+                    using-network-security.html#creating-security-group
+    """
+    if rec['detail']['eventName'] != 'AuthorizeSecurityGroupIngress':
+        return False
+
+    ipv4_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIp', [])
+    ipv6_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIpv6', [])
+
+    if '0.0.0.0/0' in ipv4_cidrs:
+        return True
+
+    if '::/0' in ipv6_cidrs:
+        return True
+
+    return False

--- a/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
@@ -21,8 +21,8 @@ def cloudtrail_security_group_ingress_anywhere(rec):
     if rec['detail']['eventName'] != 'AuthorizeSecurityGroupIngress':
         return False
 
-    ipv4_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIp', [])
-    ipv6_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIpv6', [])
+    ipv4_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIp')
+    ipv6_cidrs = select_key(rec['detail']['requestParameters'], 'cidrIpv6')
 
     if '0.0.0.0/0' in ipv4_cidrs:
         return True

--- a/tests/integration/rules/cloudtrail/cloudtrail_security_group_ingress_anywhere.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_security_group_ingress_anywhere.json
@@ -72,7 +72,10 @@
               }
             },
             "description": "A Security Group that allows ingress from anywhere on the internet should create an alert.",
-            "trigger": true,
+            "log": "cloudwatch:events",
+            "trigger_rules": [
+              "cloudtrail_security_group_ingress_anywhere"
+            ],
             "source": "prefix_cluster1_stream_alert_kinesis",
             "service": "kinesis"
         },
@@ -140,7 +143,9 @@
               }
             },
             "description": "A Security Group that allows ingress from an RFC1918 IP should not create an alert.",
-            "trigger": false,
+            "log": "cloudwatch:events",
+            "trigger_rules": [
+            ],
             "source": "prefix_cluster1_stream_alert_kinesis",
             "service": "kinesis"
         }

--- a/tests/integration/rules/cloudtrail_security_group_ingress_anywhere.json
+++ b/tests/integration/rules/cloudtrail_security_group_ingress_anywhere.json
@@ -1,0 +1,148 @@
+{
+    "records": [
+        {
+            "data": {
+              "account": 12345,
+              "region": "...",
+              "detail-type": "...",
+              "source": "...",
+              "version": "1.05",
+              "time": "...",
+              "id": "12345",
+              "resources": {
+                  "test": "..."
+              },
+              "detail": {
+                "eventVersion": "1.05",
+                "userIdentity": {
+                    "type": "IAMUser",
+                    "principalId": "...",
+                    "arn": "...",
+                    "accountId": "12345",
+                    "accessKeyId": "...",
+                    "userName": "...",
+                    "sessionContext": {
+                        "attributes": {
+                            "mfaAuthenticated": "false",
+                            "creationDate": "2017-10-11T16:57:31Z"
+                        }
+                    }
+                },
+                "eventTime": "2017-10-11T17:02:32Z",
+                "eventSource": "ec2.amazonaws.com",
+                "eventName": "AuthorizeSecurityGroupIngress",
+                "awsRegion": "...",
+                "sourceIPAddress": "...",
+                "userAgent": "console.ec2.amazonaws.com",
+                "requestParameters": {
+                    "groupId": "...",
+                    "ipPermissions": {
+                        "items": [
+                            {
+                                "ipProtocol": "-1",
+                                "groups": {},
+                                "ipRanges": {
+                                    "items": [
+                                        {
+                                            "cidrIp": "0.0.0.0/0",
+                                            "description": "..."
+                                        }
+                                    ]
+                                },
+                                "ipv6Ranges": {
+                                    "items": [
+                                        {
+                                            "cidrIpv6": "::/0",
+                                            "description": "..."
+                                        }
+                                    ]
+                                },
+                                "prefixListIds": {}
+                            }
+                        ]
+                    }
+                },
+                "responseElements": {
+                    "_return": true
+                },
+                "requestID": "...",
+                "eventID": "...",
+                "eventType": "AwsApiCall",
+                "recipientAccountId": "12345"
+              }
+            },
+            "description": "A Security Group that allows ingress from anywhere on the internet should create an alert.",
+            "trigger": true,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        },
+        {
+            "data": {
+              "account": 12345,
+              "region": "...",
+              "detail-type": "...",
+              "source": "...",
+              "version": "1.05",
+              "time": "...",
+              "id": "12345",
+              "resources": {
+                  "test": "..."
+              },
+              "detail": {
+                "eventVersion": "1.05",
+                "userIdentity": {
+                    "type": "IAMUser",
+                    "principalId": "...",
+                    "arn": "...",
+                    "accountId": "12345",
+                    "accessKeyId": "...",
+                    "userName": "...",
+                    "sessionContext": {
+                        "attributes": {
+                            "mfaAuthenticated": "false",
+                            "creationDate": "2017-10-11T16:57:31Z"
+                        }
+                    }
+                },
+                "eventTime": "2017-10-11T17:02:32Z",
+                "eventSource": "ec2.amazonaws.com",
+                "eventName": "AuthorizeSecurityGroupIngress",
+                "awsRegion": "...",
+                "sourceIPAddress": "...",
+                "userAgent": "console.ec2.amazonaws.com",
+                "requestParameters": {
+                    "groupId": "...",
+                    "ipPermissions": {
+                        "items": [
+                            {
+                                "ipProtocol": "-1",
+                                "groups": {},
+                                "ipRanges": {
+                                    "items": [
+                                        {
+                                            "cidrIp": "10.0.0.0/8",
+                                            "description": "..."
+                                        }
+                                    ]
+                                },
+                                "prefixListIds": {}
+                            }
+                        ]
+                    }
+                },
+                "responseElements": {
+                    "_return": true
+                },
+                "requestID": "...",
+                "eventID": "...",
+                "eventType": "AwsApiCall",
+                "recipientAccountId": "12345"
+              }
+            },
+            "description": "A Security Group that allows ingress from an RFC1918 IP should not create an alert.",
+            "trigger": false,
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis"
+        }
+    ]
+}


### PR DESCRIPTION
to: @ryandeivert or @jacknagz 
cc: @airbnb/streamalert-maintainers

size: small

## Background

Alerts on Security Groups that allow anyone on the interwebs to touch your EC2 instance(s).

## Changes

- Helper function called `select_key`
- Rule called `cloudtrail_security_group_ingress_anywhere`
- Tests

## Testing

```
$ python manage.py lambda test --processor rule --test-files cloudtrail_security_group_ingress_anywhere
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

cloudtrail_security_group_ingress_anywhere
       [Pass]  [trigger=1]                   rule      (kinesis): A Security Group that allows ingress from anywhere on the internet should create an alert.
       [Pass]  [trigger=0]                   rule      (kinesis): A Security Group that allows ingress from an RFC1918 IP should not create an alert.



StreamAlertCLI [INFO]: (2/2) Successful Tests
StreamAlertCLI [INFO]: Completed
```
