### PR TITLE
[apps] handle app date formatting in config

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -40,7 +40,7 @@ def app(subclass):
     return subclass
 
 
-def get_app(config):
+def get_app(config, init=True):
     """Return the proper app integration for this service
 
     Args:
@@ -50,6 +50,9 @@ def get_app(config):
         AppIntegration: Subclass of AppIntegration
     """
     try:
+        if not init:
+            return STREAMALERT_APPS[config['type']]
+
         return STREAMALERT_APPS[config['type']](config)
     except KeyError:
         if 'type' not in config:
@@ -138,6 +141,14 @@ class AppIntegration(object):
 
         Returns:
             int: Number of seconds the polling function should sleep for
+        """
+
+    @classmethod
+    def date_formatter(cls):
+        """Returns a format string to assist in formatting dates for this service
+
+        Returns:
+            str: A format string for formatting date/time values (ie: '%Y-%m-%dT%H:%M:%SZ')
         """
 
     def _sleep(self):

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from datetime import datetime
 import re
 
 from app_integrations import LOGGER
@@ -40,6 +39,14 @@ class OneLoginApp(AppIntegration):
     def _type(cls):
         return 'events'
 
+    @classmethod
+    def service(cls):
+        return 'onelogin'
+
+    @classmethod
+    def date_formatter(cls):
+        return '%Y-%m-%dT%H:%M:%SZ'
+
     def _token_endpoint(self):
         """Get the endpoint URL to retrieve tokens
 
@@ -63,10 +70,6 @@ class OneLoginApp(AppIntegration):
             str: Full URL to retrieve rate limit details in the OneLogin API
         """
         return self._ONELOGIN_RATE_LIMIT_URL.format(self._config['auth']['region'])
-
-    @classmethod
-    def service(cls):
-        return 'onelogin'
 
     def _generate_headers(self):
         """Each request will request a new token to call the resources APIs.
@@ -181,16 +184,7 @@ class OneLoginApp(AppIntegration):
             params = None
             request_url = self._next_page_url
         else:
-            # Check the type to understand the format stored
-            if isinstance(self._last_timestamp, int):
-                # OneLogin API expects the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
-                formatted_date = datetime.utcfromtimestamp(
-                    self._last_timestamp).strftime('%Y-%m-%dT%H:%M:%SZ')
-            else:
-                # We should have already this timestamp in format ISO 8601
-                formatted_date = self._last_timestamp
-
-            params = {'since': formatted_date}
+            params = {'since': self._last_timestamp}
             request_url = self._events_endpoint()
 
         result, response = self._make_get_request(request_url, self._auth_headers, params)

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -45,6 +45,7 @@ class OneLoginApp(AppIntegration):
 
     @classmethod
     def date_formatter(cls):
+        """OneLogin API expects the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"""
         return '%Y-%m-%dT%H:%M:%SZ'
 
     def _token_endpoint(self):


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Different services utilize different date formats (duo=unix epoch, gsuite=rfc 3339). Instead of relying on each subclass to implement the conversion properly, the subclass should just have to provide the **format** while the base class can handle the actual conversion.

## Changes

* Adding support for converting the initial timestamp from a simple unix epoch to a formatted date, depending on the date format returned by the subclass.
  * The default will be the unix epoch if no format is provided.
  * This method is defined as a `classmethod` as opposed to an `abstractmethod` because it is dependent upon the service and may not always be required.
* Adding ability to get the app *class* without instantiating it with a config
* Updating onelogin app to go with date format changes

## Testing

Updating unit tests to cover the new date formatting in the config. Also adding some additional tests for various exceptions that could occur, etc.
