### PR TITLE
[output] phantom and slack output fixes

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -242,7 +242,7 @@ class PhantomOutput(StreamOutputBase):
         # Limit the query to 1 page, since we only care if one container exists with
         # this name.
         params = {
-            '_filter_name': rule_name,
+            '_filter_name': '"{}"'.format(rule_name),
             'page_size': 1
         }
         resp = self._get_request(container_url, params, headers, False)
@@ -521,7 +521,7 @@ class SlackOutput(StreamOutputBase):
 
         slack_message = self._format_message(kwargs['rule_name'], kwargs['alert'])
 
-        resp = self._get_request(creds['url'], slack_message)
+        resp = self._post_request(creds['url'], slack_message)
         success = self._check_http_response(resp)
 
         return self._log_status(success)

--- a/tests/unit/stream_alert_alert_processor/test_main.py
+++ b/tests/unit/stream_alert_alert_processor/test_main.py
@@ -98,7 +98,7 @@ def test_sort_dict_recursive():
         assert_equal(sub_keys[index], key)
 
 
-@patch('requests.get')
+@patch('requests.post')
 @patch('stream_alert.alert_processor.main._load_output_config')
 @patch('stream_alert.alert_processor.output_base.StreamOutputBase._load_creds')
 def test_running_success(creds_mock, config_mock, get_mock):

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -441,7 +441,7 @@ class TestPhantomOutput(object):
                                    alert=alert)
 
         full_url = 'http://phantom.foo.bar/rest/container'
-        params = {'_filter_name': 'rule_name', 'page_size': 1}
+        params = {'_filter_name': '"rule_name"', 'page_size': 1}
         headers = {'ph-auth-token': 'mocked_auth_token'}
         get_mock.assert_has_calls([call(full_url, params, headers, False)])
         rule_description = 'Info about this rule and what actions to take'
@@ -606,7 +606,7 @@ class TestSlackOutput(object):
         return get_alert()
 
     @patch('logging.Logger.info')
-    @patch('requests.get')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
     def test_dispatch_success(self, url_mock, log_info_mock):
@@ -622,7 +622,7 @@ class TestSlackOutput(object):
         log_info_mock.assert_called_with('Successfully sent alert to %s', self.__service)
 
     @patch('logging.Logger.error')
-    @patch('requests.get')
+    @patch('requests.post')
     @mock_s3
     @mock_kms
     def test_dispatch_failure(self, url_mock, log_error_mock):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves #445 

Two bugs are causing slack and phantom outputs to fail.

* Phantom output parameter needs to be wrapped in quotes
* Slack get request needs to be a post request