### PR TITLE
[cli][docs] adding doc updates to reflect the --processor cli arg changes

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -114,5 +114,5 @@ The recommended process is to deploy both the `apps` function and the `rule` pro
 
 .. code-block:: bash
 
-  $ python manage.py lambda deploy --processor rule --processor apps
+  $ python manage.py lambda deploy --processor rule apps
 

--- a/manage.py
+++ b/manage.py
@@ -916,8 +916,9 @@ Command:
 
 Required Arguments:
 
-    -p/--processor                     The name of the Lambda function to deploy.
-                                         Valid options include: rule, alert, athena, apps, or all.
+    -p/--processor                     A list of the Lambda functions to deploy.
+                                         Valid options include: rule, alert, athena, apps,
+                                         all, or any combination of these.
 
 Optional Arguments:
 
@@ -925,7 +926,7 @@ Optional Arguments:
 
 Examples:
 
-    manage.py lambda deploy --processor all
+    manage.py lambda deploy --processor rule alert
 
 """.format(version))
     lambda_deploy_parser = lambda_subparsers.add_parser(
@@ -955,8 +956,9 @@ Command:
 
 Required Arguments:
 
-    -p/--processor                     The name of the Lambda function to rollback.
-                                         Valid options include: rule, alert, athena, apps, or all.
+    -p/--processor                     A list of the Lambda functions to rollback.
+                                         Valid options include: rule, alert, athena, apps,
+                                         all, or any combination of these.
 
 Optional Arguments:
 
@@ -964,7 +966,7 @@ Optional Arguments:
 
 Examples:
 
-    manage.py lambda rollback --processor all
+    manage.py lambda rollback --processor rule alert
 
 """.format(version))
     lambda_rollback_parser = lambda_subparsers.add_parser(
@@ -994,8 +996,9 @@ Command:
 
 Required Arguments:
 
-    -p/--processor                     The name of the Lambda function to test.
-                                         Valid options include: rule, alert, or all.
+    -p/--processor                     A list of the Lambda functions to test.
+                                         Valid options include: rule, alert, all, or
+                                         any combination of these.
     -r/--test-rules                    List of rules to test, separated by spaces.
                                          Cannot be used in conjunction with `--test-files`
     -f/--test-files                    List of files to test, separated by spaces.
@@ -1010,7 +1013,7 @@ Optional Arguments:
 
 Example:
 
-    manage.py lambda test --processor rule --rules lateral_movement root_logins
+    manage.py lambda test --processor rule --test-rules lateral_movement root_logins
 
 """.format(version))
     lambda_test_parser = lambda_subparsers.add_parser(
@@ -1028,7 +1031,7 @@ Example:
         '-p', '--processor',
         choices=['alert', 'all', 'rule'],
         help=ARGPARSE_SUPPRESS,
-        nargs=1,
+        nargs='+',
         action=UniqueSetAction,
         required=True
     )

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -752,13 +752,13 @@ def stream_alert_test(options, config):
         log_mem_hanlder = get_log_memory_hanlder()
 
         # Check if the rule processor should be run for these tests
-        test_rules = (set(run_options.get('processor')).issubset({'rule', 'all'})
+        test_rules = (not run_options.get('processor').isdisjoint({'rule', 'all'})
                       if run_options.get('processor') else
                       run_options.get('command') == 'live-test' or
                       run_options.get('command') == 'validate-schemas')
 
         # Check if the alert processor should be run for these tests
-        test_alerts = (set(run_options.get('processor')).issubset({'alert', 'all'})
+        test_alerts = (not run_options.get('processor').isdisjoint({'alert', 'all'})
                        if run_options.get('processor') else
                        run_options.get('command') == 'live-test')
 

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -752,12 +752,16 @@ def stream_alert_test(options, config):
         log_mem_hanlder = get_log_memory_hanlder()
 
         # Check if the rule processor should be run for these tests
+        # Using NOT set.isdisjoint will check to see if there are commonalities between
+        # the options in 'processor' and {'rule', 'all'}
         test_rules = (not run_options.get('processor').isdisjoint({'rule', 'all'})
                       if run_options.get('processor') else
                       run_options.get('command') == 'live-test' or
                       run_options.get('command') == 'validate-schemas')
 
         # Check if the alert processor should be run for these tests
+        # Using NOT set.isdisjoint will check to see if there are commonalities between
+        # the options in 'processor' and {'alert', 'all'}
         test_alerts = (not run_options.get('processor').isdisjoint({'alert', 'all'})
                        if run_options.get('processor') else
                        run_options.get('command') == 'live-test')


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers 
size: small
resolves N/A

## Background

Previous changes to the CLI updated the `manage.py lambda deploy` and `rollback` commands to use a list of functions passed to the `--processor` arg. This PR updates the `test` command and also updates docs to go with previous changes.

## Changes

* Updating the `manage.py lambda test` command to support multiple args.
* Updating docs to depict the usage of CLI `--processor` flag which now accepts a list of functions to test/deploy/rollback.
* The previous method of using multiple `--processor` flags is no longer supported and will result in only the *last* `--processor` flag having any affect.

## Testing

Ran tests with various options to ensure the proper behavior occurs.
