### PR TITLE
[apps] catching connect and read timeout exceptions raised by requests

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -65,6 +65,17 @@ def get_app(config, init=True):
                                           '{}'.format(config['type']))
 
 
+def safe_timeout(func):
+    """Try/Except decorator to catch any timeout error raised by requests"""
+    def _wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except requests.exceptions.Timeout:
+            LOGGER.exception('Request timed out for %s', args[0].type())
+            return False, None
+    return _wrapper
+
+
 class AppIntegration(object):
     """Base class for all app integrations to be implemented for various services"""
     __metaclass__ = ABCMeta
@@ -301,6 +312,7 @@ class AppIntegration(object):
 
         return success
 
+    @safe_timeout
     def _make_get_request(self, full_url, headers, params=None):
         """Method for returning the json loaded response for this GET request
 
@@ -317,6 +329,7 @@ class AppIntegration(object):
 
         return self._check_http_response(response), response.json()
 
+    @safe_timeout
     def _make_post_request(self, full_url, headers, data):
         """Method for returning the json loaded response for this POST request
 

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -25,6 +25,7 @@ from nose.tools import (
     assert_true,
     raises
 )
+from requests.exceptions import ConnectTimeout
 
 from app_integrations.apps.app_base import AppIntegration, get_app
 from app_integrations.batcher import Batcher
@@ -255,3 +256,11 @@ class TestAppIntegration(object):
         # and to check the response, to log the message. If it was called three times,
         # it means `logs = response.json()['response']` is being called and should not be
         assert_equal(requests_mock.return_value.json.call_count, 2)
+
+    @patch('requests.get')
+    def test_make_request_timeout(self, requests_mock):
+        """App Integration - Make Request, Timeout"""
+        requests_mock.side_effect = ConnectTimeout(None, response='too slow')
+        result, response = self._app._make_get_request('hostname', None, None)
+        assert_false(result)
+        assert_is_none(response)


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

If connections or reads using `requests` ever timeout, the requests library catches those timeouts and raises its own exception(s). `requests.exceptions.ConnectTimeout` will be raised for connection-related timeouts, and `requests.exceptions.ReadTimeout` will be raised for timeouts during read.

Traceback observed in CloudWatch:
```
Traceback (most recent call last):
File "/var/task/app_integrations/main.py", line 39, in handler
app.gather()
File "/var/task/app_integrations/apps/app_base.py", line 410, in gather
while (self._gather() + self._sleep_seconds() <
File "/var/task/app_integrations/apps/app_base.py", line 395, in _gather
exec_time = Decimal(timeit(do_gather, number=1))
File "/usr/lib64/python2.7/timeit.py", line 237, in timeit
return Timer(stmt, setup, timer).timeit(number)
File "/usr/lib64/python2.7/timeit.py", line 202, in timeit
timing = self.inner(it, self.timer)
File "/usr/lib64/python2.7/timeit.py", line 100, in inner
_func()
File "/var/task/app_integrations/apps/app_base.py", line 370, in do_gather
logs = self._gather_logs()
File "/var/task/app_integrations/apps/onelogin.py", line 115, in _gather_logs
return self._get_onelogin_events()
File "/var/task/app_integrations/apps/onelogin.py", line 196, in _get_onelogin_events
result, response = self._make_get_request(request_url, self._auth_headers, params)
File "/var/task/app_integrations/apps/app_base.py", line 316, in _make_get_request
params=params, timeout=self._DEFAULT_REQUEST_TIMEOUT)
File "/var/task/requests/api.py", line 72, in get
return request('get', url, params=params, **kwargs)
File "/var/task/requests/api.py", line 58, in request
return session.request(method=method, url=url, **kwargs)
File "/var/task/requests/sessions.py", line 508, in request
resp = self.send(prep, **send_kwargs)
File "/var/task/requests/sessions.py", line 618, in send
r = adapter.send(request, **kwargs)
File "/var/task/requests/adapters.py", line 496, in send
raise ConnectTimeout(e, request=request)
ConnectTimeout: HTTPSConnectionPool(host='api.us.onelogin.com', port=443): Max retries exceeded with url: /api/1/events?since=2017-11-07T02:24:51.808Z&after_cursor=cGFnZV9udW1iZXI6OjoxOA (Caused by ConnectTimeoutError(<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8c839be90>, 'Connection to api.us.onelogin.com timed out. (connect timeout=3.05)'))
```

## Changes

* Creating a decorator to wrap any function that uses `requests` with a timeout to catch exceptions of type `requests.exceptions.Timeout`.
  * This is the type that both connection and read exceptions inherit from, so it will catch both of those.

## Testing

* Added unit test to ensure the catch happens properly.