### PR TITLE
[test] allow tests to run when using the firehose output and not us-east-1

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -475,9 +475,10 @@ def get_context_from_config(cluster, config):
     # Return a mocked context if the cluster is not provided
     # Otherwise construct the context from the config using the cluster
     if not cluster:
+        region = config['global']['account']['region']
         context.invoked_function_arn = (
-            'arn:aws:lambda:us-east-1:123456789012:'
-            'function:test_streamalert_processor:development')
+            'arn:aws:lambda:{}:123456789012:'
+            'function:test_streamalert_processor:development').format(region)
         context.function_name = 'test_streamalert_alert_processor'
         context.mocked = True
     else:


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves #460

## Background

If you are deploying StreamAlert in a region other than us-east-1, and you configure a firehose output, currently `./tests/scripts/rule_test.sh` will not work.  This fixes that.

## Changes

* Uses the configured region for the mocked lambda location.

## Testing

In `conf/global.json` configure a firehose output and set the region to `us-west-2`.  Then run the tests and note they fail. Now apply this change, and note it passes.
