### PR TITLE
[bug][data normalization] Improve 'datatypes' checking.

### DIFF
--- a/conf/sources.json
+++ b/conf/sources.json
@@ -3,13 +3,15 @@
     "prefix_cluster1_stream_alert_kinesis": {
       "logs": [
         "cloudwatch",
-        "ghe"
+        "ghe",
+        "osquery"
       ]
     }
   },
   "s3": {
     "prefix.cluster.sample.bucket": {
       "logs": [
+        "carbonblack",
         "cloudtrail"
       ]
     }

--- a/conf/sources.json
+++ b/conf/sources.json
@@ -3,15 +3,13 @@
     "prefix_cluster1_stream_alert_kinesis": {
       "logs": [
         "cloudwatch",
-        "ghe",
-        "osquery"
+        "ghe"
       ]
     }
   },
   "s3": {
     "prefix.cluster.sample.bucket": {
       "logs": [
-        "carbonblack",
         "cloudtrail"
       ]
     }

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -209,7 +209,7 @@ class StreamRules(object):
                 cls.update(results, key, nested_results)
             else:
                 for datatype in datatypes:
-                    if normalized_types.get(datatype) and (key in normalized_types[datatype]):
+                    if datatype in normalized_types and key in normalized_types[datatype]:
                         if not datatype in results:
                             results[datatype] = [[key]]
                         else:

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -183,9 +183,8 @@ class StreamRules(object):
                     "defined_type2": [[original_key2, sub_key2], [original_key3]]
                 }
         """
-        results = None
-        if not (datatypes and cls.validate_datatypes(normalized_types, datatypes)):
-            return results
+        if not (datatypes and normalized_types):
+            return
 
         return cls.match_types_helper(record, normalized_types, datatypes)
 
@@ -210,7 +209,7 @@ class StreamRules(object):
                 cls.update(results, key, nested_results)
             else:
                 for datatype in datatypes:
-                    if key in normalized_types[datatype]:
+                    if normalized_types.get(datatype) and (key in normalized_types[datatype]):
                         if not datatype in results:
                             results[datatype] = [[key]]
                         else:
@@ -264,25 +263,6 @@ class StreamRules(object):
                     results[key] = val
                 else:
                     results[key] = [val]
-
-    @classmethod
-    def validate_datatypes(cls, normalized_types, datatypes):
-        """Check is datatype valid
-
-        Args:
-            normalized_types (dict): normalized_types for certain log
-            datatypes (list): defined in rule options, users interested types
-
-        Returns:
-            (boolean): return true if all datatypes are defined
-        """
-        if not normalized_types:
-            return False
-
-        for datatype in datatypes:
-            if not datatype in normalized_types:
-                return False
-        return True
 
     @classmethod
     def process_rule(cls, record, rule):

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -490,8 +490,11 @@ class TestStreamRules(object):
               outputs=['s3:sample_bucket'],
               datatypes=['sourceAddress', 'command'])
         def mismatch_types(rec): # pylint: disable=unused-variable
-            """Testing rule with non-existing normalized type in the record. It
-            should not trigger alert.
+            """Testing rule with non-existing normalized type in the record.
+
+            It will trigger alert since we change rule paramemter 'datatypes' to
+            OR operation among CEF types. See the discussion at
+            https://github.com/airbnb/streamalert/issues/365
             """
             results = fetch_values_by_datatype(rec, 'sourceAddress')
 
@@ -535,34 +538,10 @@ class TestStreamRules(object):
             alerts.extend(StreamRules.process(payload))
 
         # check alert output
-        assert_equal(len(alerts), 1)
+        assert_equal(len(alerts), 2)
 
         # alert tests
         assert_equal(alerts[0]['rule_name'], 'match_ipaddress')
-
-    def test_validate_datatypes(self):
-        """Rules Engine - validate datatypes"""
-        normalized_types, datatypes = None, ['type1']
-        assert_equal(
-            StreamRules.validate_datatypes(normalized_types, datatypes),
-            False
-            )
-
-        normalized_types = {
-            'type1': ['key1'],
-            'type2': ['key2']
-            }
-        datatypes = ['type1']
-        assert_equal(
-            StreamRules.validate_datatypes(normalized_types, datatypes),
-            True
-            )
-
-        datatypes = ['type1', 'type3']
-        assert_equal(
-            StreamRules.validate_datatypes(normalized_types, datatypes),
-            False
-            )
 
     def test_update(self):
         """Rules Engine - Update results passed to update method"""

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -478,7 +478,11 @@ class TestStreamRules(object):
               outputs=['s3:sample_bucket'],
               datatypes=['sourceAddress'])
         def match_ipaddress(rec): # pylint: disable=unused-variable
-            """Testing rule to detect matching IP address"""
+            """Testing rule to detect matching IP address
+
+            Datatype 'sourceAddress' is defined in tests/unit/conf/types.json
+            for cloudwatch logs. This rule should be trigger by testing event.
+            """
             results = fetch_values_by_datatype(rec, 'sourceAddress')
 
             for result in results:
@@ -492,8 +496,10 @@ class TestStreamRules(object):
         def mismatch_types(rec): # pylint: disable=unused-variable
             """Testing rule with non-existing normalized type in the record.
 
-            It will trigger alert since we change rule paramemter 'datatypes' to
-            OR operation among CEF types. See the discussion at
+            Datatype 'sourceAddress' is defined in tests/unit/conf/types.json
+            for cloudwatch logs, but 'command' is not. This rule should be
+            triggered by testing event since we change rule parameter 'datatypes'
+            to OR operation among CEF types. See the discussion at
             https://github.com/airbnb/streamalert/issues/365
             """
             results = fetch_values_by_datatype(rec, 'sourceAddress')


### PR DESCRIPTION
to: @mime-frame or @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves #365

## Background
Changing rule parameter `datatypes` (it is a list) to an *OR* operation from *AND* operation.
* When it is a *AND* operation, it requires all the datatypes in the list should be defined in `conf/types.json` for all the log sources expected to be analyzed. 
* When it is *OR* operation, it will not has such constraint.
Please refer to issue #365 for more details. 

## Changes
* Remove method `validate_datatypes` from Rule Processor;
* Add checking to skip if CEF datatype is not defined for a log source, but still analyze log if other CEF datatypes in `datatype` list are defined. 
* Clean up the unconecessry code.

## Testing
* Unit Test
  * Test case `test_match_types` catch this change, and updated its assertion.

* Rule Test
  * Add local rules and testing events, and rule test is passed.  