### PR TITLE
[tf] Workaround for 64 characters limit exceeded

### DIFF
--- a/terraform/modules/tf_stream_alert_app/iam.tf
+++ b/terraform/modules/tf_stream_alert_app/iam.tf
@@ -1,6 +1,6 @@
 // IAM Role: StreamAlert App Execution Role
 resource "aws_iam_role" "stream_alert_app_role" {
-  name               = "${var.function_prefix}_app_role"
+  name               = "${var.cluster}_${var.type}_app_role"
   assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role_policy.json}"
 }
 
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 
 // IAM Role Policy: Allow the StreamAlert App function to invoke the Rule Processor
 resource "aws_iam_role_policy" "stream_alert_app_invoke_lambda_role_policy" {
-  name   = "${var.function_prefix}_app_invoke_lambda_role_policy"
+  name   = "${var.cluster}_${var.type}_app_invoke_lambda_role_policy"
   role   = "${aws_iam_role.stream_alert_app_role.id}"
   policy = "${data.aws_iam_policy_document.app_invoke_rule_processor_policy.json}"
 }
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "app_invoke_rule_processor_policy" {
 
 // IAM Role Policy: Allow the StreamAlert App function to publish sns (used for DLQ)
 resource "aws_iam_role_policy" "stream_alert_app_publish_sns_role_policy" {
-  name   = "${var.function_prefix}_app_publish_sns_role_policy"
+  name   = "${var.cluster}_${var.type}_app_publish_sns_role_policy"
   role   = "${aws_iam_role.stream_alert_app_role.id}"
   policy = "${data.aws_iam_policy_document.app_publish_sns_policy.json}"
 }
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "app_publish_sns_policy" {
 
 // IAM Role Policy: Allow the StreamAlert App function to create/update CloudWatch logs
 resource "aws_iam_role_policy" "stream_alert_app_cloudwatch_logs_role_policy" {
-  name   = "${var.function_prefix}_app_cloudwatch_logs_role_policy"
+  name   = "${var.cluster}_${var.type}_app_cloudwatch_logs_role_policy"
   role   = "${aws_iam_role.stream_alert_app_role.id}"
   policy = "${data.aws_iam_policy_document.app_cloudwatch_logs_policy.json}"
 }
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "app_cloudwatch_logs_policy" {
 
 // IAM Role Policy: Allow the StreamAlert App function to create/update SSM Parameter Store Values
 resource "aws_iam_role_policy" "stream_alert_app_parameter_store_role_policy" {
-  name   = "${var.function_prefix}_app_parameter_store_role_policy"
+  name   = "${var.cluster}_${var.type}_app_parameter_store_role_policy"
   role   = "${aws_iam_role.stream_alert_app_role.id}"
   policy = "${data.aws_iam_policy_document.app_parameter_store_policy.json}"
 }

--- a/terraform/modules/tf_stream_alert_app/main.tf
+++ b/terraform/modules/tf_stream_alert_app/main.tf
@@ -46,7 +46,7 @@ resource "aws_ssm_parameter" "config" {
 
 // AWS CloudWatch Event Rule for invoking StreamAlert App lambda on interval
 resource "aws_cloudwatch_event_rule" "interval_rule" {
-  name        = "${var.function_prefix}_app_interval_rule"
+  name        = "${var.cluster}_${var.type}_app_interval_rule"
   description = "Schedule for executing the ${var.function_prefix}_app function"
 
   # https://amzn.to/2u5t0hS


### PR DESCRIPTION
to: @ryandeivert @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

During the deployment of the OneLogin integration app, we were hitting a 64 characters limit for app names, due to using prefixes.

## Changes

* Avoid the 64 characters limit by not using prefixes that make names too long.
