### PR TITLE
[cli][tests] adding mocking for firehose output

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -381,6 +381,29 @@ def put_mock_creds(output_name, creds, bucket, region, alias):
     put_mock_s3_object(bucket, output_name, enc_creds, region)
 
 
+def create_delivery_stream(region, stream_name, prefix=''):
+    """Create a mock AWS Kinesis Firehose stream
+
+    Args:
+        region (str): The AWS region for the boto3 client
+    """
+    firehose_client = boto3.client('firehose', region_name=region)
+
+    firehose_client.create_delivery_stream(
+        DeliveryStreamName=stream_name,
+        S3DestinationConfiguration={
+            'RoleARN': 'arn:aws:iam::123456789012:role/firehose_delivery_role',
+            'BucketARN': 'arn:aws:s3:::kinesis-test',
+            'Prefix': prefix,
+            'BufferingHints': {
+                'SizeInMBs': 123,
+                'IntervalInSeconds': 124
+            },
+            'CompressionFormat': 'Snappy',
+        }
+    )
+
+
 @mock_kinesis
 def setup_mock_firehose_delivery_streams(config):
     """Mock Kinesis Firehose Streams for rule testing
@@ -389,21 +412,10 @@ def setup_mock_firehose_delivery_streams(config):
         config (CLIConfig): The StreamAlert config
     """
     region = config['global']['account']['region']
-    firehose_client = boto3.client('firehose', region_name=region)
     for log_type in enabled_firehose_logs(config):
-        firehose_client.create_delivery_stream(
-            DeliveryStreamName='streamalert_data_{}'.format(log_type),
-            S3DestinationConfiguration={
-                'RoleARN': 'arn:aws:iam::123456789012:role/firehose_delivery_role',
-                'BucketARN': 'arn:aws:s3:::kinesis-test',
-                'Prefix': '{}/'.format(log_type),
-                'BufferingHints': {
-                    'SizeInMBs': 123,
-                    'IntervalInSeconds': 124
-                },
-                'CompressionFormat': 'Snappy',
-            }
-        )
+        stream_name = 'streamalert_data_{}'.format(log_type)
+        prefix = '{}/'.format(log_type)
+        create_delivery_stream(region, stream_name, prefix)
 
 
 def put_mock_s3_object(bucket, key, data, region):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -608,6 +608,7 @@ class AlertProcessorTester(object):
         self.secrets_bucket = 'test.streamalert.secrets'
         self.outputs_config = load_outputs_config()
         self._cleanup_old_secrets()
+        self.region = config['global']['account']['region']
         helpers.setup_mock_firehose_delivery_streams(config)
 
     def test_processor(self, alerts):
@@ -735,6 +736,11 @@ class AlertProcessorTester(object):
                     client.head_bucket(Bucket=bucket)
                 except ClientError:
                     client.create_bucket(Bucket=bucket)
+
+            elif service == 'aws-firehose':
+                stream_name = self.outputs_config[service][descriptor]
+                helpers.create_delivery_stream(self.region, stream_name)
+
             elif service == 'aws-lambda':
                 lambda_function = self.outputs_config[service][descriptor]
                 parts = lambda_function.split(':')
@@ -743,6 +749,7 @@ class AlertProcessorTester(object):
                 else:
                     lambda_function = parts[-1]
                 helpers.create_lambda_function(lambda_function, 'us-east-1')
+
             elif service == 'pagerduty':
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'service_key': '247b97499078a015cc6c586bc0a92de6'}


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers 
size: small
resolves N/A

## Background

Rule tests that were run with `python manage.py lambda test -p all` would fail for any rules that were using firehose outputs with an error similar to:
```
ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the PutRecord operation: Stream airbnb_streamalert_alert_delivery under account 123456789012 not found.
```

## Changes

* Adding mocking support for AWS firehose output

## Testing

Added a firehose output for rules and ran tests successfully.
