### PR TITLE
[docs] updates for gsuite apps

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -32,7 +32,20 @@ Supported Services
 
   - Events Logs
 
-* *Soon to come:* `Box <https://github.com/airbnb/streamalert/issues/398>`_, `GSuite <https://github.com/airbnb/streamalert/issues/348>`_, and more
+* G Suite Reports (`Activities <https://developers.google.com/admin-sdk/reports/v1/reference/activities>`_)
+
+  - Admin
+  - Calendar
+  - Google Drive
+  - Groups
+  - Google Plus
+  - Logins
+  - Mobile Audit
+  - Rules
+  - SAML
+  - Authorization Tokens
+
+* *Soon to come:* `Box <https://github.com/airbnb/streamalert/issues/398>`_, and more
 
 
 Getting Started


### PR DESCRIPTION
to: @mime-frame 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Adding doc updates to go with #426 (GSuite apps)

## Changes

* Adds the following to currently supported services:

* G Suite Reports ([Activities](https://developers.google.com/admin-sdk/reports/v1/reference/activities))

  - Admin
  - Calendar
  - Google Drive
  - Groups
  - Google Plus
  - Logins
  - Mobile Audit
  - Rules
  - SAML
  - Authorization Tokens


## Testing

* Tested locally with `tests/scripts/test_the_docs.sh `