### PR TITLE
[data normalization] OneLogin proxy_ip as sourceAddress

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -141,7 +141,8 @@
   },
   "onelogin": {
     "sourceAddress": [
-      "ipaddr"
+      "ipaddr",
+      "proxy_ip"
     ],
     "userName": [
       "actor_user_name",


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The fields in the OneLogin events returned data can be used with data normalization. There is a non-documented field discovered after inspecting the events returned from the API that can be added as `sourceAddress`.

## Changes

* Adding `proxy_ip` as `sourceAddress`.
