### PR TITLE
[outputs] jira output

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -102,7 +102,7 @@ Examples:
     output_parser.add_argument(
         '--service',
         choices=[
-            'aws-firehose', 'aws-lambda', 'aws-s3', 'pagerduty', 'pagerduty-v2',
+            'aws-firehose', 'aws-lambda', 'aws-s3', 'jira', 'pagerduty', 'pagerduty-v2',
             'pagerduty-incident', 'phantom', 'slack'
         ],
         required=True,

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -19,12 +19,14 @@ import json
 import os
 import tempfile
 import requests
+import urllib3
 
 import boto3
 from botocore.exceptions import ClientError
 
 from stream_alert.alert_processor import LOGGER
 
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 OutputProperty = namedtuple('OutputProperty',
                             'description, value, input_restrictions, mask_input, cred_requirement')
 OutputProperty.__new__.__defaults__ = ('', '', {' ', ':'}, False, False)
@@ -224,11 +226,9 @@ class StreamOutputBase(object):
         """
         success = response is not None and (200 <= response.status_code <= 299)
         if not success:
-            resp_json = response.json()
-            LOGGER.error('Encountered an error while sending to %s: %s\n%s',
+            LOGGER.error('Encountered an error while sending to %s:\n%s',
                          cls.__service__,
-                         resp_json.get('message'),
-                         resp_json.get('errors'))
+                         response.content)
         return success
 
     @classmethod

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -38,6 +38,8 @@ from stream_alert.shared.backoff_handlers import (
 # All included subclasses are designated using the '@output' class decorator
 # The keys are the name of the service and the value is the class itself
 # {cls.__service__: <cls>}
+
+# pylint: disable=too-many-lines
 STREAM_OUTPUTS = {}
 
 
@@ -1054,3 +1056,286 @@ class LambdaOutput(AWSOutput):
                                  Payload=alert_string)
 
         return self._log_status(resp)
+
+@output
+class JiraOutput(StreamOutputBase):
+    """JiraOutput handles all alert dispatching for Jira"""
+    __service__ = 'jira'
+
+    DEFAULT_HEADERS = {'Content-Type': 'application/json'}
+    LOGIN_ENDPOINT = 'rest/auth/1/session'
+    SEARCH_ENDPOINT = 'rest/api/2/search'
+    ISSUE_ENDPOINT = 'rest/api/2/issue'
+    COMMENT_ENDPOINT = 'rest/api/2/issue/{}/comment'
+
+    def __init__(self, *args, **kwargs):
+        StreamOutputBase.__init__(self, *args, **kwargs)
+        self._base_url = None
+        self._auth_cookie = None
+
+    def get_user_defined_properties(self):
+        """Get properties that must be asssigned by the user when configuring a new Jira
+        output.  This should be sensitive or unique information for this use-case that needs
+        to come from the user.
+
+        Every output should return a dict that contains a 'descriptor' with a description of the
+        integration being configured.
+
+        Jira requires a username, password, URL, project key, and issue type for alert dispatching.
+        These values should be masked during input and are credential requirements.
+
+        An additional parameter 'aggregate' is used to determine if alerts are aggregated into a
+        single Jira issue based on the StreamAlert rule.
+
+        Returns:
+            OrderedDict: Contains various OutputProperty items
+        """
+        return OrderedDict([
+            ('descriptor',
+             OutputProperty(description='a short and unique descriptor for this '
+                                        'Jira integration')),
+            ('username',
+             OutputProperty(description='the Jira username',
+                            mask_input=True,
+                            cred_requirement=True)),
+            ('password',
+             OutputProperty(description='the Jira password',
+                            mask_input=True,
+                            cred_requirement=True)),
+            ('url',
+             OutputProperty(description='the Jira url',
+                            mask_input=True,
+                            cred_requirement=True)),
+            ('project_key',
+             OutputProperty(description='the Jira project key',
+                            mask_input=False,
+                            cred_requirement=True)),
+            ('issue_type',
+             OutputProperty(description='the Jira issue type',
+                            mask_input=False,
+                            cred_requirement=True)),
+            ('aggregate',
+             OutputProperty(description='the Jira aggregation behavior to aggregate '
+                                        'alerts by rule name (yes/no)',
+                            mask_input=False,
+                            cred_requirement=True))
+        ])
+
+    @classmethod
+    def _get_default_headers(cls):
+        """Class method to be used to pass the default headers"""
+        return cls.DEFAULT_HEADERS.copy()
+
+    def _get_headers(self):
+        """Instance method used to pass the default headers plus the auth cookie"""
+        return dict(self._get_default_headers(), **{'cookie': self._auth_cookie})
+
+    def _search_jira(self, jql, fields=None, max_results=100, validate_query=True):
+        """Search Jira for issues using a JQL query
+
+        Args:
+            jql (str): The JQL query
+            fields (list): List of fields to return for each issue
+            max_results (int): Maximum number of results to return
+            validate_query (bool): Whether to validate the JQL query or not
+
+        Returns:
+            list: list of issues matching JQL query
+        """
+        search_url = os.path.join(self._base_url, self.SEARCH_ENDPOINT)
+        params = {
+            'jql': jql,
+            'maxResults': max_results,
+            'validateQuery': validate_query,
+            'fields': fields
+        }
+
+        resp = self._get_request(search_url,
+                                 params=params,
+                                 headers=self._get_headers(),
+                                 verify=False)
+
+        success = self._check_http_response(resp)
+        if not success:
+            return []
+
+        return resp.json()['issues']
+
+    def _create_comment(self, issue_id, comment):
+        """Add a comment to an existing issue
+
+        Args:
+            issue_id (str): The existing issue ID or key
+            comment (str): The body of the comment
+
+        Returns:
+            int: ID of the created comment or False if unsuccessful
+        """
+        comment_url = os.path.join(self._base_url, self.COMMENT_ENDPOINT.format(issue_id))
+        resp = self._post_request(comment_url,
+                                  data={'body': comment},
+                                  headers=self._get_headers(),
+                                  verify=False)
+
+        success = self._check_http_response(resp)
+        if not success:
+            return False
+
+        return resp.json()['id']
+
+    def _get_comments(self, issue_id):
+        """Get all comments for an existing Jira issue
+
+        Args:
+            issue_id (str): The existing issue ID or key
+
+        Returns:
+            list: List of comments associated with a Jira issue
+        """
+        comment_url = os.path.join(self._base_url, self.COMMENT_ENDPOINT.format(issue_id))
+        resp = self._get_request(comment_url,
+                                 headers=self._get_headers(),
+                                 verify=False)
+
+        success = self._check_http_response(resp)
+        if not success:
+            return []
+
+        return resp.json()['comments']
+
+    def _get_existing_issue(self, issue_summary, project_key):
+        """Find an existing Jira issue based on the issue summary
+
+        Args:
+            issue_summary (str): The Jira issue summary
+            project_key (str): The Jira project to search
+
+        Returns:
+            int: ID of the found issue or False if existing issue does not exist
+        """
+        jql = 'summary ~ "{}" and project="{}"'.format(issue_summary, project_key)
+        resp = self._search_jira(jql, fields=['id', 'summary'], max_results=1)
+        jira_id = False
+
+        try:
+            jira_id = int(resp[0]['id'])
+        except (IndexError, KeyError):
+            LOGGER.debug('Existing Jira issue not found')
+
+        return jira_id
+
+    def _create_issue(self, issue_name, project_key, issue_type, description):
+        """Create a Jira issue to write alerts to. Alert is written to the "description"
+        field of an issue.
+
+        Args:
+            issue_name (str): The name of the Jira issue
+            project_key (str): The Jira project key which issues will be associated with
+            issue_type (str): The type of issue being created
+            description (str): The body of text which describes the issue
+
+        Returns:
+            int: ID of the created issue or False if unsuccessful
+        """
+        issue_url = os.path.join(self._base_url, self.ISSUE_ENDPOINT)
+        issue_body = {
+            'fields': {
+                'project': {
+                    'key': project_key
+                },
+                'summary': issue_name,
+                'description': description,
+                'issuetype': {
+                    'name': issue_type
+                }
+            }
+        }
+
+        resp = self._post_request(issue_url,
+                                  data=issue_body,
+                                  headers=self._get_headers(),
+                                  verify=False)
+
+        success = self._check_http_response(resp)
+        if not success:
+            return False
+
+        return resp.json()['id']
+
+    def _establish_session(self, username, password):
+        """Establish a cookie based Jira session via basic user auth.
+
+        Args:
+            username (str): The Jira username used for establishing the session
+            password (str): The Jira password used for establishing the session
+
+        Returns:
+            str: Header value intended to be passed with every subsequent Jira request
+                 or False if unsuccessful
+        """
+        login_url = os.path.join(self._base_url, self.LOGIN_ENDPOINT)
+        auth_info = {'username': username, 'password': password}
+
+        resp = self._post_request(login_url,
+                                  data=auth_info,
+                                  headers=self._get_default_headers(),
+                                  verify=False)
+
+        success = self._check_http_response(resp)
+        if not success:
+            LOGGER.error("Failed to authenticate to Jira")
+            return False
+        resp_dict = resp.json()
+
+        return '{}={}'.format(resp_dict['session']['name'],
+                              resp_dict['session']['value'])
+
+    def dispatch(self, **kwargs):
+        """Send alert to Jira
+
+        Args:
+            **kwargs: consists of any combination of the following items:
+                descriptor (str): Service descriptor (ie: slack channel, pd integration)
+                rule_name (str): Name of the triggered rule
+                alert (dict): Alert relevant to the triggered rule
+        """
+        creds = self._load_creds(kwargs['descriptor'])
+        if not creds:
+            return self._log_status(False)
+
+        issue_id = None
+        comment_id = None
+        issue_summary = 'StreamAlert {}'.format(kwargs['rule_name'])
+        alert_body = '{{code:JSON}}{}{{code}}'.format(json.dumps(kwargs['alert']))
+        self._base_url = creds['url']
+        self._auth_cookie = self._establish_session(creds['username'], creds['password'])
+
+        # Validate successful authentication
+        if not self._auth_cookie:
+            return self._log_status(False)
+
+        # If aggregation is enabled, attempt to add alert to an existing issue. If a
+        # failure occurs in this block, creation of a new Jira issue will be attempted.
+        if creds.get('aggregate', '').lower() == 'yes':
+            issue_id = self._get_existing_issue(issue_summary, creds['project_key'])
+            if issue_id:
+                comment_id = self._create_comment(issue_id, alert_body)
+                if comment_id:
+                    LOGGER.debug('Sending alert to an existing Jira issue %s with comment %s',
+                                 issue_id,
+                                 comment_id)
+                    return self._log_status(True)
+                else:
+                    LOGGER.error('Encountered an error when adding alert to existing '
+                                 'Jira issue %s. Attempting to create new Jira issue.',
+                                 issue_id)
+
+        # Create a new Jira issue
+        issue_id = self._create_issue(issue_summary,
+                                      creds['project_key'],
+                                      creds['issue_type'],
+                                      alert_body)
+        if issue_id:
+            LOGGER.debug('Sending alert to a new Jira issue %s', issue_id)
+
+        return self._log_status(issue_id or comment_id)

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -784,6 +784,16 @@ class AlertProcessorTester(object):
                 helpers.put_mock_creds(output_name, creds, self.secrets_bucket,
                                        self.region, self.kms_alias)
 
+            elif service == 'jira':
+                output_name = '{}/{}'.format(service, descriptor)
+                creds = {'username': 'jira@foo.bar',
+                         'password': 'jirafoobar',
+                         'url': 'jira.foo.bar',
+                         'project_key': 'foobar',
+                         'issue_type': 'Task',
+                         'aggregate': 'no'}
+                helpers.put_mock_creds(output_name, creds, self.secrets_bucket,
+                                       'us-east-1', self.kms_alias)
 
     @staticmethod
     def _cleanup_old_secrets():

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -1299,3 +1299,182 @@ class TestLambdaOuput(object):
                                    alert=alert)
 
         log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+
+@mock_s3
+@mock_kms
+class TestJiraOutput(object):
+    """Test class for PhantomOutput"""
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__service = 'jira'
+        cls.__descriptor = 'unit_test_jira'
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         CONFIG)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.__dispatcher = None
+
+    def _setup_dispatch(self):
+        """Helper for setting up JiraOutput dispatch"""
+        remove_temp_secrets()
+
+        output_name = self.__dispatcher.output_cred_name(self.__descriptor)
+
+        creds = {'username': 'jira@foo.bar',
+                 'password': 'jirafoobar',
+                 'url': 'jira.foo.bar',
+                 'project_key': 'foobar',
+                 'issue_type': 'Task',
+                 'aggregate': 'yes'}
+
+        put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket, REGION, KMS_ALIAS)
+
+        return get_alert()
+
+    @patch('logging.Logger.info')
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_issue_new(self, post_mock, get_mock, log_mock):
+        """JiraOutput dispatch success, new issue"""
+        alert = self._setup_dispatch()
+        # setup the request to not find an existing issue
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.return_value = json.loads('{"issues":[]}')
+        # setup the auth and successful creation responses
+        auth_resp = '{"session": {"name": "cookie_name", "value": "cookie_value"}}'
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.json.side_effect = [json.loads(auth_resp),
+                                                   json.loads('{"id": 5000}')]
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+    @patch('logging.Logger.info')
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_issue_existing(self, post_mock, get_mock, log_mock):
+        """JiraOutput dispatch success, existing issue"""
+        alert = self._setup_dispatch()
+        # setup the request to find an existing issue
+        get_mock.return_value.status_code = 200
+        existing_issues = '{"issues": [{"fields": {"summary": "Bogus"}, "id": "5000"}]}'
+        get_mock.return_value.json.return_value = json.loads(existing_issues)
+        auth_resp = '{"session": {"name": "cookie_name", "value": "cookie_value"}}'
+        # setup the auth and successful creation responses
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.json.side_effect = [json.loads(auth_resp),
+                                                   json.loads('{"id": 5000}')]
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+    @patch('requests.get')
+    def test_get_comments_success(self, get_mock):
+        """JiraOutput get comments success"""
+        # setup successful get comments response
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.return_value = json.loads('{"comments": [{},{}]}')
+
+        self.__dispatcher._load_creds('jira')
+        resp = self.__dispatcher._get_comments('5000')
+        assert_equal(resp, [{}, {}])
+
+    @patch('requests.get')
+    def test_get_comments_failure(self, get_mock):
+        """JiraOutput get comments failure"""
+        # setup successful get comments response
+        get_mock.return_value.status_code = 400
+
+        self.__dispatcher._load_creds('jira')
+        resp = self.__dispatcher._get_comments('5000')
+        assert_equal(resp, [])
+
+    @patch('requests.get')
+    def test_search_failure(self, get_mock):
+        """JiraOutput search failure"""
+        # setup successful get comments response
+        get_mock.return_value.status_code = 400
+
+        self.__dispatcher._load_creds('jira')
+        resp = self.__dispatcher._search_jira('foobar')
+        assert_equal(resp, [])
+
+    @patch('logging.Logger.error')
+    @patch('requests.post')
+    def test_auth_failure(self, post_mock, log_mock):
+        """JiraOutput auth failure"""
+        alert = self._setup_dispatch()
+
+        # setup unsuccesful auth response
+        post_mock.return_value.status_code = 400
+        post_mock.return_value.content = '{}'
+        post_mock.return_value.json.return_value = json.loads('{}')
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_has_calls([call('Encountered an error while sending to %s:\n%s',
+                                        'jira', '{}'),
+                                   call('Failed to authenticate to Jira'),
+                                   call('Failed to send alert to %s', self.__service)])
+
+    @patch('logging.Logger.error')
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_issue_creation_failure(self, post_mock, get_mock, log_mock):
+        """JiraOutput issue creation failure"""
+        alert = self._setup_dispatch()
+        # setup the successful search response - no results
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.return_value = json.loads('{"issues": []}')
+        # setup successful auth response and failed issue creation
+        auth_resp = '{"session": {"name": "cookie_name", "value": "cookie_value"}}'
+        type(post_mock.return_value).status_code = PropertyMock(side_effect=[200, 400])
+        post_mock.return_value.content = '{}'
+        post_mock.return_value.json.side_effect = [json.loads(auth_resp),
+                                                   json.loads('{}')]
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_has_calls([call('Encountered an error while sending to %s:\n%s',
+                                        self.__service, '{}'),
+                                   call('Failed to send alert to %s', self.__service)])
+
+    @patch('logging.Logger.error')
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_comment_creation_failure(self, post_mock, get_mock, log_mock):
+        """JiraOutput comment creation failure"""
+        alert = self._setup_dispatch()
+        # setup successful search response
+        get_mock.return_value.status_code = 200
+        existing_issues = '{"issues": [{"fields": {"summary": "Bogus"}, "id": "5000"}]}'
+        get_mock.return_value.json.return_value = json.loads(existing_issues)
+        auth_resp = '{"session": {"name": "cookie_name", "value": "cookie_value"}}'
+        # setup successful auth, failed comment creation, and successful issue creation
+        type(post_mock.return_value).status_code = PropertyMock(side_effect=[200, 400, 200])
+        post_mock.return_value.content = '{}'
+        post_mock.return_value.json.side_effect = [json.loads(auth_resp),
+                                                   json.loads('{"id": 6000}')]
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        log_mock.assert_called_with('Encountered an error when adding alert to existing Jira '
+                                    'issue %s. Attempting to create new Jira issue.', 5000)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size:medium
resolves: #23 

## Background
Introduction of an additional output for Jira.  Alerts can now generate Jira issues.

## Changes
* Jira output option added which supports multiple Jira apps (core, service desk, software)
* Jira output can be configured to create individual issues per StreamAlert alert, or to aggregate into a single issue based on rule name
* Aggregation behavior is identical to how the Phantom output aggregates alerts today
* Alert content appears in the "description" field of a Jira issue, while appended alerts are added as comments
* Unused "get_comments" method added to assist with more advanced aggregation in the future
* output_base.py modified to prevent noisy warning messages related to unverified requests from flooding the logs.  Performed with urllib3.disable_warnings()
* Both outputs.py and test_outputs.py now exceed 1000 lines, so pylint "too-many-lines" temporarily disabled
* Modified one of the mocked attributes in a Phantom unit tests as is doesn't seem possible to use "side_effect" on an object attribute.  The fix looks kind of hacky, but the [docs](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock) mention this method.
* Modified _check_http_response() to use a more general error message, and not call response.json() in favor of response.content
## Testing
* Live outputs with aggregation enabled and disabled
* Integration/Unit tests passing
