### PR TITLE
[apps] fix for improperly marking app config as failing

### DIFF
--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -43,6 +43,7 @@ class AppConfig(dict):
 
     class States(object):
         """States object to encapsulate various acceptable states"""
+        PARTIAL = 'partial'
         RUNNING = 'running'
         SUCCEEDED = 'succeeded'
         FAILED = 'failed'
@@ -392,6 +393,11 @@ class AppConfig(dict):
         return self.current_state == self.States.FAILED
 
     @property
+    def is_partial(self):
+        """Check if the current state is 'partial'"""
+        return self.current_state == self.States.PARTIAL
+
+    @property
     def is_running(self):
         """Check if the current state is 'running'"""
         return self.current_state == self.States.RUNNING
@@ -400,6 +406,11 @@ class AppConfig(dict):
     def is_success(self):
         """Check if the current state is 'succeeded'"""
         return self.current_state == self.States.SUCCEEDED
+
+    def mark_partial(self):
+        """Helper method to mark the state as 'partial'"""
+        LOGGER.debug('Marking current_state as: %s', self.States.PARTIAL)
+        self[self._STATE_KEY] = self.States.PARTIAL
 
     def mark_running(self):
         """Helper method to mark the state as 'running'"""

--- a/app_integrations/main.py
+++ b/app_integrations/main.py
@@ -38,8 +38,8 @@ def handler(event, context):
         # Run the gather operation
         app.gather()
     finally:
-        # If the config was loaded, save a bad state if the current state is not
-        # marked as a success (aka running)
+        # If the config was loaded, save a bad state if the current state is still
+        # marked as 'running' (aka not 'success' or 'partial' runs)
         if 'config' in locals():
-            if not config.is_success:
+            if config.is_running:
                 config.mark_failure()

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -146,6 +146,13 @@ class TestAppIntegration(object):
         assert_false(self._app._initialize())
         log_mock.assert_called_with('App already running for service \'%s\'.', 'type')
 
+    @patch('logging.Logger.error')
+    def test_initialize_partial(self, log_mock):
+        """App Integration - Initialize, Partial Execution"""
+        self._app._config['current_state'] = 'partial'
+        assert_false(self._app._initialize())
+        log_mock.assert_called_with('App in partial execution state for service \'%s\'.', 'type')
+
     def test_finalize(self):
         """App Integration - Finalize, Valid"""
         test_new_time = 50000000

--- a/tests/unit/app_integrations/test_main.py
+++ b/tests/unit/app_integrations/test_main.py
@@ -54,6 +54,19 @@ def test_handler_bad_type(config_mock, failure_mock):
     failure_mock.assert_called()
 
 
+@patch('app_integrations.config.AppConfig.mark_failure')
+@patch('app_integrations.config.AppConfig.load_config')
+@patch('app_integrations.apps.app_base.AppIntegration.gather')
+def test_handler_success(gather_mock, config_mock, failure_mock):
+    """App Integration - Test Handler, Success"""
+    base_config = get_valid_config_dict('duo_auth')
+    config_mock.return_value = AppConfig(base_config)
+    gather_mock.return_value = None
+    handler(None, get_mock_context())
+
+    failure_mock.assert_not_called()
+
+
 @patch('logging.Logger.error')
 def test_init_logging_bad(log_mock):
     """App Integration - Logging, Bad Level"""


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Discovered that a partial execution of log collection would mark the config state as 'failing' upon completion, even though there was no failure. This was due to the state toggling naively marking the state to 'failing' if it was still set to 'running' at the time of exit.

## Changes

* Adding a new state of `'partial'` that will get set when there are more logs to poll and a new apps function is invoked.
* The new 'partial' state must now exist in conjunction with the 'successive_invocation' event type in order for an invocation to continue.

## Testing

* Adding unit tests to verify that the 'partial' flag is working as expected, and additional unit tests.
