### PR TITLE
[cli][test] fix for rule tests that should not trigger alerts

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -244,17 +244,17 @@ class RuleProcessorTester(object):
         alerts, all_records_matched_schema = self.test_rule(event)
 
         # Get a list of any rules that triggerer but are not defined in the 'trigger_rules'
-        bad_alerts = []
+        unexpected_alerts = []
 
         # we only want alerts for the specific rule being tested (if trigger_rules are defined)
         if test_event['trigger_rules']:
-            bad_alerts = [alert for alert in alerts
-                          if alert['rule_name'] not in test_event['trigger_rules']]
+            unexpected_alerts = [alert for alert in alerts
+                                 if alert['rule_name'] not in test_event['trigger_rules']]
 
             alerts = [alert for alert in alerts
                       if alert['rule_name'] in test_event['trigger_rules']]
 
-        alerted_properly = (len(alerts) == expected_alert_count) and not bad_alerts
+        alerted_properly = (len(alerts) == expected_alert_count) and not unexpected_alerts
         current_test_passed = alerted_properly and all_records_matched_schema
 
         self.all_tests_passed = current_test_passed and self.all_tests_passed
@@ -286,11 +286,12 @@ class RuleProcessorTester(object):
                 context = 'is triggering the following rules but should not trigger at all: {}'
                 trigger_rules = ' ,'.join('\'{}\''.format(alert['rule_name']) for alert in alerts)
                 message = '{} {}'.format(message, context.format(trigger_rules))
-            elif bad_alerts:
+            elif unexpected_alerts:
                 # If there was a failure due to alerts triggering for other rules outside
                 # of the rules defined in the trigger_rules list for the event
                 context = 'is triggering the following rules but should not be: {}'
-                bad_rules = ' ,'.join('\'{}\''.format(alert['rule_name']) for alert in bad_alerts)
+                bad_rules = ' ,'.join(
+                    '\'{}\''.format(alert['rule_name']) for alert in unexpected_alerts)
                 message = '{} {}'.format(message, context.format(bad_rules))
             elif expected_alert_count != len(alerts):
                 # If there was a failure due to alerts NOT triggering for 1+ rules

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -243,10 +243,18 @@ class RuleProcessorTester(object):
         # Run tests on the formatted record
         alerts, all_records_matched_schema = self.test_rule(event)
 
-        # we only want alerts for the specific rule being tested
-        alerts = [alert for alert in alerts if alert['rule_name'] in test_event['trigger_rules']]
+        # Get a list of any rules that triggerer but are not defined in the 'trigger_rules'
+        bad_alerts = []
 
-        alerted_properly = (len(alerts) == expected_alert_count)
+        # we only want alerts for the specific rule being tested (if trigger_rules are defined)
+        if test_event['trigger_rules']:
+            bad_alerts = [alert for alert in alerts
+                          if alert['rule_name'] not in test_event['trigger_rules']]
+
+            alerts = [alert for alert in alerts
+                      if alert['rule_name'] in test_event['trigger_rules']]
+
+        alerted_properly = (len(alerts) == expected_alert_count) and not bad_alerts
         current_test_passed = alerted_properly and all_records_matched_schema
 
         self.all_tests_passed = current_test_passed and self.all_tests_passed
@@ -270,7 +278,31 @@ class RuleProcessorTester(object):
             if message:
                 self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
         elif not alerted_properly:
-            message = 'Rule failure: [{}.json] {}'.format(file_name, test_event['description'])
+            message = ('Test failure: [{}.json] Test event with description '
+                       '\'{}\'').format(file_name, test_event['description'])
+            if alerts and not test_event['trigger_rules']:
+                # If there was a failure due to alerts triggering for a test event
+                # that does not have any trigger_rules configured
+                context = 'is triggering the following rules but should not trigger at all: {}'
+                trigger_rules = ' ,'.join('\'{}\''.format(alert['rule_name']) for alert in alerts)
+                message = '{} {}'.format(message, context.format(trigger_rules))
+            elif bad_alerts:
+                # If there was a failure due to alerts triggering for other rules outside
+                # of the rules defined in the trigger_rules list for the event
+                context = 'is triggering the following rules but should not be: {}'
+                bad_rules = ' ,'.join('\'{}\''.format(alert['rule_name']) for alert in bad_alerts)
+                message = '{} {}'.format(message, context.format(bad_rules))
+            elif expected_alert_count != len(alerts):
+                # If there was a failure due to alerts NOT triggering for 1+ rules
+                # defined in the trigger_rules list for the event
+                context = 'did not trigger the following rules: {}'
+                non_triggered_rules = ' ,'.join(
+                    '\'{}\''.format(rule) for rule in test_event['trigger_rules']
+                    if rule not in [alert['rule_name'] for alert in alerts])
+                message = '{} {}'.format(message, context.format(non_triggered_rules))
+            else:
+                # If there was a failure for some other reason, just use a default message
+                message = 'Rule failure: [{}.json] {}'.format(file_name, test_event['description'])
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
 
         # Return the alerts back to caller

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
@@ -3,7 +3,7 @@
     {
       "data": {
         "action": "bypass_create",
-        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": false, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": false, \"valid_secs\": 10, \"remaining_uses\": 100, \"user_id\": \"...\"}",
         "object": "...",
         "timestamp": "1234567890",
         "username": "..."
@@ -19,7 +19,7 @@
     {
       "data": {
         "action": "bypass_create",
-        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": 10, \"remaining_uses\": 100, \"user_id\": \"...\"}",
         "object": "...",
         "timestamp": "1234567890",
         "username": "..."
@@ -28,8 +28,7 @@
       "log": "duo:administrator",
       "service": "stream_alert_app",
       "source": "prefix_cluster_duo_admin_sm-app-name_app",
-      "trigger_rules": [
-      ]
+      "trigger_rules": []
     }
   ]
 }

--- a/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
@@ -3,7 +3,7 @@
     {
       "data": {
         "action": "bypass_create",
-        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": null, \"remaining_uses\": null, \"user_id\": \"...\"}",
+        "description": "{\"bypass\": \"\", \"count\": 1, \"auto_generated\": true, \"valid_secs\": 10, \"remaining_uses\": null, \"user_id\": \"...\"}",
         "object": "...",
         "timestamp": "1234567890",
         "username": "..."


### PR DESCRIPTION
to: @jacknagz or @chunyong-lin 
cc: @airbnb/streamalert-maintainers, @fusionrace 
size: small
resolves #397 

## Background

See #397 

## Changes

* Fixing bug for test events that should not trigger rules were not flagging tests as failures.
  * This was due to not checking if the `trigger_rules` list had any rules defined before filtering alerts based on those rules.
* Adding more context to the output to explain various failures that can occur
* This will likely cause some other test events to fail, since it's more strict about defining rules that should trigger.

## Testing

* Updated some test events that were triggering more rules than defined in the event's `trigger_rules` list to avoid multiple alerts per test event.
  * In the future, test events that can trigger more than one rule can be placed in a single test file and have multiple rules listed within them (and the test file can be named with something more generic than the actual rule name).