### PR TITLE
[docs][apps] Updating documentation for OneLogin new app

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -28,7 +28,11 @@ Supported Services
   - Authentication Logs
   - Administrator Logs
 
-* *Soon to come:* `OneLogin <https://github.com/airbnb/streamalert/issues/347>`_, `GSuite <https://github.com/airbnb/streamalert/issues/348>`_, and more
+* OneLogin
+
+  - Events Logs
+
+* *Soon to come:* `Box <https://github.com/airbnb/streamalert/issues/398>`_, `GSuite <https://github.com/airbnb/streamalert/issues/348>`_, and more
 
 
 Getting Started

--- a/docs/source/datasources.rst
+++ b/docs/source/datasources.rst
@@ -33,7 +33,7 @@ Example non-AWS use-cases:
 * Host logs (syslog, auditd, osquery, ...)
 * Network logs (Palo Alto Networks, Cisco, ...)
 * Web Application logs (Apache, nginx, ...)
-* SaaS logs (Box, OneLogin, …)
+* SaaS logs (Box, GSuite, OneLogin, ...)
 
 AWS Kinesis Streams
 -------------------


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

New integration app [added](https://github.com/airbnb/streamalert/pull/355) for OneLogin events. Documentation had to be updated.

## Changes

* Show OneLogin as available and updated the list of upcoming apps.

## Testing

User the script from `tests/scripts/test_the_docs.sh` to make sure the change is valid.