### PR TITLE
[output] Adding new output for PagerDuty Incidents

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -153,6 +153,23 @@ Examples:
         req_subkeys={'columns':['port', 'protocol']})
         ...
 
+context
+~~~~~~~~~~~
+
+``context`` is an optional field to pass extra instructions to the alert processor on how to route the alert. It can be particulary helpful to pass data to an output.
+
+Example:
+
+.. code-block:: python
+
+  # Context provided to the pagerduty-incident output
+  # with instructions to assign the incident to a user.
+
+  @rule(logs=['osquery:differential'],
+        outputs=['pagerduty', 'aws-s3'],
+        context={'pagerduty-incident':{'assigned_user': 'valid_user'}})
+        ...
+
 
 Helpers
 -------

--- a/manage.py
+++ b/manage.py
@@ -102,7 +102,8 @@ Examples:
     output_parser.add_argument(
         '--service',
         choices=[
-            'aws-firehose', 'aws-lambda', 'aws-s3', 'pagerduty', 'pagerduty-v2', 'phantom', 'slack'
+            'aws-firehose', 'aws-lambda', 'aws-s3', 'pagerduty', 'pagerduty-v2',
+            'pagerduty-incident', 'phantom', 'slack'
         ],
         required=True,
         help=ARGPARSE_SUPPRESS)

--- a/stream_alert/alert_processor/helpers.py
+++ b/stream_alert/alert_processor/helpers.py
@@ -38,7 +38,8 @@ def validate_alert(alert):
         'log_source',
         'outputs',
         'source_service',
-        'source_entity'
+        'source_entity',
+        'context'
     }
     if not set(alert.keys()) == alert_keys:
         LOGGER.error('The alert object must contain the following keys: %s',
@@ -51,6 +52,11 @@ def validate_alert(alert):
         if key == 'record':
             if not isinstance(alert['record'], dict):
                 LOGGER.error('The alert record must be a map (dict)')
+                return False
+
+        elif key == 'context':
+            if not isinstance(alert['context'], dict):
+                LOGGER.error('The alert context must be a map (dict)')
                 return False
 
         elif key == 'outputs':

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -308,7 +308,6 @@ class PagerDutyIncidentOutput(StreamOutputBase):
         """Method to verify the existance of a escalation policy with the API
 
         Args:
-            api_url (str): Base URL of the API
             policy (str): Escalation policy to query about in the API
             default_policy (str): Escalation policy to use if the first one is not verified
 
@@ -332,7 +331,6 @@ class PagerDutyIncidentOutput(StreamOutputBase):
         """Method to verify the existance of a service with the API
 
         Args:
-            api_url (str): Base URL of the API
             service (str): Service to query about in the API
 
         Returns:
@@ -392,7 +390,7 @@ class PagerDutyIncidentOutput(StreamOutputBase):
         # Extracting context data to assign the incident
         rule_context = kwargs['alert'].get('context', {})
         if rule_context:
-            rule_context = rule_context[self.__service__]
+            rule_context = rule_context.get(self.__service__, {})
 
         # Check if a user to assign the incident is provided
         user_to_assign = rule_context.get('assigned_user', False)

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -386,7 +386,7 @@ class PagerDutyIncidentOutput(StreamOutputBase):
                 return 'assignments', [{'assignee': user_assignee}]
 
         # If escalation policy was not provided, use default one
-        policy_to_assign = context.get('assigned_policy') or self._escalation_policy
+        policy_to_assign = context.get('assigned_policy', self._escalation_policy)
 
         # Verify escalation policy, return tuple
         return 'escalation_policy', self._policy_verify(policy_to_assign, self._escalation_policy)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -28,7 +28,8 @@ RuleAttributes = namedtuple('Rule', ['rule_name',
                                      'datatypes',
                                      'logs',
                                      'outputs',
-                                     'req_subkeys'])
+                                     'req_subkeys',
+                                     'context'])
 
 
 class StreamRules(object):
@@ -70,6 +71,7 @@ class StreamRules(object):
             matchers = opts.get('matchers')
             datatypes = opts.get('datatypes')
             req_subkeys = opts.get('req_subkeys')
+            context = opts.get('context', {})
 
             if not (logs or datatypes):
                 LOGGER.error(
@@ -92,7 +94,8 @@ class StreamRules(object):
                                                     datatypes,
                                                     logs,
                                                     outputs,
-                                                    req_subkeys)
+                                                    req_subkeys,
+                                                    context)
             return rule
         return decorator
 
@@ -387,7 +390,8 @@ class StreamRules(object):
                         'log_type': payload.type,
                         'outputs': rule.outputs,
                         'source_service': payload.service(),
-                        'source_entity': payload.entity}
+                        'source_entity': payload.entity,
+                        'context': rule.context}
                     alerts.append(alert)
 
         return alerts

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -762,6 +762,14 @@ class AlertProcessorTester(object):
                 helpers.put_mock_creds(output_name, creds, self.secrets_bucket,
                                        'us-east-1', self.kms_alias)
 
+            elif service == 'pagerduty-incident':
+                output_name = '{}/{}'.format(service, descriptor)
+                creds = {'token': '247b97499078a015cc6c586bc0a92de6',
+                         'service_key': '247b97499078a015cc6c586bc0a92de6',
+                         'escalation_policy': '247b97499078a015cc6c586bc0a92de6'}
+                helpers.put_mock_creds(output_name, creds, self.secrets_bucket,
+                                       'us-east-1', self.kms_alias)
+
             elif service == 'phantom':
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'ph_auth_token': '6c586bc047b9749a92de29078a015cc6',

--- a/tests/unit/stream_alert_alert_processor/helpers.py
+++ b/tests/unit/stream_alert_alert_processor/helpers.py
@@ -79,10 +79,7 @@ def get_alert(index=0, context=None):
         index (int): test_index value (0 by default)
         context(dict): context dictionary (empty by default)
     """
-    if not context:
-        ctx = {}
-    else:
-        ctx = context
+    context = context or {}
 
     return {
         'record': {
@@ -101,7 +98,7 @@ def get_alert(index=0, context=None):
         'outputs': [
             'slack:unit_test_channel'
         ],
-        'context': ctx,
+        'context': context,
         'source_service': 's3',
         'source_entity': 'corp-prefix.prod.cb.region',
         'log_type': 'json',

--- a/tests/unit/stream_alert_alert_processor/helpers.py
+++ b/tests/unit/stream_alert_alert_processor/helpers.py
@@ -72,7 +72,18 @@ def get_random_alert(key_count, rule_name, omit_rule_desc=False):
     return alert
 
 
-def get_alert(index=0):
+def get_alert(index=0, context=None):
+    """This function generates a sample alert for testing purposes
+
+    Args:
+        index (int): test_index value (0 by default)
+        context(dict): context dictionary (empty by default)
+    """
+    if not context:
+        ctx = {}
+    else:
+        ctx = context
+
     return {
         'record': {
             'test_index': index,
@@ -90,6 +101,7 @@ def get_alert(index=0):
         'outputs': [
             'slack:unit_test_channel'
         ],
+        'context': ctx,
         'source_service': 's3',
         'source_entity': 'corp-prefix.prod.cb.region',
         'log_type': 'json',

--- a/tests/unit/stream_alert_alert_processor/helpers.py
+++ b/tests/unit/stream_alert_alert_processor/helpers.py
@@ -77,7 +77,7 @@ def get_alert(index=0, context=None):
 
     Args:
         index (int): test_index value (0 by default)
-        context(dict): context dictionary (empty by default)
+        context(dict): context dictionary (None by default)
     """
     context = context or {}
 

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -324,6 +324,79 @@ class TestPagerDutyIncidentOutput(object):
         """Replace method with cached method"""
         self.__dispatcher._get_default_properties = self.__backup_method
 
+    @patch('requests.get')
+    def test_check_exists_get_id(self, get_mock):
+        """Check Exists Get Id - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"check": [{"id": "checked_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', {}, 'check')
+        assert_equal(checked, 'checked_id')
+
+    @patch('requests.get')
+    def test_user_verify_success(self, get_mock):
+        """User Verify Success - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"users": [{"id": "verified_user_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        user_verified = self.__dispatcher._user_verify('http://mock_url', 'valid_user', {})
+        assert_equal(user_verified['id'], 'verified_user_id')
+        assert_equal(user_verified['type'], 'user_reference')
+
+    @patch('requests.get')
+    def test_user_verify_fail(self, get_mock):
+        """User Verify Fail - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"not_users": [{"not_id": "verified_user_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        user_verified = self.__dispatcher._user_verify('http://mock_url', 'valid_user', {})
+        assert_false(user_verified)
+
+    @patch('requests.get')
+    def test_policy_verify_success(self, get_mock):
+        """Policy Verify Success - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"escalation_policies": [{"id": "verified_policy_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        policy_verified = self.__dispatcher._policy_verify('http://mock_url', 'valid_policy', {})
+        assert_equal(policy_verified['id'], 'verified_policy_id')
+        assert_equal(policy_verified['type'], 'escalation_policy_reference')
+
+    @patch('requests.get')
+    def test_policy_verify_fail(self, get_mock):
+        """Policy Verify Fail - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"not_escalation_policies": [{"not_id": "verified_policy_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        policy_verified = self.__dispatcher._policy_verify('http://mock_url', 'valid_policy', {})
+        assert_false(policy_verified)
+
+    @patch('requests.get')
+    def test_service_verify_success(self, get_mock):
+        """Service Verify Success - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"services": [{"id": "verified_service_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        service_verified = self.__dispatcher._service_verify('http://mock_url', 'valid_user', {})
+        assert_equal(service_verified['id'], 'verified_service_id')
+        assert_equal(service_verified['type'], 'service_reference')
+
+    @patch('requests.get')
+    def test_service_verify_fail(self, get_mock):
+        """Service Verify Fail - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"not_services": [{"not_id": "verified_service_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        service_verified = self.__dispatcher._service_verify('http://mock_url', 'valid_user', {})
+        assert_false(service_verified)
+
     @patch('logging.Logger.info')
     @patch('requests.post')
     @patch('requests.get')

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -331,7 +331,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"check": [{"id": "checked_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', {}, 'check')
+        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', 'check')
         assert_equal(checked, 'checked_id')
 
     @patch('requests.get')
@@ -341,7 +341,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"users": [{"id": "verified_user_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        user_verified = self.__dispatcher._user_verify('http://mock_url', 'valid_user', {})
+        user_verified = self.__dispatcher._user_verify('valid_user')
         assert_equal(user_verified['id'], 'verified_user_id')
         assert_equal(user_verified['type'], 'user_reference')
 
@@ -352,7 +352,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"not_users": [{"not_id": "verified_user_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        user_verified = self.__dispatcher._user_verify('http://mock_url', 'valid_user', {})
+        user_verified = self.__dispatcher._user_verify('valid_user')
         assert_false(user_verified)
 
     @patch('requests.get')
@@ -362,7 +362,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"escalation_policies": [{"id": "verified_policy_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        policy_verified = self.__dispatcher._policy_verify('http://mock_url', 'valid_policy', {})
+        policy_verified = self.__dispatcher._policy_verify('valid_policy')
         assert_equal(policy_verified['id'], 'verified_policy_id')
         assert_equal(policy_verified['type'], 'escalation_policy_reference')
 
@@ -373,7 +373,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"not_escalation_policies": [{"not_id": "verified_policy_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        policy_verified = self.__dispatcher._policy_verify('http://mock_url', 'valid_policy', {})
+        policy_verified = self.__dispatcher._policy_verify('valid_policy')
         assert_false(policy_verified)
 
     @patch('requests.get')
@@ -383,7 +383,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"services": [{"id": "verified_service_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        service_verified = self.__dispatcher._service_verify('http://mock_url', 'valid_user', {})
+        service_verified = self.__dispatcher._service_verify('valid_service')
         assert_equal(service_verified['id'], 'verified_service_id')
         assert_equal(service_verified['type'], 'service_reference')
 
@@ -394,8 +394,31 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"not_services": [{"not_id": "verified_service_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        service_verified = self.__dispatcher._service_verify('http://mock_url', 'valid_user', {})
+        service_verified = self.__dispatcher._service_verify('valid_service')
         assert_false(service_verified)
+
+    @patch('requests.get')
+    def test_item_verify_success(self, get_mock):
+        """Item Verify Success - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"items": [{"id": "verified_item_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        item_verified = self.__dispatcher._item_verify('http://mock_url', 'valid_item',
+                                                       'items', 'item_reference')
+        assert_equal(item_verified['id'], 'verified_item_id')
+        assert_equal(item_verified['type'], 'item_reference')
+
+    @patch('requests.get')
+    def test_item_verify_fail(self, get_mock):
+        """Item Verify Fail - PagerDutyIncidentOutput"""
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"not_items": [{"not_id": "verified_item_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        item_verified = self.__dispatcher._item_verify('http://mock_url', 'valid_item',
+                                                       'items', 'item_reference')
+        assert_false(item_verified)
 
     @patch('logging.Logger.info')
     @patch('requests.post')

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -336,6 +336,17 @@ class TestPagerDutyIncidentOutput(object):
         assert_equal(checked, 'checked_id')
 
     @patch('requests.get')
+    def test_check_exists_get_id_fail(self, get_mock):
+        """Check Exists Get Id Fail - PagerDutyIncidentOutput"""
+        # /check
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{}')
+        get_mock.return_value.json.return_value = json_check
+
+        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', 'check')
+        assert_false(checked)
+
+    @patch('requests.get')
     def test_user_verify_success(self, get_mock):
         """User Verify Success - PagerDutyIncidentOutput"""
         get_mock.return_value.status_code = 200

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -101,11 +101,13 @@ class TestStreamRules(object):
             'log_source',
             'outputs',
             'source_service',
-            'source_entity'
+            'source_entity',
+            'context'
         }
         assert_items_equal(alerts[0].keys(), alert_keys)
         assert_is_instance(alerts[0]['record'], dict)
         assert_is_instance(alerts[0]['outputs'], list)
+        assert_is_instance(alerts[0]['context'], dict)
 
         # test alert fields
         assert_is_instance(alerts[0]['rule_name'], str)
@@ -207,7 +209,8 @@ class TestStreamRules(object):
             datatypes=[],
             logs=['test_log_type_json_nested'],
             outputs=['s3:sample_bucket'],
-            req_subkeys={'requestParameters': ['program']}
+            req_subkeys={'requestParameters': ['program']},
+            context={}
         )
 
         data = json.dumps({


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

Migrating to the PagerDuty REST API helps to simplify the code and utilize features only present in v2. You can read up on more advantages of the migration to the new API [here](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2).
After adding support for the PagerDuty Events API v2, next step is to be able to create Incidents using the API.

## Changes

* Adding support for PagerDuty Incidents API v2 (REST API) as output. [API reference for creating incidents.](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Incidents/post_incidents).
* Added tests for new output.
* Adding context field as decorator in the alert, as `RuleAttributes` field. This allows specific rules to add some context to the alert record to be used in places like the outputs.
* Added documentation for new field for rule `context`.

## Testing

```
$ ./tests/scripts/unit_tests.sh
...
TOTAL                                            2388     81    97%
----------------------------------------------------------------------
Ran 425 tests in 8.940s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (96/96) Alert Tests Passed
StreamAlertCLI [INFO]: Completed

```