### PR TITLE
streamalert - rules - duo - bypass codes

### DIFF
--- a/conf/sources.json
+++ b/conf/sources.json
@@ -19,6 +19,11 @@
       "logs": [
         "duo"
       ]
+    },
+    "prefix_cluster_duo_admin_sm-app-name_app": {
+      "logs": [
+        "duo"
+      ]
     }
   }
 }

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
@@ -16,5 +16,5 @@ def duo_bypass_code_create_non_auto_generated(rec):
     """
     return (
         rec['action'] == 'bypass_create' and
-        json.loads(rec['description']).get('auto_generated') == False
+        json.loads(rec['description']).get('auto_generated') is False
     )

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
@@ -1,0 +1,20 @@
+"""Alert when a DUO bypass code is artisanly crafted and not auto-generated."""
+import json
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['duo:administrator'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def duo_bypass_code_create_non_auto_generated(rec):
+    """
+    author:       @mimeframe
+    description:  Alert when a DUO bypass code is artisanly crafted and not auto-generated.
+    reference:    https://duo.com/docs/administration-users#generating-a-bypass-code
+    """
+    return (
+        rec['action'] == 'bypass_create' and
+        json.loads(rec['description']).get('auto_generated') == False
+    )

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
@@ -16,5 +16,5 @@ def duo_bypass_code_create_non_expiring(rec):
     """
     return (
         rec['action'] == 'bypass_create' and
-        json.loads(rec['description']).get('valid_secs') == None
+        json.loads(rec['description']).get('valid_secs') is None
     )

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
@@ -1,0 +1,20 @@
+"""Alert when a DUO bypass code is created that is non-expiring."""
+import json
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['duo:administrator'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def duo_bypass_code_create_non_expiring(rec):
+    """
+    author:       @mimeframe
+    description:  Alert when a DUO bypass code is created that is non-expiring.
+    reference:    https://duo.com/docs/administration-users#generating-a-bypass-code
+    """
+    return (
+        rec['action'] == 'bypass_create' and
+        json.loads(rec['description']).get('valid_secs') == None
+    )

--- a/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
@@ -16,5 +16,5 @@ def duo_bypass_code_create_unlimited_use(rec):
     """
     return (
         rec['action'] == 'bypass_create' and
-        json.loads(rec['description']).get('remaining_uses') == None
+        json.loads(rec['description']).get('remaining_uses') is None
     )

--- a/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
@@ -1,0 +1,20 @@
+"""Alert when a DUO bypass code is created that has unlimited use."""
+import json
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['duo:administrator'],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'])
+def duo_bypass_code_create_unlimited_use(rec):
+    """
+    author:       @mimeframe
+    description:  Alert when a DUO bypass code is created that has unlimited use.
+    reference:    https://duo.com/docs/administration-users#generating-a-bypass-code
+    """
+    return (
+        rec['action'] == 'bypass_create' and
+        json.loads(rec['description']).get('remaining_uses') == None
+    )

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
@@ -1,0 +1,35 @@
+{
+  "records": [
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": false, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that was hand crafted should create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+        "duo_bypass_code_create_non_auto_generated"
+      ]
+    },
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that was auto generated should not create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+      ]
+    }
+  ]
+}

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
@@ -11,7 +11,7 @@
       "description": "A DUO bypass code that was hand crafted should create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
         "duo_bypass_code_create_non_auto_generated"
       ]
@@ -27,7 +27,7 @@
       "description": "A DUO bypass code that was auto generated should not create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
       ]
     }

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
@@ -11,7 +11,7 @@
       "description": "A DUO bypass code that has no expiration should create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
         "duo_bypass_code_create_non_expiring"
       ]
@@ -27,7 +27,7 @@
       "description": "A DUO bypass code that has an expiration should not create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
       ]
     }

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
@@ -1,0 +1,35 @@
+{
+  "records": [
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": null, \"remaining_uses\": 1, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that has no expiration should create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+        "duo_bypass_code_create_non_expiring"
+      ]
+    },
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": 60, \"remaining_uses\": 1, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that has an expiration should not create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+      ]
+    }
+  ]
+}

--- a/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
@@ -1,0 +1,35 @@
+{
+  "records": [
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that has unlimited use should create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+        "duo_bypass_code_create_unlimited_use"
+      ]
+    },
+    {
+      "data": {
+        "action": "bypass_create",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": 60, \"remaining_uses\": 1, \"user_id\": \"...\"}",
+        "object": "...",
+        "timestamp": "1234567890",
+        "username": "..."
+      },
+      "description": "A DUO bypass code that has finite remaining uses should not create an alert.",
+      "log": "duo:administrator",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "trigger_rules": [
+      ]
+    }
+  ]
+}

--- a/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
@@ -11,7 +11,7 @@
       "description": "A DUO bypass code that has unlimited use should create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
         "duo_bypass_code_create_unlimited_use"
       ]
@@ -27,7 +27,7 @@
       "description": "A DUO bypass code that has finite remaining uses should not create an alert.",
       "log": "duo:administrator",
       "service": "stream_alert_app",
-      "source": "prefix_cluster_duo_auth_sm-app-name_app",
+      "source": "prefix_cluster_duo_admin_sm-app-name_app",
       "trigger_rules": [
       ]
     }


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers

size: small

## Background

* 3 new rules for DUO admin logs that are centered around the creation of bypass codes.

## Changes

* 3 new rules
* Associated tests

## Testing

```
python manage.py lambda test --processor all

StreamAlertCLI [INFO]: (31/31) Successful Tests
StreamAlertCLI [INFO]: (60/60) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
