### PR TITLE
[cli] cleanup athena tf.json and fix cw generate bug

### DIFF
--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -293,7 +293,7 @@ def generate_cluster(**kwargs):
 
     generate_cloudwatch_metric_alarms(cluster_name, cluster_dict, config)
 
-    if modules.get('cloudwatch_monitoring'):
+    if modules.get('cloudwatch_monitoring', {}).get('enabled'):
         if not generate_monitoring(cluster_name, cluster_dict, config):
             return
 

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -176,6 +176,7 @@ def terraform_clean(config):
 
     cleanup_files = ['{}.tf.json'.format(cluster) for cluster in config.clusters()]
     cleanup_files.extend([
+        'athena.tf.json',
         'main.tf.json',
         'terraform.tfstate',
         'terraform.tfstate.backup'


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

@chunyong-lin identified a bug where if `enabled: false` was set in the cloudwatch monitoring config, it would fail Terraform.

## Changes

* Fix the bug as described above
* Remove the old Athena files

## Testing

Ran `python manage.py terraform generate` and unit tests prior to pushing
