### PR TITLE
[output] Replace urllib2 with requests

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -4,7 +4,9 @@
     "source_bucket": "PREFIX_GOES_HERE.streamalert.source",
     "source_current_hash": "<auto_generated>",
     "source_object_key": "<auto_generated>",
-    "third_party_libraries": []
+    "third_party_libraries": [
+      "requests"
+    ]
   },
   "rule_processor_config": {
     "handler": "stream_alert.rule_processor.main.handler",

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -184,9 +184,9 @@ class StreamOutputBase(object):
 
         Args:
             url (str): Endpoint for this request
-            headers (dict): Dictionary containing request-specific header parameters
             params (dict): Payload to send with this request
-            verify (bool): Whether or not SSL should be used for this request
+            headers (dict): Dictionary containing request-specific header parameters
+            verify (bool): Whether or not the server's SSL certificate should be verified
         Returns:
             dict: Contains the http response object
         """
@@ -198,16 +198,15 @@ class StreamOutputBase(object):
 
         Args:
             url (str): Endpoint for this request
+            data (dict): Payload to send with this request
             headers (dict): Dictionary containing request-specific header parameters
-            params (dict): Payload to send with this request
-            verify (bool): Whether or not SSL should be used for this request
+            verify (bool): Whether or not the server's SSL certificate should be verified
         Returns:
             dict: Contains the http response object
         """
         return requests.post(url, headers=headers, json=data, verify=verify)
 
-    @staticmethod
-    def _check_http_response(response):
+    def _check_http_response(self, response):
         """Method for checking for a valid HTTP response code
 
         Args:
@@ -216,7 +215,14 @@ class StreamOutputBase(object):
         Returns:
             bool: Indicator of whether or not this request was successful
         """
-        return response is not None and (200 <= response.status_code <= 299)
+        success = response is not None and (200 <= response.status_code <= 299)
+        if not success:
+            resp_json = response.json()
+            LOGGER.error('Encountered an error while sending to %s: %s\n%s',
+                         self.__service__,
+                         resp_json.get('message'),
+                         resp_json.get('errors'))
+        return success
 
     @classmethod
     def _get_default_properties(cls):

--- a/stream_alert/alert_processor/output_base.py
+++ b/stream_alert/alert_processor/output_base.py
@@ -17,9 +17,8 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 import json
 import os
-import ssl
 import tempfile
-import urllib2
+import requests
 
 import boto3
 from botocore.exceptions import ClientError
@@ -180,39 +179,44 @@ class StreamOutputBase(object):
         return bool(success)
 
     @staticmethod
-    def _request_helper(url, data, headers=None, verify=True):
-        """URL request helper to send a payload to an endpoint
+    def _get_request(url, params=None, headers=None, verify=True):
+        """Method to return the json loaded response for this GET request
 
         Args:
             url (str): Endpoint for this request
-            data (str): Payload to send with this request
             headers (dict): Dictionary containing request-specific header parameters
+            params (dict): Payload to send with this request
             verify (bool): Whether or not SSL should be used for this request
         Returns:
-            file handle: Contains the http response to be read
+            dict: Contains the http response object
         """
-        try:
-            context = None
-            if not verify:
-                context = ssl.create_default_context()
-                context.check_hostname = False
-                context.verify_mode = ssl.CERT_NONE
-
-            http_headers = headers or {}
-
-            # Omitting data means a GET request should occur, not POST
-            if not data:
-                request = urllib2.Request(url, headers=http_headers)
-            else:
-                request = urllib2.Request(url, data=data, headers=http_headers)
-            resp = urllib2.urlopen(request, context=context)
-            return resp
-        except urllib2.HTTPError as err:
-            raise OutputRequestFailure('Failed to send to {} - [{}]'.format(err.url, err.code))
+        return requests.get(url, headers=headers, params=params, verify=verify)
 
     @staticmethod
-    def _check_http_response(resp):
-        return resp and (200 <= resp.getcode() <= 299)
+    def _post_request(url, data=None, headers=None, verify=True):
+        """Method to return the json loaded response for this POST request
+
+        Args:
+            url (str): Endpoint for this request
+            headers (dict): Dictionary containing request-specific header parameters
+            params (dict): Payload to send with this request
+            verify (bool): Whether or not SSL should be used for this request
+        Returns:
+            dict: Contains the http response object
+        """
+        return requests.post(url, headers=headers, json=data, verify=verify)
+
+    @staticmethod
+    def _check_http_response(response):
+        """Method for checking for a valid HTTP response code
+
+        Args:
+            response (requests.Response): Response object from requests
+
+        Returns:
+            bool: Indicator of whether or not this request was successful
+        """
+        return response is not None and (200 <= response.status_code <= 299)
 
     @classmethod
     def _get_default_properties(cls):

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -107,17 +107,9 @@ class PagerDutyOutput(StreamOutputBase):
             'details': details,
             'client': 'StreamAlert'
         }
-        headers = None
-        verify = True
 
-        resp = self._post_request(creds['url'], data, headers, verify)
+        resp = self._post_request(creds['url'], data, None, True)
         success = self._check_http_response(resp)
-
-        if not success and resp:
-            response = resp.json()
-            LOGGER.error('Encountered an error while sending to PagerDuty: %s\n%s',
-                         response['message'],
-                         response['errors'])
 
         return self._log_status(success)
 
@@ -193,17 +185,9 @@ class PagerDutyOutputV2(StreamOutputBase):
             'event_action': 'trigger',
             'client': 'StreamAlert'
         }
-        headers = None
-        verify = True
 
-        resp = self._post_request(creds['url'], data, headers, verify)
+        resp = self._post_request(creds['url'], data, None, True)
         success = self._check_http_response(resp)
-
-        if not success and resp:
-            response = resp.json()
-            LOGGER.error('Encountered an error while sending to PagerDuty: %s\n%s',
-                         response['message'],
-                         response['errors'])
 
         return self._log_status(success)
 
@@ -265,17 +249,12 @@ class PhantomOutput(StreamOutputBase):
         if not self._check_http_response(resp):
             return False
 
-        try:
-            response = json.loads(resp.text)
-        except ValueError as err:
-            LOGGER.error('An error occurred while decoding Phantom container query '
-                         'response to JSON: %s', err)
-            return False
+        response = resp.json()
 
         # If the count == 0 then we know there are no containers with this name and this
         # will evaluate to False. Otherwise there is at least one item in the list
         # of 'data' with a container id we can use
-        return response and response['count'] and response['data'][0]['id']
+        return response and response.get('count') and response.get('data')[0]['id']
 
     def _setup_container(self, rule_name, rule_description, base_url, headers):
         """Establish a Phantom container to write the alerts to. This checks to see
@@ -304,14 +283,9 @@ class PhantomOutput(StreamOutputBase):
         if not self._check_http_response(resp):
             return False
 
-        try:
-            response = json.loads(resp.text)
-        except ValueError as err:
-            LOGGER.error('An error occurred while decoding Phantom container creation '
-                         'response to JSON: %s', err)
-            return False
+        response = resp.json()
 
-        return response and response['id']
+        return response and response.get('id')
 
     def dispatch(self, **kwargs):
         """Send alert to Phantom
@@ -549,12 +523,6 @@ class SlackOutput(StreamOutputBase):
 
         resp = self._get_request(creds['url'], slack_message)
         success = self._check_http_response(resp)
-
-        if not success and resp:
-            response = resp.json()
-            LOGGER.error('Encountered an error while sending to Slack: %s\n%s',
-                         response['message'],
-                         response['errors'])
 
         return self._log_status(success)
 

--- a/tests/unit/stream_alert_alert_processor/test_main.py
+++ b/tests/unit/stream_alert_alert_processor/test_main.py
@@ -98,14 +98,14 @@ def test_sort_dict_recursive():
         assert_equal(sub_keys[index], key)
 
 
-@patch('urllib2.urlopen')
+@patch('requests.get')
 @patch('stream_alert.alert_processor.main._load_output_config')
 @patch('stream_alert.alert_processor.output_base.StreamOutputBase._load_creds')
-def test_running_success(creds_mock, config_mock, url_mock):
+def test_running_success(creds_mock, config_mock, get_mock):
     """Alert Processor run handler - success"""
     config_mock.return_value = _load_output_config('tests/unit/conf/outputs.json')
-    creds_mock.return_value = {'url': 'mock.url'}
-    url_mock.return_value.getcode.return_value = 200
+    creds_mock.return_value = {'url': 'http://mock.url'}
+    get_mock.return_value.status_code = 200
 
     alert = get_alert()
     context = get_mock_context()
@@ -158,18 +158,18 @@ def test_running_no_dispatcher(dispatch_mock, config_mock):
 
 
 @patch('logging.Logger.exception')
-@patch('urllib2.urlopen')
+@patch('requests.get')
 @patch('stream_alert.alert_processor.main._load_output_config')
 @patch('stream_alert.alert_processor.main.get_output_dispatcher')
 @patch('stream_alert.alert_processor.output_base.StreamOutputBase._load_creds')
-def test_running_exception_occurred(creds_mock, dispatch_mock, config_mock, url_mock, log_mock):
+def test_running_exception_occurred(creds_mock, dispatch_mock, config_mock, get_mock, log_mock):
     """Alert Processor run handler - exception occurred"""
     # Use TypeError as the mock's side_effect
     err = TypeError('bad error')
     creds_mock.return_value = {'url': 'mock.url'}
     dispatch_mock.return_value.dispatch.side_effect = err
     config_mock.return_value = _load_output_config('tests/unit/conf/outputs.json')
-    url_mock.return_value.getcode.return_value = 200
+    get_mock.return_value.status_code = 200
 
     alert = _sort_dict(get_alert())
     context = get_mock_context()

--- a/tests/unit/stream_alert_alert_processor/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_output_base.py
@@ -116,17 +116,17 @@ class TestStreamOutputBase(object):
         self.__dispatcher._log_status(False)
         log_mock.assert_called_with('Failed to send alert to %s', 'test_service')
 
-    @patch('urllib2.urlopen')
-    def test_check_http_response(self, mock_getcode):
+    @patch('requests.Response')
+    def test_check_http_response(self, mock_response):
         """StreamOutputBase Check HTTP Response"""
         # Test with a good response code
-        mock_getcode.getcode.return_value = 200
-        result = self.__dispatcher._check_http_response(mock_getcode)
+        mock_response.status_code = 200
+        result = self.__dispatcher._check_http_response(mock_response)
         assert_equal(result, True)
 
         # Test with a bad response code
-        mock_getcode.getcode.return_value = 440
-        result = self.__dispatcher._check_http_response(mock_getcode)
+        mock_response.status_code = 440
+        result = self.__dispatcher._check_http_response(mock_response)
         assert_equal(result, False)
 
     @mock_s3

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 # pylint: disable=protected-access
 from collections import Counter, OrderedDict
-import json
 
 import boto3
 from mock import call, patch
@@ -120,13 +119,14 @@ class TestPagerDutyOutput(object):
         self.__dispatcher._get_default_properties = self.__backup_method
 
     @patch('logging.Logger.info')
-    @patch('urllib2.urlopen')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
-    def test_dispatch_success(self, url_mock, log_info_mock):
+    def test_dispatch_success(self, post_mock, log_info_mock):
         """PagerDutyOutput dispatch success"""
         alert = self._setup_dispatch()
-        url_mock.return_value.getcode.return_value = 200
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.text = ''
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -137,15 +137,14 @@ class TestPagerDutyOutput(object):
         log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
-    def test_dispatch_failure(self, url_mock, log_error_mock):
+    def test_dispatch_failure(self, post_mock, log_error_mock):
         """PagerDutyOutput dispatch failure"""
         alert = self._setup_dispatch()
-        bad_message = '{"error": {"message": "failed", "errors": ["err1", "err2"]}}'
-        url_mock.return_value.read.return_value = bad_message
-        url_mock.return_value.getcode.return_value = 400
+        post_mock.return_value.text = '{"message": "error message", "errors": ["error1"]}'
+        post_mock.return_value.status_code = 400
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -195,7 +194,7 @@ class TestPagerDutyOutputV2(object):
                      'https://events.pagerduty.com/v2/enqueue')
 
     def _setup_dispatch(self):
-        """Helper for setting up PagerDutyOutput dispatch"""
+        """Helper for setting up PagerDutyOutputV2 dispatch"""
         remove_temp_secrets()
 
         # Cache the _get_default_properties and set it to return None
@@ -216,13 +215,14 @@ class TestPagerDutyOutputV2(object):
         self.__dispatcher._get_default_properties = self.__backup_method
 
     @patch('logging.Logger.info')
-    @patch('urllib2.urlopen')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
-    def test_dispatch_success(self, url_mock, log_info_mock):
-        """PagerDutyOutput dispatch success"""
+    def test_dispatch_success(self, post_mock, log_info_mock):
+        """PagerDutyOutputV2 dispatch success"""
         alert = self._setup_dispatch()
-        url_mock.return_value.getcode.return_value = 200
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.text = ''
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -233,15 +233,14 @@ class TestPagerDutyOutputV2(object):
         log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
-    def test_dispatch_failure(self, url_mock, log_error_mock):
-        """PagerDutyOutput dispatch failure"""
+    def test_dispatch_failure(self, post_mock, log_error_mock):
+        """PagerDutyOutputV2 dispatch failure"""
         alert = self._setup_dispatch()
-        bad_message = '{"error": {"message": "failed", "errors": ["err1", "err2"]}}'
-        url_mock.return_value.read.return_value = bad_message
-        url_mock.return_value.getcode.return_value = 400
+        post_mock.return_value.text = '{"message": "error message", "errors": ["error1"]}'
+        post_mock.return_value.status_code = 400
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -255,7 +254,7 @@ class TestPagerDutyOutputV2(object):
     @mock_s3
     @mock_kms
     def test_dispatch_bad_descriptor(self, log_error_mock):
-        """PagerDutyOutput dispatch bad descriptor"""
+        """PagerDutyOutputV2 dispatch bad descriptor"""
         alert = self._setup_dispatch()
         self.__dispatcher.dispatch(descriptor='bad_descriptor',
                                    rule_name='rule_name',
@@ -299,12 +298,16 @@ class TestPhantomOutput(object):
         return get_alert()
 
     @patch('logging.Logger.info')
-    @patch('urllib2.urlopen')
-    def test_dispatch_existing_container(self, url_mock, log_mock):
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_existing_container(self, post_mock, get_mock, log_mock):
         """PhantomOutput dispatch success, existing container"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        url_mock.return_value.getcode.return_value = 200
-        url_mock.return_value.read.side_effect = ['{"count": 1, "data": [{"id": 1948}]}']
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = '{"count": 1, "data": [{"id": 1948}]}'
+        # dispatch
+        post_mock.return_value.status_code = 200
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -313,12 +316,17 @@ class TestPhantomOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.info')
-    @patch('urllib2.urlopen')
-    def test_dispatch_new_container(self, url_mock, log_mock):
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_new_container(self, post_mock, get_mock, log_mock):
         """PhantomOutput dispatch success, new container"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        url_mock.return_value.getcode.return_value = 200
-        url_mock.return_value.read.side_effect = ['{"count": 0, "data": []}', '{"id": 1948}']
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = '{"count": 0, "data": []}'
+        # _setup_container, dispatch
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.text = '{"id": 1948}'
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -327,11 +335,18 @@ class TestPhantomOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
-    def test_dispatch_container_failure(self, url_mock, log_mock):
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_container_failure(self, post_mock, get_mock, log_mock):
         """PhantomOutput dispatch failure (setup container)"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        url_mock.return_value.getcode.return_value = 400
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = '{"count": 0, "data": []}'
+        # _setup_container
+        post_mock.return_value.status_code = 400
+        post_mock.return_value.text = '{"message": "error message", "errors": ["error1"]}'
+
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
@@ -339,64 +354,103 @@ class TestPhantomOutput(object):
         log_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
-    def test_dispatch_container_error(self, url_mock, log_mock):
-        """PhantomOutput dispatch decode error (setup container)"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        url_mock.return_value.getcode.return_value = 200
-        url_mock.return_value.read.return_value = 'this\nis\nnot\njson'
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_check_container_error(self, post_mock, get_mock, log_mock):
+        """PhantomOutput dispatch decode error (check container)"""
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = 'this\nis\nnot\njson'
+        # _setup_container
+        post_mock.return_value.status_code = 400
+        post_mock.return_value.text = '{"message": "error message", "errors": ["error1"]}'
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
 
         response = str(
-            call('An error occurred while decoding '
-                 'Phantom container query response to JSON: %s', ValueError(
-                     'No JSON object could be decoded',)))
+            call('An error occurred while decoding Phantom container query '
+                 'response to JSON: %s', ValueError('No JSON object could be decoded',)))
 
         assert_equal(str(log_mock.call_args_list[0]), response)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
-    def test_dispatch_failure(self, url_mock, log_mock):
-        """PhantomOutput dispatch failure (artifact)"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        url_mock.return_value.read.side_effect = ['', '{"id": 1902}']
-        # Use side_effect to change the getcode return value the second time
-        # it is called. This allows testing issues down the chain somewhere
-        url_mock.return_value.getcode.side_effect = [200, 400]
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_setup_container_error(self, post_mock, get_mock, log_mock):
+        """PhantomOutput dispatch decode error (setup container)"""
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = '{"count": 0, "data": []}'
+        # _setup_container
+        post_mock.return_value.status_code = 200
+        post_mock.return_value.text = 'this\nis\nnot\njson'
+
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
 
+        response = str(
+            call('An error occurred while decoding Phantom container creation '
+                 'response to JSON: %s', ValueError('No JSON object could be decoded',)))
+
+        assert_equal(str(log_mock.call_args_list[0]), response)
+
+
+    @patch('logging.Logger.error')
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_dispatch_failure(self, post_mock, get_mock, log_mock):
+        """PhantomOutput dispatch failure (artifact)"""
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        # _check_container_exists
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.text = '{"count": 0, "data": []}'
+        # _setup_container, dispatch
+        post_mock.return_value.status_code.side_effect = [200, 400]
+        post_mock.return_value.text.side_effect = ['{"id": 1948}', '{"message": "error"}']
+
+        result = self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                            rule_name='rule_name',
+                                            alert=alert)
+
         log_mock.assert_called_with('Failed to send alert to %s', self.__service)
+        assert_equal(result, False)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_error_mock):
         """PhantomOutput dispatch bad descriptor"""
-        alert = self._setup_dispatch('phantom.foo.bar')
-        self.__dispatcher.dispatch(descriptor='bad_descriptor',
-                                   rule_name='rule_name',
-                                   alert=alert)
+        alert = self._setup_dispatch('http://phantom.foo.bar')
+        result = self.__dispatcher.dispatch(descriptor='bad_descriptor',
+                                            rule_name='rule_name',
+                                            alert=alert)
 
         log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
+        assert_equal(result, False)
 
-    @patch('stream_alert.alert_processor.output_base.StreamOutputBase._request_helper')
-    def test_dispatch_container_query(self, request_mock):
+    @patch('stream_alert.alert_processor.output_base.StreamOutputBase._get_request')
+    @patch('stream_alert.alert_processor.output_base.StreamOutputBase._post_request')
+    def test_dispatch_container_query(self, post_mock, get_mock):
         """PhantomOutput - Container Query URL"""
-        alert = self._setup_dispatch('phantom.foo.bar')
+        alert = self._setup_dispatch('http://phantom.foo.bar')
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
 
-        full_url = 'phantom.foo.bar/rest/container?_filter_name="rule_name"&page_size=1'
+        full_url = 'http://phantom.foo.bar/rest/container'
+        params = {'_filter_name': 'rule_name', 'page_size': 1}
         headers = {'ph-auth-token': 'mocked_auth_token'}
-        request_mock.assert_has_calls([call(full_url, None, headers, False)])
+        get_mock.assert_has_calls([call(full_url, params, headers, False)])
+        rule_description = 'Info about this rule and what actions to take'
+        ph_container = {'name': 'rule_name', 'description': rule_description}
+        post_mock.assert_has_calls([call(full_url, ph_container, headers, False)])
 
 
 class TestSlackOutput(object):
-    """Test class for PagerDutyOutput"""
+    """Test class for SlackOutput"""
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
@@ -416,7 +470,7 @@ class TestSlackOutput(object):
         """Format Single Message - Slack"""
         rule_name = 'test_rule_single'
         alert = get_random_alert(25, rule_name)
-        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+        loaded_message = self.__dispatcher._format_message(rule_name, alert)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -429,7 +483,7 @@ class TestSlackOutput(object):
         """Format Multi-Message - Slack"""
         rule_name = 'test_rule_multi-part'
         alert = get_random_alert(30, rule_name)
-        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+        loaded_message = self.__dispatcher._format_message(rule_name, alert)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -444,7 +498,7 @@ class TestSlackOutput(object):
         """Format Message Default Rule Description - Slack"""
         rule_name = 'test_empty_rule_description'
         alert = get_random_alert(10, rule_name, True)
-        loaded_message = json.loads(self.__dispatcher._format_message(rule_name, alert))
+        loaded_message = self.__dispatcher._format_message(rule_name, alert)
 
         # tests
         default_rule_description = '*Rule Description:*\nNo rule description provided\n'
@@ -552,13 +606,14 @@ class TestSlackOutput(object):
         return get_alert()
 
     @patch('logging.Logger.info')
-    @patch('urllib2.urlopen')
+    @patch('requests.get')
     @mock_s3
     @mock_kms
     def test_dispatch_success(self, url_mock, log_info_mock):
         """SlackOutput dispatch success"""
         alert = self._setup_dispatch()
-        url_mock.return_value.getcode.return_value = 200
+        url_mock.return_value.status_code = 200
+        url_mock.return_value.text = ''
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
@@ -567,23 +622,20 @@ class TestSlackOutput(object):
         log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('urllib2.urlopen')
+    @patch('requests.get')
     @mock_s3
     @mock_kms
     def test_dispatch_failure(self, url_mock, log_error_mock):
         """SlackOutput dispatch failure"""
         alert = self._setup_dispatch()
-        error_message = 'a helpful error message'
-        url_mock.return_value.read.return_value = error_message
-        url_mock.return_value.getcode.return_value = 400
+        url_mock.return_value.text = '{"message": "error message", "errors": ["error1"]}'
+        url_mock.return_value.status_code = 400
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',
                                    alert=alert)
 
-        log_error_mock.assert_any_call('Encountered an error while sending to Slack: %s',
-                                       error_message)
-        log_error_mock.assert_any_call('Failed to send alert to %s', self.__service)
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
 
     @patch('logging.Logger.error')
     @mock_s3


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: medium
resolves #158 

## Background

Outputs in StreamAlert were using `urllib2` to process HTTP requests. For certain things (parsing output, parameter encoding) is simpler to use `requests` and we are already using it in app integrations.

## Changes

* Replacing `urllib2` by `requests` in the `output_base.py`, to handle `GET`, `POST` checking for successful traffic.
* Added all the relevant code to the dispatchers for PagerDuty, Phantom and Slack to use the new methods using `requests`.
* Updated unit tests.
* Added `requests` as third party library in the `alert_processor_config`.

## Testing

Unit tests, linter and StreamAlert processor:
```
$ ./tests/scripts/unit_tests.sh
...
TOTAL                                            2219     46    98%
----------------------------------------------------------------------
Ran 397 tests in 8.224s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (55/55) Successful Tests
StreamAlertCLI [INFO]: (90/90) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
