### PR TITLE
[docs] add athena data table creation docs

### DIFF
--- a/docs/source/account.rst
+++ b/docs/source/account.rst
@@ -10,9 +10,9 @@ However, the StreamAlert application itself, and its supporting services, must b
 
 Configuration
 -------------
-As outlined above, choose or create the AWS account you'll use to house the StreamAlert infrastructure.
+As outlined above, choose or create the AWS account you will use to house the StreamAlert infrastructure.
 
-If you're interested in demo'ing StreamAlert, you can create a hassle free-tier AWS account `here <https://aws.amazon.com/free/>`_.
+If you are interested in simply demo'ing StreamAlert, you can create a hassle free-tier AWS account `here <https://aws.amazon.com/free/>`_.
 
 account_id
 ~~~~~~~~~~

--- a/docs/source/athena-setup.rst
+++ b/docs/source/athena-setup.rst
@@ -49,13 +49,30 @@ Next, create the ``streamalert`` database:
 
   $ python manage.py athena create-db
 
-Finally, create the ``alerts`` table for searching generated StreamAlerts:
+Create the ``alerts`` table for searching generated StreamAlerts:
 
 .. code-block:: bash
 
   $ python manage.py athena create-table --type alerts --bucket <s3.bucket.id.goes.here>
 
-Next Steps
-~~~~~~~~~~
+Create tables for data sent to StreamAlert:
 
-`Configure and deploy the Athena Partition Refresher Lambda function <athena-deploy.html>`_
+.. code-block:: bash
+
+  $ python manage.py athena create-table \ 
+    --type data \
+    --bucket <prefix>.streamalert.data \
+    --refresh_type add_hive_partition \
+    --table_name <log_name>
+
+Note: The log name above is representative of an enabled log source to your StreamAlert deployment.
+
+For example, if you have 'cloudwatch' in your sources, you would want to create tables for all possible subtypes.  This includes ``cloudwatch_events`` and ``cloudwatch_flow_logs``.  Also notice that ``:`` is substituted with ``_``; this is due to Hive limitations on table names.
+
+Repeat this process for all relevant data tables in your deployment.
+
+Next Steps
+----------
+
+* `Configure and deploy the Athena Partition Refresher Lambda function <athena-deploy.html>`_
+* `Configure and deploy Kinesis Firehose for delivery of data to S3 <firehose.html>`_

--- a/docs/source/firehose.rst
+++ b/docs/source/firehose.rst
@@ -6,10 +6,10 @@ Overview
 
 * To enable historical search of all data classified by StreamAlert, Kinesis Firehose can be used.
 * This feature can be used for long-term data persistence and historical search (coming soon).
-* This works by delivering data to Amazon S3, which can be loaded and queried by AWS Athena.
+* This works by delivering data to AWS S3, which can be loaded and queried by AWS Athena.
 
-Infrastructure
---------------
+Configuration
+-------------
 
 When enabling the Kinesis Firehose module, a dedicated Delivery Stream is created per each log type.
 
@@ -112,3 +112,13 @@ Key                      Required  Default               Description
 ``buffer_interval``      ``No``    ``300 (seconds)``     The frequency of data delivery to Amazon S3
 ``compression_format``   ``No``    ``GZIP``              The compression algorithm to use on data stored in S3
 ======================   ========  ====================  ===========
+
+Deploying
+---------
+
+Once the options above are set, deploy the infrastructure with the following commands:
+
+.. code-block:: bash
+
+  $ python manage.py terraform build
+  $ python manage.py lambda deploy --processor rule


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

We recently added support for searching data via Athena and Firehose, but there are no steps on how to set this up.

## Changes

* Add some DOCS

## Testing

Locally with the test_the_docs.sh script
