### PR TITLE
[cli] fixing bug in reporting errors with sources

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -469,7 +469,7 @@ class RuleProcessorTester(object):
         source = test_event['source']
         service = test_event['service']
         log = test_event['log'].split(':')[0]
-        if not log in self.cli_config['sources'][service][source]:
+        if not log in self.cli_config['sources'][service][source]['logs']:
             message = ('The \'sources.json\' file does not include the log type \'{}\' '
                        'in the list of logs for this service & entity (\'{}:{}\').')
             message = '{} {}'.format(base_message, message.format(log, service, source))
@@ -569,6 +569,7 @@ class RuleProcessorTester(object):
                        '{}.'.format(base_message, missing_key_list))
 
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
+            return
 
         unexpected_keys = test_record_keys.difference(schema_keys)
         if unexpected_keys:


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Discovered a bug where the 'logs' list within the `sources.json` file was not properly being checked for a log type. Example:
`
StreamAlertCLI [ERROR]: (1/3) Failures
`
`
StreamAlertCLI [ERROR]: (1/1) Invalid test event in file 'test_file.json' with description 'This is the description of the test event'. The 'sources.json' file does not include the log type 'carbonblack' in the list of logs for this service & entity ('s3:this.is.the.entity').
`

The above is a bug, since `carbonblack` is in the `sources.json`

## Changes

* Checking the logs list for a log type instead of the 'source' which would always result in an misleading error being logged.
* Adding `return` to return after logging one error with a log to avoid confusion.

## Testing

Added invalid test event with a bad 'log' type to see if it was properly reported, like so:
`
StreamAlertCLI [ERROR]: (1/3) Failures
`
`
StreamAlertCLI [ERROR]: (1/1) Invalid test event in file 'test_file.json' with description 'This is the description of the test event'. The 'sources.json' file does not include the log type 'carbonflack' in the list of logs for this service & entity ('s3:this.is.the.entity').
`

The above is now correct, since `carbonflack` (read: `flack`) is NOT in the `sources.json`