### PR TITLE
[schema] adding opt key to carbonblack:feed.storage.hit.binary

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -637,6 +637,7 @@
       "file_version": "string",
       "group": [],
       "host_count": "integer",
+      "internal_name": "string",
       "is_64bit": "boolean",
       "is_executable_image": "boolean",
       "last_seen": "string",
@@ -676,6 +677,7 @@
         "facet_id",
         "file_desc",
         "file_version",
+        "internal_name",
         "last_seen",
         "legal_copyright"
       ],


### PR DESCRIPTION
to: @mime-frame 
cc: @airbnb/streamalert-maintainers
size: small|medium|large
resolves #<related-issue-goes-here>

## Background

* Observed parse failure with `carbonblack:feed.storage.hit.binary`

## Changes

* Adding optional `internal_name` key to schema.
