### PR TITLE
[testing] Remove dependency on filesystem for test_config unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ ply==3.10
 psutil==5.1.3
 pyasn1==0.2.3
 pycodestyle==2.3.1
+pyfakefs==3.2
 pyflakes==1.5.0
 Pygments==2.2.0
 pylint==1.7.2

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=protected-access
-# pylint: disable=no-self-use
 import json
 
 from mock import Mock, patch


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves #395

## Background

CLIConfig uses the filesystem to find the filenames of cluster configuration files. In the config unit tests, these filesystem operations need to be mocked out because cluster configuration files are user configured. Currently `__builtin__.open()` is mocked out, but we also need to mock out `os.path.listdir()`. Instead of mocking individual functions, __pyfakefs__ is used to create a mock filesystem.

## Changes

* Added new python dependency pyfakefs to create a mock filesystem
* Update tests in test_config.py to use the mocked filesystem instead of mock_open

## Testing

* Remove `prod.json` cluster config and added `abc.json` cluster config
* Step through CLIConfig.load() to make sure os.listdir() returns `prod.json`
* Run `nosetests -v tests/unit`
* Run `./tests/scripts/pylint.sh`