### PR TITLE
[apps] bug fixes and adding padding for cleanup before func timeout

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -78,6 +78,8 @@ class AppIntegration(object):
     # _DEFAULT_REQUEST_TIMEOUT indicates long the requests library will wait before timing
     # out for both get and post requests. This applies to both connection and read timeouts
     _DEFAULT_REQUEST_TIMEOUT = 3.05
+    # _EOF_SECONDS_BUFFER is the end-of-function padding in seconds needed to handle cleanup, etc
+    _EOF_SECONDS_BUFFER = 2
 
     def __init__(self, config):
         self._config = config
@@ -388,7 +390,8 @@ class AppIntegration(object):
         if not self._initialize():
             return
 
-        while self._gather() + self._sleep_seconds() < self._config.remaining_ms() / 1000.0:
+        while (self._gather() + self._sleep_seconds() <
+               (self._config.remaining_ms() / 1000.0) - self._EOF_SECONDS_BUFFER):
             LOGGER.debug('More logs to poll for \'%s\': %s', self.type(), self._more_to_poll)
             self._config.report_remaining_seconds()
             if not self._more_to_poll:

--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -75,6 +75,9 @@ class AppIntegration(object):
     # saving to parameter store and spawning a new Lambda invocation if there are more
     # logs to poll for this interval
     _POLL_BUFFER_MULTIPLIER = 1.5
+    # _DEFAULT_REQUEST_TIMEOUT indicates long the requests library will wait before timing
+    # out for both get and post requests. This applies to both connection and read timeouts
+    _DEFAULT_REQUEST_TIMEOUT = 3.05
 
     def __init__(self, config):
         self._config = config
@@ -290,7 +293,8 @@ class AppIntegration(object):
                      self.type(), self._poll_count)
 
         # Perform the request and return the response as a dict
-        response = requests.get(full_url, headers=headers, params=params)
+        response = requests.get(full_url, headers=headers,
+                                params=params, timeout=self._DEFAULT_REQUEST_TIMEOUT)
 
         return self._check_http_response(response), response.json()
 
@@ -305,7 +309,8 @@ class AppIntegration(object):
                      self.type(), self._poll_count)
 
         # Perform the request and return the response as a dict
-        response = requests.post(full_url, headers=headers, json=data)
+        response = requests.post(full_url, headers=headers,
+                                 json=data, timeout=self._DEFAULT_REQUEST_TIMEOUT)
 
         return self._check_http_response(response), response.json()
 

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import calendar
 from datetime import datetime
 import json
 import re
@@ -272,7 +273,7 @@ class AppConfig(dict):
         """
         if not self.last_timestamp:
             interval_time = self.evaluate_interval()
-            current_time = int(time.mktime(time.gmtime()))
+            current_time = int(calendar.timegm(time.gmtime()))
             time_delta = current_time - interval_time
             LOGGER.debug('Current timestamp: %s seconds. Calculated delta: %s seconds',
                          current_time, time_delta)

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -223,7 +223,7 @@ class TestAppIntegration(object):
     @patch('app_integrations.apps.app_base.AppIntegration._gather')
     @patch('app_integrations.apps.app_base.AppIntegration._sleep_seconds', Mock(return_value=1))
     @patch('app_integrations.config.AppConfig.remaining_ms',
-           Mock(side_effect=[5000, 5000, 2000, 2000]))
+           Mock(side_effect=[8000, 8000, 2000, 2000]))
     def test_gather_multiple(self, gather_mock):
         """App Integration - Gather, Entry Point, Multiple Calls"""
         # 3 == number of 'seconds' this ran for. This is compared against the remaining_ms mock

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -112,7 +112,7 @@ class TestAppIntegrationConfig(object):
         self._config['interval'] = 'rate(5 hours)'
         assert_equal(self._config.evaluate_interval(), 3600 * 5)
 
-    @patch('time.mktime')
+    @patch('calendar.timegm')
     def test_determine_last_timestamp_duo(self, time_mock):
         """AppIntegrationConfig - Determine Last Timestamp, Duo"""
         # Reset the last timestamp to None
@@ -124,7 +124,7 @@ class TestAppIntegrationConfig(object):
         self._config['interval'] = 'rate(5 hours)'
         assert_equal(self._config._determine_last_time(), 1234567890 - (3600 * 5))
 
-    @patch('time.mktime')
+    @patch('calendar.timegm')
     def test_determine_last_timestamp_onelogin(self, time_mock):
         """AppIntegrationConfig - Determine Last Timestamp, OneLogin"""
         with patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient(app_type='onelogin_events')):
@@ -137,7 +137,7 @@ class TestAppIntegrationConfig(object):
             time_mock.return_value = 1234567890
             assert_equal(self._config._determine_last_time(), '2009-02-13T22:31:30Z')
 
-    @patch('time.mktime')
+    @patch('calendar.timegm')
     def test_determine_last_timestamp_gsuite(self, time_mock):
         """AppIntegrationConfig - Determine Last Timestamp, GSuite"""
         with patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient(app_type='gsuite_admin')):


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

There are a handful of fixes in this PR that are the result of things I observed while writing the Box app. The gist is:
1. While observing CloudWatch logs, I noticed a `requests.get` call took the entire duration of an app invocation and results in the function timing out.
2. I also happened to notice that there was occasional instances of functions timing out during the cleanup phase of the app invocation - ie, if there were more logs to be collected, and the function invoked another lambda (a successor), the new invocation would happen but the current function would time out before exiting cleanly.
3. During some local testing, I identified a discrepancy with the `_determine_last_time` calculation. I was improperly assuming that `time.mktime` returned the current time in utc, while it in fact it returns the local time of the system.
    * This was not an actual problem in production, since the AWS Lambda environment runs in UTC, and thus the `time.mktime` function _does_ return the expected time in production.

## Changes

* For 1 above: `requests` now uses a default timeout (for both `connection` and `read` calls) of 3.05 seconds, as recommended by the [requests docs](http://docs.python-requests.org/en/master/user/advanced/#timeouts).
* For 2 above: adding an 'end of function' buffer in seconds that will ensure that there is enough time to exit cleanly if the function is nearing timeout. This value defaults to `2` seconds which should be enough to save the state and invoke a lambda.
* For 3 above: switching to using `calendar.timegm` which will always return the current time in UTC regardless of locale.

## Testing

* Updating all unit tests, which are passing for all changes
  * `tests/scripts/unit_tests.sh`
