### PR TITLE
Prefix streamalert to normalized types and remove duplicated IOC info

### DIFF
--- a/helpers/base.py
+++ b/helpers/base.py
@@ -20,6 +20,7 @@ import time
 from netaddr import IPAddress, IPNetwork
 from netaddr.core import AddrFormatError
 
+from stream_alert.rule_processor.rules_engine import NORMALIZATION_KEY
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 
 logging.basicConfig()
@@ -101,13 +102,13 @@ def fetch_values_by_datatype(rec, datatype):
         (list) The values of normalized types
     """
     results = []
-    if not rec.get('normalized_types'):
+    if not rec.get(NORMALIZATION_KEY):
         return results
 
-    if not datatype in rec['normalized_types']:
+    if not datatype in rec[NORMALIZATION_KEY]:
         return results
 
-    for original_keys in rec['normalized_types'][datatype]:
+    for original_keys in rec[NORMALIZATION_KEY][datatype]:
         result = rec
         if isinstance(original_keys, list):
             for original_key in original_keys:
@@ -134,10 +135,10 @@ def is_ioc(rec, lowercase_ioc=True):
     intel = StreamThreatIntel.get_intelligence()
     datatypes_ioc_mapping = StreamThreatIntel.get_config()
 
-    if not (datatypes_ioc_mapping and rec.get('normalized_types')):
+    if not (datatypes_ioc_mapping and rec.get(NORMALIZATION_KEY)):
         return False
 
-    for datatype in rec['normalized_types']:
+    for datatype in rec[NORMALIZATION_KEY]:
         if datatype not in datatypes_ioc_mapping:
             continue
         results = fetch_values_by_datatype(rec, datatype)

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -20,7 +20,7 @@ import time
 from netaddr import IPAddress, IPNetwork
 from netaddr.core import AddrFormatError
 
-from stream_alert.rule_processor.rules_engine import NORMALIZATION_KEY
+from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 
 logging.basicConfig()

--- a/helpers/base.py
+++ b/helpers/base.py
@@ -177,7 +177,7 @@ def insert_ioc_info(rec, ioc_type, ioc_value):
     """
     if StreamThreatIntel.IOC_KEY in rec:
         if (ioc_type in rec[StreamThreatIntel.IOC_KEY] and
-                not ioc_value in rec[StreamThreatIntel.IOC_KEY][ioc_type]):
+                ioc_value not in rec[StreamThreatIntel.IOC_KEY][ioc_type]):
             rec[StreamThreatIntel.IOC_KEY][ioc_type].append(ioc_value)
         else:
             rec[StreamThreatIntel.IOC_KEY][ioc_type] = [ioc_value]

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -19,7 +19,7 @@ import json
 from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.helpers import validate_alert
 from stream_alert.alert_processor.outputs import get_output_dispatcher
-from stream_alert.rule_processor.rules_engine import NORMALIZATION_KEY
+from stream_alert.shared import NORMALIZATION_KEY
 
 
 def handler(event, context):

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -19,6 +19,7 @@ import json
 from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.helpers import validate_alert
 from stream_alert.alert_processor.outputs import get_output_dispatcher
+from stream_alert.rule_processor.rules_engine import NORMALIZATION_KEY
 
 
 def handler(event, context):
@@ -133,7 +134,7 @@ def _sort_dict(unordered_dict):
     """
     result = OrderedDict()
     for key, value in sorted(unordered_dict.items(), key=lambda t: t[0]):
-        if key == 'normalized_types':
+        if key == NORMALIZATION_KEY:
             continue
         if isinstance(value, dict):
             result[key] = _sort_dict(value)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -18,6 +18,7 @@ from copy import copy
 import json
 
 from stream_alert.rule_processor import LOGGER
+from stream_alert.shared import NORMALIZATION_KEY
 
 DEFAULT_RULE_DESCRIPTION = 'No rule description provided'
 
@@ -28,8 +29,6 @@ RuleAttributes = namedtuple('Rule', ['rule_name',
                                      'logs',
                                      'outputs',
                                      'req_subkeys'])
-
-NORMALIZATION_KEY = 'streamalert:normalization'
 
 
 class StreamRules(object):

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -29,6 +29,8 @@ RuleAttributes = namedtuple('Rule', ['rule_name',
                                      'outputs',
                                      'req_subkeys'])
 
+NORMALIZATION_KEY = 'streamalert:normalization'
+
 
 class StreamRules(object):
     """Container class for StreamAlert Rules
@@ -202,7 +204,7 @@ class StreamRules(object):
         """
         results = dict()
         for key, val in record.iteritems():
-            if key == 'normalized_types':
+            if key == NORMALIZATION_KEY:
                 continue
             if isinstance(val, dict):
                 nested_results = cls.match_types_helper(val, normalized_types, datatypes)
@@ -369,7 +371,7 @@ class StreamRules(object):
 
                 if types_result:
                     record_copy = record.copy()
-                    record_copy['normalized_types'] = types_result
+                    record_copy[NORMALIZATION_KEY] = types_result
                 else:
                     record_copy = record
                 # rule analysis

--- a/stream_alert/shared/__init__.py
+++ b/stream_alert/shared/__init__.py
@@ -6,6 +6,7 @@ import os
 ALERT_PROCESSOR_NAME = 'alert_processor'
 ATHENA_PARTITION_REFRESH_NAME = 'athena_partition_refresh'
 RULE_PROCESSOR_NAME = 'rule_processor'
+NORMALIZATION_KEY = 'streamalert:normalization'
 
 # Create a package level logger to import
 LEVEL = os.environ.get('LOGGER_LEVEL', 'INFO').upper()

--- a/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
@@ -111,7 +111,7 @@ def test_fetch_values_by_datatype():
         'detail-type': '...',
         'source': '1.1.1.2',
         'version': '1.05',
-        'normalized_types': {
+        'streamalert:normalization': {
             'ipv4': [['detail', 'sourceIPAddress'], ['source']],
             'username': [['detail', 'userIdentity', 'userName']]
         },
@@ -158,7 +158,7 @@ def test_detect_ioc_rule():
         'detail-type': '...',
         'source': '1.1.1.2',
         'version': '1.05',
-        'normalized_types': {
+        'streamalert:normalization': {
             'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
             'username': [['detail', 'userIdentity', 'userName']]
         },
@@ -192,7 +192,7 @@ def test_is_ioc_with_no_matching():
         'detail-type': '...',
         'source': '1.1.1.2',
         'version': '1.05',
-        'normalized_types': {
+        'streamalert:normalization': {
             'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
             'username': [['detail', 'userIdentity', 'userName']]
         },
@@ -218,7 +218,7 @@ def test_is_ioc_with_lowercase_ioc_is_true():
         "local_ip": "127.0.0.1",
         "local_port": 54279,
         "md5": "EF69CD89AD7ADDB9A16BB6F26F1EFAF7",
-        'normalized_types': {
+        'streamalert:normalization': {
             'destinationDomain': [['domain']],
             'fileHash': [['md5']]
         }
@@ -250,7 +250,7 @@ def test_is_ioc_with_lowercase_ioc_is_false():
         "local_ip": "127.0.0.1",
         "local_port": 54279,
         "md5": "EF69CD89AD7ADDB9A16BB6F26F1EFAF7",
-        'normalized_types': {
+        'streamalert:normalization': {
             'destinationDomain': [['domain']],
             'fileHash': [['md5']]
         }

--- a/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
@@ -156,7 +156,7 @@ def test_detect_ioc_rule():
             'recipientAccountId': '12345'
         },
         'detail-type': '...',
-        'source': '1.1.1.2',
+        'source': '90.163.54.11',
         'version': '1.05',
         'streamalert:normalization': {
             'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
@@ -171,10 +171,9 @@ def test_detect_ioc_rule():
 
     ioc_result = base.is_ioc(rec)
     assert_equal(ioc_result, True)
-    expected_ioc_info = [{
-        'type': 'ip',
-        'value': '90.163.54.11'
-    }]
+    expected_ioc_info = {
+        'ip': ['90.163.54.11']
+    }
     assert_equal(rec[StreamThreatIntel.IOC_KEY], expected_ioc_info)
 
 @with_setup(setup=setup, teardown=teardown)
@@ -226,16 +225,10 @@ def test_is_ioc_with_lowercase_ioc_is_true():
 
     ioc_result = base.is_ioc(rec)
     assert_equal(ioc_result, True)
-    expected_ioc_info = [
-        {
-            'type': 'domain',
-            'value': 'test_evil.net'
-        },
-        {
-            'type': 'md5',
-            'value': 'ef69cd89ad7addb9a16bb6f26f1efaf7'
-        }
-    ]
+    expected_ioc_info = {
+        'domain': ['test_evil.net'],
+        'md5': ['ef69cd89ad7addb9a16bb6f26f1efaf7']
+    }
     assert_equal(rec[StreamThreatIntel.IOC_KEY], expected_ioc_info)
 
 @with_setup(setup=setup, teardown=teardown)
@@ -257,3 +250,48 @@ def test_is_ioc_with_lowercase_ioc_is_false():
     }
     ioc_result = base.is_ioc(rec, lowercase_ioc=False)
     assert_equal(ioc_result, False)
+
+@with_setup(setup=setup, teardown=teardown)
+def test_insert_ioc_info():
+    """Helpers - Insert IOC info to a record"""
+    # rec has no IOC info
+    rec = {
+        'key1': 'foo',
+        'key2': 'bar'
+    }
+
+    base.insert_ioc_info(rec, 'ip', '1.2.3.4')
+    expected_results = {
+        "ip": ['1.2.3.4']
+    }
+    assert_equal(rec['streamalert:ioc'], expected_results)
+
+    # rec has IOC info and new info is duplicated
+    rec_with_ioc_info = {
+        'key1': 'foo',
+        'key2': 'bar',
+        'streamalert:ioc': {
+            'ip': ['1.2.3.4']
+        }
+    }
+
+    base.insert_ioc_info(rec_with_ioc_info, 'ip', '1.2.3.4')
+    expected_results = {
+        "ip": ['1.2.3.4']
+    }
+    assert_equal(rec_with_ioc_info['streamalert:ioc'], expected_results)
+
+    # rec has IOC info
+    rec_with_ioc_info = {
+        'key1': 'foo',
+        'key2': 'bar',
+        'streamalert:ioc': {
+            'ip': ['4.3.2.1']
+        }
+    }
+
+    base.insert_ioc_info(rec_with_ioc_info, 'ip', '1.2.3.4')
+    expected_results = {
+        "ip": ['4.3.2.1', '1.2.3.4']
+    }
+    assert_equal(rec_with_ioc_info['streamalert:ioc'], expected_results)

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -28,7 +28,9 @@ from nose.tools import (
 
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.parsers import get_parser
-from stream_alert.rule_processor.rules_engine import RuleAttributes, StreamRules, NORMALIZATION_KEY
+from stream_alert.rule_processor.rules_engine import RuleAttributes, StreamRules
+from stream_alert.shared import NORMALIZATION_KEY
+
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     get_mock_context,
     load_and_classify_payload,

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -28,7 +28,7 @@ from nose.tools import (
 
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.parsers import get_parser
-from stream_alert.rule_processor.rules_engine import RuleAttributes, StreamRules
+from stream_alert.rule_processor.rules_engine import RuleAttributes, StreamRules, NORMALIZATION_KEY
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     get_mock_context,
     load_and_classify_payload,
@@ -186,8 +186,8 @@ class TestStreamRules(object):
         # doing this because after kinesis_data is read in, types are casted per
         # the schema
         for alert in alerts:
-            if 'normalized_types' in alert['record'].keys():
-                alert['record'].remove('normalized_types')
+            if NORMALIZATION_KEY in alert['record'].keys():
+                alert['record'].remove(NORMALIZATION_KEY)
             assert_items_equal(alert['record'].keys(), kinesis_data.keys())
             assert_items_equal(alert['outputs'], rule_outputs_map[alert['rule_name']])
 
@@ -805,7 +805,7 @@ class TestStreamRules(object):
 
         assert_equal(len(alerts), 3)
         for alert in alerts:
-            has_key_normalized_types = 'normalized_types' in alert['record']
+            has_key_normalized_types = NORMALIZATION_KEY in alert['record']
             if alert.get('rule_name') == 'test_02_rule_without_datatypes':
                 assert_equal(has_key_normalized_types, False)
             else:


### PR DESCRIPTION
to: @jacknagz or @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small
resolves #413 

## Background
1. Data Normalization: For fields added to the parsed record during rule processing, such as `envelope_keys` and `normalized_types`, they should always be prefixed with `streamalert:` to avoid collision with valid data fields.  `normalized_types` does not follow this convention.

2. Threat Intel: Remove IOC info duplication. In some records, different keys may contain the same value. After the record being normalized, there may have duplicated IOC info inserted into the record. 
  * Example, a coming record 
```
{
  "local_ip": "1.2.3.4",
  "ipv4": "1.2.3.4"
}
```
  * Keys `local_ip` and `ipv4` will be normalized to [sourceAddress](https://github.com/airbnb/streamalert/blob/master/conf/types.json#L42-L44). Assume IP `1.2.3.4` is malicious, record will have duplicated IOC info after applying Threat Intel feature. 
```
  "local_ip": "1.2.3.4",
  "ipv4": "1.2.3.4",
  "streamalert:ioc": [
    {
      "type": "ip",
      "value": "1.2.3.4"
    },
   {
      "type": "ip",
      "value": "1.2.3.4"
    }
  ]
```
## Changes
1. Data Normalization: Prefix normalization key with `streamalert:`.
2. Threat Intel: Remove dumplicaiton IOC info by changing type of `streamalert:ioc` to a dictionary from list and add logic to check if the IOC value exists or not. 

## Testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (55/55) Successful Tests
StreamAlertCLI [INFO]: (90/90) Alert Tests Passed
StreamAlertCLI [INFO]: Completed

./tests/scripts/unit_tests.sh
Ran 392 tests in 5.502s
OK
```
