### PR TITLE
streamalert - rules - cloudtrail - network acl - ingress

### DIFF
--- a/rules/community/cloudtrail/cloudtrail_network_acl_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_network_acl_ingress_anywhere.py
@@ -1,0 +1,29 @@
+"""Alert on AWS Network ACLs that allow ingress from anywhere."""
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+
+@rule(logs=['cloudwatch:events'],
+      matchers=[],
+      outputs=['aws-s3:sample-bucket',
+               'pagerduty:sample-integration',
+               'slack:sample-channel'],
+      req_subkeys={'detail': ['eventName', 'requestParameters']})
+def cloudtrail_network_acl_ingress_anywhere(rec):
+    """
+    author:         @mimeframe
+    description:    Alert on AWS Network ACLs that allow ingress from anywhere.
+    reference_1:    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html
+    reference_2:    http://docs.aws.amazon.com/AWSEC2/
+                    latest/APIReference/API_CreateNetworkAclEntry.html
+    """
+    if rec['detail']['eventName'] != 'CreateNetworkAclEntry':
+        return False
+
+    req_params = rec['detail']['requestParameters']
+
+    return (
+        req_params['cidrBlock'] == '0.0.0.0/0' and
+        req_params['ruleAction'] == 'allow' and
+        req_params['egress'] is False
+    )

--- a/tests/integration/rules/cloudtrail/cloudtrail_network_acl_ingress_anywhere.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_network_acl_ingress_anywhere.json
@@ -1,0 +1,131 @@
+{
+    "records": [
+        {
+            "data": {
+                "account": 12345,
+                "region": "123456123456",
+                "detail-type": "...",
+                "source": "1.1.1.2",
+                "version": "1.05",
+                "time": "...",
+                "id": "12345",
+                "resources": {
+                    "test": "..."
+                },
+                "detail": {
+                  "eventVersion": "1.05",
+                  "userIdentity": {
+                      "type": "IAMUser",
+                      "principalId": "...",
+                      "arn": "...",
+                      "accountId": "12345",
+                      "accessKeyId": "...",
+                      "userName": "...",
+                      "sessionContext": {
+                          "attributes": {
+                              "mfaAuthenticated": "...",
+                              "creationDate": "..."
+                          }
+                      }
+                  },
+                  "eventTime": "...",
+                  "eventSource": "...",
+                  "eventName": "CreateNetworkAclEntry",
+                  "awsRegion": "...",
+                  "sourceIPAddress": "...",
+                  "userAgent": "...",
+                  "requestParameters": {
+                      "networkAclId": "...",
+                      "ruleNumber": 100,
+                      "egress": false,
+                      "ruleAction": "allow",
+                      "icmpTypeCode": {},
+                      "portRange": {
+                          "from": -1,
+                          "to": -1
+                      },
+                      "aclProtocol": "-1",
+                      "cidrBlock": "0.0.0.0/0"
+                  },
+                  "responseElements": {
+                      "_return": true
+                  },
+                  "requestID": "...",
+                  "eventID": "...",
+                  "eventType": "AwsApiCall",
+                  "recipientAccountId": "12345"
+                }
+            },
+            "description": "A Network ACL that allows ingress from anywhere should create an alert.",
+            "log": "cloudwatch:events",
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis",
+            "trigger_rules": [
+              "cloudtrail_network_acl_ingress_anywhere"
+            ]
+        },
+        {
+            "data": {
+                "account": 12345,
+                "region": "123456123456",
+                "detail-type": "...",
+                "source": "...",
+                "version": "1.05",
+                "time": "...",
+                "id": "12345",
+                "resources": {
+                    "test": "..."
+                },
+                "detail": {
+                  "eventVersion": "1.05",
+                  "userIdentity": {
+                      "type": "IAMUser",
+                      "principalId": "...",
+                      "arn": "...",
+                      "accountId": "12345",
+                      "accessKeyId": "...",
+                      "userName": "...",
+                      "sessionContext": {
+                          "attributes": {
+                              "mfaAuthenticated": "...",
+                              "creationDate": "..."
+                          }
+                      }
+                  },
+                  "eventTime": "...",
+                  "eventSource": "...",
+                  "eventName": "CreateNetworkAclEntry",
+                  "awsRegion": "...",
+                  "sourceIPAddress": "...",
+                  "userAgent": "...",
+                  "requestParameters": {
+                      "networkAclId": "...",
+                      "ruleNumber": 100,
+                      "egress": false,
+                      "ruleAction": "deny",
+                      "icmpTypeCode": {},
+                      "portRange": {
+                          "from": -1,
+                          "to": -1
+                      },
+                      "aclProtocol": "-1",
+                      "cidrBlock": "0.0.0.0/0"
+                  },
+                  "responseElements": {
+                      "_return": true
+                  },
+                  "requestID": "...",
+                  "eventID": "...",
+                  "eventType": "AwsApiCall",
+                  "recipientAccountId": "12345"
+                }
+            },
+            "description": "A Network ACL that denies internet ingress should not create an alert.",
+            "log": "cloudwatch:events",
+            "source": "prefix_cluster1_stream_alert_kinesis",
+            "service": "kinesis",
+            "trigger_rules": [
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small

## Background

* Alert whenever a NACL exposes resources to the internet
* Complimentary to the existing SG rule

## Changes

* New rule
* New tests

## Testing

```
StreamAlertCLI [INFO]: (35/35) Successful Tests
StreamAlertCLI [INFO]: (66/66) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```