### PR TITLE
[apps][box] a few bug fixes with config and box app

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -354,11 +354,15 @@ class AppIntegration(object):
             bool: Indicator of successful validation
         """
         if not self._config:
-            raise AppIntegrationConfigError('Config for service \'{}\' is empty', self.type())
+            raise AppIntegrationConfigError(
+                'Config for service \'{}\' is empty'.format(self.type())
+            )
 
         # The config validates that the 'auth' dict was loaded, but do a safety check here
         if not self._config.auth:
-            raise AppIntegrationConfigError('Auth config for service \'{}\' is empty', self.type())
+            raise AppIntegrationConfigError(
+                'Auth config for service \'{}\' is empty'.format(self.type())
+            )
 
         # Get the required authentication keys from the info returned by the subclass
         required_keys = set(self.required_auth_info())

--- a/app_integrations/apps/box.py
+++ b/app_integrations/apps/box.py
@@ -81,7 +81,7 @@ class BoxApp(AppIntegration):
             LOGGER.debug('Client already instantiated for %s', self.type())
             return True
 
-        auth = self._load_auth(self._config.auth)
+        auth = self._load_auth(self._config.auth['keyfile'])
         if not auth:
             return False
 

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -165,9 +165,8 @@ class AppConfig(dict):
         # Add the auth config info to the 'auth' key since these key/values can vary
         # from service to service
         base_config[cls.AUTH_CONFIG_SUFFIX] = {
-            key: value.encode('utf-8')
+            key: value.encode('utf-8') if isinstance(value, unicode) else value
             for key, value in params[param_names[cls.AUTH_CONFIG_SUFFIX]].iteritems()
-            if isinstance(value, unicode)
         }
 
         return AppConfig(base_config, event)

--- a/tests/unit/app_integrations/test_apps/test_box.py
+++ b/tests/unit/app_integrations/test_apps/test_box.py
@@ -90,13 +90,13 @@ class TestBoxApp(object):
         cred_mock.side_effect = ValueError('Bad things happened')
         assert_false(self._app._load_auth('fakedata'))
 
-    @patch('app_integrations.apps.box.BoxApp._load_auth',
-           Mock(return_value=True))
     @patch('app_integrations.apps.box.Client',
            Mock(return_value=True))
-    def test_create_client(self):
+    @patch('app_integrations.apps.box.BoxApp._load_auth')
+    def test_create_client(self, auth_mock):
         """BoxApp - Create Client, Success"""
         assert_true(self._app._create_client())
+        auth_mock.assert_called_with(self._app._config.auth['keyfile'])
 
     @patch('logging.Logger.debug')
     def test_create_client_exists(self, log_mock):


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

During a deployment of an app for box admin event, a few bugs were discovered.
1) Two `AppIntegrationConfigError` exceptions did not have the proper string formatting for error messages.
2) Auth for the box app uses the `keyfile` stored within the auth info and the app was trying to load to use the base `auth` dict instead of the appropriate key.
3) The logic used in the config to cast auth values that are of type `unicode` to type `str` would result in nested dictionaries being omitted from the config.
    * Box is the first app to actually utilize and entire dict within the auth config, so this went previously unnoticed.

## Changes

* App Base: Formatting messages within exceptions properly (instead of just being a tuple within the exception).
* Box: Loading the box authentication from the `keyfile` with the `auth` dictionary instead of using the root auth dictionary.
* Fixing casting of unicode --> str entries so dictionaries entries are not skipped.

## Testing

* Added unit test for auth loading in box to make sure the `_load_auth` method is being called with the correct parameter.
* Unit & rule tests passing.