### PR TITLE
[output] Adding support for PagerDuty Events API v2

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -46,11 +46,86 @@ def get_output_dispatcher(service, region, function_name, config):
     except KeyError:
         LOGGER.error('designated output service [%s] does not exist', service)
 
-
 @output
 class PagerDutyOutput(StreamOutputBase):
-    """PagerDutyOutput handles all alert dispatching for PagerDuty Events API v2"""
+    """PagerDutyOutput handles all alert dispatching for PagerDuty Events API v1"""
     __service__ = 'pagerduty'
+
+    @classmethod
+    def _get_default_properties(cls):
+        """Get the standard url used for PagerDuty. This value the same for everyone, so
+        is hard-coded here and does not need to be configured by the user
+        Returns:
+            dict: Contains various default items for this output (ie: url)
+        """
+        return {
+            'url': 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+        }
+
+    def get_user_defined_properties(self):
+        """Get properties that must be asssigned by the user when configuring a new PagerDuty
+        output.  This should be sensitive or unique information for this use-case that needs
+        to come from the user.
+        Every output should return a dict that contains a 'descriptor' with a description of the
+        integration being configured.
+        PagerDuty also requires a service_key that represnts this integration. This
+        value should be masked during input and is a credential requirement.
+        Returns:
+            OrderedDict: Contains various OutputProperty items
+        """
+        return OrderedDict([
+            ('descriptor',
+             OutputProperty(description='a short and unique descriptor for this '
+                                        'PagerDuty integration')),
+            ('service_key',
+             OutputProperty(description='the service key for this PagerDuty integration',
+                            mask_input=True,
+                            cred_requirement=True))
+        ])
+
+    def dispatch(self, **kwargs):
+        """Send alert to Pagerduty
+        Args:
+            **kwargs: consists of any combination of the following items:
+                descriptor (str): Service descriptor (ie: slack channel, pd integration)
+                rule_name (str): Name of the triggered rule
+                alert (dict): Alert relevant to the triggered rule
+        """
+        creds = self._load_creds(kwargs['descriptor'])
+        if not creds:
+            return self._log_status(False)
+
+        message = 'StreamAlert Rule Triggered - {}'.format(kwargs['rule_name'])
+        rule_desc = kwargs['alert']['rule_description']
+        details = {
+            'rule_description': rule_desc,
+            'record': kwargs['alert']['record']
+        }
+        values_json = json.dumps({
+            'service_key': creds['service_key'],
+            'event_type': 'trigger',
+            'description': message,
+            'details': details,
+            'client': 'StreamAlert'
+        })
+
+        resp = self._request_helper(creds['url'], values_json)
+        success = self._check_http_response(resp)
+
+        if not success:
+            response_value = json.load(resp)
+            error_message = response_value['error']['message']
+            detailed_errors = response_value['error']['errors']
+            LOGGER.error('Encountered an error while sending to PagerDuty: %s\n%s',
+                         error_message,
+                         '\n'.join(detailed_errors))
+
+        return self._log_status(success)
+
+@output
+class PagerDutyOutputV2(StreamOutputBase):
+    """PagerDutyOutput handles all alert dispatching for PagerDuty Events API v2"""
+    __service__ = 'pagerdutyv2'
 
     @classmethod
     def _get_default_properties(cls):

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -177,11 +177,16 @@ class PagerDutyOutputV2(StreamOutputBase):
             return self._log_status(False)
 
         summary = 'StreamAlert Rule Triggered - {}'.format(kwargs['rule_name'])
+
+        details = {
+            'rule_description': kwargs['alert']['rule_description'],
+            'record': kwargs['alert']['record']
+        }
         payload = {
             'summary': summary,
-            'source': kwargs['alert']['rule_description'],
+            'source': kwargs['alert']['log_source'],
             'severity': 'critical',
-            'custom_details': kwargs['alert']['record']
+            'custom_details': details
         }
         values_json = json.dumps({
             'routing_key': creds['routing_key'],

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -97,7 +97,7 @@ class TestPagerDutyOutput(object):
         props = self.__dispatcher._get_default_properties()
         assert_equal(len(props), 1)
         assert_equal(props['url'],
-                     'https://events.pagerduty.com/generic/2010-04-15/create_event.json')
+                     'https://events.pagerduty.com/v2/enqueue')
 
     def _setup_dispatch(self):
         """Helper for setting up PagerDutyOutput dispatch"""
@@ -110,7 +110,7 @@ class TestPagerDutyOutput(object):
         output_name = self.__dispatcher.output_cred_name(self.__descriptor)
 
         creds = {'url': 'http://pagerduty.foo.bar/create_event.json',
-                 'service_key': 'mocked_service_key'}
+                 'routing_key': 'mocked_routing_key'}
 
         put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket, REGION, KMS_ALIAS)
 


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The API v2 is available since June 2016 with no new additions added to the Events API v1 since July 2016. It will be deprecated in February 2018.

## Changes

* Without breaking current code, this PR adds a new output to handle the PagerDuty Events API v2. This can be enabled gradually for rules or at once, but in any case the code is ready.

## Testing

Added unit tests for the new class `PagerDutyOutputV2`. Ran unit tests, linter and rules checks:
```
$ ./tests/scripts/unit_tests.sh
...
TOTAL                                            2231     63    97%
----------------------------------------------------------------------
Ran 396 tests in 7.514s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (55/55) Successful Tests
StreamAlertCLI [INFO]: (90/90) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```