### PR TITLE
Nested JSON Support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,I0011
+disable=fixme,I0011,E1102
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/docs/source/firehose.rst
+++ b/docs/source/firehose.rst
@@ -42,19 +42,19 @@ And the following schemas are defined in ``logs.json``:
   {
     "cloudwatch:events": {
       "parser": "json",
-      "...", "..."
+      "schema": {"key": "type"}
     },
     "cloudwatch:flow_logs": {
       "parser": "json",
-      "...", "..."
+      "schema": {"key": "type"}
     },
     "osquery": {
       "parser": "json",
-      "...", "..."
+      "schema": {"key": "type"}
     },
     "cloudtrail": {
       "parser": "json",
-      "...", "..."
+      "schema": {"key": "type"}
     }
   }
 
@@ -67,10 +67,10 @@ The Firehose module will create four Delivery Streams, one for each type:
 
 Each Delivery Stream delivers data to the same S3 bucket created by the module in a prefix based on the corresponding log type:
 
-- ``arn:aws:s3:::my-data-bucket/cloudwatch_events/YYYY/MM/DD/data``
-- ``arn:aws:s3:::my-data-bucket/cloudwatch_flow_logs/YYYY/MM/DD/data``
-- ``arn:aws:s3:::my-data-bucket/osquery/YYYY/MM/DD/data``
-- ``arn:aws:s3:::my-data-bucket/cloudtrail/YYYY/MM/DD/data``
+- ``arn:aws:s3:::my-data-bucket/cloudwatch_events/YYYY/MM/DD/data_here``
+- ``arn:aws:s3:::my-data-bucket/cloudwatch_flow_logs/YYYY/MM/DD/data_here``
+- ``arn:aws:s3:::my-data-bucket/osquery/YYYY/MM/DD/data_here``
+- ``arn:aws:s3:::my-data-bucket/cloudtrail/YYYY/MM/DD/data_here``
 
 Limits
 ------
@@ -86,8 +86,6 @@ Fields
 
 The following Firehose configuration settings are defined in ``global.json``:
 
-Example:
-
 .. code-block:: json
 
   {
@@ -95,9 +93,9 @@ Example:
       "firehose": {
         "enabled": true,
         "s3_bucket_suffix": "streamalert.data",
-        "buffer_size": 5,
+        "buffer_size": 64,
         "buffer_interval": 300,
-        "compression_format": "Snappy"
+        "compression_format": "GZIP"
       }
     }
   }
@@ -110,7 +108,7 @@ Key                      Required  Default               Description
 ----------------------   --------  --------------------  -----------
 ``enabled``              ``Yes``   ``None``              If set to ``false``, will not create a Kinesis Firehose
 ``s3_bucket_suffix``     ``No``    ``streamalert.data``  The suffix of the S3 bucket used for Kinesis Firehose data. The naming scheme is: ``prefix.suffix``
-``buffer_size``          ``No``    ``5 (MB)``            The amount of buffered incoming data before delivering it to Amazon S3
+``buffer_size``          ``No``    ``64 (MB)``           The amount of buffered incoming data before delivering it to Amazon S3
 ``buffer_interval``      ``No``    ``300 (seconds)``     The frequency of data delivery to Amazon S3
-``compression_format``   ``No``    ``Snappy``            The compression algorithm to use on data stored in S3
+``compression_format``   ``No``    ``GZIP``              The compression algorithm to use on data stored in S3
 ======================   ========  ====================  ===========

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -172,11 +172,11 @@ def generate_main(**kwargs):
             'prefix': config['global']['account']['prefix'],
             'logs': enabled_firehose_logs(config),
             'buffer_size': config['global']['infrastructure']
-                           ['firehose'].get('buffer_size', 5),
+                           ['firehose'].get('buffer_size', 64),
             'buffer_interval': config['global']['infrastructure']
                                ['firehose'].get('buffer_interval', 300),
             'compression_format': config['global']['infrastructure']
-                                  ['firehose'].get('compression_format', 'Snappy'),
+                                  ['firehose'].get('compression_format', 'GZIP'),
             's3_logging_bucket': logging_bucket,
             's3_bucket_name': firehose_s3_bucket_name
         }

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -298,5 +298,32 @@
     "configuration": {
       "json_path": "logEvents[*].extractedFields"
     }
+  },
+  "json:regex_key_with_envelope": {
+    "schema": {
+      "nested_key_1": "string",
+      "nested_key_2": "string",
+      "nested_key_3": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "envelope_keys": {
+        "time": "string",
+        "date": "string",
+        "host": "string"
+      },
+      "json_regex_key": "message"
+    }
+  },
+  "json:regex_key": {
+    "schema": {
+      "nested_key_1": "string",
+      "nested_key_2": "string",
+      "nested_key_3": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "json_regex_key": "message"
+    }
   }
 }

--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -65,7 +65,7 @@ class TestKVParser(TestParser):
         return 'kv'
 
     def test_kv_parsing(self):
-        """KV Parser - 'key:value,key:value'"""
+        """KV Parser - Basic key value pairs"""
         # setup
         schema = {
             'name': 'string',
@@ -188,6 +188,23 @@ class TestJSONParser(TestParser):
             assert_items_equal(result.keys(), expected_keys)
             assert_items_equal(result['streamalert:envelope_keys'].keys(),
                                expected_envelope_keys)
+
+    def test_json_regex_key_with_envelope(self):
+        """JSON Parser - Regex key with envelope"""
+        schema = {
+            'time': 'string',
+            'date': 'string',
+            'host': 'string'
+            'message': 'string'
+        }
+        options = {
+            'envelope_keys': {
+                'time': 'string',
+                'date': 'string',
+                'host': 'string'
+            },
+            'json_regex_key': 'message'
+        }
 
     def test_basic_json(self):
         """JSON Parser - Non-nested JSON objects"""

--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -191,20 +191,52 @@ class TestJSONParser(TestParser):
 
     def test_json_regex_key_with_envelope(self):
         """JSON Parser - Regex key with envelope"""
-        schema = {
-            'time': 'string',
-            'date': 'string',
-            'host': 'string'
-            'message': 'string'
-        }
-        options = {
-            'envelope_keys': {
-                'time': 'string',
-                'date': 'string',
-                'host': 'string'
-            },
-            'json_regex_key': 'message'
-        }
+        schema = self.config['logs']['json:regex_key_with_envelope']['schema']
+        options = self.config['logs']['json:regex_key_with_envelope']['configuration']
+
+        data = json.dumps({
+            'time': '14:01',
+            'date': 'Jan 01, 2017',
+            'host': 'host1.test.domain.tld',
+            'message': '<10> auditd[1300] info: '
+                       '{"nested_key_1": "nested_info",'
+                       '"nested_key_2": "more_nested_info",'
+                       '"nested_key_3": "even_more"}'
+        })
+        parsed_result = self.parser_helper(data=data,
+                                           schema=schema,
+                                           options=options)
+
+        assert_items_equal(parsed_result[0]['streamalert:envelope_keys'].keys(),
+                           ['date', 'time', 'host'])
+        assert_items_equal(parsed_result[0].keys(),
+                           ['nested_key_1',
+                            'nested_key_2',
+                            'nested_key_3',
+                            'streamalert:envelope_keys'])
+
+    def test_json_regex_key(self):
+        """JSON Parser - Regex key"""
+        schema = self.config['logs']['json:regex_key']['schema']
+        options = self.config['logs']['json:regex_key']['configuration']
+
+        data = json.dumps({
+            'time': '14:01',
+            'date': 'Jan 01, 2017',
+            'host': 'host1.test.domain.tld',
+            'message': '<10> auditd[1300] info: '
+                       '{"nested_key_1": "nested_info",'
+                       '"nested_key_2": "more_nested_info",'
+                       '"nested_key_3": "even_more"}'
+        })
+        parsed_result = self.parser_helper(data=data,
+                                           schema=schema,
+                                           options=options)
+
+        assert_items_equal(parsed_result[0].keys(),
+                           ['nested_key_1',
+                            'nested_key_2',
+                            'nested_key_3'])
 
     def test_basic_json(self):
         """JSON Parser - Non-nested JSON objects"""


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

When using forwarders such as `fluentd`, `logstash`, or `rsyslog`, log data may be wrapped with additional context keys:

```
{
  "collector": "my-app-1",
  "date-collected": "Oct 12, 2017",
  "@timestamp": "1507845487",
  "data": "<0> program[pid]: {"actual": "data is here"}
}
```

In order to get to the actual payload to apply rules against, helper functions are currently needed.  

This PR adds functionality to the `json` parser to parse JSON string payloads from wrapped keys.

Usage:

Example schema per the data above:

```
  "json:regex_key_with_envelope": {
    "schema": {
      "actual": "string"                    # the schema of the nested data
    },
    "parser": "json",
    "configuration": {
      "envelope_keys": {
        "collector": "string",
        "date-collected": "string",   # optional context to include as envelope keys
        "@timestamp": "string"
      },
      "json_regex_key": "data"        # where the nested JSON exists
    }
  },
```

Optionally, you can omit envelope keys as needed.

## Changes

* Augment the JSON parser to support nested JSON parsing within payload keys
* Update unit tests

## Testing

* Local unit testing
* Deploy in staging account
