### PR TITLE
[apps] adding G Suite app for all activity audit reports

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -117,8 +117,9 @@ class AppIntegration(object):
         """
         return '_'.join([cls.service(), cls._type()])
 
+    @classmethod
     @abstractmethod
-    def required_auth_info(self):
+    def required_auth_info(cls):
         """Get the expected info that this service's auth dictionary should contain.
 
         This should be implemented by subclasses and provide context as to what authentication
@@ -347,6 +348,7 @@ class AppIntegration(object):
             # Make sure there are logs, this can be False if there was an issue polling
             # of if there are no new logs to be polled
             if not logs:
+                self._more_to_poll = False
                 LOGGER.error('Gather process for service \'%s\' was not able to poll any logs '
                              'on poll #%d', self.type(), self._poll_count)
                 return

--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -319,12 +319,12 @@ class AppIntegration(object):
             raise AppIntegrationConfigError('Config for service \'{}\' is empty', self.type())
 
         # The config validates that the 'auth' dict was loaded, but do a safety check here
-        if not 'auth' in self._config:
+        if not self._config.auth:
             raise AppIntegrationConfigError('Auth config for service \'{}\' is empty', self.type())
 
         # Get the required authentication keys from the info returned by the subclass
         required_keys = set(self.required_auth_info())
-        auth_key_diff = required_keys.difference(set(self._config['auth']))
+        auth_key_diff = required_keys.difference(set(self._config.auth))
         if not auth_key_diff:
             return
 

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -39,7 +39,7 @@ class DuoApp(AppIntegration):
         Raises:
             NotImplementedError: If the subclasses do not properly implement this method
         """
-        raise NotImplementedError
+        raise NotImplementedError('Subclasses should implement the _endpoint method')
 
     @classmethod
     def service(cls):
@@ -137,7 +137,8 @@ class DuoApp(AppIntegration):
         # Return the list of logs to the caller so they can be send to the batcher
         return logs
 
-    def required_auth_info(self):
+    @classmethod
+    def required_auth_info(cls):
         return {
             'api_hostname':
                 {

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -57,14 +57,14 @@ class DuoApp(AppIntegration):
                                  self._endpoint(), urllib.urlencode(params)])
 
         try:
-            signature = hmac.new(self._config['auth']['secret_key'],
+            signature = hmac.new(self._config.auth['secret_key'],
                                  auth_string, hashlib.sha1)
         except TypeError:
             LOGGER.exception('Could not generate hmac signature')
             return False
 
         # Format the basic auth with integration key and the hmac hex digest
-        basic_auth = ':'.join([self._config['auth']['integration_key'],
+        basic_auth = ':'.join([self._config.auth['integration_key'],
                                signature.hexdigest()])
 
         return {
@@ -75,7 +75,7 @@ class DuoApp(AppIntegration):
 
     def _gather_logs(self):
         """Gather the Duo log events."""
-        hostname = self._config['auth']['api_hostname']
+        hostname = self._config.auth['api_hostname']
         full_url = 'https://{hostname}{endpoint}'.format(
             hostname=hostname,
             endpoint=self._endpoint()

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -180,6 +180,15 @@ class GSuiteAdminReports(GSuiteReportsApp):
 
 
 @app
+class GSuiteCalendarReports(GSuiteReportsApp):
+    """G Suite Calendar Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'calendar'
+
+
+@app
 class GSuiteDriveReports(GSuiteReportsApp):
     """G Suite Drive Activity Report app integration"""
 
@@ -189,12 +198,57 @@ class GSuiteDriveReports(GSuiteReportsApp):
 
 
 @app
+class GSuiteGroupsReports(GSuiteReportsApp):
+    """G Suite Groups Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'groups'
+
+
+@app
+class GSuiteGPlusReports(GSuiteReportsApp):
+    """G Suite Google Plus Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'gplus'
+
+
+@app
 class GSuiteLoginReports(GSuiteReportsApp):
     """G Suite Login Activity Report app integration"""
 
     @classmethod
     def _type(cls):
         return 'login'
+
+
+@app
+class GSuiteMobileReports(GSuiteReportsApp):
+    """G Suite Mobile Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'mobile'
+
+
+@app
+class GSuiteRulesReports(GSuiteReportsApp):
+    """G Suite Rules Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'rules'
+
+
+@app
+class GSuiteSAMLReports(GSuiteReportsApp):
+    """G Suite SAML Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'saml'
 
 
 @app

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -1,0 +1,206 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+
+from apiclient import discovery, errors
+from oauth2client.service_account import ServiceAccountCredentials
+
+from app_integrations import LOGGER
+from app_integrations.apps.app_base import app, AppIntegration
+
+
+class GSuiteReportsApp(AppIntegration):
+    """G Suite Reports base app integration. This is subclassed for various endpoints"""
+    _SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly']
+
+    def __init__(self, config):
+        super(GSuiteReportsApp, self).__init__(config)
+        self._activities_service = None
+        self._next_page_token = None
+
+    @classmethod
+    def _type(cls):
+        raise NotImplementedError('Subclasses should implement the _type method')
+
+    @classmethod
+    def service(cls):
+        return 'gsuite'
+
+    @classmethod
+    def date_formatter(cls):
+        """Return a format string for a date, ie: 2010-10-28T10:26:35.000Z"""
+        return '%Y-%m-%dT%H:%M:%SZ'
+
+    @classmethod
+    def _load_credentials(cls, keydata):
+        """Load ServiceAccountCredentials from Google service account JSON keyfile
+
+        Args:
+            keydata (dict): The loaded keyfile data from a Google service account
+                JSON file
+        """
+        try:
+            creds = ServiceAccountCredentials.from_json_keyfile_dict(
+                keydata, scopes=cls._SCOPES)
+        except (ValueError, KeyError):
+            # This has the potential to raise errors. See: https://tinyurl.com/y8q5e9rm
+            LOGGER.exception('Could not generate credentials from keyfile for %s',
+                             cls.type())
+            return False
+
+        return creds
+
+    def _create_service(self):
+        """GSuite requests must be signed with the keyfile
+
+        Returns:
+            bool: True if the Google API discovery service was successfully established or False
+                if any errors occurred during the creation of the Google discovery service,
+        """
+        if self._activities_service:
+            LOGGER.debug('Service already instantiated for %s', self.type())
+            return True
+
+        creds = self._load_credentials(self._config.auth['keyfile'])
+        if not creds:
+            return False
+
+        try:
+            resource = discovery.build('admin', 'reports_v1', credentials=creds)
+        except errors.Error:
+            LOGGER.exception('Failed to build discovery service for %s', self.type())
+            return False
+
+        # The google discovery service 'Resource' class that is returned by
+        # 'discovery.build' dynamically loads methods/attributes, so pylint will complain
+        # about no 'activities' member existing without the below pylint comment
+        self._activities_service = resource.activities() # pylint: disable=no-member
+
+        return True
+
+    def _gather_logs(self):
+        """Gather the G Suite Admin Report logs for this application type
+
+        Returns:
+            bool or list: If the execution fails for some reason, return False.
+                Otherwise, return a list of activies for this application type.
+        """
+        if not self._create_service():
+            return False
+
+        activities_list = self._activities_service.list(
+            userKey='all',
+            applicationName=self._type(),
+            startTime=self._last_timestamp,
+            pageToken=self._next_page_token if self._next_page_token else None
+        )
+
+        try:
+            results = activities_list.execute()
+        except errors.HttpError:
+            LOGGER.exception('Failed to execute activities listing')
+            return False
+
+        if not results:
+            LOGGER.error('No results received from the G Suite API request for %s', self.type())
+            return False
+
+        self._next_page_token = results.get('nextPageToken')
+        self._more_to_poll = bool(self._next_page_token)
+
+        activities = results.get('items', [])
+        if not activities:
+            LOGGER.info('No logs in response from G Suite API request for %s', self.type())
+            return False
+
+        self._last_timestamp = activities[-1]['id']['time']
+
+        return activities
+
+    @classmethod
+    def required_auth_info(cls):
+        # Use a validation function to ensure the file the user provides is valid
+        def keyfile_validator(keyfile):
+            """A JSON formatted (not p12) Google service account private key file key"""
+            try:
+                with open(keyfile.strip(), 'r') as json_keyfile:
+                    keydata = json.load(json_keyfile)
+            except (IOError, ValueError):
+                return False
+
+            if not cls._load_credentials(keydata):
+                return False
+
+            return keydata
+
+        return {
+            'keyfile':
+                {
+                    'description': ('the path on disk to the JSON formatted Google '
+                                    'service account private key file'),
+                    'format': keyfile_validator
+                }
+            }
+
+    def _sleep_seconds(self):
+        """Return the number of seconds this polling function should sleep for
+        between requests to avoid failed requests. The Google Admin API allows for
+        5 queries per second. Since it is very unlikely we will hit that, and since
+        we are using Google's api client for requests, this can default to 0.
+
+        Resource(s):
+            https://developers.google.com/admin-sdk/reports/v1/limits
+
+        Returns:
+            int: Number of seconds that this function should sleep for between requests
+        """
+        return 0
+
+
+@app
+class GSuiteAdminReports(GSuiteReportsApp):
+    """G Suite Admin Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'admin'
+
+
+@app
+class GSuiteDriveReports(GSuiteReportsApp):
+    """G Suite Drive Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'drive'
+
+
+@app
+class GSuiteLoginReports(GSuiteReportsApp):
+    """G Suite Login Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'login'
+
+
+@app
+class GSuiteTokenReports(GSuiteReportsApp):
+    """G Suite Token Activity Report app integration"""
+
+    @classmethod
+    def _type(cls):
+        return 'token'

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -54,7 +54,7 @@ class OneLoginApp(AppIntegration):
         Returns:
             str: Full URL to generate tokens for the OneLogin API
         """
-        return self._ONELOGIN_TOKEN_URL.format(self._config['auth']['region'])
+        return self._ONELOGIN_TOKEN_URL.format(self._config.auth['region'])
 
     def _events_endpoint(self):
         """Get the endpoint URL to retrieve events
@@ -62,7 +62,7 @@ class OneLoginApp(AppIntegration):
         Returns:
             str: Full URL to retrieve events in the OneLogin API
         """
-        return self._ONELOGIN_EVENTS_URL.format(self._config['auth']['region'])
+        return self._ONELOGIN_EVENTS_URL.format(self._config.auth['region'])
 
     def _rate_limit_endpoint(self):
         """Get the endpoint URL to retrieve rate limit details
@@ -70,7 +70,7 @@ class OneLoginApp(AppIntegration):
         Returns:
             str: Full URL to retrieve rate limit details in the OneLogin API
         """
-        return self._ONELOGIN_RATE_LIMIT_URL.format(self._config['auth']['region'])
+        return self._ONELOGIN_RATE_LIMIT_URL.format(self._config.auth['region'])
 
     def _generate_headers(self):
         """Each request will request a new token to call the resources APIs.
@@ -85,7 +85,7 @@ class OneLoginApp(AppIntegration):
             return True
 
         authorization = 'client_id: {}, client_secret: {}'.format(
-            self._config['auth']['client_id'], self._config['auth']['client_secret'])
+            self._config.auth['client_id'], self._config.auth['client_secret'])
 
         headers_token = {'Authorization': authorization,
                          'Content-Type': 'application/json'}

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -206,8 +206,7 @@ class OneLoginApp(AppIntegration):
 
         # Fail if response is invalid
         if not response:
-            LOGGER.error('Response is invalid for service \'%s\'',
-                         self.type())
+            LOGGER.error('Response is invalid for service \'%s\'', self.type())
             return False
 
         # Set pagination link, if there is any
@@ -216,8 +215,7 @@ class OneLoginApp(AppIntegration):
 
         # Adjust the last seen event, if the events list is not empty
         if not response['data']:
-            LOGGER.error('Empty list of events for service \'%s\'',
-                         self.type())
+            LOGGER.info('Empty list of events for service \'%s\'', self.type())
             return False
 
         self._last_timestamp = response['data'][-1]['created_at']
@@ -225,7 +223,8 @@ class OneLoginApp(AppIntegration):
         # Return the list of events to the caller so they can be send to the batcher
         return response['data']
 
-    def required_auth_info(self):
+    @classmethod
+    def required_auth_info(cls):
         return {
             'region':
                 {

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -164,8 +164,9 @@ class AppConfig(dict):
         # Add the auth config info to the 'auth' key since these key/values can vary
         # from service to service
         base_config[cls.AUTH_CONFIG_SUFFIX] = {
-            key: str(value) for key, value in
-            params[param_names[cls.AUTH_CONFIG_SUFFIX]].iteritems()
+            key: value.encode('utf-8')
+            for key, value in params[param_names[cls.AUTH_CONFIG_SUFFIX]].iteritems()
+            if isinstance(value, unicode)
         }
 
         return AppConfig(base_config, event)

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -362,6 +362,11 @@ class AppConfig(dict):
         LOGGER.info('Lambda remaining seconds: %.2f', self.remaining_ms() / 1000.0)
 
     @property
+    def auth(self):
+        """Get the auth sub dictionary from the config"""
+        return self.get(self.AUTH_CONFIG_SUFFIX)
+
+    @property
     def current_state(self):
         """Cache the current time to be written to the config"""
         LOGGER.debug('Getting current_state: %s', self.get(self._STATE_KEY))

--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -23,6 +23,7 @@
     "source_current_hash": "<auto_generated>",
     "source_object_key": "<auto_generated>",
     "third_party_libraries": [
+      "google-api-python-client",
       "requests"
     ]
   }

--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1088,6 +1088,17 @@
       ]
     }
   },
+  "gsuite:reports": {
+    "schema": {
+      "kind": "string",
+      "id": {},
+      "actor": {},
+      "ownerDomain": "string",
+      "ipAddress": "string",
+      "events": []
+    },
+    "parser": "json"
+  },
   "onelogin:events": {
     "schema": {
       "account_id": "integer",

--- a/conf/sources.json
+++ b/conf/sources.json
@@ -31,6 +31,11 @@
       "logs": [
         "duo"
       ]
+    },
+    "prefix_cluster_gsuite_admin_sm-app-name_app": {
+      "logs": [
+        "gsuite"
+      ]
     }
   }
 }

--- a/docs/source/app-development.rst
+++ b/docs/source/app-development.rst
@@ -109,9 +109,9 @@ to outline what methods from the base ``AppIntegration`` class must be implement
 
     def _get_oauth(self):
       """This should return the oauth token for this request"""
-      secret_key = self._config['auth']['secret_key']
-      client_id = self._config['auth']['client_id']
-      token = self._config['auth']['token']
+      secret_key = self._config.auth['secret_key']
+      client_id = self._config.auth['client_id']
+      token = self._config.auth['token']
 
       # Do something to generate oauth
       return generated_oauth

--- a/manage.py
+++ b/manage.py
@@ -214,6 +214,7 @@ Examples:
     # add the optional ability to test against specific files
     schema_validation_parser.add_argument(
         '-f', '--test-files',
+        dest='files',
         nargs='+',
         help=ARGPARSE_SUPPRESS,
         action=UniqueSetAction,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ extras==1.0.0
 fixtures==3.0.0
 funcsigs==1.0.2
 futures==3.1.1
+google-api-python-client==1.6.4
+httplib2==0.10.3
 httpretty==0.8.10
 hurry.filesize==0.9
 imagesize==0.7.1
@@ -39,11 +41,13 @@ mox3==0.21.0
 netaddr==0.7.18
 nose==1.3.7
 numpy==1.12.0
+oauth2client==4.1.2
 packaging==16.8
 pbr==2.0.0
 ply==3.10
 psutil==5.1.3
 pyasn1==0.2.3
+pyasn1-modules==0.1.5
 pycodestyle==2.3.1
 pyfakefs==3.2
 pyflakes==1.5.0
@@ -67,6 +71,7 @@ testtools==2.2.0
 traceback2==1.4.0
 typing==3.6.1
 unittest2==1.1.0
+uritemplate==3.0.0
 virtualenv==15.1.0
 Werkzeug==0.12.1
 wrapt==1.10.10

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -376,7 +376,7 @@ class CLIConfig(object):
                 a new app integration
         """
         exists, prompt_for_auth, overwrite = False, True, False
-        app = get_app(app_info)
+        app = get_app(app_info, False)
 
         # Check to see if there is an existing configuration for this app integration
         cluster_config = self.config['clusters'][app_info['cluster']]

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -402,7 +402,7 @@ def _app_integration_handler(options):
         app_info['function_name'] = '_'.join([app_info.get(value)
                                               for value in func_parts] + ['app'])
 
-        app = get_app(app_info)
+        app = get_app(app_info, False)
 
         if not save_app_auth_info(app, app_info, True):
             return

--- a/tests/integration/rules/gsuite/gsuite_admin.json
+++ b/tests/integration/rules/gsuite/gsuite_admin.json
@@ -1,0 +1,43 @@
+{
+  "records": [
+    {
+      "data": {
+        "kind": "audit#activity",
+        "id": {
+          "time": "2011-06-17T15:39:18.460Z",
+          "uniqueQualifier": "report's unique ID",
+          "applicationName": "admin",
+          "customerId": "C03az79cb"
+        },
+        "actor": {
+          "callerType": "USER",
+          "email": "liz@example.com",
+          "profileId": "user's unique G Suite profile ID",
+          "key": "consumer key of requestor in OAuth 2LO requests"
+        },
+        "ownerDomain": "example.com",
+        "ipAddress": "user's IP address",
+        "events": [
+          {
+            "type": "GROUP_SETTINGS",
+            "name": "CHANGE_GROUP_SETTING",
+            "parameters": [
+              {
+                "name": "SETTING_NAME",
+                "value": "WHO_CAN_JOIN",
+                "intValue": "integer value of parameter",
+                "boolValue": "boolean value of parameter"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "G Suite Admin Report Log exmaple (validation only)",
+      "log": "gsuite:report",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_gsuite_admin_sm-app-name_app",
+      "trigger_rules": [],
+      "validate_schema_only": true
+    }
+  ]
+}

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -46,7 +46,7 @@ class TestDuoApp(object):
     @patch('logging.Logger.exception')
     def test_generate_auth_hmac_failure(self, log_mock):
         """DuoApp - Generate Auth, hmac Failure"""
-        self._app._config['auth']['secret_key'] = {'bad_secret'}
+        self._app._config.auth['secret_key'] = {'bad_secret'}
         assert_false(self._app._generate_auth('hostname', {}))
         log_mock.assert_called_with('Could not generate hmac signature')
 
@@ -87,7 +87,7 @@ class TestDuoApp(object):
     @patch('requests.get')
     def test_get_duo_logs_bad_headers(self, requests_mock):
         """DuoApp - Get Duo Logs, Bad Headers"""
-        self._app._config['auth']['secret_key'] = {'bad_secret'}
+        self._app._config.auth['secret_key'] = {'bad_secret'}
         assert_false(self._app._get_duo_logs('hostname', 'full_url'))
         requests_mock.assert_not_called()
 

--- a/tests/unit/app_integrations/test_apps/test_gsuite.py
+++ b/tests/unit/app_integrations/test_apps/test_gsuite.py
@@ -1,0 +1,225 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method,attribute-defined-outside-init
+import json
+from mock import Mock, mock_open, patch
+
+from apiclient import errors
+from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true, raises
+
+from app_integrations.apps.gsuite import GSuiteReportsApp #, DuoAdminApp, DuoAuthApp
+from app_integrations.config import AppConfig
+
+from tests.unit.app_integrations.test_helpers import (
+    get_valid_config_dict,
+    MockSSMClient
+)
+
+@patch.object(GSuiteReportsApp, '_type', Mock(return_value='admin'))
+@patch.object(GSuiteReportsApp, 'type', Mock(return_value='type'))
+@patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient())
+class TestGSuiteReportsApp(object):
+    """Test class for the GSuiteReportsApp"""
+
+    # Remove all abstractmethods so we can instantiate GSuiteReportsApp for testing
+    @patch.object(GSuiteReportsApp, '__abstractmethods__', frozenset())
+    def setup(self):
+        """Setup before each method"""
+        self._app = GSuiteReportsApp(AppConfig(get_valid_config_dict('gsuite_admin')))
+
+    def test_sleep(self):
+        """GSuiteReportsApp - Sleep Seconds"""
+        assert_equal(self._app._sleep_seconds(), 0)
+
+    def test_required_auth_info(self):
+        """GSuiteReportsApp - Required Auth Info"""
+        assert_items_equal(self._app.required_auth_info().keys(), {'keyfile'})
+
+    @patch('app_integrations.apps.gsuite.ServiceAccountCredentials.from_json_keyfile_dict',
+           Mock(return_value=True))
+    def test_keyfile_validator(self):
+        """GSuiteReportsApp - Keyfile Validation, Success"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        data = {'test': 'keydata'}
+        mocker = mock_open(read_data=json.dumps(data))
+        with patch('__builtin__.open', mocker):
+            loaded_keydata = validation_function('fakepath')
+            assert_equal(loaded_keydata, data)
+
+    @patch('app_integrations.apps.gsuite.ServiceAccountCredentials.from_json_keyfile_dict')
+    def test_keyfile_validator_failure(self, cred_mock):
+        """GSuiteReportsApp - Keyfile Validation, Failure"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        cred_mock.return_value = False
+        mocker = mock_open(read_data=json.dumps({'test': 'keydata'}))
+        with patch('__builtin__.open', mocker):
+            assert_false(validation_function('fakepath'))
+            cred_mock.assert_called()
+
+    @patch('app_integrations.apps.gsuite.ServiceAccountCredentials.from_json_keyfile_dict')
+    def test_keyfile_validator_bad_json(self, cred_mock):
+        """GSuiteReportsApp - Keyfile Validation, Bad JSON"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        mocker = mock_open(read_data='invalid json')
+        with patch('__builtin__.open', mocker):
+            assert_false(validation_function('fakepath'))
+            cred_mock.assert_not_called()
+
+    @patch('app_integrations.apps.gsuite.ServiceAccountCredentials.from_json_keyfile_dict',
+           Mock(return_value=True))
+    def test_load_credentials(self):
+        """GSuiteReportsApp - Load Credentials, Success"""
+        assert_true(self._app._load_credentials('fakedata'))
+
+    @patch('app_integrations.apps.gsuite.ServiceAccountCredentials.from_json_keyfile_dict')
+    def test_load_credentials_bad(self, cred_mock):
+        """GSuiteReportsApp - Load Credentials, ValueError"""
+        cred_mock.side_effect = ValueError('Bad things happened')
+        assert_false(self._app._load_credentials('fakedata'))
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._load_credentials',
+           Mock(return_value=True))
+    @patch('app_integrations.apps.gsuite.discovery.build')
+    def test_create_service(self, build_mock):
+        """GSuiteReportsApp - Create Service, Success"""
+        build_mock.return_value.activities.return_value = True
+        assert_true(self._app._create_service())
+
+    @patch('logging.Logger.debug')
+    def test_create_service_exists(self, log_mock):
+        """GSuiteReportsApp - Create Service, Exists"""
+        self._app._activities_service = True
+        assert_true(self._app._create_service())
+        log_mock.assert_called_with('Service already instantiated for %s', 'type')
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._load_credentials',
+           Mock(return_value=False))
+    def test_create_service_fail_creds(self):
+        """GSuiteReportsApp - Create Service, Credential Failure"""
+        assert_false(self._app._create_service())
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._load_credentials',
+           Mock(return_value=True))
+    @patch('app_integrations.apps.gsuite.discovery.build')
+    def test_create_service_fail_resource(self, build_mock):
+        """GSuiteReportsApp - Create Service, Resource Failure"""
+        build_mock.side_effect = errors.Error('This is bad')
+        assert_false(self._app._create_service())
+
+    def test_gather_logs(self):
+        """GSuiteReportsApp - Gather Logs, Success"""
+        with patch.object(self._app, '_activities_service') as service_mock:
+            payload = {
+                'kind': 'reports#auditActivities',
+                'nextPageToken': 'the next page\'s token',
+                'items': self._get_sample_logs(10)
+            }
+            service_mock.list.return_value.execute.return_value = payload
+
+            assert_equal(len(self._app._gather_logs()), 10)
+            assert_equal(self._app._last_timestamp, '2011-06-17T15:39:18.460Z')
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._create_service',
+           Mock(return_value=True))
+    @patch('logging.Logger.exception')
+    def test_gather_logs_http_error(self, log_mock):
+        """GSuiteReportsApp - Gather Logs, HTTP Error"""
+        with patch.object(self._app, '_activities_service') as service_mock:
+            error = errors.HttpError('response', bytes('bad'))
+            service_mock.list.return_value.execute.side_effect = error
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('Failed to execute activities listing')
+
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._load_credentials',
+           Mock(return_value=False))
+    def test_gather_logs_no_service(self):
+        """GSuiteReportsApp - Gather Logs, No Service"""
+        with patch.object(self._app, '_activities_service') as service_mock:
+            self._app._activities_service = False
+            assert_false(self._app._gather_logs())
+            service_mock.list.assert_not_called()
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._create_service',
+           Mock(return_value=True))
+    @patch('logging.Logger.error')
+    def test_gather_logs_no_results(self, log_mock):
+        """GSuiteReportsApp - Gather Logs, No Results From API"""
+        with patch.object(self._app, '_activities_service') as service_mock:
+            service_mock.list.return_value.execute.return_value = None
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('No results received from the G Suite API request for %s',
+                                        'type')
+
+    @patch('app_integrations.apps.gsuite.GSuiteReportsApp._create_service',
+           Mock(return_value=True))
+    @patch('logging.Logger.info')
+    def test_gather_logs_empty_items(self, log_mock):
+        """GSuiteReportsApp - Gather Logs, Empty Activities List"""
+        with patch.object(self._app, '_activities_service') as service_mock:
+            payload = {
+                'kind': 'reports#auditActivities',
+                'nextPageToken': 'the next page\'s token',
+                'items': []
+            }
+            service_mock.list.return_value.execute.return_value = payload
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('No logs in response from G Suite API request for %s',
+                                        'type')
+
+    @staticmethod
+    def _get_sample_logs(count):
+        """Helper function for returning sample gsuite (admin) logs"""
+        return [{
+            'kind': 'audit#activity',
+            'id': {
+                'time': '2011-06-17T15:39:18.460Z',
+                'uniqueQualifier': 'report\'s unique ID',
+                'applicationName': 'admin',
+                'customerId': 'C03az79cb'
+            },
+            'actor': {
+                'callerType': 'USER',
+                'email': 'liz@example.com',
+                'profileId': 'user\'s unique G Suite profile ID',
+                'key': 'consumer key of requestor in OAuth 2LO requests'
+            },
+            'ownerDomain': 'example.com',
+            'ipAddress': 'user\'s IP address',
+            'events': [
+                {
+                    'type': 'GROUP_SETTINGS',
+                    'name': 'CHANGE_GROUP_SETTING',
+                    'parameters': [
+                        {
+                            'name': 'SETTING_NAME',
+                            'value': 'WHO_CAN_JOIN',
+                            'intValue': 'integer value of parameter',
+                            'boolValue': 'boolean value of parameter'
+                        }
+                    ]
+                }
+            ]
+        } for _ in range(count)]
+
+
+@raises(NotImplementedError)
+def test_type_not_implemented():
+    """GSuiteReportsApp - Subclass Type Not Implemented"""
+    class GSuiteFakeApp(GSuiteReportsApp):
+        """Fake GSuiteReports app that should raise a NotImplementedError"""
+
+    GSuiteFakeApp._type()

--- a/tests/unit/app_integrations/test_apps/test_onelogin.py
+++ b/tests/unit/app_integrations/test_apps/test_onelogin.py
@@ -44,9 +44,9 @@ class TestOneLoginApp(object):
 
     def set_config_values(self, region, client_id, client_secret):
         """Helper function to setup the auth values"""
-        self._app._config['auth']['region'] = region
-        self._app._config['auth']['client_id'] = client_id
-        self._app._config['auth']['client_secret'] = client_secret
+        self._app._config.auth['region'] = region
+        self._app._config.auth['client_id'] = client_id
+        self._app._config.auth['client_secret'] = client_secret
 
     @patch('requests.post')
     def test_generate_headers_bad_response(self, requests_mock):

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -137,6 +137,19 @@ class TestAppIntegrationConfig(object):
             time_mock.return_value = 1234567890
             assert_equal(self._config._determine_last_time(), '2009-02-13T22:31:30Z')
 
+    @patch('time.mktime')
+    def test_determine_last_timestamp_gsuite(self, time_mock):
+        """AppIntegrationConfig - Determine Last Timestamp, GSuite"""
+        with patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient(app_type='gsuite_admin')):
+            self._config = AppConfig.load_config(get_mock_context(), None)
+
+            # Reset the last timestamp to None
+            self._config.last_timestamp = None
+
+            # Use a mocked current time
+            time_mock.return_value = 1234567890
+            assert_equal(self._config._determine_last_time(), '2009-02-13T22:31:30Z')
+
     @patch('logging.Logger.error')
     def test_set_item(self, log_mock):
         """AppIntegrationConfig - Set Item, Bad Value"""

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -172,11 +172,11 @@ class TestAppIntegrationConfig(object):
     def test_scrub_auth_info(self):
         """AppIntegrationConfig - Scrub Auth Info"""
         auth_key = '{}_auth'.format(FUNCTION_NAME)
-        param_dict = {auth_key: self._config['auth']}
+        param_dict = {auth_key: self._config.auth}
         scrubbed_config = self._config._scrub_auth_info(param_dict, auth_key)
         assert_equal(scrubbed_config[auth_key]['api_hostname'],
-                     '*' * len(self._config['auth']['api_hostname']))
+                     '*' * len(self._config.auth['api_hostname']))
         assert_equal(scrubbed_config[auth_key]['integration_key'],
-                     '*' * len(self._config['auth']['integration_key']))
+                     '*' * len(self._config.auth['integration_key']))
         assert_equal(scrubbed_config[auth_key]['secret_key'],
-                     '*' * len(self._config['auth']['secret_key']))
+                     '*' * len(self._config.auth['secret_key']))

--- a/tests/unit/app_integrations/test_helpers.py
+++ b/tests/unit/app_integrations/test_helpers.py
@@ -111,6 +111,24 @@ class MockSSMClient(object):
                 'client_secret': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 'client_id': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             }
+        elif app_type in {'gsuite', 'gsuite_admin', 'gsuite_drive',
+                          'gsuite_login', 'gsuite_token'}:
+            return {
+                'keyfile': {
+                    'type': 'service_account',
+                    'project_id': 'myapp-123456',
+                    'private_key_id': 'a5427e441234a5f416ab0a2e5d759752ef69fbf1',
+                    'private_key': ('-----BEGIN PRIVATE KEY-----\nVGhpcyBpcyBub3QgcmVhbA==\n'
+                                    '-----END PRIVATE KEY-----\n'),
+                    'client_email': 'a-test-200%40myapp-123456.iam.gserviceaccount.com',
+                    'client_id': '316364948779587921167',
+                    'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                    'token_uri': 'https://accounts.google.com/o/oauth2/token',
+                    'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
+                    'client_x509_cert_url': ('https://www.googleapis.com/robot/v1/metadata/x509/'
+                                             'a-test-200%40myapp-123456.iam.gserviceaccount.com')
+                }
+            }
 
         # Fill this out with future supported apps/services
         return {}
@@ -172,6 +190,9 @@ def get_formatted_timestamp(app_type):
         return 1505316432
     elif app_type in {'onelogin', 'onelogin_events'}:
         return '2017-10-10T22:03:57Z'
+    elif app_type in {'gsuite', 'gsuite_admin', 'gsuite_drive',
+                      'gsuite_login', 'gsuite_token'}:
+        return '2017-06-17T15:39:18.460Z'
 
 
 def get_valid_config_dict(app_type):


### PR DESCRIPTION
to: @javuto and @austinbyers 
cc: @airbnb/streamalert-maintainers
size: large
resolves #348 

## Background

See #348 

tl;dr - Consume all GSuite logs:

https://developers.google.com/admin-sdk/reports/v1/guides/manage-audit-admin
https://developers.google.com/admin-sdk/reports/v1/guides/manage-audit-login
https://developers.google.com/admin-sdk/reports/v1/guides/manage-audit-tokens
https://developers.google.com/admin-sdk/reports/v1/guides/manage-audit-drive
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/saml
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/rules
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/mobile
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/gplus
...

## Changes

* Adding initial implementation of G Suite StreamAlertApp
* This app utilizes the `google-api-python-client` module, which has been added to the `requirements.txt` (along with other dependencies) and to the 3rd party libraries that get packaged with the Apps lambda function.
* All `GSuite` apps must use a Google [service account key](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) which must be configured by an admin, along with access to the `Admin SDK` api.
  * The service account key type must be in the Google-recommended JSON format (not p12):
![image](https://user-images.githubusercontent.com/13773789/32116851-153f29d2-bb01-11e7-8124-ca04036a3382.png)
  * Attempting to create a GSuite application with a p12 keyfile will fail and inform the user that a JSON keyfile must be provided.


### Other Changes
* Adding an `auth` property helper to the `AppConfig` so the `auth` subdictionary within the config dict can now be accessed via 'AppConfig.auth' instead of requiring apps to do a dictionary lookup of `'auth'` any time authentication info needs to be retrieved.
  * Also updating all unit tests to go with the above change.
* Making the `AppIntegration.required_auth_info` method a classmethod to the app does not need to be instantiated in the CLI to access this method.
  * Also making corresponding change to the cli's `runner.py` and `config.py` so the apps do not get instantiated when prompting the user for required authentication information.
* Adding support for complex input validation for items that are provided by the user.
  * A function can now be passed to the `user_input` cli helper that can be used to properly validate input. Previously only a simple `x is not in y` or regex comparison could be used.

### Bug Fixes
* Marking the `AppIntegration._more_to_poll` to `False` if there was nothing returned from an app's gather function. This avoids potentially bad looping in the subclasses.
* Fixing potential issue where casting auth values to a string could potentially cast dict values. This is meant to only case `unicode` to str, so checking for unicode first.
* Fixing bug in `validate-schemas` command that caused the `--test-files` flag to not work as expected

## Testing

* Added unit tests for the `GSuiteReportsApp`s.
* Also added the schema for `gsuite:reports` and added a test event for validation purposes only to test the schema.
* All tests passing.
