### PR TITLE
[bug][threat intel] IOC matching with string case insensitive.

### DIFF
--- a/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
@@ -171,10 +171,10 @@ def test_detect_ioc_rule():
 
     ioc_result = base.is_ioc(rec)
     assert_equal(ioc_result, True)
-    expected_ioc_info = {
+    expected_ioc_info = [{
         'type': 'ip',
         'value': '90.163.54.11'
-    }
+    }]
     assert_equal(rec[StreamThreatIntel.IOC_KEY], expected_ioc_info)
 
 @with_setup(setup=setup, teardown=teardown)
@@ -204,4 +204,56 @@ def test_is_ioc_with_no_matching():
     }
 
     ioc_result = base.is_ioc(rec)
+    assert_equal(ioc_result, False)
+
+@with_setup(setup=setup, teardown=teardown)
+def test_is_ioc_with_lowercase_ioc_is_true():
+    """Helpers - IOC is lowercase while related data is mixcase."""
+    rec = {
+        'server': "test-server",
+        'computer_name': 'test-pc',
+        "domain": "test_Evil.net",
+        "event_type": "netconn",
+        "ipv4": "0.0.0.0",
+        "local_ip": "127.0.0.1",
+        "local_port": 54279,
+        "md5": "EF69CD89AD7ADDB9A16BB6F26F1EFAF7",
+        'normalized_types': {
+            'destinationDomain': [['domain']],
+            'fileHash': [['md5']]
+        }
+    }
+
+    ioc_result = base.is_ioc(rec)
+    assert_equal(ioc_result, True)
+    expected_ioc_info = [
+        {
+            'type': 'domain',
+            'value': 'test_evil.net'
+        },
+        {
+            'type': 'md5',
+            'value': 'ef69cd89ad7addb9a16bb6f26f1efaf7'
+        }
+    ]
+    assert_equal(rec[StreamThreatIntel.IOC_KEY], expected_ioc_info)
+
+@with_setup(setup=setup, teardown=teardown)
+def test_is_ioc_with_lowercase_ioc_is_false():
+    """Helpers - IOC is lowercase while lowercase_ioc flag is set to False."""
+    rec = {
+        'server': "test-server",
+        'computer_name': 'test-pc',
+        "domain": "test_Evil.net",
+        "event_type": "netconn",
+        "ipv4": "0.0.0.0",
+        "local_ip": "127.0.0.1",
+        "local_port": 54279,
+        "md5": "EF69CD89AD7ADDB9A16BB6F26F1EFAF7",
+        'normalized_types': {
+            'destinationDomain': [['domain']],
+            'fileHash': [['md5']]
+        }
+    }
+    ioc_result = base.is_ioc(rec, lowercase_ioc=False)
     assert_equal(ioc_result, False)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves #385 

## Background
This bug was discovered during rule testings. It is case-sensitive while comparing record data against IOCs from IOC files. In the use case that fileHash in a record is in upper cases, however, the IOCs from IOC files maybe in lower cases, it will never have a match. 

This PR implements IOC comparison with case-insensitive and condition that users should have known if IOCs in IOC files are lowercase or uppercase.

## Changes

* Add `lowercase_ioc` flag to helper function `is_ioc`.
* Add unit test cases. 
* Fix another bug that `rec['streamalert:ioc']` should be a list.

## Testing
* Unit testing is passed
```
./tests/scripts/unit_tests.sh
```
* Rule testing
  * Add a local testing rule, and it is passed.
