### PR TITLE
[data normalization] Adding for OneLogin events

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -139,6 +139,15 @@
       "current_user"
     ]
   },
+  "onelogin": {
+    "sourceAddress": [
+      "ipaddr"
+    ],
+    "userName": [
+      "actor_user_name",
+      "user_name"
+    ]
+  },
   "osquery": {
     "command": [
       "cmdline",


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

A new integration app for OneLogin events was just added ([here](https://github.com/airbnb/streamalert/pull/355)) and those events have a new number of fields that can be used to extract data, using data normalization. See all the events fields [here](https://developers.onelogin.com/api-docs/1/events/get-events).

## Changes

* Adding `ipaddr` as `sourceAddress`.
* Adding `actor_user_name` and `user_name` as `userName`.

## Testing

I am not sure there is a way to test this, without a rule already in place.