### PR TITLE
[apps] using factory-style class decorator for registering StreamAlertApps

### DIFF
--- a/app_integrations/apps/box.py
+++ b/app_integrations/apps/box.py
@@ -21,10 +21,10 @@ from boxsdk.object.events import EnterpriseEventsStreamType
 from requests.exceptions import ConnectionError
 
 from app_integrations import LOGGER
-from app_integrations.apps.app_base import app, AppIntegration, safe_timeout
+from app_integrations.apps.app_base import StreamAlertApp, AppIntegration, safe_timeout
 
 
-@app
+@StreamAlertApp
 class BoxApp(AppIntegration):
     """BoxApp integration"""
     _MAX_CHUNK_SIZE = 500

--- a/app_integrations/apps/duo.py
+++ b/app_integrations/apps/duo.py
@@ -23,7 +23,7 @@ import urllib
 import requests
 
 from app_integrations import LOGGER
-from app_integrations.apps.app_base import app, AppIntegration
+from app_integrations.apps.app_base import StreamAlertApp, AppIntegration
 
 
 class DuoApp(AppIntegration):
@@ -178,7 +178,7 @@ class DuoApp(AppIntegration):
         return abs((self._poll_count % 2) - 1) * 60
 
 
-@app
+@StreamAlertApp
 class DuoAuthApp(DuoApp):
     """Duo authentication log app integration"""
 
@@ -198,7 +198,7 @@ class DuoAuthApp(DuoApp):
         return cls._DUO_AUTH_LOGS_ENDPOINT
 
 
-@app
+@StreamAlertApp
 class DuoAdminApp(DuoApp):
     """Duo administrator log app integration"""
 

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -19,7 +19,7 @@ from apiclient import discovery, errors
 from oauth2client.service_account import ServiceAccountCredentials
 
 from app_integrations import LOGGER
-from app_integrations.apps.app_base import app, AppIntegration
+from app_integrations.apps.app_base import StreamAlertApp, AppIntegration
 
 
 class GSuiteReportsApp(AppIntegration):
@@ -174,7 +174,7 @@ class GSuiteReportsApp(AppIntegration):
         return 0
 
 
-@app
+@StreamAlertApp
 class GSuiteAdminReports(GSuiteReportsApp):
     """G Suite Admin Activity Report app integration"""
 
@@ -183,7 +183,7 @@ class GSuiteAdminReports(GSuiteReportsApp):
         return 'admin'
 
 
-@app
+@StreamAlertApp
 class GSuiteCalendarReports(GSuiteReportsApp):
     """G Suite Calendar Activity Report app integration"""
 
@@ -192,7 +192,7 @@ class GSuiteCalendarReports(GSuiteReportsApp):
         return 'calendar'
 
 
-@app
+@StreamAlertApp
 class GSuiteDriveReports(GSuiteReportsApp):
     """G Suite Drive Activity Report app integration"""
 
@@ -201,7 +201,7 @@ class GSuiteDriveReports(GSuiteReportsApp):
         return 'drive'
 
 
-@app
+@StreamAlertApp
 class GSuiteGroupsReports(GSuiteReportsApp):
     """G Suite Groups Activity Report app integration"""
 
@@ -210,7 +210,7 @@ class GSuiteGroupsReports(GSuiteReportsApp):
         return 'groups'
 
 
-@app
+@StreamAlertApp
 class GSuiteGPlusReports(GSuiteReportsApp):
     """G Suite Google Plus Activity Report app integration"""
 
@@ -219,7 +219,7 @@ class GSuiteGPlusReports(GSuiteReportsApp):
         return 'gplus'
 
 
-@app
+@StreamAlertApp
 class GSuiteLoginReports(GSuiteReportsApp):
     """G Suite Login Activity Report app integration"""
 
@@ -228,7 +228,7 @@ class GSuiteLoginReports(GSuiteReportsApp):
         return 'login'
 
 
-@app
+@StreamAlertApp
 class GSuiteMobileReports(GSuiteReportsApp):
     """G Suite Mobile Activity Report app integration"""
 
@@ -237,7 +237,7 @@ class GSuiteMobileReports(GSuiteReportsApp):
         return 'mobile'
 
 
-@app
+@StreamAlertApp
 class GSuiteRulesReports(GSuiteReportsApp):
     """G Suite Rules Activity Report app integration"""
 
@@ -246,7 +246,7 @@ class GSuiteRulesReports(GSuiteReportsApp):
         return 'rules'
 
 
-@app
+@StreamAlertApp
 class GSuiteSAMLReports(GSuiteReportsApp):
     """G Suite SAML Activity Report app integration"""
 
@@ -255,7 +255,7 @@ class GSuiteSAMLReports(GSuiteReportsApp):
         return 'saml'
 
 
-@app
+@StreamAlertApp
 class GSuiteTokenReports(GSuiteReportsApp):
     """G Suite Token Activity Report app integration"""
 

--- a/app_integrations/apps/onelogin.py
+++ b/app_integrations/apps/onelogin.py
@@ -16,10 +16,10 @@ limitations under the License.
 import re
 
 from app_integrations import LOGGER
-from app_integrations.apps.app_base import app, AppIntegration
+from app_integrations.apps.app_base import StreamAlertApp, AppIntegration
 
 
-@app
+@StreamAlertApp
 class OneLoginApp(AppIntegration):
     """OneLogin StreamAlert App"""
     _ONELOGIN_EVENTS_URL = 'https://api.{}.onelogin.com/api/1/events'

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -23,7 +23,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from app_integrations import LOGGER
-from app_integrations.apps.app_base import get_app
+from app_integrations.apps.app_base import StreamAlertApp
 from app_integrations.exceptions import AppIntegrationConfigError, AppIntegrationStateError
 
 AWS_RATE_RE = re.compile(r'^rate\(((1) (minute|hour|day)|'
@@ -279,7 +279,7 @@ class AppConfig(dict):
 
             # Request the date format from the app since some services expect different types
             # Using init=False will return the class without instantiating it
-            date_format = get_app(self, init=False).date_formatter()
+            date_format = StreamAlertApp.get_app(self, init=False).date_formatter()
             if date_format:
                 self.last_timestamp = datetime.utcfromtimestamp(time_delta).strftime(date_format)
             else:

--- a/app_integrations/main.py
+++ b/app_integrations/main.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from app_integrations.apps.app_base import get_app
+from app_integrations.apps.app_base import StreamAlertApp
 from app_integrations.config import AppConfig
 
 
@@ -33,7 +33,7 @@ def handler(event, context):
         config = AppConfig.load_config(context, event)
 
         # The config specifies what app this function is supposed to run
-        app = get_app(config)
+        app = StreamAlertApp.get_app(config)
 
         # Run the gather operation
         app.gather()

--- a/docs/source/app-development.rst
+++ b/docs/source/app-development.rst
@@ -23,7 +23,9 @@ to outline what methods from the base ``AppIntegration`` class must be implement
   :name: app_integrations/apps/box.py
 
   # app_integrations/apps/box.py
+  from app_integrations.apps.app_base import StreamAlertApp, AppIntegration
 
+  # @StreamAlertApp
   class BoxApp(AppIntegration):
     """Box StreamAlert App"""
 

--- a/manage.py
+++ b/manage.py
@@ -33,7 +33,7 @@ from stream_alert_cli import __version__ as version
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.runner import cli_runner
 from app_integrations.config import AWS_RATE_RE
-from app_integrations.apps.app_base import STREAMALERT_APPS
+from app_integrations.apps.app_base import StreamAlertApp
 
 
 class UniqueSetAction(Action):
@@ -242,7 +242,11 @@ Available Subcommands:
     app_integration_subparsers = app_integration_parser.add_subparsers()
 
     _add_app_integration_list_subparser(app_integration_subparsers)
-    _add_app_integration_new_subparser(app_integration_subparsers, set(STREAMALERT_APPS), clusters)
+    _add_app_integration_new_subparser(
+        app_integration_subparsers,
+        sorted(StreamAlertApp.get_all_apps()),
+        clusters
+    )
     _add_app_integration_update_auth_subparser(app_integration_subparsers, clusters)
 
 

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -18,7 +18,7 @@ import json
 import os
 import re
 
-from app_integrations.apps.app_base import get_app
+from app_integrations.apps.app_base import StreamAlertApp
 from stream_alert.shared import metrics
 from stream_alert_cli.helpers import continue_prompt
 from stream_alert_cli.logger import LOGGER_CLI
@@ -378,7 +378,7 @@ class CLIConfig(object):
                 a new app integration
         """
         exists, prompt_for_auth, overwrite = False, True, False
-        app = get_app(app_info, False)
+        app = StreamAlertApp.get_app(app_info, False)
 
         # Check to see if there is an existing configuration for this app integration
         cluster_config = self.config['clusters'][app_info['cluster']]

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from app_integrations.apps.app_base import get_app
+from app_integrations.apps.app_base import StreamAlertApp
 from stream_alert.alert_processor.outputs import get_output_dispatcher
 from stream_alert_cli.apps import save_app_auth_info
 from stream_alert_cli.athena.handler import athena_handler
@@ -226,7 +226,7 @@ def _app_integration_handler(options):
         app_info['function_name'] = '_'.join([app_info.get(value)
                                               for value in func_parts] + ['app'])
 
-        app = get_app(app_info, False)
+        app = StreamAlertApp.get_app(app_info, False)
 
         if not save_app_auth_info(app, app_info, True):
             return

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -22,12 +22,13 @@ from nose.tools import (
     assert_false,
     assert_is_none,
     assert_is_not_none,
+    assert_items_equal,
     assert_true,
     raises
 )
 from requests.exceptions import ConnectTimeout
 
-from app_integrations.apps.app_base import AppIntegration, get_app
+from app_integrations.apps.app_base import AppIntegration, StreamAlertApp
 from app_integrations.batcher import Batcher
 from app_integrations.config import AppConfig
 from app_integrations.exceptions import AppIntegrationConfigError, AppIntegrationException
@@ -37,11 +38,33 @@ from tests.unit.app_integrations.test_helpers import (
     MockSSMClient
 )
 
+def test_get_all_apps():
+    """App Integration - App Base, Get All Apps"""
+    expected_apps = {
+        'box_admin_events',
+        'duo_admin',
+        'duo_auth',
+        'gsuite_admin',
+        'gsuite_calendar',
+        'gsuite_drive',
+        'gsuite_gplus',
+        'gsuite_groups',
+        'gsuite_login',
+        'gsuite_mobile',
+        'gsuite_rules',
+        'gsuite_saml',
+        'gsuite_token',
+        'onelogin_events'
+    }
+
+    apps = StreamAlertApp.get_all_apps()
+    assert_items_equal(expected_apps, apps)
+
 
 def test_get_app():
     """App Integration - App Base, Get App"""
     config = AppConfig(get_valid_config_dict('duo_auth'))
-    app = get_app(config)
+    app = StreamAlertApp.get_app(config)
     assert_is_not_none(app)
 
 
@@ -50,7 +73,7 @@ def test_get_app_exception_type():
     """App Integration - App Base, Get App Exception for No 'type'"""
     config = AppConfig(get_valid_config_dict('duo_auth'))
     del config['type']
-    get_app(config)
+    StreamAlertApp.get_app(config)
 
 
 @raises(AppIntegrationException)
@@ -58,7 +81,7 @@ def test_get_app_exception_invalid():
     """App Integration - App Base, Get App Exception for Invalid Service"""
     config = AppConfig(get_valid_config_dict('duo_auth'))
     config['type'] = 'bad_service_type'
-    get_app(config)
+    StreamAlertApp.get_app(config)
 
 
 # Patch the required_auth_info method with values that a subclass _would_ return


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

The `StreamAlertApp`s are currently loaded and cached using the `@app` class decorator while a separate function is used for returning a requested app type. Encapsulating this functionality into one place via a factory-style class to be used as a decorator would simplify this logic.

## Changes

* This change is to convert the class decorator into a factory-style class to be used for decorating all subclasses.
* Adding methods for loading an app to this new decorator class.

## Other Changes

* Apps will now be sorted in the help output printed with:
  * `python manage.py app new --help`
* Adding reference to using `@StreamAlertApp` class decorator to docs.

## Testing

* Adding unit tests to make sure all supported apps get registered.
* Deployed in test AWS account.
