### PR TITLE
[apps][box] add default timeout to requests made through boxsdk

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -66,7 +66,14 @@ def get_app(config, init=True):
 
 
 def safe_timeout(func):
-    """Try/Except decorator to catch any timeout error raised by requests"""
+    """Try/Except decorator to catch any timeout error raised by requests
+
+    NOTE: Use this wrapper on instance methods only, ie: methods with 'self' as the first param
+
+    Args:
+        func (im_func): Instance method wrapper function for safety netting requests
+            that could result in a connection or read timeout.
+    """
     def _wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)

--- a/manage.py
+++ b/manage.py
@@ -923,7 +923,7 @@ Required Arguments:
     -r/--test-rules                    List of rules to test, separated by spaces.
                                          Cannot be used in conjunction with `--test-files`
     -f/--test-files                    List of files to test, separated by spaces.
-                                         Cannot be used in conjunction with `--test-files`
+                                         Cannot be used in conjunction with `--test-rules`
                                          This flag supports the full file name, with extension,
                                          or the base file name, without extension
                                          (ie: test_file_name.json or test_file_name).


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

I noticed a single instance of the box app timing out in CloudWatch logs and determined that the `boxsdk` does not use a default timeout for connection or read requests (and can run indefinitely).

## Changes

* Adding a timeout to the requests performed through the `boxsdk` that is the same as the default timeout for requests made through the app base.
* Wrapping the request with the `safe_timeout` function to make sure timeout exceptions that are raised do not crash the box app.

## Other Changes
* Fixing typo in the cli within some helper text (`--test-files` --> `--test-rules`)

## Testing

* Adding unit tests to verify that the timeout is properly caught and logged.

