### PR TITLE
[docs] adding box to list of supported apps

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -23,12 +23,12 @@ Apps are made possible through the use of AWS technologies:
 Supported Services
 ------------------
 
-* Duo
+* `Duo <https://duo.com/docs/administration-reporting>`_
 
   - Authentication Logs
   - Administrator Logs
 
-* OneLogin
+* `OneLogin <https://support.onelogin.com/hc/en-us/articles/202123754-Events>`_
 
   - Events Logs
 
@@ -45,7 +45,11 @@ Supported Services
   - SAML
   - Authorization Tokens
 
-* *Soon to come:* `Box <https://github.com/airbnb/streamalert/issues/398>`_, and more
+* `Box <https://developer.box.com/v2.0/reference#events>`_
+
+  - Admin Events
+
+* *More to come*
 
 
 Getting Started


### PR DESCRIPTION
to: @mime-frame 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

The docs were not updated to include box as a supported service for apps.

## Changes

* Adding box to the list of supported services for apps.
* Adding some links to other supported services.

## Testing

Tested with:
`sphinx-build -W docs/source docs/build && open docs/build/index.html`
