### PR TITLE
Optional Envelope Keys

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,5 +6,6 @@ Core Members:
   * `Jamie Brim <https://www.github.com/strcrzy>`_
   * `Austin Byers <https://github.com/austinbyers>`_
   * `Chunyong Lin <https://github.com/chunyong-lin>`_
+  * `Ryan Deivert <https://github.com/ryandeivert>`_
 
 Contributors:

--- a/docs/source/conf-schemas.rst
+++ b/docs/source/conf-schemas.rst
@@ -63,12 +63,13 @@ Configuration Options
 ===========================  ======================
 Key                          Description
 ---------------------------  ----------------------
-``optional_top_level_keys``  Keys that may or may not be present in a log being parsed
+``delimiter``                For use with key/value or csv logs to identify the delimiter character for the log
+``envelope_keys``            Used with nested records to identify keys that are at a higher level than the nested records, but still hold some value and should be stored
 ``json_path``                Path to nested records to be 'extracted' from within a JSON object
 ``json_regex_key``           The key name containing a JSON string to parse.  This will become the final record
-``envelope_keys``            Used with nested records to identify keys that are at a higher level than the nested records, but still hold some value and should be stored
 ``log_patterns``             Various patterns to enforce within a log given provided fields
-``delimiter``                For use with key/value or csv logs to identify the delimiter character for the log
+``optional_top_level_keys``  Keys that may or may not be present in a log being parsed
+``optional_envelope_keys``   Keys that may or may not be present in the envelope of a log being parsed
 ``separator``                For use with key/value logs to identify the separator character for the log
 ===========================  ======================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ virtualenv==15.1.0
 Werkzeug==0.12.1
 wrapt==1.10.10
 xmltodict==0.10.2
+yapf==0.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ nocapture=1
 
 [pycodestyle]
 max-line-length=90
+
+[yapf]
+COLUMN_LIMIT=100

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -219,15 +219,18 @@ class JSONParser(ParserBase):
             return [json_payload]
 
         envelope_schema = self.options.get('envelope_keys')
-        # If envelope_keys are declared, and this payload does not have every key specified
-        # in these envelope_keys, then it's safe to skip trying to extract records using json_path
-        if envelope_schema:
+        optional_envelope_keys = self.options.get('optional_envelope_keys')
+
+        if envelope_schema and optional_envelope_keys:
             missing_keys_schema = {}
-            for key, key_type in envelope_schema.iteritems():
+            for key in optional_envelope_keys:
                 if key not in json_payload:
-                    missing_keys_schema[key] = key_type
+                    missing_keys_schema[key] = envelope_schema[key]
             if missing_keys_schema:
                 self._add_optional_keys([json_payload], envelope_schema, missing_keys_schema)
+
+        elif envelope_schema and not all(x in json_payload for x in envelope_schema):
+            return [json_payload]
 
         envelope = {}
         if envelope_schema:

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -221,6 +221,8 @@ class JSONParser(ParserBase):
         envelope_schema = self.options.get('envelope_keys')
         optional_envelope_keys = self.options.get('optional_envelope_keys')
 
+        # If the schema has a defined envelope schema, with optional keys in
+        # the envelope.  This occurs in some cases when using json_regex_key.
         if envelope_schema and optional_envelope_keys:
             missing_keys_schema = {}
             for key in optional_envelope_keys:
@@ -229,6 +231,8 @@ class JSONParser(ParserBase):
             if missing_keys_schema:
                 self._add_optional_keys([json_payload], envelope_schema, missing_keys_schema)
 
+        # If the envelope schema is defined and all envelope keys are required
+        # to be present in the record.
         elif envelope_schema and not all(x in json_payload for x in envelope_schema):
             return [json_payload]
 

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -312,6 +312,9 @@
         "date": "string",
         "host": "string"
       },
+      "optional_envelope_keys": [
+        "host"
+      ],
       "json_regex_key": "message"
     }
   },


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: smalll

## Background

https://github.com/airbnb/streamalert/pull/387 introduced a performance hit when applying default values to envelope keys implicitly.  This change adds an explicit option to the `JSON` parser to prevent this from occuring

## Changes

* Adds a parser option for optional_envelope_keys, which is needed when using json_regex_key
* Also adds `yapf`, updates AUTHORs, and docs

## Testing

Unit tested
