### PR TITLE
[cli] reporting failures due to issue we cannot directly diagnose

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -582,6 +582,11 @@ class RuleProcessorTester(object):
                        '{}.'.format(base_message, unexpected_key_list))
 
             self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
+            return
+
+        # Add a generic error message if we can not determine what the issue is
+        message = '{} Please look for any errors above.'.format(base_message)
+        self.status_messages.append(StatusMessage(StatusMessage.FAILURE, message))
 
 
 class AlertProcessorTester(object):


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers 
size: small
resolves N/A

## Background

Identified a bug in cli where a difficult to diagnose failure that occurs (ie: an invalid type for a value in a log causes a failure), we would not be properly report the failure at the end of processing.

For example:
```
$ python manage.py lambda test --processor rule --test-files test_log_for_bad_type
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

test_log_for_bad_type
StreamAlert [ERROR]: Invalid schema. Value for key [hostname] is not an int: This-Is-Not-An-Int
       [Fail]  [log='unknown']               validation  (s3): Test Log for Bad Type


StreamAlertCLI [INFO]: (1/1) Successful Tests
StreamAlertCLI [INFO]: Completed

## Check the status code:
$  echo $?
1
```

## Changes

* This fix is to log a generic failure message when an issue like this occurs, pointing the user to the output for more information.

The result is now something like:
```
$ python manage.py lambda test --processor rule --test-files test_log_for_bad_type
StreamAlertCLI [INFO]: Issues? Report here: https://github.com/airbnb/streamalert/issues

test_log_for_bad_type
StreamAlert [ERROR]: Invalid schema. Value for key [hostname] is not an int: This-Is-Not-An-Int
       [Fail]  [log='unknown']               validation  (s3): Test Log for Bad Type


StreamAlertCLI [INFO]: (0/1) Successful Tests
StreamAlertCLI [ERROR]: (1/1) Failures
StreamAlertCLI [ERROR]: (1/1) Invalid test event in file 'test_log_for_bad_type.json' with description 'Test Log for Bad Type'. Please look for any errors above.

## Check the status code:
$  echo $?
1
```

## Testing

See before and after above.
