### PR TITLE
[outputs] Firehose Output and Terraform Cleanup

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -5,6 +5,7 @@
     "source_current_hash": "<auto_generated>",
     "source_object_key": "<auto_generated>",
     "third_party_libraries": [
+      "backoff",
       "requests"
     ]
   },

--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -323,15 +323,15 @@ class StreamAlertAthenaClient(object):
                              athena_table)
                 continue
 
-            # Gather all of the partitions to add per bucket
-            s3_key_regex = self.STREAMALERTS_REGEX if athena_table == 'alerts' \
-                else self.FIREHOSE_REGEX
             # Iterate over each key
             for key in keys:
-                match = s3_key_regex.search(key)
+                for pattern in (self.FIREHOSE_REGEX, self.STREAMALERTS_REGEX):
+                    match = pattern.search(key)
+                    if match:
+                        break
+
                 if not match:
-                    LOGGER.error('The key %s does not match the regex %s, skipping',
-                                 key, s3_key_regex.pattern)
+                    LOGGER.error('The key %s does not match any regex, skipping', key)
                     continue
 
                 # Convert the match groups to a dict for easy access

--- a/terraform/modules/tf_stream_alert/firehose.tf
+++ b/terraform/modules/tf_stream_alert/firehose.tf
@@ -1,0 +1,118 @@
+// IAM Role: Alert Firehose S3 Role
+resource "aws_iam_role" "firehose" {
+  name = "${var.prefix}_${var.cluster}_streamalert_delivery_firehose"
+
+  assume_role_policy = "${data.aws_iam_policy_document.firehose_assume_role_policy.json}"
+}
+
+// IAM Policy: Service AssumeRole
+data "aws_iam_policy_document" "firehose_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+// IAM Policy: Write data to S3
+resource "aws_iam_role_policy" "stream_alert_firehose_s3" {
+  name = "S3PutAlerts"
+  role = "${aws_iam_role.firehose.id}"
+
+  policy = "${data.aws_iam_policy_document.firehose_s3.json}"
+}
+
+// IAM Policy Document: Write data to S3
+data "aws_iam_policy_document" "firehose_s3" {
+  statement {
+    effect = "Allow"
+
+    # Ref: http://amzn.to/2u5t0hS
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.prefix}.streamalerts",
+      "arn:aws:s3:::${var.prefix}.streamalerts/*",
+    ]
+  }
+}
+
+// CloudWatch Log Group: Firehose
+resource "aws_cloudwatch_log_group" "firehose" {
+  name              = "/aws/kinesisfirehose/${var.prefix}_${var.cluster}_streamalert_alert_delivery"
+  retention_in_days = "${var.cloudwatch_log_retention}"
+}
+
+// CloudWatch Log Stream: S3Delivery
+resource "aws_cloudwatch_log_stream" "s3_delivery" {
+  name           = "S3Delivery"
+  log_group_name = "${aws_cloudwatch_log_group.firehose.name}"
+}
+
+// IAM Policy: Write logs to CloudWatch
+resource "aws_iam_role_policy" "firehose_logging" {
+  name = "CloudWatchPutLogs"
+  role = "${aws_iam_role.firehose.id}"
+
+  policy = "${data.aws_iam_policy_document.firehose_cloudwatch.json}"
+}
+
+data "aws_iam_policy_document" "firehose_cloudwatch" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/kinesisfirehose/${var.prefix}_${var.cluster}_streamalert_alert_delivery:*",
+    ]
+  }
+}
+
+// AWS Firehose Stream for Alerts
+resource "aws_kinesis_firehose_delivery_stream" "stream_alerts" {
+  name        = "${var.prefix}_${var.cluster}_streamalert_alert_delivery"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn           = "${aws_iam_role.firehose.arn}"
+    bucket_arn         = "arn:aws:s3:::${var.prefix}.streamalerts"
+    prefix             = "alerts/"
+    buffer_size        = "${var.firehose_buffer_size}"
+    buffer_interval    = "${var.firehose_buffer_interval}"
+    compression_format = "${var.firehose_compression_format}"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = "/aws/kinesisfirehose/${var.prefix}_${var.cluster}_streamalert_alert_delivery"
+      log_stream_name = "S3Delivery"
+    }
+  }
+}

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -142,60 +142,11 @@ resource "aws_lambda_permission" "rule_processor" {
 // Log Retention Policy: Rule Processor
 resource "aws_cloudwatch_log_group" "rule_processor" {
   name              = "/aws/lambda/${var.prefix}_${var.cluster}_streamalert_rule_processor"
-  retention_in_days = 60
+  retention_in_days = "${var.cloudwatch_log_retention}"
 }
 
 // Log Retention Policy: Alert Processor
 resource "aws_cloudwatch_log_group" "alert_processor" {
   name              = "/aws/lambda/${var.prefix}_${var.cluster}_streamalert_alert_processor"
-  retention_in_days = 60
-}
-
-// CloudWatch metric filters for the rule processor
-// The split list is made up of: <filter_name>, <filter_pattern>, <value>
-resource "aws_cloudwatch_log_metric_filter" "rule_processor_cw_metric_filters" {
-  count          = "${length(var.rule_processor_metric_filters)}"
-  name           = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
-  pattern        = "${element(split(",", var.rule_processor_metric_filters[count.index]), 1)}"
-  log_group_name = "${aws_cloudwatch_log_group.rule_processor.name}"
-
-  metric_transformation {
-    name      = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
-    namespace = "${var.namespace}"
-    value     = "${element(split(",", var.rule_processor_metric_filters[count.index]), 2)}"
-  }
-}
-
-// CloudWatch metric filters for the alert processor
-// The split list is made up of: <filter_name>, <filter_pattern>, <value>
-resource "aws_cloudwatch_log_metric_filter" "alert_processor_cw_metric_filters" {
-  count          = "${length(var.alert_processor_metric_filters)}"
-  name           = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
-  pattern        = "${element(split(",", var.alert_processor_metric_filters[count.index]), 1)}"
-  log_group_name = "${aws_cloudwatch_log_group.alert_processor.name}"
-
-  metric_transformation {
-    name      = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
-    namespace = "${var.namespace}"
-    value     = "${element(split(",", var.alert_processor_metric_filters[count.index]), 2)}"
-  }
-}
-
-// CloudWatch metric alarms that are created per-cluster
-// The split list is our way around poor tf support for lists of maps and is made up of:
-// <alarm_name>, <alarm_description>, <comparison_operator>, <evaluation_periods>,
-// <metric>, <period>, <statistic>, <threshold>
-// TODO: update this logic to simply use a variable that is a list of maps once Terraform fixes this
-resource "aws_cloudwatch_metric_alarm" "cw_metric_alarms" {
-  count               = "${length(var.metric_alarms)}"
-  alarm_name          = "${element(split(",", var.metric_alarms[count.index]), 0)}"
-  alarm_description   = "${element(split(",", var.metric_alarms[count.index]), 1)}"
-  comparison_operator = "${element(split(",", var.metric_alarms[count.index]), 2)}"
-  evaluation_periods  = "${element(split(",", var.metric_alarms[count.index]), 3)}"
-  metric_name         = "${element(split(",", var.metric_alarms[count.index]), 4)}"
-  period              = "${element(split(",", var.metric_alarms[count.index]), 5)}"
-  statistic           = "${element(split(",", var.metric_alarms[count.index]), 6)}"
-  threshold           = "${element(split(",", var.metric_alarms[count.index]), 7)}"
-  namespace           = "${var.namespace}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+  retention_in_days = "${var.cloudwatch_log_retention}"
 }

--- a/terraform/modules/tf_stream_alert/metrics.tf
+++ b/terraform/modules/tf_stream_alert/metrics.tf
@@ -1,0 +1,48 @@
+// CloudWatch metric filters for the rule processor
+// The split list is made up of: <filter_name>, <filter_pattern>, <value>
+resource "aws_cloudwatch_log_metric_filter" "rule_processor_cw_metric_filters" {
+  count          = "${length(var.rule_processor_metric_filters)}"
+  name           = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
+  pattern        = "${element(split(",", var.rule_processor_metric_filters[count.index]), 1)}"
+  log_group_name = "${aws_cloudwatch_log_group.rule_processor.name}"
+
+  metric_transformation {
+    name      = "${element(split(",", var.rule_processor_metric_filters[count.index]), 0)}"
+    namespace = "${var.namespace}"
+    value     = "${element(split(",", var.rule_processor_metric_filters[count.index]), 2)}"
+  }
+}
+
+// CloudWatch metric filters for the alert processor
+// The split list is made up of: <filter_name>, <filter_pattern>, <value>
+resource "aws_cloudwatch_log_metric_filter" "alert_processor_cw_metric_filters" {
+  count          = "${length(var.alert_processor_metric_filters)}"
+  name           = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
+  pattern        = "${element(split(",", var.alert_processor_metric_filters[count.index]), 1)}"
+  log_group_name = "${aws_cloudwatch_log_group.alert_processor.name}"
+
+  metric_transformation {
+    name      = "${element(split(",", var.alert_processor_metric_filters[count.index]), 0)}"
+    namespace = "${var.namespace}"
+    value     = "${element(split(",", var.alert_processor_metric_filters[count.index]), 2)}"
+  }
+}
+
+// CloudWatch metric alarms that are created per-cluster
+// The split list is our way around poor tf support for lists of maps and is made up of:
+// <alarm_name>, <alarm_description>, <comparison_operator>, <evaluation_periods>,
+// <metric>, <period>, <statistic>, <threshold>
+// TODO: update this logic to simply use a variable that is a list of maps once Terraform fixes this
+resource "aws_cloudwatch_metric_alarm" "cw_metric_alarms" {
+  count               = "${length(var.metric_alarms)}"
+  alarm_name          = "${element(split(",", var.metric_alarms[count.index]), 0)}"
+  alarm_description   = "${element(split(",", var.metric_alarms[count.index]), 1)}"
+  comparison_operator = "${element(split(",", var.metric_alarms[count.index]), 2)}"
+  evaluation_periods  = "${element(split(",", var.metric_alarms[count.index]), 3)}"
+  metric_name         = "${element(split(",", var.metric_alarms[count.index]), 4)}"
+  period              = "${element(split(",", var.metric_alarms[count.index]), 5)}"
+  statistic           = "${element(split(",", var.metric_alarms[count.index]), 6)}"
+  threshold           = "${element(split(",", var.metric_alarms[count.index]), 7)}"
+  namespace           = "${var.namespace}"
+  alarm_actions       = ["${var.sns_topic_arn}"]
+}

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -2,20 +2,100 @@ variable "account_id" {
   default = ""
 }
 
-variable "region" {
-  default = ""
+variable "alert_processor_config" {
+  type    = "map"
+  default = {}
 }
 
-variable "prefix" {
-  default = ""
+variable "alert_processor_log_level" {
+  type    = "string"
+  default = "info"
+}
+
+variable "alert_processor_enable_metrics" {
+  default = false
+}
+
+variable "alert_processor_version" {}
+
+variable "alert_processor_memory" {}
+
+variable "alert_processor_timeout" {}
+
+variable "alert_processor_vpc_enabled" {
+  default = false
+}
+
+variable "alert_processor_vpc_subnet_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "alert_processor_vpc_security_group_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "alert_processor_metric_filters" {
+  type    = "list"
+  default = []
+}
+
+variable "cloudwatch_log_retention" {
+  default = 60
 }
 
 variable "cluster" {
   type = "string"
 }
 
+variable "input_sns_topics" {
+  type    = "list"
+  default = []
+}
+
+variable "firehose_buffer_size" {
+  default = 128
+}
+
+variable "firehose_buffer_interval" {
+  default = 300
+}
+
+variable "firehose_compression_format" {
+  default = "GZIP"
+}
+
 variable "kms_key_arn" {
   type = "string"
+}
+
+variable "metric_alarms" {
+  type    = "list"
+  default = []
+}
+
+variable "namespace" {
+  type    = "string"
+  default = "StreamAlert"
+}
+
+variable "output_lambda_functions" {
+  type    = "list"
+  default = []
+}
+
+variable "output_s3_buckets" {
+  type    = "list"
+  default = []
+}
+
+variable "prefix" {
+  default = ""
+}
+
+variable "region" {
+  default = ""
 }
 
 variable "rule_processor_config" {
@@ -38,73 +118,9 @@ variable "rule_processor_memory" {}
 
 variable "rule_processor_timeout" {}
 
-variable "alert_processor_config" {
-  type    = "map"
-  default = {}
-}
-
-variable "alert_processor_log_level" {
-  type    = "string"
-  default = "info"
-}
-
-variable "alert_processor_enable_metrics" {
-  default = false
-}
-
-variable "alert_processor_version" {}
-
-variable "alert_processor_memory" {}
-
-variable "alert_processor_timeout" {}
-
-variable "output_lambda_functions" {
-  type    = "list"
-  default = []
-}
-
-variable "output_s3_buckets" {
-  type    = "list"
-  default = []
-}
-
-variable "input_sns_topics" {
-  type    = "list"
-  default = []
-}
-
-variable "alert_processor_vpc_enabled" {
-  default = false
-}
-
-variable "alert_processor_vpc_subnet_ids" {
-  type    = "list"
-  default = []
-}
-
-variable "alert_processor_vpc_security_group_ids" {
-  type    = "list"
-  default = []
-}
-
 variable "rule_processor_metric_filters" {
   type    = "list"
   default = []
-}
-
-variable "alert_processor_metric_filters" {
-  type    = "list"
-  default = []
-}
-
-variable "metric_alarms" {
-  type    = "list"
-  default = []
-}
-
-variable "namespace" {
-  type    = "string"
-  default = "StreamAlert"
 }
 
 variable "sns_topic_arn" {}

--- a/terraform/modules/tf_stream_alert_athena/iam.tf
+++ b/terraform/modules/tf_stream_alert_athena/iam.tf
@@ -109,7 +109,15 @@ data "aws_iam_policy_document" "athena_permissions" {
     effect = "Allow"
 
     actions = [
-      "glue:*",
+      "glue:BatchCreatePartition",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetTable",
+      "glue:GetTableVersions",
+      "glue:GetTables",
+      "glue:UpdateDatabase",
+      "glue:UpdatePartition",
+      "glue:UpdateTable",
     ]
 
     resources = [

--- a/terraform/modules/tf_stream_alert_athena/iam.tf
+++ b/terraform/modules/tf_stream_alert_athena/iam.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 
 // IAM Role Policy: Allow the Lambda function to use Cloudwatch logging
 resource "aws_iam_role_policy" "cloudwatch" {
-  name = "cloudwatch_logs"
+  name = "CloudWatchPutLogs"
   role = "${aws_iam_role.athena_partition_role.id}"
 
   policy = "${data.aws_iam_policy_document.cloudwatch.json}"
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "cloudwatch" {
 
 // IAM Role Policy: Allow the Lambda function to use Cloudwatch logging
 resource "aws_iam_role_policy" "sqs" {
-  name = "sqs"
+  name = "SQSReadDeleteMessages"
   role = "${aws_iam_role.athena_partition_role.id}"
 
   policy = "${data.aws_iam_policy_document.sqs.json}"
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "sqs" {
 // IAM Role Policy: Allow the Lambda function to execute Athena queries
 // Ref: http://amzn.to/2tSyxUV
 resource "aws_iam_role_policy" "athena_query_permissions" {
-  name = "athena"
+  name = "AthenaQuery"
   role = "${aws_iam_role.athena_partition_role.id}"
 
   policy = "${data.aws_iam_policy_document.athena_permissions.json}"
@@ -139,7 +139,7 @@ data "aws_iam_policy_document" "athena_permissions" {
 
 // IAM Role Policy: Allow the Lambda function to read data buckets
 resource "aws_iam_role_policy" "athena_query_data_bucket_permissions" {
-  name = "athena_data_buckets"
+  name = "AthenaGetData"
   role = "${aws_iam_role.athena_partition_role.id}"
 
   policy = "${data.aws_iam_policy_document.athena_data_bucket_read.json}"

--- a/terraform/modules/tf_stream_alert_athena/iam.tf
+++ b/terraform/modules/tf_stream_alert_athena/iam.tf
@@ -109,6 +109,18 @@ data "aws_iam_policy_document" "athena_permissions" {
     effect = "Allow"
 
     actions = [
+      "glue:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
       "s3:GetBucketLocation",
       "s3:GetObject",
       "s3:ListBucket",

--- a/terraform/modules/tf_stream_alert_kinesis_events/README.md
+++ b/terraform/modules/tf_stream_alert_kinesis_events/README.md
@@ -11,6 +11,18 @@
     <th>Required</th>
   </tr>
   <tr>
+    <td>batch_size</td>
+    <td>The number of records fetched from Kinesis on a single Lambda invocation</td>
+    <td>100</td>
+    <td>False</td>
+  </tr>  
+  <tr>
+    <td>kinesis_stream_arn</td>
+    <td>The ARN of the Kinesis Stream</td>
+    <td>None</td>
+    <td>True</td>
+  </tr>
+  <tr>
     <td>lambda_role_id</td>
     <td>The AWS IAM Role ID attached to the Lambda function</td>
     <td>None</td>
@@ -25,12 +37,6 @@
   <tr>
     <td>lambda_function_arn</td>
     <td>The ARN of the Lambda function to read from Kinesis</td>
-    <td>None</td>
-    <td>True</td>
-  </tr>
-  <tr>
-    <td>kinesis_stream_arn</td>
-    <td>The ARN of the Kinesis Stream</td>
     <td>None</td>
     <td>True</td>
   </tr>

--- a/terraform/modules/tf_stream_alert_kinesis_events/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_events/main.tf
@@ -1,33 +1,41 @@
 // AWS Lambda Function Policy
 resource "aws_iam_role_policy" "stream_alert_lambda_kinesis" {
-  name = "stream_alert_lambda_kinesis_${var.role_policy_prefix}"
+  name = "KinesisGetRecords"
   role = "${var.lambda_role_id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "kinesis:DescribeStream",
-        "kinesis:GetRecords",
-        "kinesis:GetShardIterator",
-        "kinesis:ListStreams",
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
-    }
-  ]
+  policy = "${data.aws_iam_policy_document.kinesis_read.json}"
 }
-EOF
+
+// IAM Policy Doc: List and Get records from Kinesis
+data "aws_iam_policy_document" "kinesis_read" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kinesis:ListStreams",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kinesis:DescribeStream",
+      "kinesis:GetRecords",
+      "kinesis:GetShardIterator",
+    ]
+
+    resources = ["${var.kinesis_stream_arn}"]
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "stream_alert_kinesis_production_event_mapping" {
   enabled           = "${var.lambda_production_enabled}"
-  batch_size        = 100
+  batch_size        = "${var.batch_size}"
   event_source_arn  = "${var.kinesis_stream_arn}"
   function_name     = "${var.lambda_function_arn}:production"
   starting_position = "TRIM_HORIZON"

--- a/terraform/modules/tf_stream_alert_kinesis_events/variables.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_events/variables.tf
@@ -1,9 +1,13 @@
+variable "batch_size" {
+  default = 100
+}
+
+variable "kinesis_stream_arn" {}
+
 variable "lambda_role_id" {}
 
 variable "lambda_production_enabled" {}
 
 variable "lambda_function_arn" {}
-
-variable "kinesis_stream_arn" {}
 
 variable "role_policy_prefix" {}

--- a/tests/unit/conf/outputs.json
+++ b/tests/unit/conf/outputs.json
@@ -1,4 +1,7 @@
 {
+  "aws-firehose": {
+    "unit_test_delivery_stream": "unit_test_delivery_stream"
+  },
   "aws-lambda": {
     "unit_test_lambda": "unit_test_function",
     "unit_test_lambda_qual": "unit_test_function:production"

--- a/tests/unit/stream_alert_alert_processor/test_main.py
+++ b/tests/unit/stream_alert_alert_processor/test_main.py
@@ -70,7 +70,7 @@ def test_load_output_config():
     config = _load_output_config('tests/unit/conf/outputs.json')
 
     assert_equal(set(config.keys()), {
-        'aws-s3', 'aws-lambda', 'pagerduty', 'phantom', 'slack'})
+        'aws-firehose', 'aws-s3', 'aws-lambda', 'pagerduty', 'phantom', 'slack'})
 
 
 def test_sort_dict():

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -19,12 +19,14 @@ from collections import Counter, OrderedDict
 import json
 import boto3
 from mock import call, patch
-from moto import mock_s3, mock_kms, mock_lambda
+from moto import mock_s3, mock_kms, mock_lambda, mock_kinesis
 from nose.tools import (
     assert_equal,
+    assert_false,
     assert_is_none,
     assert_is_not_none,
-    assert_set_equal
+    assert_set_equal,
+    assert_true
 )
 
 from stream_alert.alert_processor import outputs
@@ -729,6 +731,71 @@ class TestS3Ouput(object):
                                    alert=alert)
 
         log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+
+class TestFirehoseOutput(object):
+    """Test class for AWS Kinesis Firehose"""
+    @classmethod
+    def setup_class(cls):
+        """Setup the class before any methods"""
+        cls.__service = 'aws-firehose'
+        cls.__descriptor = 'unit_test_delivery_stream'
+        cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
+                                                         REGION,
+                                                         FUNCTION_NAME,
+                                                         CONFIG)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown the class after all methods"""
+        cls.dispatcher = None
+
+    def test_locals(self):
+        """Output local variables - Kinesis Firehose"""
+        assert_equal(self.__dispatcher.__class__.__name__, 'KinesisFirehoseOutput')
+        assert_equal(self.__dispatcher.__service__, self.__service)
+
+    def _setup_dispatch(self):
+        """Helper for setting up S3Output dispatch"""
+        delivery_stream = CONFIG[self.__service][self.__descriptor]
+        boto3.client('firehose', region_name=REGION).create_delivery_stream(
+            DeliveryStreamName=delivery_stream,
+            S3DestinationConfiguration={
+                'RoleARN': 'arn:aws:iam::123456789012:role/firehose_delivery_role',
+                'BucketARN': 'arn:aws:s3:::unit_test',
+                'Prefix': '/',
+                'BufferingHints': {
+                    'SizeInMBs': 128,
+                    'IntervalInSeconds': 128
+                },
+                'CompressionFormat': 'GZIP',
+            }
+        )
+
+        return get_alert()
+
+    @patch('logging.Logger.info')
+    @mock_kinesis
+    def test_dispatch(self, log_mock):
+        """Output Dispatch - Kinesis Firehose"""
+        alert = self._setup_dispatch()
+        resp = self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                          rule_name='rule_name',
+                                          alert=alert)
+
+        assert_true(resp)
+        log_mock.assert_called_with('Successfully sent alert to %s', self.__service)
+
+    @mock_kinesis
+    def test_dispatch_ignore_large_payload(self):
+        """Output Dispatch - Kinesis Firehose with Large Payload"""
+        alert = self._setup_dispatch()
+        alert['record'] = 'test' * 1000 * 1000
+        resp = self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                          rule_name='rule_name',
+                                          alert=alert)
+
+        assert_false(resp)
 
 
 class TestLambdaOuput(object):

--- a/tests/unit/stream_alert_cli/test_outputs.py
+++ b/tests/unit/stream_alert_cli/test_outputs.py
@@ -30,18 +30,24 @@ from stream_alert_cli.outputs import (
 
 
 def test_load_output_config():
-    """Load outputs configuration"""
+    """CLI - Outputs - Load outputs configuration"""
     config = load_outputs_config('tests/unit/conf')
     loaded_config_keys = sorted(config.keys())
 
-    expected_config_keys = [u'aws-lambda', u'aws-s3', u'pagerduty', u'phantom', u'slack']
+    expected_config_keys = [
+        u'aws-firehose',
+        u'aws-lambda',
+        u'aws-s3',
+        u'pagerduty',
+        u'phantom',
+        u'slack']
 
     assert_list_equal(loaded_config_keys, expected_config_keys)
 
 
 @raises(ValueError)
 def test_load_output_config_error():
-    """Load outputs configuration - exception"""
+    """CLI - Outputs - Load outputs configuration - exception"""
     mock = mock_open(read_data='non-json string that will raise an exception')
     with patch('__builtin__.open', mock):
         load_outputs_config()
@@ -49,7 +55,7 @@ def test_load_output_config_error():
 
 @patch('json.dump')
 def test_write_outputs_config(json_mock):
-    """Write outputs configuration"""
+    """CLI - Outputs - Write outputs configuration"""
     with patch('__builtin__.open', new_callable=mock_open()) as mocker:
         data = {'test': 'values', 'to': 'write'}
         write_outputs_config(data)
@@ -59,7 +65,7 @@ def test_write_outputs_config(json_mock):
 
 @patch('stream_alert_cli.outputs.load_outputs_config')
 def test_load_config(method_mock):
-    """Load config - check for existing output"""
+    """CLI - Outputs - Load config - check for existing output"""
     # Patch the return value of the load_outputs_config method to return
     # the unit testing outputs configuration
     method_mock.return_value = load_outputs_config(conf_dir="tests/unit/conf")
@@ -76,7 +82,7 @@ def test_load_config(method_mock):
 @mock_kms
 @mock_s3
 def test_encrypt_and_push_creds_to_s3(cli_mock):
-    """Encrypt and push creds to s3"""
+    """CLI - Outputs - Encrypt and push creds to s3"""
     props = {
         'non-secret': OutputProperty(
             description='short description of info needed',
@@ -104,7 +110,7 @@ def test_encrypt_and_push_creds_to_s3(cli_mock):
 @patch('boto3.client')
 @patch('logging.Logger.error')
 def test_encrypt_and_push_creds_to_s3_kms_failure(log_mock, boto_mock):
-    """Encrypt and push creds to s3 - kms failure"""
+    """CLI - Outputs - Encrypt and push creds to s3 - kms failure"""
     props = {
         'secret': OutputProperty(
             description='short description of secret needed',
@@ -129,7 +135,7 @@ def test_encrypt_and_push_creds_to_s3_kms_failure(log_mock, boto_mock):
 
 @patch('json.dump')
 def test_update_outputs_config(json_mock):
-    """Update outputs config"""
+    """CLI - Outputs - Update outputs config"""
     with patch('__builtin__.open', new_callable=mock_open()) as mocker:
         service = 'mock_service'
         original_config = {service: ['value01', 'value02']}


### PR DESCRIPTION
to: @ryandeivert (Lambda) @chunyong-lin (Infra)
cc: @airbnb/streamalert-maintainers
size: large

## Background

Alerts are generally sent in low volume, but there may be scenarios where this is not the case.  When using S3 as an alert output, the Alert Processor can only handle so many requests per second before timing out. 

To fix this issue, alerts can now land in S3 to be searchable in Athena via a new Firehose Delivery Stream.  This enables the Alert Processor to asynchronously send data to S3 in high volume.

## Lambda Changes

* Write a new `KinesisFirehose` output plugin.
* Adjust the Athena Partition Refresh to determine the S3 key regex dynamically.
  * This allows for backwards compatibility between the S3 and Firehose output plugins, since the resultant S3 key is determined based on the service.
  * S3: `alerts/dt=YYYY-MM-DD-HH/<uuid>.json`
  * Firehose: `alerts/YYYY/MM/DD/HH/<uuid>.json`

## Infra Changes

* Create a new Firehose Delivery Stream for alert delivery.
  * Used a buffer interval of 300 (5 minutes) to deliver alerts to S3 quicker
  * Includes Error Logging too:
![screen shot 2017-11-07 at 4 26 21 pm](https://user-images.githubusercontent.com/11466941/32526270-4b65692e-c3dd-11e7-82d3-93798675ca3c.png)
* Create IAM Role and Policies for the new Firehose Stream
* Move CloudWatch Metrics code into a separate file in the main `stream_alert` module (cc @ryandeivert)
* Cleanup the Rule and Alert processor Role Policy naming.  They were previously unnecessarily verbose.
* Cleanup the Kinesis Events policy.  It was previously overly permissive with the ability to read from any Kinesis Stream.
* Cleanup the IAM policy names for Athena, similar to the previous changes above.
* Add permissions to account for Glue+Athena users.

## Testing

* Linted
* Unit Tested
* Deployed in AWS test account and verified end-to-end
