### PR TITLE
[cli][test] fixing comma formatting bug

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -282,20 +282,20 @@ class RuleProcessorTester(object):
                 # If there was a failure due to alerts triggering for a test event
                 # that does not have any trigger_rules configured
                 context = 'is triggering the following rules but should not trigger at all: {}'
-                trigger_rules = ' ,'.join('\'{}\''.format(alert['rule_name']) for alert in alerts)
+                trigger_rules = ', '.join('\'{}\''.format(alert['rule_name']) for alert in alerts)
                 message = '{} {}'.format(message, context.format(trigger_rules))
             elif unexpected_alerts:
                 # If there was a failure due to alerts triggering for other rules outside
                 # of the rules defined in the trigger_rules list for the event
                 context = 'is triggering the following rules but should not be: {}'
-                bad_rules = ' ,'.join(
+                bad_rules = ', '.join(
                     '\'{}\''.format(alert['rule_name']) for alert in unexpected_alerts)
                 message = '{} {}'.format(message, context.format(bad_rules))
             elif expected_alert_count != len(alerts):
                 # If there was a failure due to alerts NOT triggering for 1+ rules
                 # defined in the trigger_rules list for the event
                 context = 'did not trigger the following rules: {}'
-                non_triggered_rules = ' ,'.join(
+                non_triggered_rules = ', '.join(
                     '\'{}\''.format(rule) for rule in test_event['trigger_rules']
                     if rule not in [alert['rule_name'] for alert in alerts])
                 message = '{} {}'.format(message, context.format(non_triggered_rules))
@@ -339,7 +339,7 @@ class RuleProcessorTester(object):
         record_keys = set(test_event)
         if not required_keys.issubset(record_keys):
             req_key_diff = required_keys.difference(record_keys)
-            missing_keys = ' ,'.join('\'{}\''.format(key) for key in req_key_diff)
+            missing_keys = ', '.join('\'{}\''.format(key) for key in req_key_diff)
             message = 'Missing required key(s) in log: {}'.format(missing_keys)
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
             return False
@@ -350,7 +350,7 @@ class RuleProcessorTester(object):
 
         # Log a warning if there are extra keys declared in the test log
         if key_diff:
-            extra_keys = ' ,'.join('\'{}\''.format(key) for key in key_diff)
+            extra_keys = ', '.join('\'{}\''.format(key) for key in key_diff)
             message = 'Additional unnecessary keys in log: {}'.format(extra_keys)
             # Remove the key(s) and just warn the user that they are extra
             record_keys.difference_update(key_diff)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Observed small bug in output formatting when listing errors with rules:

`
StreamAlertCLI [ERROR]: (1/1) Test failure: [duo_bypass_code_create_non_auto_generated.json] Test event with description 'A DUO bypass code that was auto generated should not create an alert.' is triggering the following rules but should not trigger at all: 'duo_bypass_code_create_non_expiring' ,'duo_bypass_code_create_unlimited_use'
`

In `'duo_bypass_code_create_non_expiring' ,'duo_bypass_code_create_unlimited_use'` above - the comma is preceded by a space instead of followed by one.

## Changes

* Changing formatting so the comma is followed by a space instead of preceded by one in the comma separated output.

## Testing

* Ran rule tests again with bad test event file to make sure the output looks correct.
