### PR TITLE
[output] Adding pagerdutyv2 to choices in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -102,7 +102,7 @@ Examples:
     # Output service options
     output_parser.add_argument(
         '--service',
-        choices=['aws-lambda', 'aws-s3', 'pagerduty', 'phantom', 'slack'],
+        choices=['aws-lambda', 'aws-s3', 'pagerduty', 'pagerdutyv2', 'phantom', 'slack'],
         required=True,
         help=ARGPARSE_SUPPRESS
     )

--- a/manage.py
+++ b/manage.py
@@ -102,7 +102,7 @@ Examples:
     # Output service options
     output_parser.add_argument(
         '--service',
-        choices=['aws-lambda', 'aws-s3', 'pagerduty', 'pagerdutyv2', 'phantom', 'slack'],
+        choices=['aws-lambda', 'aws-s3', 'pagerduty', 'pagerduty-v2', 'phantom', 'slack'],
         required=True,
         help=ARGPARSE_SUPPRESS
     )

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -123,7 +123,7 @@ class PagerDutyOutput(StreamOutputBase):
 @output
 class PagerDutyOutputV2(StreamOutputBase):
     """PagerDutyOutput handles all alert dispatching for PagerDuty Events API v2"""
-    __service__ = 'pagerdutyv2'
+    __service__ = 'pagerduty-v2'
 
     @classmethod
     def _get_default_properties(cls):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -704,7 +704,7 @@ class AlertProcessorTester(object):
 
                 # Set the patched requests.post return value to 200
                 post_mock.return_value.status_code = 200
-            elif service == 'pagerdutyv2':
+            elif service == 'pagerduty-v2':
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'routing_key': '247b97499078a015cc6c586bc0a92de6'}
                 helpers.put_mock_creds(output_name, creds, self.secrets_bucket,

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -176,8 +176,8 @@ class TestPagerDutyOutputV2(object):
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
-        cls.__service = 'pagerdutyv2'
-        cls.__descriptor = 'unit_test_pagerdutyv2'
+        cls.__service = 'pagerduty-v2'
+        cls.__descriptor = 'unit_test_pagerduty-v2'
         cls.__backup_method = None
         cls.__dispatcher = outputs.get_output_dispatcher(cls.__service,
                                                          REGION,


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

PagerDuty Events API v2 [was added](https://github.com/airbnb/streamalert/pull/436).

## Changes

* Added `pagerdutyv2` to the list of choices in `manage.py` so it can be added from the CLI.

## Testing

```
$ ./tests/scripts/unit_tests.sh
...
TOTAL                                            2332     45    98%
----------------------------------------------------------------------
Ran 420 tests in 7.407s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (96/96) Alert Tests Passed
StreamAlertCLI [INFO]: Completed

```