### PR TITLE
[apps] fix for potential but unlikely race condition

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -224,9 +224,9 @@ class AppIntegration(object):
         # the config as 'partial'. Marking the state as 'partial' prevents
         # scheduled function invocations from running alongside chained invocations.
         if self._more_to_poll:
-            self._invoke_successive_gather()
-
             self._config.mark_partial()
+
+            self._invoke_successive_gather()
             return
 
         self._config.mark_success()

--- a/app_integrations/main.py
+++ b/app_integrations/main.py
@@ -40,6 +40,5 @@ def handler(event, context):
     finally:
         # If the config was loaded, save a bad state if the current state is still
         # marked as 'running' (aka not 'success' or 'partial' runs)
-        if 'config' in locals():
-            if config.is_running:
-                config.mark_failure()
+        if 'config' in locals() and config.is_running:
+            config.mark_failure()


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Identified a very unlikely but possible race condition that could occur. In short, a 'chained' invocation of a app function could be started before the config in Parameter Store was properly updated with the `partial` state value. This could then cause the new invocation of the lambda to fail if it read the state as `running` before it was written to `partial`

## Changes

* Writing the `partial` state config to parameter store before invoking the new lambda function.

## Testing

* Unit tests passing.
