### PR TITLE
[tf][kinesis] Disabling shard level metrics by default

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -7,7 +7,8 @@
   },
   "infrastructure": {
     "monitoring": {
-      "create_sns_topic": true
+      "create_sns_topic": true,
+      "shard_level_metrics": []
     }
   },
   "terraform": {

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,17 +1,25 @@
 Metrics
 =======
 
-StreamAlert enables `Enhanced Monitoring`_ to surface infrastructure metrics at a granular level.
+StreamAlert allows to enable `Enhanced Monitoring`_ to surface infrastructure metrics at a granular level.
 
 .. _Enhanced Monitoring: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.html
 
-Go to AWS Console -> CloudWatch -> Metrics -> Kinesis to view them.
+When enabled, access them by going to AWS Console -> CloudWatch -> Metrics -> Kinesis.
 
-Example metrics:
+Enhanced metrics can be enabled in ``conf/global.json`` as ``shard_level_metrics``, for example:
 
-* IncomingBytes
-* IncomingRecords
-* Error/Exceptions
+.. code-block:: bash
+
+  "shard_level_metrics": [
+    "IncomingBytes",
+    "IncomingRecords",
+    "OutgoingBytes",
+    "OutgoingRecords",
+    "WriteProvisionedThroughputExceeded",
+    "ReadProvisionedThroughputExceeded",
+    "IteratorAgeMilliseconds",
+  ]
 
 These metrics can be viewed at the shard-level or the stream-level (cluster/environment).
 

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -18,7 +18,7 @@ Enhanced metrics can be enabled in ``conf/global.json`` as ``shard_level_metrics
     "OutgoingRecords",
     "WriteProvisionedThroughputExceeded",
     "ReadProvisionedThroughputExceeded",
-    "IteratorAgeMilliseconds",
+    "IteratorAgeMilliseconds"
   ]
 
 These metrics can be viewed at the shard-level or the stream-level (cluster/environment).

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -29,6 +29,7 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
     """
     prefix = config['global']['account']['prefix']
     config_modules = config['clusters'][cluster_name]['modules']
+    shard_level_metrics = config['global']['infrastructure']['monitoring']['shard_level_metrics']
 
     cluster_dict['module']['kinesis_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_streams',
@@ -38,6 +39,7 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
         'prefix': config['global']['account']['prefix'],
         'stream_name': '{}_{}_stream_alert_kinesis'.format(prefix, cluster_name),
         'shards': config_modules['kinesis']['streams']['shards'],
+        'shard_level_metrics': shard_level_metrics,
         'retention': config_modules['kinesis']['streams']['retention']
     }
 

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -29,7 +29,12 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
     """
     prefix = config['global']['account']['prefix']
     config_modules = config['clusters'][cluster_name]['modules']
-    shard_level_metrics = config['global']['infrastructure']['monitoring']['shard_level_metrics']
+
+    infrastructure_config = config['global'].get('infrastructure')
+    shard_level_metrics = []
+    if infrastructure_config and 'monitoring' in infrastructure_config:
+        if 'shard_level_metrics' in infrastructure_config['monitoring']:
+            shard_level_metrics = infrastructure_config['monitoring']['shard_level_metrics']
 
     cluster_dict['module']['kinesis_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_streams',

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -30,11 +30,10 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
     prefix = config['global']['account']['prefix']
     config_modules = config['clusters'][cluster_name]['modules']
 
-    infrastructure_config = config['global'].get('infrastructure')
-    shard_level_metrics = []
-    if infrastructure_config and 'monitoring' in infrastructure_config:
-        if 'shard_level_metrics' in infrastructure_config['monitoring']:
-            shard_level_metrics = infrastructure_config['monitoring']['shard_level_metrics']
+    shard_level_metrics = config['global']['infrastructure']['monitoring'].get(
+        'shard_level_metrics',
+        list()
+    )
 
     cluster_dict['module']['kinesis_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_streams',

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -31,9 +31,7 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
     config_modules = config['clusters'][cluster_name]['modules']
 
     shard_level_metrics = config['global']['infrastructure']['monitoring'].get(
-        'shard_level_metrics',
-        list()
-    )
+        'shard_level_metrics', [])
 
     cluster_dict['module']['kinesis_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_streams',

--- a/terraform/modules/tf_stream_alert_kinesis_streams/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/main.tf
@@ -4,15 +4,7 @@ resource "aws_kinesis_stream" "stream_alert_stream" {
   shard_count      = "${var.shards}"
   retention_period = "${var.retention}"
 
-  shard_level_metrics = [
-    "IncomingBytes",
-    "IncomingRecords",
-    "OutgoingBytes",
-    "OutgoingRecords",
-    "WriteProvisionedThroughputExceeded",
-    "ReadProvisionedThroughputExceeded",
-    "IteratorAgeMilliseconds",
-  ]
+  shard_level_metrics = "${var.shard_level_metrics}"
 
   tags {
     Name    = "StreamAlert"

--- a/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
@@ -21,3 +21,9 @@ variable "shards" {
 variable "retention" {
   default = 24
 }
+
+// Default values for shard_level_metrics
+variable "shard_level_metrics" {
+  type    = "list"
+  default = []
+}

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -7,7 +7,8 @@
   },
   "infrastructure": {
     "monitoring": {
-      "create_sns_topic": true
+      "create_sns_topic": true,
+      "shard_level_metrics": []
     }
   },
   "terraform": {

--- a/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
+++ b/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
@@ -31,6 +31,7 @@ def test_kinesis_streams():
             'kinesis_advanced': {
                 'source': 'modules/tf_stream_alert_kinesis_streams',
                 'account_id': '12345678910',
+                'shard_level_metrics': [],
                 'region': 'us-west-1',
                 'prefix': 'unit-testing',
                 'cluster_name': 'advanced',


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

StreamAlert was enabling by default [enhanced monitoring](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.html) to surface infrastructure metrics at a granular level. This could ended up costly since those metrics are charged and they should be enabled when needed, instead of adding a unnecessary cost and not being utilized properly. 

## Changes

* Shard level metrics are now empty by default, with the necessary documentation to enable them.

## Testing

Changes were tested running `python manage.py terraform init`, `python manage.py terraform build` and `python manage.py terraform destroy` to make sure all the infrastructure is created and destroyed properly.
