### PR TITLE
Removing .coveragerc and adding config to setup.cfg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[report]
-omit =
-    stream_alert_cli/*
-
-show_missing = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,7 @@ max-line-length=90
 
 [yapf]
 COLUMN_LIMIT=100
+
+[coverage:report]
+omit=stream_alert_cli/*
+show_missing=True


### PR DESCRIPTION
to: @jacknagz @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

Previous change added `show_missing = True` to `.coveragerc` to display the missing lines for unit tests. It turns out it can be all covered in the `setup.cfg` file, so we don't need to use an extra file for the coverage plugin.

## Changes

* Adding coverage plugin configuration to `setup.cfg`.

## Testing

Running `./tests/scripts/unit_tests.sh` to show the missing lines when the file `.coveragerc` is deleted.