### PR TITLE
[apps][box] bumping max log limit for box from 100 --> 500

### DIFF
--- a/app_integrations/apps/box.py
+++ b/app_integrations/apps/box.py
@@ -27,7 +27,7 @@ from app_integrations.apps.app_base import app, AppIntegration
 @app
 class BoxApp(AppIntegration):
     """BoxApp integration"""
-    _MAX_CHUNK_SIZE = 100
+    _MAX_CHUNK_SIZE = 500
 
     def __init__(self, config):
         super(BoxApp, self).__init__(config)


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers 
size: small
resolves N/A

## Background

After taking a second look at the docs (https://developer.box.com/reference#get-events-in-an-enterprise) I realized the _default_ limit is 100, while the actual _max_ is 500.

## Changes

* This change is get the max amount possible on each call (500 instead of the default of 100).
* This should reduce the number of api calls we have to make and make the box app function run for a shorter amount of time.

## Testing

* No substantial changes, but `tests/scripts/unit_tests.sh` passing
