### PR TITLE
[apps] box app for admin events

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -123,13 +123,30 @@ class AppIntegration(object):
         return '_'.join([cls.service(), cls._type()])
 
     @classmethod
-    @abstractmethod
     def required_auth_info(cls):
-        """Get the expected info that this service's auth dictionary should contain.
+        """Public method to get the expected info that this service's auth dict should contain.
 
-        This should be implemented by subclasses and provide context as to what authentication
+        This public method calls the protected `_required_auth_info` and then validates its
+        type to ensure the caller does not get a non-iterable result due to a poor implementation
+        by a subclass.
+
+        Returns:
+            dict: Required authentication keys, with optional description and
+                format they should follow
+        """
+        req_auth_info = cls._required_auth_info()
+        return req_auth_info if isinstance(req_auth_info, dict) else dict()
+
+    @classmethod
+    @abstractmethod
+    def _required_auth_info(cls):
+        """Protected method to get the expected info that this service's auth dict should contain.
+
+        This must be implemented by subclasses and provide context as to what authentication
         information is required as well as a description of the data and an optional regex
         that the data should conform to.
+
+        This is called from the public `required_auth_info` method and validated there.
 
         Returns:
             dict: Required authentication keys, with optional description and

--- a/app_integrations/apps/box.py
+++ b/app_integrations/apps/box.py
@@ -152,6 +152,7 @@ class BoxApp(AppIntegration):
                 Otherwise, return a list of box admin event entries.
         """
         if not self._create_client():
+            LOGGER.error('Could not create box client for %s', self.type())
             return False
 
         response = self._make_request()

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -138,7 +138,7 @@ class DuoApp(AppIntegration):
         return logs
 
     @classmethod
-    def required_auth_info(cls):
+    def _required_auth_info(cls):
         return {
             'api_hostname':
                 {

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -51,6 +51,10 @@ class GSuiteReportsApp(AppIntegration):
         Args:
             keydata (dict): The loaded keyfile data from a Google service account
                 JSON file
+
+        Returns:
+            oauth2client.service_account.ServiceAccountCredentials: Instance of
+                service account credentials for this discovery service
         """
         try:
             creds = ServiceAccountCredentials.from_json_keyfile_dict(
@@ -131,7 +135,7 @@ class GSuiteReportsApp(AppIntegration):
         return activities
 
     @classmethod
-    def required_auth_info(cls):
+    def _required_auth_info(cls):
         # Use a validation function to ensure the file the user provides is valid
         def keyfile_validator(keyfile):
             """A JSON formatted (not p12) Google service account private key file key"""

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -224,7 +224,7 @@ class OneLoginApp(AppIntegration):
         return response['data']
 
     @classmethod
-    def required_auth_info(cls):
+    def _required_auth_info(cls):
         return {
             'region':
                 {

--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -25,6 +25,7 @@
     "source_current_hash": "<auto_generated>",
     "source_object_key": "<auto_generated>",
     "third_party_libraries": [
+      "boxsdk[jwt]==2.0.0a11",
       "google-api-python-client",
       "requests"
     ]

--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1,4 +1,18 @@
 {
+  "box:admin_events": {
+    "schema": {
+      "additional_details": "string",
+      "created_at": "string",
+      "created_by": {},
+      "event_id": "string",
+      "event_type": "string",
+      "ip_address": "string",
+      "session_id": "string",
+      "source": {},
+      "type": "string"
+    },
+    "parser": "json"
+  },
   "carbonblack:binarystore.file.added": {
     "schema": {
       "cb_server": "string",

--- a/conf/sources.json
+++ b/conf/sources.json
@@ -36,6 +36,11 @@
       "logs": [
         "gsuite"
       ]
+    },
+    "prefix_cluster_box_admin_events_sm-app-name_app": {
+      "logs": [
+        "box"
+      ]
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,16 @@ backports.functools-lru-cache==1.4
 boto==2.46.1
 boto3==1.4.4
 botocore==1.5.85
+boxsdk[jwt]==2.0.0a11
+certifi==2017.7.27.1
+cffi==1.11.2
+chainmap==1.0.2
+chardet==3.0.4
 colorama==0.3.7
 configparser==3.5.0
 coverage==4.3.4
 coveralls==1.1
+cryptography==2.1.2
 decorator==4.0.11
 docopt==0.6.2
 docutils==0.13.1
@@ -26,7 +32,9 @@ google-api-python-client==1.6.4
 httplib2==0.10.3
 httpretty==0.8.10
 hurry.filesize==0.9
+idna==2.6
 imagesize==0.7.1
+ipaddress==1.0.18
 isort==4.2.15
 Jinja2==2.9.5
 jmespath==0.9.3
@@ -49,6 +57,8 @@ psutil==5.1.3
 pyasn1==0.2.3
 pyasn1-modules==0.1.5
 pycodestyle==2.3.1
+pycparser==2.18
+PyJWT==1.5.3
 pyfakefs==3.2
 pyflakes==1.5.0
 Pygments==2.2.0
@@ -59,6 +69,7 @@ python-mimeparse==1.6.0
 pytz==2016.10
 PyYAML==3.12
 requests==2.13.0
+requests-toolbelt==0.8.0
 rsa==3.4.2
 s3transfer==0.1.10
 singledispatch==3.4.0.3

--- a/tests/integration/rules/box/box_admin_events.json
+++ b/tests/integration/rules/box/box_admin_events.json
@@ -1,0 +1,33 @@
+{
+  "records": [
+    {
+      "data": {
+        "additional_details": null,
+        "created_at": "2017-10-27T12:31:22-07:00",
+        "created_by": {
+          "id": "2810219233",
+          "login": "testemail@email.com",
+          "name": "User Name",
+          "type": "user"
+        },
+        "event_id": "0e0b8122-17ed-42ee-8a9d-d9a57bf8dd83",
+        "event_type": "ADD_LOGIN_ACTIVITY_DEVICE",
+        "ip_address": "1.1.1.1",
+        "session_id": null,
+        "source": {
+          "id": "2810219233",
+          "login": "testemail@email.com",
+          "name": "User Name",
+          "type": "user"
+        },
+        "type": "event"
+      },
+      "description": "Box admin event log exmaple (validation only)",
+      "log": "box:admin_events",
+      "service": "stream_alert_app",
+      "source": "prefix_cluster_box_admin_events_sm-app-name_app",
+      "trigger_rules": [],
+      "validate_schema_only": true
+    }
+  ]
+}

--- a/tests/unit/app_integrations/test_apps/test_box.py
+++ b/tests/unit/app_integrations/test_apps/test_box.py
@@ -1,0 +1,207 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method,attribute-defined-outside-init
+import json
+from mock import Mock, mock_open, patch
+
+from boxsdk.exception import BoxException
+from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true
+from requests.exceptions import ConnectionError
+
+from app_integrations.apps.box import BoxApp
+from app_integrations.config import AppConfig
+
+from tests.unit.app_integrations.test_helpers import (
+    get_valid_config_dict,
+    MockSSMClient
+)
+
+@patch.object(BoxApp, 'type', Mock(return_value='type'))
+@patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient())
+class TestBoxApp(object):
+    """Test class for the BoxApp"""
+
+    # Remove all abstractmethods so we can instantiate BoxApp for testing
+    @patch.object(BoxApp, '__abstractmethods__', frozenset())
+    def setup(self):
+        """Setup before each method"""
+        self._app = BoxApp(AppConfig(get_valid_config_dict('box_admin_events')))
+
+    def test_sleep(self):
+        """BoxApp - Sleep Seconds"""
+        assert_equal(self._app._sleep_seconds(), 0)
+
+    def test_required_auth_info(self):
+        """BoxApp - Required Auth Info"""
+        assert_items_equal(self._app.required_auth_info().keys(), {'keyfile'})
+
+    @patch('app_integrations.apps.box.JWTAuth.from_settings_dictionary',
+           Mock(return_value=True))
+    def test_keyfile_validator(self):
+        """BoxApp - Keyfile Validation, Success"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        data = {'test': 'keydata'}
+        mocker = mock_open(read_data=json.dumps(data))
+        with patch('__builtin__.open', mocker):
+            loaded_keydata = validation_function('fakepath')
+            assert_equal(loaded_keydata, data)
+
+    @patch('app_integrations.apps.box.JWTAuth.from_settings_dictionary')
+    def test_keyfile_validator_failure(self, cred_mock):
+        """BoxApp - Keyfile Validation, Failure"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        cred_mock.return_value = False
+        mocker = mock_open(read_data=json.dumps({'test': 'keydata'}))
+        with patch('__builtin__.open', mocker):
+            assert_false(validation_function('fakepath'))
+            cred_mock.assert_called()
+
+    @patch('app_integrations.apps.box.JWTAuth.from_settings_dictionary')
+    def test_keyfile_validator_bad_json(self, cred_mock):
+        """BoxApp - Keyfile Validation, Bad JSON"""
+        validation_function = self._app.required_auth_info()['keyfile']['format']
+        mocker = mock_open(read_data='invalid json')
+        with patch('__builtin__.open', mocker):
+            assert_false(validation_function('fakepath'))
+            cred_mock.assert_not_called()
+
+    @patch('app_integrations.apps.box.JWTAuth.from_settings_dictionary',
+           Mock(return_value=True))
+    def test_load_credentials(self):
+        """BoxApp - Load Auth, Success"""
+        assert_true(self._app._load_auth('fakedata'))
+
+    @patch('app_integrations.apps.box.JWTAuth.from_settings_dictionary')
+    def test_load_credentials_bad(self, cred_mock):
+        """BoxApp - Load Auth, ValueError"""
+        cred_mock.side_effect = ValueError('Bad things happened')
+        assert_false(self._app._load_auth('fakedata'))
+
+    @patch('app_integrations.apps.box.BoxApp._load_auth',
+           Mock(return_value=True))
+    @patch('app_integrations.apps.box.Client',
+           Mock(return_value=True))
+    def test_create_client(self):
+        """BoxApp - Create Client, Success"""
+        assert_true(self._app._create_client())
+
+    @patch('logging.Logger.debug')
+    def test_create_client_exists(self, log_mock):
+        """BoxApp - Create Client, Exists"""
+        self._app._client = True
+        assert_true(self._app._create_client())
+        log_mock.assert_called_with('Client already instantiated for %s', 'type')
+
+    @patch('app_integrations.apps.box.BoxApp._load_auth',
+           Mock(return_value=False))
+    def test_create_client_fail_auth(self):
+        """BoxApp - Create Client, Auth Failure"""
+        assert_false(self._app._create_client())
+
+    def test_gather_logs(self):
+        """BoxApp - Gather Logs, Success"""
+        with patch.object(self._app, '_client') as client_mock:
+            payload = {
+                'chunk_size': 10,
+                'next_stream_position': '1152922976252290886',
+                'entries': self._get_sample_logs(10)
+            }
+            client_mock.make_request.return_value.json.return_value = payload
+
+            assert_equal(len(self._app._gather_logs()), 10)
+            assert_equal(self._app._last_timestamp, '2017-10-27T12:31:22-07:00')
+
+    @patch('app_integrations.apps.box.BoxApp._create_client',
+           Mock(return_value=True))
+    @patch('logging.Logger.exception')
+    def test_gather_logs_box_error(self, log_mock):
+        """BoxApp - Gather Logs, BoxException"""
+        with patch.object(self._app, '_client') as client_mock:
+            client_mock.make_request.side_effect = BoxException('bad error')
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('Failed to get events for %s', 'type')
+
+    @patch('app_integrations.apps.box.BoxApp._create_client',
+           Mock(return_value=True))
+    @patch('logging.Logger.exception')
+    def test_gather_logs_requests_error(self, log_mock):
+        """BoxApp - Gather Logs, ConnectionError"""
+        with patch.object(self._app, '_client') as client_mock:
+            self._app._next_stream_position = 10241040195019
+            client_mock.make_request.side_effect = ConnectionError(response='bad error')
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('Bad response received from host, will retry once')
+
+    @patch('app_integrations.apps.box.BoxApp._load_auth',
+           Mock(return_value=False))
+    def test_gather_logs_no_client(self):
+        """BoxApp - Gather Logs, No Client"""
+        with patch.object(self._app, '_client') as client_mock:
+            self._app._client = False
+            assert_false(self._app._gather_logs())
+            client_mock.make_request.assert_not_called()
+
+    @patch('app_integrations.apps.box.BoxApp._create_client',
+           Mock(return_value=True))
+    @patch('logging.Logger.error')
+    def test_gather_logs_no_results(self, log_mock):
+        """BoxApp - Gather Logs, No Results From API"""
+        with patch.object(self._app, '_client') as client_mock:
+            client_mock.make_request.return_value.json.return_value = None
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('No results received from the Box API request for %s',
+                                        'type')
+
+    @patch('app_integrations.apps.box.BoxApp._create_client',
+           Mock(return_value=True))
+    @patch('logging.Logger.info')
+    def test_gather_logs_empty_items(self, log_mock):
+        """BoxApp - Gather Logs, Empty Entries List"""
+        with patch.object(self._app, '_client') as client_mock:
+            payload = {
+                'chunk_size': 0,
+                'next_stream_position': '1152922976252290886',
+                'entries': []
+            }
+            client_mock.make_request.return_value.json.return_value = payload
+            assert_false(self._app._gather_logs())
+            log_mock.assert_called_with('No events in response from the Box API request for %s',
+                                        'type')
+
+    @staticmethod
+    def _get_sample_logs(count):
+        """Helper function for returning sample Box admin event logs"""
+        return [{
+            'additional_details': None,
+            'created_at': '2017-10-27T12:31:22-07:00',
+            'created_by': {
+                'id': '2710218233',
+                'login': 'testemail@email.com',
+                'name': 'User Name',
+                'type': 'user'
+            },
+            'event_id': '0e0b8122-17ed-42ee-8a9d-d9a57bf8dd83',
+            'event_type': 'ADD_LOGIN_ACTIVITY_DEVICE',
+            'ip_address': '1.1.1.22',
+            'session_id': None,
+            'source': {
+                'id': '2710218233',
+                'login': 'testemail@email.com',
+                'name': 'User Name',
+                'type': 'user'
+            },
+            'type': 'event'
+        } for _ in range(count)]

--- a/tests/unit/app_integrations/test_apps/test_gsuite.py
+++ b/tests/unit/app_integrations/test_apps/test_gsuite.py
@@ -20,7 +20,7 @@ from mock import Mock, mock_open, patch
 from apiclient import errors
 from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true, raises
 
-from app_integrations.apps.gsuite import GSuiteReportsApp #, DuoAdminApp, DuoAuthApp
+from app_integrations.apps.gsuite import GSuiteReportsApp
 from app_integrations.config import AppConfig
 
 from tests.unit.app_integrations.test_helpers import (

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -150,6 +150,19 @@ class TestAppIntegrationConfig(object):
             time_mock.return_value = 1234567890
             assert_equal(self._config._determine_last_time(), '2009-02-13T22:31:30Z')
 
+    @patch('calendar.timegm')
+    def test_determine_last_timestamp_box(self, time_mock):
+        """AppIntegrationConfig - Determine Last Timestamp, Box"""
+        with patch.object(AppConfig, 'SSM_CLIENT', MockSSMClient(app_type='box_admin_events')):
+            self._config = AppConfig.load_config(get_mock_context(), None)
+
+            # Reset the last timestamp to None
+            self._config.last_timestamp = None
+
+            # Use a mocked current time
+            time_mock.return_value = 1234567890
+            assert_equal(self._config._determine_last_time(), '2009-02-13T22:31:30-00:00')
+
     @patch('logging.Logger.error')
     def test_set_item(self, log_mock):
         """AppIntegrationConfig - Set Item, Bad Value"""

--- a/tests/unit/app_integrations/test_helpers.py
+++ b/tests/unit/app_integrations/test_helpers.py
@@ -129,6 +129,23 @@ class MockSSMClient(object):
                                              'a-test-200%40myapp-123456.iam.gserviceaccount.com')
                 }
             }
+        elif app_type in {'box', 'box_admin_events'}:
+            return {
+                'keyfile' : {
+                    'boxAppSettings': {
+                        'clientID': 'sc0ikmesi43elk4rxus11sbee1najitr',
+                        'clientSecret': '9ccOBWPh8ab5wHN2uGy0nFOrUtY82xcZ',
+                        'appAuth': {
+                            'publicKeyID': 'zqxhbd44',
+                            'privateKey': ('-----BEGIN ENCRYPTED PRIVATE KEY-----\n'
+                                           'VGhpcyBpcyBub3QgcmVhbA==\n-----END ENCRYPTED '
+                                           'PRIVATE KEY-----\n'),
+                            'passphrase': 'e8a88b08eff2797234d6313686f7bad7'
+                        }
+                    },
+                    'enterpriseID': '12345678'
+                }
+            }
 
         # Fill this out with future supported apps/services
         return {}
@@ -193,6 +210,8 @@ def get_formatted_timestamp(app_type):
     elif app_type in {'gsuite', 'gsuite_admin', 'gsuite_drive',
                       'gsuite_login', 'gsuite_token'}:
         return '2017-06-17T15:39:18.460Z'
+    elif app_type in {'box', 'box_admin_events'}:
+        return '2017-10-27T12:31:22-07:00'
 
 
 def get_valid_config_dict(app_type):


### PR DESCRIPTION
to: @javuto & @jacknagz 
cc: @airbnb/streamalert-maintainers
size: medium
resolves #398 

## Background

See #398:

Create an App to support Box Events (admin logs):
* https://developer.box.com/reference#events

## Changes

* Updates `required_auth_info` of the base app to ensure that the subclasses return an iterable (ie dict). This is to prevent subclasses from poorly implementing this method.
* New `BoxApp` for for admin (enterprise) events
  * Similarly to the G Suite app(s), the box app requires a box service account to be created in the admin console of Box. This will provide the user with a json file needed for JWT authorization.
  * Updating `requirements.txt` for the box sdk with jwt support (`boxsdk[jwt]==2.0.0a11`).
    * This uses an alpha build of the box sdk due to [this requirement](https://github.com/box/box-python-sdk/pull/245) that will be officially included in v2. 
* Adding the `boxsdk` to the third party package requirements for the apps Lambda function.
* Adding a schema for box admin events to the `logs.json`.

## Testing

Added unit tests for the new `BoxApp`. Also scripted the app locally to ensure it functions properly with the Box api.
