### PR TITLE
[cli][test] fixing bug that broke live-test command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -159,7 +159,9 @@ Examples:
     live_test_parser.add_argument(
         '-r', '--rules',
         nargs='+',
-        help=ARGPARSE_SUPPRESS
+        help=ARGPARSE_SUPPRESS,
+        action=UniqueSetAction,
+        default=set()
     )
 
     # allow verbose output for the CLI with the --debug option
@@ -1039,6 +1041,7 @@ Example:
     # add the optional ability to test against a rule/set of rules
     lambda_test_parser.add_argument(
         '-r', '--test-rules',
+        dest='rules',
         nargs='+',
         help=ARGPARSE_SUPPRESS,
         action=UniqueSetAction,
@@ -1050,6 +1053,7 @@ Example:
     # add the optional ability to test against a rule/set of rules
     test_filter_group.add_argument(
         '-f', '--test-files',
+        dest='files',
         nargs='+',
         help=ARGPARSE_SUPPRESS,
         action=UniqueSetAction,

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -828,11 +828,12 @@ def stream_alert_test(options, config):
 
         validate_schemas = options.command == 'validate-schemas'
 
-        rules_filter = options.test_rules if not validate_schemas else None
+        rules_filter = run_options.get('rules', {})
+        files_filter = run_options.get('files', {})
 
         # Run the rule processor for all rules or designated rule set
         for alerts in rule_proc_tester.test_processor(rules_filter,
-                                                      options.test_files,
+                                                      files_filter,
                                                       validate_schemas):
             # If the alert processor should be tested, process any alerts
             if test_alerts:
@@ -850,7 +851,7 @@ def stream_alert_test(options, config):
         # If this is not just a validation run, and rule/file filters are not in place
         # then warn the user if there are test files without corresponding rules
         # Also check all of the rule files to make sure they have tests configured
-        if not (validate_schemas or rules_filter or options.test_files):
+        if not (validate_schemas or rules_filter or files_filter):
             all_test_rules = all_test_rules or helpers.get_rules_from_test_events(TEST_EVENTS_DIR)
             check_untested_files(all_test_rules)
             check_untested_rules(all_test_rules)


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Identified a bug when running the `python manage.py live-test --cluster prod`:

`
  File "/Users/<username>/<repo-root>/stream_alert_cli/test.py", line 833, in run_tests
    rules_filter = options.test_rules if not validate_schemas else options.rules if not context.mocked else None
`
`
AttributeError: 'Namespace' object has no attribute 'test_rules'
`

## Changes

* Normalizing similar input flags so they save to the same var name 
  * `--test-rules` and `--rules` now save to the same Namespace attribute of `rules`
* Using a dictionary of the namespace (cast with `vars`) to lookup attributes.
* The list of rules passed to `live-test` (ie: `live-test --rules <rule01> <rule02>`) will now be a unique set (duplicates are ignored) with the usage of `action=UniqueSetAction`.

## Testing

Tested all of the following:

`$ python manage.py live-test --cluster prod --rules duo_fraud`
`$ python manage.py live-test --cluster prod`
`$ python manage.py lambda test --processor rule`
`$ python manage.py lambda test --processor alert`
`$ python manage.py lambda test --processor all`