### PR TITLE
[output] Using timeout in requests methods

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -75,7 +75,7 @@ class AppIntegration(object):
     # saving to parameter store and spawning a new Lambda invocation if there are more
     # logs to poll for this interval
     _POLL_BUFFER_MULTIPLIER = 1.5
-    # _DEFAULT_REQUEST_TIMEOUT indicates long the requests library will wait before timing
+    # _DEFAULT_REQUEST_TIMEOUT indicates how long the requests library will wait before timing
     # out for both get and post requests. This applies to both connection and read timeouts
     _DEFAULT_REQUEST_TIMEOUT = 3.05
     # _EOF_SECONDS_BUFFER is the end-of-function padding in seconds needed to handle cleanup, etc


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Requests is replacing urllib2 in the outputs.

## Changes

* Having `requests` to use a default timeout (for both `connection` and `read` calls) of 3.05 seconds, as recommended by the [requests docs](http://docs.python-requests.org/en/master/user/advanced/#timeouts).

## Testing

```
$ ./tests/scripts/unit_tests.sh
...
TOTAL                                            2219     46    98%
----------------------------------------------------------------------
Ran 397 tests in 8.224s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (55/55) Successful Tests
StreamAlertCLI [INFO]: (90/90) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
