### PR TITLE
[bug][cli] returning after logging error if log not declared

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -269,7 +269,7 @@ class RuleProcessorTester(object):
             if message:
                 self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
         elif not alerted_properly:
-            message = 'Rule failure: [{}] {}'.format(file_name, test_event['description'])
+            message = 'Rule failure: [{}.json] {}'.format(file_name, test_event['description'])
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
 
         # Return the alerts back to caller
@@ -435,7 +435,7 @@ class RuleProcessorTester(object):
             rule_name (str): Name of rule being tested
             test_event (dict): Actual record data being tested
         """
-        base_message = ('Invalid test event in file \'{}\' with description '
+        base_message = ('Invalid test event in file \'{}.json\' with description '
                         '\'{}\'.'.format(file_name, test_event['description']))
 
         log_type = test_event['log']
@@ -444,6 +444,7 @@ class RuleProcessorTester(object):
                        'logs.json'.format(base_message, log_type))
 
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
+            return
 
         config_log_info = self.cli_config['logs'][log_type]
         schema_keys = config_log_info['schema']


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

* Observed bug when a log was defined in a test event without having a corresponding schema in logs.json:
```
...
  File ".../streamalert/stream_alert_cli/test.py", line 773, in run_tests
    validate_schemas):
  File ".../streamalert/stream_alert_cli/test.py", line 147, in test_processor
    yield self._run_rule_tests(name, test_event, formatted_record, print_header)
  File ".../streamalert/stream_alert_cli/test.py", line 268, in _run_rule_tests
    message = self.analyze_record_delta(file_name, test_event)
  File ".../streamalert/stream_alert_cli/test.py", line 448, in analyze_record_delta
    config_log_info = self.cli_config['logs'][log_type]
KeyError: u'type_of_log'
...
```

## Changes

* Returning after the check to see if the logs exists in the logs.json entries.

## Testing

* Changed test event to have an invalid log type, then tested to make sure the error is reported properly:
```
StreamAlertCLI [ERROR]: (1/4) Failures
StreamAlertCLI [ERROR]: (1/1) Invalid test event in file 'name_of_test_file' with description 'This is the test event description'. Log ('type_of_log') declared in test event does not exist in logs.json
```
* Switched to using a valid log type and all tests passed.
