### PR TITLE
[cli][bug] fix potential bug that could throw an error if a mocked s3 bucket exists

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -27,6 +27,7 @@ import zipfile
 import zlib
 
 import boto3
+from botocore.exceptions import ClientError
 from moto import mock_cloudwatch, mock_kms, mock_kinesis, mock_lambda, mock_s3
 
 from stream_alert_cli.logger import LOGGER_CLI
@@ -414,7 +415,12 @@ def put_mock_s3_object(bucket, key, data, region):
         region (str): the aws region to use for this boto3 client
     """
     s3_client = boto3.client('s3', region_name=region)
-    s3_client.create_bucket(Bucket=bucket)
+    try:
+        # Check if the bucket exists before creating it
+        s3_client.head_bucket(Bucket=bucket)
+    except ClientError:
+        s3_client.create_bucket(Bucket=bucket)
+
     s3_client.put_object(
         Body=data,
         Bucket=bucket,

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -21,6 +21,7 @@ import sys
 import time
 
 import boto3
+from botocore.exceptions import ClientError
 import jsonpath_rw
 from mock import Mock, patch
 
@@ -670,7 +671,12 @@ class AlertProcessorTester(object):
 
             if service == 'aws-s3':
                 bucket = self.outputs_config[service][descriptor]
-                boto3.client('s3', region_name='us-east-1').create_bucket(Bucket=bucket)
+                client = boto3.client('s3', region_name='us-east-1')
+                try:
+                    # Check if the bucket exists before creating it
+                    client.head_bucket(Bucket=bucket)
+                except ClientError:
+                    client.create_bucket(Bucket=bucket)
             elif service == 'aws-lambda':
                 lambda_function = self.outputs_config[service][descriptor]
                 parts = lambda_function.split(':')


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers, @securityclippy
size: small
resolves N/A

## Background

@securityclippy reported a bug via slack:

```
$ python manage.py live-test --cluster testing
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues
Traceback (most recent call last):
  File "manage.py", line 1346, in <module>
    main()
  File "manage.py", line 1341, in main
    cli_runner(options)
  File "/repos/streamalert/stream_alert_cli/runner.py", line 58, in cli_runner
    stream_alert_test(options, CONFIG)
  File "/repos/streamalert/stream_alert_cli/test.py", line 877, in stream_alert_test
    run_tests(options, context)
  File "/repos/streamalert/stream_alert_cli/helpers.py", line 450, in unmocked
    return func(options, context)
  File "/repos/streamalert/stream_alert_cli/test.py", line 838, in run_tests
    validate_schemas):
  File "/repos/streamalert/stream_alert_cli/test.py", line 139, in test_processor
    formatted_record = helpers.format_lambda_test_record(test_event)
  File "/repos/streamalert/stream_alert_cli/helpers.py", line 302, in format_lambda_test_record
    put_mock_s3_object(source, test_record['key'], data, 'us-east-1')
  File "/repos/streamalert/stream_alert_cli/helpers.py", line 417, in put_mock_s3_object
    s3_client.create_bucket(Bucket=bucket)
  File "/repos/streamalert/venv/local/lib/python2.7/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/repos/streamalert/venv/local/lib/python2.7/site-packages/botocore/client.py", line 599, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.BucketAlreadyExists: An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.
```

## Changes

* When S3 buckets get created for `live-test` or other tests, we will now check if the bucket exists before trying to re-create it.

## Testing

* Attempted live-test with valid rule/output and passing.
