### PR TITLE
[logs] adding optional top level key for box admin events

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1,6 +1,7 @@
 {
   "box:admin_events": {
     "schema": {
+      "accessible_by": {},
       "additional_details": "string",
       "created_at": "string",
       "created_by": {},
@@ -11,7 +12,12 @@
       "source": {},
       "type": "string"
     },
-    "parser": "json"
+    "parser": "json",
+    "configuration": {
+      "optional_top_level_keys": [
+        "accessible_by"
+      ]
+    }
   },
   "carbonblack:binarystore.file.added": {
     "schema": {


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Discovered an undocumented optional top level key for the box admin event logs of `accessible_by` after an initial deployment.

## Changes

* Adding `accessible_by` as an optional top level key for box admin event log types.

## Testing

Tests still passing with `python manage.py lambda test -p rule -f box_admin_events`
