### PR TITLE
[cli][test] output from tests will now be sorted on file name

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -105,7 +105,8 @@ class RuleProcessorTester(object):
             files_filter
         )
 
-        for name, path in test_file_info.iteritems():
+        for name in sorted(test_file_info):
+            path = test_file_info[name]
             events, error = helpers.load_test_file(path)
             if not events:
                 self.all_tests_passed = False


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers, @fusionrace 
size: small
resolves #382 

## Background

* Recent changes to the testing framework altered the order in which output from tests would be presented to the user. Previously, a single directory was used to house all of the test events. Now, test events can be organized into subfolders. The logic used to store references to files is unordered, and thus could cause std out to show a different order each time tests are ran.

## Changes

* Test output will now be sorted alphabetically based on filename.

## Testing

* Ran `python manage.py lambda test --processor rule` before the change and observed std out - names were **not** alphabetically ordered.
* Ran `python manage.py lambda test --processor rule` after the change and observed std out - names are now alphabetically ordered.