### PR TITLE
[test] Slack integration tests need to mock a post request

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -717,7 +717,7 @@ class AlertProcessorTester(object):
                                        'us-east-1', self.kms_alias)
 
                 # Set the patched requests.get return value to 200
-                get_mock.return_value.status_code = 200
+                post_mock.return_value.status_code = 200
 
 
 def report_output(passed, cols):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small

## Background

The Slack integration tests were incorrectly mocking out a `GET` request instead of a `POST`. This was not picked up because all the integration tests included at least one output that did mock out a `POST` request.

If you just have slack as a rule output, the integration tests will fail.

```
@rule(logs=['cloudtrail:events'],
      matchers=[],
      outputs=['slack:sample-channel'])
def cloudtrail_critical_api_calls(rec):
```

```
cloudtrail_critical_api_calls
       [Pass]  [trigger=1]                   rule      (s3): Deleting an AWS subnet (DeleteSubnet) will create an alert.
StreamAlertOutput [ERROR]: Encountered an error while sending to slack: <Mock name='mock().json().get()' id='4549616976'>
<Mock name='mock().json().get()' id='4549616976'>
StreamAlertOutput [ERROR]: Failed to send alert to slack
       [Fail]                                alert     (slack): sending alert to 'sample-channel'
       [Pass]  [trigger=1]                   rule      (s3): Deleting an AWS VPC (DeleteVpc) will create an alert.
```

When checking the Slack integration, it does indeed do a POST

```resp = self._post_request(creds['url'], slack_message)```

## Changes

* Change the test to use `post_mock` for slack outputs.

## Testing

1. Run a rule integration test with a single slack output, tests fail.
2. Apply the fix.
3. Tests pass.