### PR TITLE
[schema] adding optionals to feed.storage.hit.binary

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -671,15 +671,22 @@
         "alliance_updated_srsthreat",
         "alliance_updated_virustotal",
         "alliance_updated_nvd",
+        "company_name",
+        "digsig_issuer",
+        "digsig_prog_name",
         "digsig_publisher",
         "digsig_sign_time",
+        "digsig_subject",
         "event_partition_id",
         "facet_id",
         "file_desc",
         "file_version",
         "internal_name",
         "last_seen",
-        "legal_copyright"
+        "legal_copyright",
+        "original_filename",
+        "product_name",
+        "product_version"
       ],
       "envelope_keys": {
         "cb_server": "string",


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Changes
* Adding optional top level keys `carbonblack:feed.storage.hit.binary` log schema

## Testing
* Added temporary test event and ran `python manage.py lambda test --processor rule`