### PR TITLE
[parser] fixing bug with json parser

### DIFF
--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -251,7 +251,10 @@ class JSONParser(ParserBase):
         if json_path_expression:
             LOGGER.debug('Parsing records with JSONPath')
             records_jsonpath = jsonpath_rw.parse(json_path_expression)
-            for match in records_jsonpath.find(json_payload):
+            matches = records_jsonpath.find(json_payload)
+            if not matches:
+                return False
+            for match in matches:
                 record = match.value
                 if envelope:
                     record.update({ENVELOPE_KEY: envelope})

--- a/tests/integration/rules/cloudtrail/cloudtrail_critical_api_calls.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_critical_api_calls.json
@@ -1,385 +1,427 @@
 {
-    "records": [
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DeleteSubnet",
-                "eventSource": "ec2.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "subnetId": "..."
-                },
-                "responseElements": {
-                    "_return": true
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
-                }
+  "records": [
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "DeleteSubnet",
+            "eventSource": "ec2.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "subnetId": "..."
             },
-            "description": "Deleting an AWS subnet (DeleteSubnet) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DeleteVpc",
-                "eventSource": "ec2.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "vpcId": "..."
-                },
-                "responseElements": {
-                    "_return": true
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
-                }
+            "responseElements": {
+              "_return": true
             },
-            "description": "Deleting an AWS VPC (DeleteVpc) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "UpdateTrail",
-                "eventSource": "cloudtrail.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "cloudWatchLogsLogGroupArn": "...",
-                    "cloudWatchLogsRoleArn": "...",
-                    "enableLogFileValidation": true,
-                    "isMultiRegionTrail": true,
-                    "kmsKeyId": "",
-                    "name": "..."
-                },
-                "responseElements": {
-                    "cloudWatchLogsLogGroupArn": "...",
-                    "cloudWatchLogsRoleArn": "...",
-                    "includeGlobalServiceEvents": true,
-                    "isMultiRegionTrail": true,
-                    "logFileValidationEnabled": true,
-                    "name": "...",
-                    "s3BucketName": "...",
-                    "trailARN": "..."
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Deleting an AWS subnet (DeleteSubnet) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "DeleteVpc",
+            "eventSource": "ec2.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "vpcId": "..."
             },
-            "description": "Updating an AWS CloudTrail trail (UpdateTrail) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "StopLogging",
-                "eventSource": "cloudtrail.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "name": "..."
-                },
-                "responseElements": null,
-                "sourceIPAddress": "...",
-                "userAgent": "...m",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
+            "responseElements": {
+              "_return": true
+            },
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Deleting an AWS VPC (DeleteVpc) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "UpdateTrail",
+            "eventSource": "cloudtrail.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "cloudWatchLogsLogGroupArn": "...",
+              "cloudWatchLogsRoleArn": "...",
+              "enableLogFileValidation": true,
+              "isMultiRegionTrail": true,
+              "kmsKeyId": "",
+              "name": "..."
             },
-            "description": "Suspending the recording of AWS API calls and log file delivery for a trail will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DeleteDBCluster",
-                "eventSource": "rds.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "dBClusterIdentifier": "...",
-                    "skipFinalSnapshot": true
-                },
-                "responseElements": {
-                    "allocatedStorage": 1,
-                    "associatedRoles": [
-                    ],
-                    "availabilityZones": [
-                        "...",
-                        "...",
-                        "..."
-                    ],
-                    "backupRetentionPeriod": 1,
-                    "clusterCreateTime": "...",
-                    "dBClusterArn": "...",
-                    "dBClusterIdentifier": "...",
-                    "dBClusterMembers": [
-                        {
-                            "dBClusterParameterGroupStatus": "...",
-                            "dBInstanceIdentifier": "...",
-                            "isClusterWriter": true,
-                            "promotionTier": 1
-                        },
-                        {
-                            "dBClusterParameterGroupStatus": "...",
-                            "dBInstanceIdentifier": "...",
-                            "isClusterWriter": false,
-                            "promotionTier": 1
-                        }
-                    ],
-                    "dBClusterParameterGroup": "...",
-                    "dBSubnetGroup": "...",
-                    "databaseName": "...",
-                    "dbClusterResourceId": "...",
-                    "earliestRestorableTime": "...",
-                    "endpoint": "...",
-                    "engine": "...",
-                    "engineVersion": "...",
-                    "hostedZoneId": "...",
-                    "iAMDatabaseAuthenticationEnabled": false,
-                    "latestRestorableTime": "...",
-                    "masterUsername": "...",
-                    "multiAZ": true,
-                    "port": 3306,
-                    "preferredBackupWindow": "...",
-                    "preferredMaintenanceWindow": "...",
-                    "readReplicaIdentifiers": [
-                    ],
-                    "readerEndpoint": "...",
-                    "status": "...",
-                    "storageEncrypted": false,
-                    "vpcSecurityGroups": [
-                        {
-                            "status": "...",
-                            "vpcSecurityGroupId": "..."
-                        }
-                    ]
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
+            "responseElements": {
+              "cloudWatchLogsLogGroupArn": "...",
+              "cloudWatchLogsRoleArn": "...",
+              "includeGlobalServiceEvents": true,
+              "isMultiRegionTrail": true,
+              "logFileValidationEnabled": true,
+              "name": "...",
+              "s3BucketName": "...",
+              "trailARN": "..."
+            },
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Updating an AWS CloudTrail trail (UpdateTrail) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "StopLogging",
+            "eventSource": "cloudtrail.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "name": "..."
             },
-            "description": "Deleting a database cluster (DeleteDBCluster) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "StopConfigurationRecorder",
-                "eventSource": "config.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "configurationRecorderName": "..."
-                },
-                "responseElements": null,
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
+            "responseElements": null,
+            "sourceIPAddress": "...",
+            "userAgent": "...m",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Suspending the recording of AWS API calls and log file delivery for a trail will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "DeleteDBCluster",
+            "eventSource": "rds.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "dBClusterIdentifier": "...",
+              "skipFinalSnapshot": true
             },
-            "description": "Suspending recording of resource changes through AWS Config (StopConfigurationRecorder) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DeleteFlowLogs",
-                "eventSource": "ec2.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "flowLogId": [
-                        "..."
-                    ]
+            "responseElements": {
+              "allocatedStorage": 1,
+              "associatedRoles": [],
+              "availabilityZones": [
+                "...",
+                "...",
+                "..."
+              ],
+              "backupRetentionPeriod": 1,
+              "clusterCreateTime": "...",
+              "dBClusterArn": "...",
+              "dBClusterIdentifier": "...",
+              "dBClusterMembers": [
+                {
+                  "dBClusterParameterGroupStatus": "...",
+                  "dBInstanceIdentifier": "...",
+                  "isClusterWriter": true,
+                  "promotionTier": 1
                 },
-                "responseElements": {
-                    "unsuccessful": [
-                    ]
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "invokedBy": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
+                {
+                  "dBClusterParameterGroupStatus": "...",
+                  "dBInstanceIdentifier": "...",
+                  "isClusterWriter": false,
+                  "promotionTier": 1
                 }
-            },
-            "description": "Deleting AWS network flow logs (DeleteFlowLogs) will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_critical_api_calls"]
-        },
-        {
-            "data": {
-                "awsRegion": "us-west-2",
-                "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
-                "eventName": "DescribeFlowLogs",
-                "eventSource": "ec2.amazonaws.com",
-                "eventTime": "2017-01-01T00:20:50Z",
-                "eventType": "AwsApiCall",
-                "eventVersion": "1.05",
-                "recipientAccountId": "123456789123",
-                "requestID": "...",
-                "requestParameters": {
-                    "flowLogId": [
-                        "..."
-                    ]
-                },
-                "responseElements": {
-                    "unsuccessful": [
-                    ]
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accessKeyId": "...",
-                    "accountId": "12345",
-                    "arn": "...",
-                    "invokedBy": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
+              ],
+              "dBClusterParameterGroup": "...",
+              "dBSubnetGroup": "...",
+              "databaseName": "...",
+              "dbClusterResourceId": "...",
+              "earliestRestorableTime": "...",
+              "endpoint": "...",
+              "engine": "...",
+              "engineVersion": "...",
+              "hostedZoneId": "...",
+              "iAMDatabaseAuthenticationEnabled": false,
+              "latestRestorableTime": "...",
+              "masterUsername": "...",
+              "multiAZ": true,
+              "port": 3306,
+              "preferredBackupWindow": "...",
+              "preferredMaintenanceWindow": "...",
+              "readReplicaIdentifiers": [],
+              "readerEndpoint": "...",
+              "status": "...",
+              "storageEncrypted": false,
+              "vpcSecurityGroups": [
+                {
+                  "status": "...",
+                  "vpcSecurityGroupId": "..."
                 }
+              ]
             },
-            "description": "Describing AWS network flog logs will not create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": []
-        }
-    ]
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Deleting a database cluster (DeleteDBCluster) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "StopConfigurationRecorder",
+            "eventSource": "config.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "configurationRecorderName": "..."
+            },
+            "responseElements": null,
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Suspending recording of resource changes through AWS Config (StopConfigurationRecorder) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "DeleteFlowLogs",
+            "eventSource": "ec2.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "flowLogId": [
+                "..."
+              ]
+            },
+            "responseElements": {
+              "unsuccessful": []
+            },
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "invokedBy": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Deleting AWS network flow logs (DeleteFlowLogs) will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_critical_api_calls"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "awsRegion": "us-west-2",
+            "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+            "eventName": "DescribeFlowLogs",
+            "eventSource": "ec2.amazonaws.com",
+            "eventTime": "2017-01-01T00:20:50Z",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.05",
+            "recipientAccountId": "123456789123",
+            "requestID": "...",
+            "requestParameters": {
+              "flowLogId": [
+                "..."
+              ]
+            },
+            "responseElements": {
+              "unsuccessful": []
+            },
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accessKeyId": "...",
+              "accountId": "12345",
+              "arn": "...",
+              "invokedBy": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Describing AWS network flog logs will not create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": []
+    }
+  ]
 }

--- a/tests/integration/rules/cloudtrail/cloudtrail_put_object_acl.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_put_object_acl.json
@@ -1,248 +1,266 @@
 {
-    "records": [
-        {
-            "data": {
-                "additionalEventData": {
-                    "x-amz-id-2": "..."
-                },
-                "awsRegion": "...",
-                "eventID": "...",
-                "eventName": "PutObject",
-                "eventSource": "...",
-                "eventTime": "...",
-                "eventType": "AwsApiCall",
-                "eventVersion": "...",
-                "readOnly": false,
-                "recipientAccountId": "12345",
-                "requestID": "...",
-                "requestParameters": {
-                    "X-Amz-Algorithm": "...",
-                    "X-Amz-Date": "...",
-                    "X-Amz-Expires": "12345",
-                    "X-Amz-SignedHeaders": "...",
-                    "accessControlList": {
-                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
-                        "x-amz-grant-read-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
-                        "x-amz-grant-write": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
-                        "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\""
-                    },
-                    "bucketName": "...",
-                    "key": "...",
-                    "x-amz-storage-class": "..."
-                },
-                "resources": [
-                    {
-                        "ARN": "...",
-                        "type": "..."
-                    },
-                    {
-                        "ARN": "...",
-                        "accountId": "12345",
-                        "type": "..."
-                    }
-                ],
-                "responseElements": {
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
-                }
+  "records": [
+    {
+      "data": {
+        "Records": [
+          {
+            "additionalEventData": {
+              "x-amz-id-2": "..."
             },
-            "description": "Storing an S3 object with an `AuthenticatedUsers` permission will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_put_object_acl"]
-        },
-        {
-            "data": {
-                "additionalEventData": {
-                    "x-amz-id-2": "..."
-                },
-                "awsRegion": "...",
-                "eventID": "...",
-                "eventName": "PutObject",
-                "eventSource": "...",
-                "eventTime": "...",
-                "eventType": "AwsApiCall",
-                "eventVersion": "...",
-                "readOnly": false,
-                "recipientAccountId": "12345",
-                "requestID": "...",
-                "requestParameters": {
-                    "X-Amz-Algorithm": "...",
-                    "X-Amz-Date": "...",
-                    "X-Amz-Expires": "12345",
-                    "X-Amz-SignedHeaders": "...",
-                    "accessControlList": {
-                        "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
-                    },
-                    "bucketName": "...",
-                    "key": "...",
-                    "x-amz-storage-class": "..."
-                },
-                "resources": [
-                    {
-                        "ARN": "...",
-                        "type": "..."
-                    },
-                    {
-                        "ARN": "...",
-                        "accountId": "12345",
-                        "type": "..."
-                    }
-                ],
-                "responseElements": {
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
-                }
+            "awsRegion": "...",
+            "eventID": "...",
+            "eventName": "PutObject",
+            "eventSource": "...",
+            "eventTime": "...",
+            "eventType": "AwsApiCall",
+            "eventVersion": "...",
+            "readOnly": false,
+            "recipientAccountId": "12345",
+            "requestID": "...",
+            "requestParameters": {
+              "X-Amz-Algorithm": "...",
+              "X-Amz-Date": "...",
+              "X-Amz-Expires": "12345",
+              "X-Amz-SignedHeaders": "...",
+              "accessControlList": {
+                "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                "x-amz-grant-read-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                "x-amz-grant-write": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\"",
+                "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", id=\"...\""
+              },
+              "bucketName": "...",
+              "key": "...",
+              "x-amz-storage-class": "..."
             },
-            "description": "Storing an S3 object with an `AllUsers` permission will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_put_object_acl"]
-        },
-        {
-            "data": {
-                "additionalEventData": {
-                    "x-amz-id-2": "..."
-                },
-                "awsRegion": "...",
-                "eventID": "...",
-                "eventName": "PutObject",
-                "eventSource": "...",
-                "eventTime": "...",
-                "eventType": "AwsApiCall",
-                "eventVersion": "...",
-                "readOnly": false,
-                "recipientAccountId": "12345",
-                "requestID": "...",
-                "requestParameters": {
-                    "X-Amz-Algorithm": "...",
-                    "X-Amz-Date": "...",
-                    "X-Amz-Expires": "12345",
-                    "X-Amz-SignedHeaders": "...",
-                    "accessControlList": {
-                        "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
-                    },
-                    "bucketName": "...",
-                    "key": "...",
-                    "x-amz-storage-class": "..."
-                },
-                "resources": [
-                    {
-                        "ARN": "...",
-                        "type": "..."
-                    },
-                    {
-                        "ARN": "...",
-                        "accountId": "12345",
-                        "type": "..."
-                    }
-                ],
-                "responseElements": {
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "false"
-                        }
-                    },
-                    "type": "..."
+            "resources": [
+              {
+                "ARN": "...",
+                "type": "..."
+              },
+              {
+                "ARN": "...",
+                "accountId": "12345",
+                "type": "..."
+              }
+            ],
+            "responseElements": {},
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Storing an S3 object with an `AuthenticatedUsers` permission will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_put_object_acl"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "additionalEventData": {
+              "x-amz-id-2": "..."
             },
-            "description": "Storing an S3 object with an `AllUsers` and `AuthenticatedUsers` permission will create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": ["cloudtrail_put_object_acl"]
-        },
-        {
-            "data": {
-                "additionalEventData": {
-                    "x-amz-id-2": "..."
-                },
-                "awsRegion": "...",
-                "eventID": "...",
-                "eventName": "PutObject",
-                "eventSource": "...",
-                "eventTime": "...",
-                "eventType": "AwsApiCall",
-                "eventVersion": "...",
-                "readOnly": false,
-                "recipientAccountId": "12345",
-                "requestID": "...",
-                "requestParameters": {
-                    "X-Amz-Algorithm": "...",
-                    "X-Amz-Date": "...",
-                    "X-Amz-Expires": "123",
-                    "X-Amz-SignedHeaders": "...",
-                    "bucketName": "...",
-                    "key": "...",
-                    "x-amz-storage-class": "..."
-                },
-                "resources": [
-                    {
-                        "ARN": "...",
-                        "type": "..."
-                    },
-                    {
-                        "ARN": "...",
-                        "accountId": "12345",
-                        "type": "..."
-                    }
-                ],
-                "responseElements": {
-                },
-                "sourceIPAddress": "...",
-                "userAgent": "...",
-                "userIdentity": {
-                    "accountId": "12345",
-                    "arn": "...",
-                    "principalId": "12345",
-                    "sessionContext": {
-                        "attributes": {
-                            "creationDate": "...",
-                            "mfaAuthenticated": "true"
-                        }
-                    },
-                    "type": "..."
+            "awsRegion": "...",
+            "eventID": "...",
+            "eventName": "PutObject",
+            "eventSource": "...",
+            "eventTime": "...",
+            "eventType": "AwsApiCall",
+            "eventVersion": "...",
+            "readOnly": false,
+            "recipientAccountId": "12345",
+            "requestID": "...",
+            "requestParameters": {
+              "X-Amz-Algorithm": "...",
+              "X-Amz-Date": "...",
+              "X-Amz-Expires": "12345",
+              "X-Amz-SignedHeaders": "...",
+              "accessControlList": {
+                "x-amz-grant-read": "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
+              },
+              "bucketName": "...",
+              "key": "...",
+              "x-amz-storage-class": "..."
+            },
+            "resources": [
+              {
+                "ARN": "...",
+                "type": "..."
+              },
+              {
+                "ARN": "...",
+                "accountId": "12345",
+                "type": "..."
+              }
+            ],
+            "responseElements": {},
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
                 }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Storing an S3 object with an `AllUsers` permission will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_put_object_acl"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "additionalEventData": {
+              "x-amz-id-2": "..."
             },
-            "description": "Storing an S3 object without an `AllUsers` or `AuthenticatedUsers` permission will not create an alert.",
-            "log": "cloudtrail:events",
-            "service": "s3",
-            "source": "prefix.cluster.sample.bucket",
-            "trigger_rules": []
-        }
-    ]
+            "awsRegion": "...",
+            "eventID": "...",
+            "eventName": "PutObject",
+            "eventSource": "...",
+            "eventTime": "...",
+            "eventType": "AwsApiCall",
+            "eventVersion": "...",
+            "readOnly": false,
+            "recipientAccountId": "12345",
+            "requestID": "...",
+            "requestParameters": {
+              "X-Amz-Algorithm": "...",
+              "X-Amz-Date": "...",
+              "X-Amz-Expires": "12345",
+              "X-Amz-SignedHeaders": "...",
+              "accessControlList": {
+                "x-amz-grant-write-acp": "uri=\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\", uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"...\""
+              },
+              "bucketName": "...",
+              "key": "...",
+              "x-amz-storage-class": "..."
+            },
+            "resources": [
+              {
+                "ARN": "...",
+                "type": "..."
+              },
+              {
+                "ARN": "...",
+                "accountId": "12345",
+                "type": "..."
+              }
+            ],
+            "responseElements": {},
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "false"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Storing an S3 object with an `AllUsers` and `AuthenticatedUsers` permission will create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": [
+        "cloudtrail_put_object_acl"
+      ]
+    },
+    {
+      "data": {
+        "Records": [
+          {
+            "additionalEventData": {
+              "x-amz-id-2": "..."
+            },
+            "awsRegion": "...",
+            "eventID": "...",
+            "eventName": "PutObject",
+            "eventSource": "...",
+            "eventTime": "...",
+            "eventType": "AwsApiCall",
+            "eventVersion": "...",
+            "readOnly": false,
+            "recipientAccountId": "12345",
+            "requestID": "...",
+            "requestParameters": {
+              "X-Amz-Algorithm": "...",
+              "X-Amz-Date": "...",
+              "X-Amz-Expires": "123",
+              "X-Amz-SignedHeaders": "...",
+              "bucketName": "...",
+              "key": "...",
+              "x-amz-storage-class": "..."
+            },
+            "resources": [
+              {
+                "ARN": "...",
+                "type": "..."
+              },
+              {
+                "ARN": "...",
+                "accountId": "12345",
+                "type": "..."
+              }
+            ],
+            "responseElements": {},
+            "sourceIPAddress": "...",
+            "userAgent": "...",
+            "userIdentity": {
+              "accountId": "12345",
+              "arn": "...",
+              "principalId": "12345",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "...",
+                  "mfaAuthenticated": "true"
+                }
+              },
+              "type": "..."
+            }
+          }
+        ]
+      },
+      "description": "Storing an S3 object without an `AllUsers` or `AuthenticatedUsers` permission will not create an alert.",
+      "log": "cloudtrail:events",
+      "service": "s3",
+      "source": "prefix.cluster.sample.bucket",
+      "trigger_rules": []
+    }
+  ]
 }

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -294,10 +294,7 @@
       "detail": {},
       "source": "string"
     },
-    "parser": "json",
-    "configuration": {
-      "json_path": "logEvents[*].extractedFields"
-    }
+    "parser": "json"
   },
   "json:regex_key_with_envelope": {
     "schema": {

--- a/tests/unit/stream_alert_rule_processor/test_classifier.py
+++ b/tests/unit/stream_alert_rule_processor/test_classifier.py
@@ -46,7 +46,7 @@ class TestStreamClassifier(object):
         """Helper method to return a preparsed and classified payload"""
         payload = load_stream_payload(service, entity, raw_record)
 
-        payload = payload.pre_parse().next()
+        payload = list(payload.pre_parse())[0]
         self.classifier.load_sources(service, entity)
         self.classifier.classify_record(payload)
 
@@ -272,7 +272,7 @@ class TestStreamClassifier(object):
 
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
         payload = load_stream_payload(service, entity, raw_record)
-        payload = payload.pre_parse().next()
+        payload = list(payload.pre_parse())[0]
 
         result = self.classifier._parse(payload)
 
@@ -301,7 +301,7 @@ class TestStreamClassifier(object):
 
         self.classifier.load_sources(service, entity)
 
-        payload = payload.pre_parse().next()
+        payload = list(payload.pre_parse())[0]
 
         schema_matches = self.classifier._process_log_schemas(payload)
 
@@ -330,7 +330,7 @@ class TestStreamClassifier(object):
 
         self.classifier.load_sources(service, entity)
 
-        payload = payload.pre_parse().next()
+        payload = list(payload.pre_parse())[0]
 
         schema_matches = self.classifier._process_log_schemas(payload)
 
@@ -359,7 +359,7 @@ class TestStreamClassifier(object):
 
         self.classifier.load_sources(service, entity)
 
-        payload = payload.pre_parse().next()
+        payload = list(payload.pre_parse())[0]
 
         schema_matches = self.classifier._process_log_schemas(payload)
 

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -111,7 +111,7 @@ def load_and_classify_payload(config, service, entity, raw_record):
     # prepare the payloads
     payload = load_stream_payload(service, entity, raw_record)
 
-    payload = payload.pre_parse().next()
+    payload = list(payload.pre_parse())[0]
     classifier = StreamClassifier(config=config)
     classifier.load_sources(service, entity)
     classifier.classify_record(payload)

--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -49,12 +49,8 @@ class TestParser(object):
     def _parser_type(cls):
         pass
 
-    def parser_helper(self, **kwargs):
+    def parser_helper(self, data, schema, options=None):
         """Helper to return the parser result"""
-        data = kwargs['data']
-        schema = kwargs['schema']
-        options = kwargs.get('options', {})
-
         parser = self.parser_class(options)
         parsed_result = parser.parse(schema, data)
         return parsed_result
@@ -113,6 +109,18 @@ class TestJSONParser(TestParser):
         parsed_data = self.parser_helper(data=data, schema=schema)
 
         assert_equal(len(parsed_data), 1)
+
+    def test_invalid_json_path(self):
+        """JSON Parser - Invalid JSON Path"""
+        # setup
+        schema = {'name': 'string', 'result': 'string'}
+        data = {'name': 'test', 'result': 'test'}
+        options = {'json_path': 'Records[*]'}
+
+        # get parsed data
+        parsed_data = self.parser_helper(data=data, schema=schema, options=options)
+
+        assert_false(parsed_data)
 
     @patch('stream_alert.rule_processor.parsers.LOGGER')
     def test_invalid_json(self, mock_logging):

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -662,8 +662,7 @@ class TestStreamRules(object):
         assert_equal(results, expected_results)
 
     def test_process_optional_logs(self):
-        """Rules Engine - Logs is optional when datatypes presented
-        """
+        """Rules Engine - Logs is optional when datatypes are present"""
         @rule(datatypes=['sourceAddress'],
               outputs=['s3:sample_bucket'])
         def no_logs_has_datatypes(rec): # pylint: disable=unused-variable
@@ -722,12 +721,11 @@ class TestStreamRules(object):
         assert_equal(len(alerts), 3)
         rule_names = ['no_logs_has_datatypes',
                       'has_logs_no_datatypes',
-                      'has_logs_datatypes'
-                     ]
+                      'has_logs_datatypes']
         assert_items_equal([alerts[i]['rule_name'] for i in range(3)], rule_names)
 
     def test_process_required_logs(self):
-        """Rules Engine - Logs is required when no datatypes defined."""
+        """Rules Engine - Logs is required when no datatypes defined"""
         @rule(outputs=['s3:sample_bucket'])
         def match_ipaddress(): # pylint: disable=unused-variable
             """Testing rule to detect matching IP address"""


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers @0xdabbad00
size: small
resolves N/A

## Background

Discovered a bug where the json parser would attempt to extract records using a json path if one was defined, but would continue processing even if the path does not exist.

## Changes

* Returning if `jsonpath_rw.parse(...).find(...)` does not find a valid json path.
* Updating misconfigured test events for `cloudtrail:events`
  * This accounts for the majority of these changes since these json files needed json prettified.
* Some other misc cleanup.

## Testing

Adding unit test to check for valid json path before continuing to process.
