### PR TITLE
[output] PagerDuty incident requires "From:" header

### DIFF
--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -295,11 +295,11 @@ class PagerDutyIncidentOutput(StreamOutputBase):
         if not response:
             return False
 
-        # If there are results, get the first occurence from the list
-        if get_id:
-            return response[target_key][0]['id'] if target_key in response else False
+        if not get_id:
+            return True
 
-        return True
+        # If there are results, get the first occurence from the list
+        return response[target_key][0]['id'] if target_key in response else False
 
     def _user_verify(self, user, get_id=True):
         """Method to verify the existance of an user with the API
@@ -366,10 +366,7 @@ class PagerDutyIncidentOutput(StreamOutputBase):
             return False
 
         if get_id:
-            return {
-                'id': item_id,
-                'type': item_type
-            }
+            return {'id': item_id, 'type': item_type}
 
         return item_id
 

--- a/stream_alert/alert_processor/outputs.py
+++ b/stream_alert/alert_processor/outputs.py
@@ -422,6 +422,7 @@ class PagerDutyIncidentOutput(StreamOutputBase):
         # Get user email to be added as From header and verify
         user_email = creds['email_from']
         if not self._user_verify(user_email, False):
+            LOGGER.error('Could not verify header From: %s, %s', user_email, self.__service__)
             return self._log_status(False)
 
         # Add From to the headers after verifying

--- a/tests/unit/stream_alert_alert_processor/test_outputs.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs.py
@@ -314,7 +314,8 @@ class TestPagerDutyIncidentOutput(object):
         creds = {'api': 'https://api.pagerduty.com',
                  'token': 'mocked_token',
                  'service_key': 'mocked_service_key',
-                 'escalation_policy': 'mocked_escalation_policy'}
+                 'escalation_policy': 'mocked_escalation_policy',
+                 'email_from': 'email@domain.com'}
 
         put_mock_creds(output_name, creds, self.__dispatcher.secrets_bucket, REGION, KMS_ALIAS)
 
@@ -332,7 +333,7 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"check": [{"id": "checked_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', 'check')
+        checked = self.__dispatcher._check_exists('filter', 'http://mock_url', 'check')
         assert_equal(checked, 'checked_id')
 
     @patch('requests.get')
@@ -343,8 +344,18 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{}')
         get_mock.return_value.json.return_value = json_check
 
-        checked = self.__dispatcher._check_exists_get_id('filter', 'http://mock_url', 'check')
+        checked = self.__dispatcher._check_exists('filter', 'http://mock_url', 'check')
         assert_false(checked)
+
+    @patch('requests.get')
+    def test_check_exists_no_get_id(self, get_mock):
+        """Check Exists No Get Id - PagerDutyIncidentOutput"""
+        # /check
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"check": [{"id": "checked_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        assert_true(self.__dispatcher._check_exists('filter', 'http://mock_url', 'check', False))
 
     @patch('requests.get')
     def test_user_verify_success(self, get_mock):
@@ -444,10 +455,19 @@ class TestPagerDutyIncidentOutput(object):
         json_check = json.loads('{"items": [{"id": "verified_item_id"}]}')
         get_mock.return_value.json.return_value = json_check
 
-        item_verified = self.__dispatcher._item_verify('http://mock_url', 'valid_item',
-                                                       'items', 'item_reference')
+        item_verified = self.__dispatcher._item_verify('valid_item', 'items', 'item_reference')
         assert_equal(item_verified['id'], 'verified_item_id')
         assert_equal(item_verified['type'], 'item_reference')
+
+    @patch('requests.get')
+    def test_item_verify_no_get_id_success(self, get_mock):
+        """Item Verify No Get Id Success - PagerDutyIncidentOutput"""
+        # /items
+        get_mock.return_value.status_code = 200
+        json_check = json.loads('{"items": [{"id": "verified_item_id"}]}')
+        get_mock.return_value.json.return_value = json_check
+
+        assert_true(self.__dispatcher._item_verify('valid_item', 'items', 'item_reference', False))
 
     @patch('requests.get')
     def test_incident_assignment_user(self, get_mock):
@@ -518,11 +538,11 @@ class TestPagerDutyIncidentOutput(object):
         }
         alert = self._setup_dispatch(context=ctx)
 
-        # /users, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200])
+        # /users, /users, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
         json_user = json.loads('{"users": [{"id": "valid_user_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_user, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_user, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 200
@@ -549,11 +569,12 @@ class TestPagerDutyIncidentOutput(object):
         }
         alert = self._setup_dispatch(context=ctx)
 
-        # /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200])
+        # /users, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
         json_policy = json.loads('{"escalation_policies": [{"id": "policy_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_policy, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 200
@@ -580,12 +601,14 @@ class TestPagerDutyIncidentOutput(object):
         }
         alert = self._setup_dispatch(context=ctx)
 
-        # /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
-        json_user = json.loads('{"not_users": [{"id": "user_id"}]}')
+        # /users, /users, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200, 200])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
+        json_not_user = json.loads('{"not_users": [{"id": "user_id"}]}')
         json_policy = json.loads('{"escalation_policies": [{"id": "policy_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_not_user,
+                                                  json_policy, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 200
@@ -607,11 +630,12 @@ class TestPagerDutyIncidentOutput(object):
         """PagerDutyIncidentOutput dispatch success - No Context"""
         alert = self._setup_dispatch()
 
-        # /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200])
+        # /users, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
         json_policy = json.loads('{"escalation_policies": [{"id": "policy_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_policy, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 200
@@ -632,10 +656,11 @@ class TestPagerDutyIncidentOutput(object):
     def test_dispatch_failure_bad_everything(self, get_mock, post_mock, log_error_mock):
         """PagerDutyIncidentOutput dispatch failure - No User, Bad Policy, Bad Service"""
         alert = self._setup_dispatch()
-        # /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[400, 400, 400])
+        # /users, /users, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 400, 400, 400])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
         json_empty = json.loads('{}')
-        get_mock.return_value.json.side_effect = [json_empty, json_empty, json_empty]
+        get_mock.return_value.json.side_effect = [json_user, json_empty, json_empty, json_empty]
 
         # /incidents
         post_mock.return_value.status_code = 400
@@ -661,13 +686,14 @@ class TestPagerDutyIncidentOutput(object):
             }
         }
         alert = self._setup_dispatch(context=ctx)
-        # /escalation_policies, /services
-        get_mock.return_value.side_effect = [400, 200, 200]
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[400, 200, 200])
+        # /users, /escalation_policies, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 400, 200, 200])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
         json_bad_policy = json.loads('{}')
         json_good_policy = json.loads('{"escalation_policies": [{"id": "policy_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_bad_policy, json_good_policy, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_bad_policy,
+                                                  json_good_policy, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 200
@@ -688,14 +714,35 @@ class TestPagerDutyIncidentOutput(object):
     def test_dispatch_bad_dispatch(self, get_mock, post_mock, log_error_mock):
         """PagerDutyIncidentOutput dispatch - Bad Dispatch"""
         alert = self._setup_dispatch()
-        # /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200])
+        # /users, /escalation_policies, /services
+        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        json_user = json.loads('{"users": [{"id": "user_id"}]}')
         json_policy = json.loads('{"escalation_policies": [{"id": "policy_id"}]}')
         json_service = json.loads('{"services": [{"id": "service_id"}]}')
-        get_mock.return_value.json.side_effect = [json_policy, json_service]
+        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
 
         # /incidents
         post_mock.return_value.status_code = 400
+
+        self.__dispatcher.dispatch(descriptor=self.__descriptor,
+                                   rule_name='rule_name',
+                                   alert=alert)
+
+        self._teardown_dispatch()
+
+        log_error_mock.assert_called_with('Failed to send alert to %s', self.__service)
+
+    @patch('logging.Logger.error')
+    @patch('requests.get')
+    @mock_s3
+    @mock_kms
+    def test_dispatch_bad_email(self, get_mock, log_error_mock):
+        """PagerDutyIncidentOutput dispatch - Bad Email"""
+        alert = self._setup_dispatch()
+        # /users, /escalation_policies, /services
+        get_mock.return_value.status_code = 400
+        json_user = json.loads('{"not_users": [{"id": "no_user_id"}]}')
+        get_mock.return_value.json.return_value = json_user
 
         self.__dispatcher.dispatch(descriptor=self.__descriptor,
                                    rule_name='rule_name',


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

New output to use PagerDuty Incidents was added [here](https://github.com/airbnb/streamalert/pull/467). The REST API requires the header `From: validpagerdutyuser@email.com` to create a new incident.

## Changes

* The header `From: ` is added to authentication, and the user will be added when creating new output.
* Modified method `_check_exists` to optionally return just a boolean.
* All tests have been modified to accommodate this change.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                2516     76    97%
----------------------------------------------------------------------
Ran 462 tests in 7.015s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```