### PR TITLE
[tests] tweaking some unit test to speed up local tests/ci

### DIFF
--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -323,7 +323,7 @@ class TestStreamAlertSQSClient(object):
     @patch('stream_alert.athena_partition_refresh.main.LOGGER')
     def test_delete_messages(self, mock_logging):
         """Athena SQS - Delete Messages"""
-        self.client.get_messages()
+        self.client.get_messages(max_tries=1)
         self.client.unique_s3_buckets_and_keys()
         self.client.delete_messages()
 
@@ -347,7 +347,7 @@ class TestStreamAlertSQSClient(object):
 
     def test_unique_s3_buckets_and_keys(self):
         """Athena SQS - Get Unique Bucket Ids"""
-        self.client.get_messages()
+        self.client.get_messages(max_tries=1)
         unique_buckets = self.client.unique_s3_buckets_and_keys()
 
         assert_equal(unique_buckets, {

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -36,6 +36,7 @@ from tests.unit.stream_alert_rule_processor.test_helpers import (
 )
 
 
+@patch('stream_alert.rule_processor.handler.MAX_BACKOFF_ATTEMPTS', 1)
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
 


### PR DESCRIPTION
to: @jacknagz, @mime-frame 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Unit tests are getting very slow and take 86+ seconds to run

## Changes

* Patching the amount of retries for backoff for firehose and sending max_tries=1 to athena get_messages.
* These changes bring unit test runs down from **86+ seconds to 3.2 seconds**

## Testing

Unit tests pass.