### PR TITLE
[apps][onelogin][bug] Making sure response is valid before accessing it

### DIFF
--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -197,7 +197,7 @@ class OneLoginApp(AppIntegration):
 
         if not result:
             # If we hit the rate limit, update the sleep time
-            if response.get('status'):
+            if response and response.get('status'):
                 r_status = response.get('status')
                 if r_status['code'] == 400 and r_status['message'] == 'rate_limit_exceeded':
                     self._set_rate_limit_sleep()


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves #470 

## Background

When a requests goes to the OneLogin API, if the result of the request is `False`, we may access the response object to get information from the response. But for example, if there is a `ConnectTimeout` exception, the response will be `None`.

## Changes

* Adds check to make sure the returned response is a valid JSON. Fixes #470.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                            2332     74    97%
----------------------------------------------------------------------
Ran 420 tests in 6.865s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (96/96) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```