### PR TITLE
[apps] app successive invocations when nearing timeout

### DIFF
--- a/app_integrations/main.py
+++ b/app_integrations/main.py
@@ -21,16 +21,16 @@ def handler(event, context):
     """Main lambda handler use as the entry point
 
     Args:
-        event (dict): Always empty (for now) event object
+        event (dict): Event object that can potentially contain details on what to
+            during this invocation. An example of this is the 'invocation_type' key
+            that is used as an override to allow for successive invocations (and in
+            the future, support for historical invocations)
         context (LambdaContxt): AWS LambdaContext object
     """
-    if event and 'full_run' in event:
-        # TODO: implement support for historical runs via input events
-        pass
-
     try:
         # Load the config from this context object, pulling info from parameter store
-        config = AppConfig.load_config(context)
+        # The event object can contain detail about what to do, ie: 'invocation_type'
+        config = AppConfig.load_config(context, event)
 
         # The config specifies what app this function is supposed to run
         app = get_app(config)

--- a/terraform/modules/tf_stream_alert_app/iam.tf
+++ b/terraform/modules/tf_stream_alert_app/iam.tf
@@ -18,8 +18,8 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 // IAM Role Policy: Allow the StreamAlert App function to invoke the Rule Processor
-resource "aws_iam_role_policy" "stream_alert_app_invoke_lambda_role_policy" {
-  name   = "${var.cluster}_${var.type}_app_invoke_lambda_role_policy"
+resource "aws_iam_role_policy" "stream_alert_app_invoke_rule_lambda_role_policy" {
+  name   = "${var.cluster}_${var.type}_app_invoke_rule_lambda_role_policy"
   role   = "${aws_iam_role.stream_alert_app_role.id}"
   policy = "${data.aws_iam_policy_document.app_invoke_rule_processor_policy.json}"
 }
@@ -130,6 +130,28 @@ data "aws_iam_policy_document" "app_parameter_store_policy" {
 
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.function_prefix}_app_state",
+    ]
+  }
+}
+
+// IAM Role Policy: Allow the StreamAlert App function to invoke itself
+resource "aws_iam_role_policy" "stream_alert_app_invoke_self_lambda_role_policy" {
+  name   = "${var.cluster}_${var.type}_app_invoke_self_lambda_role_policy"
+  role   = "${aws_iam_role.stream_alert_app_role.id}"
+  policy = "${data.aws_iam_policy_document.app_invoke_self_policy.json}"
+}
+
+// IAM Policy Doc: Allow the StreamAlert App function to invoke itself
+data "aws_iam_policy_document" "app_invoke_self_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "lambda:InvokeFunction",
+    ]
+
+    resources = [
+      "${aws_lambda_function.stream_alert_app.arn}",
     ]
   }
 }

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -78,7 +78,7 @@ class TestAppIntegration(object):
     @patch.object(AppIntegration, '__abstractmethods__', frozenset())
     def setup(self):
         """Setup before each method"""
-        self._app = AppIntegration(AppConfig(get_valid_config_dict('duo_admin')))
+        self._app = AppIntegration(AppConfig(get_valid_config_dict('duo_admin'), None))
 
     @patch('logging.Logger.debug')
     def test_no_sleep(self, log_mock):
@@ -165,7 +165,8 @@ class TestAppIntegration(object):
         self._app._last_timestamp = self._app._config.start_last_timestamp
         self._app._finalize()
         log_mock.assert_called_with('Ending last timestamp is the same as '
-                                    'the beginning last timestamp')
+                                    'the beginning last timestamp. This could occur if '
+                                    'there were no logs collected for this execution.')
 
     @patch('logging.Logger.info')
     def test_gather_success(self, log_mock):

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-# pylint: disable=abstract-class-instantiated,protected-access,no-self-use
+# pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method
 from mock import Mock, patch
 
-from nose.tools import assert_equal, assert_false, assert_items_equal
+from nose.tools import assert_equal, assert_false, assert_items_equal, raises
 
 from app_integrations.apps.duo import DuoApp, DuoAdminApp, DuoAuthApp
 from app_integrations.config import AppConfig
@@ -133,17 +133,32 @@ class TestDuoApp(object):
         assert_false(self._app._gather_logs())
 
 
+@raises(NotImplementedError)
+def test_endpoint_not_implemented():
+    """DuoApp - Subclass Endpoint Not Implemented"""
+    class DuoFakeApp(DuoApp):
+        """Fake Duo app that should raise a NotImplementedError"""
+        @classmethod
+        def _type(cls):
+            return 'fake'
+
+    DuoFakeApp(get_valid_config_dict('duo'))._endpoint()
+
+
 def test_duo_admin_endpoint():
     """DuoAdminApp - Verify Endpoint"""
     assert_equal(DuoAdminApp._endpoint(), '/admin/v1/logs/administrator')
+
 
 def test_duo_admin_type():
     """DuoAdminApp - Verify Type"""
     assert_equal(DuoAdminApp._type(), 'admin')
 
+
 def test_duo_auth_endpoint():
     """DuoAuthApp - Verify Endpoint"""
     assert_equal(DuoAuthApp._endpoint(), '/admin/v1/logs/authentication')
+
 
 def test_duo_auth_type():
     """DuoAuthApp - Verify Type"""

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -33,7 +33,7 @@ class TestAppIntegrationConfig(object):
         """Setup before each method"""
         self.ssm_patcher = patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient())
         self.mock_ssm = self.ssm_patcher.start()
-        self._config = AppConfig.load_config(get_mock_context())
+        self._config = AppConfig.load_config(get_mock_context(), None)
 
     def teardown(self):
         """Teardown after each method"""
@@ -119,7 +119,7 @@ class TestAppIntegrationConfig(object):
     def test_determine_last_timestamp_onelogin(self, time_mock):
         """AppIntegrationConfig - Determine Last Timestamp, OneLogin"""
         with patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient(app_type='onelogin_events')):
-            self._config = AppConfig.load_config(get_mock_context())
+            self._config = AppConfig.load_config(get_mock_context(), None)
 
             # Reset the last timestamp to None
             self._config.last_timestamp = None


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: medium
resolves N/A

## Background

The apps function has built in logic to detect if the execution is close to timing out, and will save state/exit cleanly if that is the case. However, if there were more logs to collect for the interval in which this lambda executed, they would not be collected until the next scheduled invocation occurs.
 For instance, if a functions executes every hour, but only has enough time to process 1/2 hour worth of log data before timing out, that remaining 1/2 hour of log data would not be collected until the next scheduled invocation of the function. This is typically not an issue, and the function will catch up eventually. However, if there is a considerable change in log throughput and (ie - a company's scale doubles), this could result in an undesired effect of always being behind in log processing.

## Changes

* Adding support for perpetually invoking an apps function if there are more logs to collect and the function is nearing time out. It will now invoke itself with a custom `event` object indicating there are more logs to be collected.
* The new execution will be started, and the current execution will not be marked as complete. This is to allow it to continue collecting logs without having other scheduled lambda invocations occurring at the same time, which would potentially cause duplicative data or collisions with 
reading/writing the config.
  * This makes collecting a lot of logs easier to handle and will allow an apps function to completely collect logs for an interval, instead of relying on a subsequent scheduled invocation to collect the leftover logs.
* The `AppConfig` object now contains the passed in `event` dict to be read from during execution. The event can only have one key right now, and the is `invocation_type`.
* Bumping the buffer multiplier to account for the additional time needed to invoke a lambda function at the end of execution.
*  Adding helper function to config for reporting the remaining seconds in the lambda execution.

## Testing

Updating unit test to verify a new invocation occurs during the `finalize` step if there are still more logs to poll.
