### PR TITLE
Rebuild Athena Partitions

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1038,7 +1038,7 @@
       "@timestamp": "string",
       "@version": "string",
       "current_user": "string",
-      "elapsed": "float",
+      "elapsed": "string",
       "half_day": "string",
       "host": "string",
       "logsource": "string",

--- a/manage.py
+++ b/manage.py
@@ -1259,11 +1259,15 @@ Examples:
 
     athena_parser.add_argument(
         'subcommand',
-        choices=['init', 'enable', 'create-db', 'create-table'],
+        choices=['init',
+                 'enable',
+                 'create-db',
+                 'create-table',
+                 'drop-all-tables',
+                 'rebuild-partitions'],
         help=ARGPARSE_SUPPRESS
     )
 
-    # TODO(jacknagz): Create a second choice for data tables, and accept a log name argument.
     athena_parser.add_argument(
         '--type',
         choices=['alerts', 'data'],

--- a/stream_alert/athena_partition_refresh/helpers.py
+++ b/stream_alert/athena_partition_refresh/helpers.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import re
+
+PARTITION_PARTS = re.compile(r'dt=(?P<year>\d{4})\-'
+                             r'(?P<month>\d{2})\-'
+                             r'(?P<day>\d{2})\-'
+                             r'(?P<hour>\d{2})')
+
+
+def unique_values_from_query(query_result):
+    """Simplify Athena query results into a set of values.
+
+    Useful for listing tables, partitions, databases, enable_metrics
+
+    Args:
+        query_result (dict): The result of run_athena_query
+
+    Returns:
+        set: Unique values from the query result"""
+    return {
+        res
+        for row in query_result['ResultSet']['Rows'] for result in row['Data']
+        for res in result.values()
+    }
+
+
+def partition_statement(partitions, bucket, table_name):
+    """Generate ALTER TABLE commands from existing partitions.
+
+    Args:
+        partitions (set): The unique set of partitions gathered from Athena
+        bucket (str): The bucket name
+        table_name (str): Theh name of the Athena table
+
+    Returns:
+        str: The ALTER TABLE statement to add the new partitions
+    """
+    statement = 'ALTER TABLE {} ADD '.format(table_name)
+
+    for partition in sorted(partitions):
+        parts = PARTITION_PARTS.match(partition)
+        if not parts:
+            continue
+
+        statement += ('PARTITION ({partition}) '
+                      'LOCATION \'s3://{bucket}/{table_name}/{year}/{month}/{day}/{hour}\' '.format(
+                          # The passed in partition is just dt=YYYY-MM-DD-HH, but we need to
+                          # quote the value of the partition when re-creating.
+                          partition='dt = \'{}-{}-{}-{}\''.format(
+                              parts.group('year'),
+                              parts.group('month'),
+                              parts.group('day'),
+                              parts.group('hour')),
+                          bucket=bucket,
+                          table_name=table_name,
+                          year=parts.group('year'),
+                          month=parts.group('month'),
+                          day=parts.group('day'),
+                          hour=parts.group('hour')))
+
+    return statement

--- a/stream_alert/athena_partition_refresh/helpers.py
+++ b/stream_alert/athena_partition_refresh/helpers.py
@@ -44,7 +44,7 @@ def partition_statement(partitions, bucket, table_name):
     Args:
         partitions (set): The unique set of partitions gathered from Athena
         bucket (str): The bucket name
-        table_name (str): Theh name of the Athena table
+        table_name (str): The name of the Athena table
 
     Returns:
         str: The ALTER TABLE statement to add the new partitions

--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -60,6 +60,8 @@ def rebuild_partitions(athena_client, options, config):
 
     Args:
         athena_client (boto3.client): Instantiated CLI AthenaClient
+        options (namedtuple): The parsed args passed from the CLI
+        config (CLIConfig): Loaded StreamAlert CLI
     """
     if not options.table_name:
         LOGGER_CLI.error('Missing command line argument --table_name')
@@ -185,6 +187,7 @@ def create_table(athena_client, options, config):
     Args:
         athena_client (boto3.client): Instantiated CLI AthenaClient
         options (namedtuple): The parsed args passed from the CLI
+        config (CLIConfig): Loaded StreamAlert CLI
     """
     if not options.bucket:
         LOGGER_CLI.error('Missing command line argument --bucket')

--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -1,0 +1,312 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from stream_alert.athena_partition_refresh.main import StreamAlertAthenaClient
+from stream_alert.athena_partition_refresh import helpers as athena_helpers
+from stream_alert.rule_processor.handler import StreamAlert
+from stream_alert_cli.logger import LOGGER_CLI
+from stream_alert_cli.helpers import continue_prompt
+from stream_alert_cli.terraform import _common as terraform_cli_helpers
+
+# How to map log schema types to athena/hive schema types
+SCHEMA_TYPE_MAPPING = {
+    'string': 'string',
+    'integer': 'bigint',
+    'boolean': 'boolean',
+    'float': 'decimal',
+    dict: 'map<string, string>',
+    list: 'array<string>'
+}
+
+
+def create_database(athena_client):
+    """Create the 'streamalert' Athena database
+
+    Args:
+        athena_client (boto3.client): Instantiated CLI AthenaClient
+    """
+    if athena_client.check_database_exists():
+        LOGGER_CLI.info('The \'streamalert\' database already exists, nothing to do')
+        return
+
+    create_db_success, create_db_result = athena_client.run_athena_query(
+        query='CREATE DATABASE streamalert')
+
+    if create_db_success and create_db_result['ResultSet'].get('Rows'):
+        LOGGER_CLI.info('streamalert database successfully created!')
+        LOGGER_CLI.info('results: %s', create_db_result['ResultSet']['Rows'])
+
+
+def rebuild_partitions(athena_client, options, config):
+    """Rebuild an Athena table's partitions
+
+    Steps:
+      - Get the list of current partitions
+      - Destroy existing table
+      - Re-create tables
+      - Re-create partitions
+
+    Args:
+        athena_client (boto3.client): Instantiated CLI AthenaClient
+    """
+    if not options.table_name:
+        LOGGER_CLI.error('Missing command line argument --table_name')
+        return
+
+    if not options.bucket:
+        LOGGER_CLI.error('Missing command line argument --bucket')
+        return
+
+    if options.type == 'data':
+        # Get the current set of partitions
+        partition_success, partitions = athena_client.run_athena_query(
+            query='SHOW PARTITIONS {}'.format(options.table_name), database='streamalert')
+        if not partition_success:
+            LOGGER_CLI.error('An error occured when loading partitions for %s', options.table_name)
+            return
+
+        unique_partitions = athena_helpers.unique_values_from_query(partitions)
+
+        # Drop the table
+        LOGGER_CLI.info('Dropping table %s', options.table_name)
+        drop_success, _ = athena_client.run_athena_query(
+            query='DROP TABLE {}'.format(options.table_name), database='streamalert')
+        if not drop_success:
+            LOGGER_CLI.error('An error occured when dropping the %s table', options.table_name)
+            return
+
+        LOGGER_CLI.info('Dropped table %s', options.table_name)
+
+        new_partitions_statement = athena_helpers.partition_statement(
+            unique_partitions, options.bucket, options.table_name)
+
+        # Re-create the table with previous partitions
+        options.refresh_type = 'add_hive_partition'
+        create_table(athena_client, options, config)
+
+        LOGGER_CLI.info('Creating %d new partitions for %s',
+                        len(unique_partitions), options.table_name)
+        new_part_success, _ = athena_client.run_athena_query(
+            query=new_partitions_statement, database='streamalert')
+        if not new_part_success:
+            LOGGER_CLI.error('Error re-creating new partitions for %s', options.table_name)
+            return
+
+        LOGGER_CLI.info('Successfully rebuilt partitions for %s', options.table_name)
+
+    else:
+        LOGGER_CLI.info('Refreshing alerts tables unsupported')
+
+
+def drop_all_tables(athena_client):
+    """Drop all 'streamalert' Athena tables
+
+    Used when cleaning up an existing deployment
+
+    Args:
+        athena_client (boto3.client): Instantiated CLI AthenaClient
+    """
+    if not continue_prompt(message='Are you sure you want to drop all Athena tables?'):
+        return
+
+    success, all_tables = athena_client.run_athena_query(
+        query='SHOW TABLES', database='streamalert')
+    if not success:
+        LOGGER_CLI.error('There was an issue getting all tables')
+        return
+
+    unique_tables = athena_helpers.unique_values_from_query(all_tables)
+
+    for table in unique_tables:
+        success, all_tables = athena_client.run_command(
+            query='DROP TABLE {}'.format(table), database='streamalert')
+        if not success:
+            LOGGER_CLI.error('Unable to drop the %s table', table)
+        else:
+            LOGGER_CLI.info('Dropped %s', table)
+
+
+def _add_to_athena_schema(log_schema, athena_schema, root_key=''):
+    """Add sanitized schemas to the Athena table schema
+
+    Args:
+        log_schema (dict): The related StreamAlert log schema
+        athena_schema (dict): The Athena table schema to add to
+        root_key (str): The hierarchy where the schema should be added
+    """
+    # Setup the root_key dict
+    if root_key and not athena_schema.get(root_key):
+        athena_schema[root_key] = {}
+
+    for key_name, key_type in log_schema.iteritems():
+        # When using special characters in the beginning or end
+        # of a column name, they have to be wrapped in backticks
+        key_name = '`{}`'.format(key_name)
+
+        special_key = None
+        # Transform the {} or [] into hashable types
+        if key_type == {}:
+            special_key = dict
+        elif key_type == []:
+            special_key = list
+        # Cast nested dict as a string for now
+        # TODO(jacknagz): support recursive schemas
+        elif isinstance(key_type, dict):
+            special_key = 'string'
+
+        # Account for envelope keys
+        if root_key:
+            if special_key is not None:
+                athena_schema[root_key][key_name] = SCHEMA_TYPE_MAPPING[special_key]
+            else:
+                athena_schema[root_key][key_name] = SCHEMA_TYPE_MAPPING[key_type]
+        else:
+            if special_key is not None:
+                athena_schema[key_name] = SCHEMA_TYPE_MAPPING[special_key]
+            else:
+                athena_schema[key_name] = SCHEMA_TYPE_MAPPING[key_type]
+
+
+def create_table(athena_client, options, config):
+    """Create a 'streamalert' Athena table
+
+    Args:
+        athena_client (boto3.client): Instantiated CLI AthenaClient
+        options (namedtuple): The parsed args passed from the CLI
+    """
+    if not options.bucket:
+        LOGGER_CLI.error('Missing command line argument --bucket')
+        return
+
+    if not options.refresh_type:
+        LOGGER_CLI.error('Missing command line argument --refresh_type')
+        return
+
+    if options.type == 'data':
+        if not options.table_name:
+            LOGGER_CLI.error('Missing command line argument --table_name')
+            return
+
+        if options.table_name not in terraform_cli_helpers.enabled_firehose_logs(config):
+            LOGGER_CLI.error('Table name %s missing from configuration or '
+                             'is not enabled.', options.table_name)
+            return
+
+        if athena_client.check_table_exists(options.table_name):
+            LOGGER_CLI.info('The \'%s\' table already exists.', options.table_name)
+            return
+
+        log_info = config['logs'][options.table_name.replace('_', ':', 1)]
+        schema = dict(log_info['schema'])
+        schema_statement = ''
+
+        sanitized_schema = StreamAlert.sanitize_keys(schema)
+        athena_schema = {}
+
+        _add_to_athena_schema(sanitized_schema, athena_schema)
+
+        # Support envelope keys
+        configuration_options = log_info.get('configuration')
+        if configuration_options:
+            envelope_keys = configuration_options.get('envelope_keys')
+            if envelope_keys:
+                sanitized_envelope_key_schema = StreamAlert.sanitize_keys(envelope_keys)
+                # Note: this key is wrapped in backticks to be Hive compliant
+                _add_to_athena_schema(sanitized_envelope_key_schema, athena_schema,
+                                      '`streamalert:envelope_keys`')
+
+        for key_name, key_type in athena_schema.iteritems():
+            # Account for nested structs
+            if isinstance(key_type, dict):
+                struct_schema = ''.join([
+                    '{0}:{1},'.format(sub_key, sub_type)
+                    for sub_key, sub_type in key_type.iteritems()
+                ])
+                nested_schema_statement = '{0} struct<{1}>, '.format(
+                    key_name,
+                    # Use the minus index to remove the last comma
+                    struct_schema[:-1])
+                schema_statement += nested_schema_statement
+            else:
+                schema_statement += '{0} {1},'.format(key_name, key_type)
+
+        query = (
+            'CREATE EXTERNAL TABLE {table_name} ({schema}) '
+            'PARTITIONED BY (dt string) '
+            'ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\' '
+            'LOCATION \'s3://{bucket}/{table_name}/\''.format(
+                table_name=options.table_name,
+                # Use the minus index to remove the last comma
+                schema=schema_statement[:-1],
+                bucket=options.bucket))
+
+    elif options.type == 'alerts':
+        if athena_client.check_table_exists(options.type):
+            LOGGER_CLI.info('The \'alerts\' table already exists.')
+            return
+
+        query = ('CREATE EXTERNAL TABLE alerts ('
+                 'log_source string,'
+                 'log_type string,'
+                 'outputs array<string>,'
+                 'record string,'
+                 'rule_description string,'
+                 'rule_name string,'
+                 'source_entity string,'
+                 'source_service string)'
+                 'PARTITIONED BY (dt string)'
+                 'ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\''
+                 'LOCATION \'s3://{bucket}/alerts/\''.format(bucket=options.bucket))
+
+    if query:
+        create_table_success, _ = athena_client.run_athena_query(
+            query=query, database='streamalert')
+
+        if create_table_success:
+            # Update the CLI config
+            config['lambda']['athena_partition_refresh_config'] \
+                  ['refresh_type'][options.refresh_type][options.bucket] = options.type
+            config.write()
+
+            table_name = options.type if options.type == 'alerts' else options.table_name
+            LOGGER_CLI.info('The %s table was successfully created!', table_name)
+
+
+def athena_handler(options, config):
+    """Main Athena handler
+
+    Args:
+        options (namedtuple): The parsed args passed from the CLI
+        config (CLIConfig): Loaded StreamAlert CLI
+    """
+    athena_client = StreamAlertAthenaClient(config, results_key_prefix='stream_alert_cli')
+
+    if options.subcommand == 'init':
+        config.generate_athena()
+
+    elif options.subcommand == 'enable':
+        config.set_athena_lambda_enable()
+
+    elif options.subcommand == 'create-db':
+        create_database(athena_client)
+
+    elif options.subcommand == 'rebuild-partitions':
+        rebuild_partitions(athena_client, options, config)
+
+    elif options.subcommand == 'drop-all-tables':
+        drop_all_tables(athena_client)
+
+    elif options.subcommand == 'create-table':
+        create_table(athena_client, options, config)

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -113,6 +113,10 @@ class CLIConfig(object):
             LOGGER_CLI.error('Invalid prefix type, must be string')
             return
 
+        if '_' in prefix:
+            LOGGER_CLI.error('Prefix cannot start with underscore')
+            return
+
         self.config['global']['account']['prefix'] = prefix
         self.config['global']['terraform']['tfstate_bucket'] = self.config['global']['terraform'][
             'tfstate_bucket'].replace('PREFIX_GOES_HERE', prefix)

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -114,7 +114,7 @@ class CLIConfig(object):
             return
 
         if '_' in prefix:
-            LOGGER_CLI.error('Prefix cannot start with underscore')
+            LOGGER_CLI.error('Prefix cannot contain underscores')
             return
 
         self.config['global']['account']['prefix'] = prefix

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -18,12 +18,8 @@ import sys
 from app_integrations import __version__ as apps_version
 from stream_alert import __version__ as current_version
 from stream_alert_cli import helpers
-from stream_alert_cli.package import (
-    AlertProcessorPackage,
-    AthenaPackage,
-    AppIntegrationPackage,
-    RuleProcessorPackage
-)
+from stream_alert_cli.manage_lambda.package import (AlertProcessorPackage, AthenaPackage,
+                                                    AppIntegrationPackage, RuleProcessorPackage)
 from stream_alert_cli.terraform.generate import terraform_generate
 from stream_alert_cli.version import LambdaVersion
 
@@ -59,47 +55,36 @@ def deploy(options, config):
 
     def _deploy_rule_processor():
         """Create Rule Processor package and publish versions"""
-        rule_package = RuleProcessorPackage(
-            config=config,
-            version=current_version
-        )
+        rule_package = RuleProcessorPackage(config=config, version=current_version)
         rule_package.create_and_upload()
         return rule_package
 
     def _deploy_alert_processor():
         """Create Alert Processor package and publish versions"""
-        alert_package = AlertProcessorPackage(
-            config=config,
-            version=current_version
-        )
+        alert_package = AlertProcessorPackage(config=config, version=current_version)
         alert_package.create_and_upload()
         return alert_package
 
     def _deploy_athena_partition_refresh():
         """Create Athena Partition Refresh package and publish"""
-        athena_package = AthenaPackage(
-            config=config,
-            version=current_version
-        )
+        athena_package = AthenaPackage(config=config, version=current_version)
         athena_package.create_and_upload()
         return athena_package
 
     def _deploy_apps_function():
         """Create app integration package and publish versions"""
-        app_integration_package = AppIntegrationPackage(
-            config=config,
-            version=apps_version
-        )
+        app_integration_package = AppIntegrationPackage(config=config, version=apps_version)
         app_integration_package.create_and_upload()
         return app_integration_package
 
     if 'all' in processor:
-        targets.update({'module.stream_alert_{}'.format(x)
-                        for x in config.clusters()})
+        targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
 
-        targets.update({'module.app_{}_{}'.format(app_name, cluster)
-                        for cluster, info in config['clusters'].iteritems()
-                        for app_name in info['modules'].get('stream_alert_apps', {})})
+        targets.update({
+            'module.app_{}_{}'.format(app_name, cluster)
+            for cluster, info in config['clusters'].iteritems()
+            for app_name in info['modules'].get('stream_alert_apps', {})
+        })
 
         packages.append(_deploy_rule_processor())
         packages.append(_deploy_alert_processor())
@@ -114,22 +99,22 @@ def deploy(options, config):
     else:
 
         if 'rule' in processor:
-            targets.update({'module.stream_alert_{}'.format(x)
-                            for x in config.clusters()})
+            targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
 
             packages.append(_deploy_rule_processor())
 
         if 'alert' in processor:
-            targets.update({'module.stream_alert_{}'.format(x)
-                            for x in config.clusters()})
+            targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
 
             packages.append(_deploy_alert_processor())
 
         if 'apps' in processor:
 
-            targets.update({'module.app_{}_{}'.format(app_name, cluster)
-                            for cluster, info in config['clusters'].iteritems()
-                            for app_name in info['modules'].get('stream_alert_apps', {})})
+            targets.update({
+                'module.app_{}_{}'.format(app_name, cluster)
+                for cluster, info in config['clusters'].iteritems()
+                for app_name in info['modules'].get('stream_alert_apps', {})
+            })
 
             packages.append(_deploy_apps_function())
 

--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -107,12 +107,14 @@ class LambdaPackage(object):
     def _copy_files(self, temp_package_path):
         """Copy all files and folders into temporary package path."""
         for package_folder in self.package_folders:
-            shutil.copytree(os.path.join(self.package_root_dir, package_folder),
-                            os.path.join(temp_package_path, package_folder))
+            shutil.copytree(
+                os.path.join(self.package_root_dir, package_folder),
+                os.path.join(temp_package_path, package_folder))
 
         for package_file in self.package_files:
-            shutil.copy(os.path.join(self.package_root_dir, package_file),
-                        os.path.join(temp_package_path, package_file))
+            shutil.copy(
+                os.path.join(self.package_root_dir, package_file),
+                os.path.join(temp_package_path, package_file))
 
     @staticmethod
     def zip(temp_package_path):
@@ -181,9 +183,7 @@ class LambdaPackage(object):
             LOGGER_CLI.info('No third-party libraries to install.')
             return True
 
-        LOGGER_CLI.info(
-            'Installing third-party libraries: %s',
-            ', '.join(third_party_libs))
+        LOGGER_CLI.info('Installing third-party libraries: %s', ', '.join(third_party_libs))
         pip_command = ['pip', 'install']
         pip_command.extend(third_party_libs)
         pip_command.extend(['--upgrade', '--target', temp_package_path])
@@ -201,8 +201,7 @@ class LambdaPackage(object):
             bool: Indicating a successful S3 upload
         """
         LOGGER_CLI.info('Uploading StreamAlert package to S3')
-        client = boto3.client(
-            's3', region_name=self.config['global']['account']['region'])
+        client = boto3.client('s3', region_name=self.config['global']['account']['region'])
 
         for package_file in (package_path, '{}.sha256'.format(package_path)):
             package_name = package_file.split('/')[-1]
@@ -213,8 +212,7 @@ class LambdaPackage(object):
                     Bucket=self.config['lambda'][self.config_key]['source_bucket'],
                     Key=os.path.join(self.package_name, package_name),
                     Body=package_fh,
-                    ServerSideEncryption='AES256'
-                )
+                    ServerSideEncryption='AES256')
             except ClientError:
                 LOGGER_CLI.exception('An error occurred while uploading %s', package_name)
                 return False
@@ -228,12 +226,8 @@ class LambdaPackage(object):
 class RuleProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Rule Processor function"""
     package_folders = {
-        'stream_alert/rule_processor',
-        'stream_alert/shared',
-        'rules',
-        'matchers',
-        'helpers',
-        'conf'}
+        'stream_alert/rule_processor', 'stream_alert/shared', 'rules', 'matchers', 'helpers', 'conf'
+    }
     if os.path.exists('threat_intel'):
         package_folders.add('threat_intel')
     package_files = {'stream_alert/__init__.py'}
@@ -244,10 +238,7 @@ class RuleProcessorPackage(LambdaPackage):
 
 class AlertProcessorPackage(LambdaPackage):
     """Deployment package class for the StreamAlert Alert Processor function"""
-    package_folders = {
-        'stream_alert/alert_processor',
-        'stream_alert/shared',
-        'conf'}
+    package_folders = {'stream_alert/alert_processor', 'stream_alert/shared', 'conf'}
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'alert_processor'
@@ -265,10 +256,7 @@ class AppIntegrationPackage(LambdaPackage):
 
 class AthenaPackage(LambdaPackage):
     """Create the Athena Partition Refresh Lambda function package"""
-    package_folders = {
-        'stream_alert/athena_partition_refresh',
-        'stream_alert/shared',
-        'conf'}
+    package_folders = {'stream_alert/athena_partition_refresh', 'stream_alert/shared', 'conf'}
     package_files = {'stream_alert/__init__.py'}
     package_root_dir = '.'
     package_name = 'athena_partition_refresh'

--- a/stream_alert_cli/manage_lambda/rollback.py
+++ b/stream_alert_cli/manage_lambda/rollback.py
@@ -29,8 +29,10 @@ def rollback(options, config):
     if 'all' in options.processor:
         lambda_functions = {'rule_processor', 'alert_processor', 'athena_partition_refresh'}
     else:
-        lambda_functions = {'{}_processor'.format(proc) for proc in options.processor
-                            if proc != 'athena'}
+        lambda_functions = {
+            '{}_processor'.format(proc)
+            for proc in options.processor if proc != 'athena'
+        }
         if 'athena' in options.processor:
             lambda_functions.add('athena_partition_refresh')
 
@@ -46,8 +48,7 @@ def rollback(options, config):
                         'current_version'] = new_vers
                     config.write()
 
-    targets = ['module.stream_alert_{}'.format(x)
-               for x in config.clusters()]
+    targets = ['module.stream_alert_{}'.format(x) for x in config.clusters()]
 
     if not terraform_generate(config=config):
         return

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -136,7 +136,7 @@ def athena_handler(options):
             athena_schema = {}
             schema_type_mapping = {
                 'string': 'string',
-                'integer': 'int',
+                'integer': 'bigint',
                 'boolean': 'boolean',
                 'float': 'decimal',
                 dict: 'map<string, string>',

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -14,19 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from app_integrations.apps.app_base import get_app
-from stream_alert.rule_processor.handler import StreamAlert
 from stream_alert.alert_processor.outputs import get_output_dispatcher
-from stream_alert.athena_partition_refresh.main import StreamAlertAthenaClient
 from stream_alert_cli.apps import save_app_auth_info
+from stream_alert_cli.athena.handler import athena_handler
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.helpers import user_input
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.manage_lambda.handler import lambda_handler
-import stream_alert_cli.outputs as config_outputs
-from stream_alert_cli.terraform._common import enabled_firehose_logs
 from stream_alert_cli.terraform.handler import terraform_handler
 from stream_alert_cli.test import stream_alert_test
-
+import stream_alert_cli.outputs as config_outputs
 
 CONFIG = CLIConfig()
 
@@ -41,8 +38,7 @@ def cli_runner(options):
             Contains the following keys for lambda commands:
                 (command, subcommand, env, func, source)
     """
-    cli_load_message = ('Issues? Report here: '
-                        'https://github.com/airbnb/streamalert/issues')
+    cli_load_message = ('Issues? Report here: https://github.com/airbnb/streamalert/issues')
     LOGGER_CLI.info(cli_load_message)
 
     if options.debug:
@@ -67,7 +63,7 @@ def cli_runner(options):
         configure_handler(options)
 
     elif options.command == 'athena':
-        athena_handler(options)
+        athena_handler(options, CONFIG)
 
     elif options.command == 'metrics':
         _toggle_metrics(options)
@@ -77,169 +73,6 @@ def cli_runner(options):
 
     elif options.command == 'app':
         _app_integration_handler(options)
-
-
-def athena_handler(options):
-    """Handle Athena operations"""
-    athena_client = StreamAlertAthenaClient(CONFIG,
-                                            results_key_prefix='stream_alert_cli')
-
-    if options.subcommand == 'init':
-        CONFIG.generate_athena()
-
-    elif options.subcommand == 'enable':
-        CONFIG.set_athena_lambda_enable()
-
-    elif options.subcommand == 'create-db':
-        if athena_client.check_database_exists():
-            LOGGER_CLI.info('The \'streamalert\' database already exists, nothing to do')
-            return
-
-        create_db_success, create_db_result = athena_client.run_athena_query(
-            query='CREATE DATABASE streamalert')
-
-        if create_db_success and create_db_result['ResultSet'].get('Rows'):
-            LOGGER_CLI.info('streamalert database successfully created!')
-            LOGGER_CLI.info('results: %s', create_db_result['ResultSet']['Rows'])
-
-    elif options.subcommand == 'create-table':
-        if not options.bucket:
-            LOGGER_CLI.error('Missing command line argument --bucket')
-            return
-
-        if not options.refresh_type:
-            LOGGER_CLI.error('Missing command line argument --refresh_type')
-            return
-
-        if options.type == 'data':
-            if not options.table_name:
-                LOGGER_CLI.error('Missing command line argument --table_name')
-                return
-
-            if options.table_name not in enabled_firehose_logs(CONFIG):
-                LOGGER_CLI.error('Table name %s missing from configuration or '
-                                 'is not enabled.',
-                                 options.table_name)
-                return
-
-            if athena_client.check_table_exists(options.table_name):
-                LOGGER_CLI.info('The \'%s\' table already exists.',
-                                options.table_name)
-                return
-
-            log_info = CONFIG['logs'][options.table_name.replace('_', ':', 1)]
-            schema = dict(log_info['schema'])
-            schema_statement = ''
-
-            sanitized_schema = StreamAlert.sanitize_keys(schema)
-
-            athena_schema = {}
-            schema_type_mapping = {
-                'string': 'string',
-                'integer': 'bigint',
-                'boolean': 'boolean',
-                'float': 'decimal',
-                dict: 'map<string, string>',
-                list: 'array<string>'
-            }
-
-            def add_to_athena_schema(schema, root_key=''):
-                """Helper function to add sanitized schemas to the Athena table schema"""
-                # Setup the root_key dict
-                if root_key and not athena_schema.get(root_key):
-                    athena_schema[root_key] = {}
-
-                for key_name, key_type in schema.iteritems():
-                    # When using special characters in the beginning or end
-                    # of a column name, they have to be wrapped in backticks
-                    key_name = '`{}`'.format(key_name)
-
-                    special_key = None
-                    # Transform the {} or [] into hashable types
-                    if key_type == {}:
-                        special_key = dict
-                    elif key_type == []:
-                        special_key = list
-                    # Cast nested dict as a string for now
-                    # TODO(jacknagz): support recursive schemas
-                    elif isinstance(key_type, dict):
-                        special_key = 'string'
-
-                    # Account for envelope keys
-                    if root_key:
-                        if special_key is not None:
-                            athena_schema[root_key][key_name] = schema_type_mapping[special_key]
-                        else:
-                            athena_schema[root_key][key_name] = schema_type_mapping[key_type]
-                    else:
-                        if special_key is not None:
-                            athena_schema[key_name] = schema_type_mapping[special_key]
-                        else:
-                            athena_schema[key_name] = schema_type_mapping[key_type]
-
-            add_to_athena_schema(sanitized_schema)
-
-            # Support envelope keys
-            configuration_options = log_info.get('configuration')
-            if configuration_options:
-                envelope_keys = configuration_options.get('envelope_keys')
-                if envelope_keys:
-                    sanitized_envelope_keys = StreamAlert.sanitize_keys(envelope_keys)
-                    # Note: this key is wrapped in backticks to be Hive compliant
-                    add_to_athena_schema(sanitized_envelope_keys, '`streamalert:envelope_keys`')
-
-            for key_name, key_type in athena_schema.iteritems():
-                # Account for nested structs
-                if isinstance(key_type, dict):
-                    struct_schema = ''.join(['{0}:{1},'.format(sub_key, sub_type)
-                                             for sub_key, sub_type
-                                             in key_type.iteritems()])
-                    nested_schema_statement = '{0} struct<{1}>, '.format(
-                        key_name,
-                        # Use the minus index to remove the last comma
-                        struct_schema[:-1])
-                    schema_statement += nested_schema_statement
-                else:
-                    schema_statement += '{0} {1},'.format(key_name, key_type)
-
-            query = ('CREATE EXTERNAL TABLE {table_name} ({schema}) '
-                     'PARTITIONED BY (dt string) '
-                     'ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\' '
-                     'LOCATION \'s3://{bucket}/{table_name}/\''.format(
-                         table_name=options.table_name,
-                         # Use the minus index to remove the last comma
-                         schema=schema_statement[:-1],
-                         bucket=options.bucket))
-
-        elif options.type == 'alerts':
-            if athena_client.check_table_exists(options.type):
-                LOGGER_CLI.info('The \'alerts\' table already exists.')
-                return
-
-            query = ('CREATE EXTERNAL TABLE alerts ('
-                     'log_source string,'
-                     'log_type string,'
-                     'outputs array<string>,'
-                     'record string,'
-                     'rule_description string,'
-                     'rule_name string,'
-                     'source_entity string,'
-                     'source_service string)'
-                     'PARTITIONED BY (dt string)'
-                     'ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\''
-                     'LOCATION \'s3://{bucket}/alerts/\''.format(bucket=options.bucket))
-
-        if query:
-            create_table_success, _ = athena_client.run_athena_query(
-                query=query,
-                database='streamalert')
-
-            if create_table_success:
-                CONFIG['lambda']['athena_partition_refresh_config'] \
-                      ['refresh_type'][options.refresh_type][options.bucket] = options.type
-                CONFIG.write()
-                table_name = options.type if options.type == 'alerts' else options.table_name
-                LOGGER_CLI.info('The %s table was successfully created!', table_name)
 
 
 def configure_handler(options):
@@ -271,9 +104,7 @@ def configure_output(options):
         kms_key_alias = kms_key_alias.split('/')[1]
 
     # Retrieve the proper service class to handle dispatching the alerts of this services
-    output = get_output_dispatcher(options.service,
-                                   region,
-                                   prefix,
+    output = get_output_dispatcher(options.service, region, prefix,
                                    config_outputs.load_outputs_config())
 
     # If an output for this service has not been defined, the error is logged
@@ -286,9 +117,8 @@ def configure_output(options):
 
     for name, prop in props.iteritems():
         # pylint: disable=protected-access
-        props[name] = prop._replace(value=user_input(prop.description,
-                                                     prop.mask_input,
-                                                     prop.input_restrictions))
+        props[name] = prop._replace(
+            value=user_input(prop.description, prop.mask_input, prop.input_restrictions))
 
     service = output.__service__
     config = config_outputs.load_config(props, service)
@@ -302,22 +132,16 @@ def configure_output(options):
 
     # Encrypt the creds and push them to S3
     # then update the local output configuration with properties
-    if config_outputs.encrypt_and_push_creds_to_s3(region,
-                                                   secrets_bucket,
-                                                   secrets_key,
-                                                   props,
+    if config_outputs.encrypt_and_push_creds_to_s3(region, secrets_bucket, secrets_key, props,
                                                    kms_key_alias):
         updated_config = output.format_output_config(config, props)
         config_outputs.update_outputs_config(config, updated_config, service)
 
-        LOGGER_CLI.info(
-            'Successfully saved \'%s\' output configuration for service \'%s\'',
-            props['descriptor'].value,
-            options.service)
+        LOGGER_CLI.info('Successfully saved \'%s\' output configuration for service \'%s\'',
+                        props['descriptor'].value, options.service)
     else:
         LOGGER_CLI.error('An error occurred while saving \'%s\' '
-                         'output configuration for service \'%s\'',
-                         props['descriptor'].value,
+                         'output configuration for service \'%s\'', props['descriptor'].value,
                          options.service)
 
 
@@ -411,8 +235,10 @@ def _app_integration_handler(options):
 
     # List all of the available app integrations, broken down by cluster
     if options.subcommand == 'list':
-        all_info = {cluster: cluster_config['modules'].get('stream_alert_apps')
-                    for cluster, cluster_config in CONFIG['clusters'].iteritems()}
+        all_info = {
+            cluster: cluster_config['modules'].get('stream_alert_apps')
+            for cluster, cluster_config in CONFIG['clusters'].iteritems()
+        }
 
         for cluster, info in all_info.iteritems():
             print '\nCluster: {}\n'.format(cluster)
@@ -422,9 +248,10 @@ def _app_integration_handler(options):
 
             for name, details in info.iteritems():
                 print '\tName: {}'.format(name)
-                print '\n'.join(['\t\t{key}:{padding_char:<{padding_count}}{value}'.format(
-                    key=key_name,
-                    padding_char=' ',
-                    padding_count=30 - (len(key_name)),
-                    value=value
-                ) for key_name, value in details.iteritems()] + ['\n'])
+                print '\n'.join([
+                    '\t\t{key}:{padding_char:<{padding_count}}{value}'.format(
+                        key=key_name,
+                        padding_char=' ',
+                        padding_count=30 - (len(key_name)),
+                        value=value) for key_name, value in details.iteritems()
+                ] + ['\n'])

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -38,7 +38,7 @@ def cli_runner(options):
             Contains the following keys for lambda commands:
                 (command, subcommand, env, func, source)
     """
-    cli_load_message = ('Issues? Report here: https://github.com/airbnb/streamalert/issues')
+    cli_load_message = 'Issues? Report here: https://github.com/airbnb/streamalert/issues'
     LOGGER_CLI.info(cli_load_message)
 
     if options.debug:

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -110,6 +110,9 @@ def terraform_handler(options, config):
         terraform_clean(config)
 
     elif options.subcommand == 'destroy':
+        if not continue_prompt(message='Are you sure you want to destroy?'):
+            sys.exit(1)
+
         if options.target:
             targets = []
             # Iterate over any targets to destroy. Global modules, like athena

--- a/tests/unit/stream_alert_cli/test_version.py
+++ b/tests/unit/stream_alert_cli/test_version.py
@@ -17,7 +17,7 @@ limitations under the License.
 from mock import patch
 from nose.tools import assert_equal, assert_true, assert_false, nottest
 
-from stream_alert_cli.package import AthenaPackage, RuleProcessorPackage
+from stream_alert_cli.manage_lambda.package import AthenaPackage, RuleProcessorPackage
 from stream_alert_cli.version import LambdaVersion
 from tests.unit.helpers.aws_mocks import MockLambdaClient
 from tests.unit.helpers.base import basic_streamalert_config, MockCLIConfig


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers @securityclippy 
size: medium
resolves #424

## Background

There are a lot of disparate changes in this PR related to the CLI.  But it mainly is for adding capabilities for Athena to drop all tables (when destroying clusters), and rebuilding table partitions (when a schema is updated).

## Changes

* Int => BigInt for Hive column defaults
* Modify the GHE schema for elapsed to be a string, there were parsing issues with Athena
* Add a continue prompt when destroying, this does some damage if you accidentally type this command
* Write helper functions for Athena when interacting with output and rebuilding partitions
* Add support for rebuilding partitions
* Add support for dropping all tables
* Other small cleanup

## Testing

All tested in a side AWS account
