### PR TITLE
[bug][apps][duo] adding a check to make sure the response was not empty

### DIFF
--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -121,6 +121,9 @@ class DuoApp(AppIntegration):
 
         # Duo stores the list of logs in the 'response' key of the response
         logs = response['response']
+        if not logs:
+            LOGGER.info('No logs in response from duo')
+            return False
 
         # Get the timestamp from the latest event. Duo produces these sequentially
         # so we can just extract the timestamp from the last item in the list

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -122,6 +122,16 @@ class TestDuoApp(object):
         assert_equal(len(gathered_logs), log_count)
         assert_equal(self._app._last_timestamp, base_time + log_count - 1)
 
+    @patch('requests.get')
+    def test_gather_logs_empty(self, requests_mock):
+        """DuoApp - Gather Logs Entry Point, Empty Response"""
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(side_effect=[{'response': []}])
+        )
+
+        assert_false(self._app._gather_logs())
+
 
 def test_duo_admin_endpoint():
     """DuoAdminApp - Verify Endpoint"""


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
* It's possible that the response from Duo's Admin API can contain 0 logs. This verifies the response contains logs before continuing.

## Changes
* Check if the list of logs is not empty before trying to extract a timestamp value/return logs.

## Testing
* Added unit test to verify effectiveness.
