### PR TITLE
Cross Account CloudTrail Support, Kinesis CLI Parser

### DIFF
--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -262,21 +262,23 @@ By default, all API calls will be logged and accessible from rules.
 
   {
     "cloudtrail": {
-      "enable_logging": true
+      "enable_logging": true,
+      "enable_kinesis": true
     }
   }
 
 **Options:**
 
-===================  ========  ==================================  ===========
-Key                  Required  Default                             Description
--------------------  --------  ----------------------------------  -----------
-``enable_logging``   ``Yes``                                       Enable/disable the CloudTrail logging.
-``enable_kinesis``   ``No``    ``true``                            Enable/disable the sending CloudTrail data to Kinesis.
-``existing_trail``   ``No``    ``false``                           Set to ``true`` if the account has an existing CloudTrail.  This is to avoid duplication of data collected by multiple CloudTrails.
-``is_global_trail``  ``No``    ``true``                            If the CloudTrail should collect events from any region.
-``event_pattern``    ``No``    ``{"account": ["<accound_id>"]}``   The CloudWatch Events pattern to send to Kinesis.  `More information <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>`_.
-===================  ========  ==================================  ===========
+=====================    ========  ==================================  ===========
+Key                      Required  Default                             Description
+---------------------    --------  ----------------------------------  -----------
+``enable_logging``       ``Yes``                                       Enable/disable the CloudTrail logging.
+``enable_kinesis``       ``No``    ``true``                            Enable/disable the sending CloudTrail data to Kinesis.
+``existing_trail``       ``No``    ``false``                           Set to ``true`` if the account has an existing CloudTrail.  This is to avoid duplication of data collected by multiple CloudTrails.
+``is_global_trail``      ``No``    ``true``                            If the CloudTrail should collect events from any region.
+``event_pattern``        ``No``    ``{"account": ["<accound_id>"]}``   The CloudWatch Events pattern to send to Kinesis.  `More information <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>`_.
+``cross_account_ids``    ``No``                                        Account IDs to grant write access to the created CloudTrail S3 bucket
+=====================    ========  ==================================  ===========
 
 Module: Flow Logs
 -----------------

--- a/stream_alert_cli/kinesis/handler.py
+++ b/stream_alert_cli/kinesis/handler.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from stream_alert_cli.helpers import tf_runner
+from stream_alert_cli.logger import LOGGER_CLI
+from stream_alert_cli.terraform.generate import terraform_generate
+
+
+def kinesis_handler(options, config):
+    """Main handler for the Kinesis parser
+
+    Args:
+        options (namedtuple): Parsed arguments
+        config (CLIConfig): Loaded StreamAlert config
+    """
+    if options.subcommand == 'disable-events':
+        LOGGER_CLI.info('Disabling Kinesis Events')
+        set_kinesis_events(options, config, False)
+    elif options.subcommand == 'enable-events':
+        LOGGER_CLI.info('Enabling Kinesis Events')
+        set_kinesis_events(options, config, True)
+
+
+def set_kinesis_events(options, config, enable=True):
+    """Enable or disable Kinesis events for given clusters
+
+    Args:
+        options (namedtuple): Parsed arguments
+        config (CLIConfig): Loaded StreamAlert config
+        enable (bool): Enable/Disable switch
+    """
+    for cluster in options.clusters or config.clusters():
+        if 'kinesis_events' in config['clusters'][cluster]['modules']:
+            config['clusters'][cluster]['modules']['kinesis_events']['enabled'] = enable
+
+    config.write()
+
+    if not options.skip_terraform:
+        terraform_generate(config)
+        tf_runner(
+            action='apply',
+            targets=[
+                'module.{}_{}'.format('kinesis_events', cluster) for cluster in config.clusters()
+            ])

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -19,6 +19,7 @@ from stream_alert_cli.apps import save_app_auth_info
 from stream_alert_cli.athena.handler import athena_handler
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.helpers import user_input
+from stream_alert_cli.kinesis.handler import kinesis_handler
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.manage_lambda.handler import lambda_handler
 from stream_alert_cli.terraform.handler import terraform_handler
@@ -73,6 +74,9 @@ def cli_runner(options):
 
     elif options.command == 'app':
         _app_integration_handler(options)
+
+    elif options.command == 'kinesis':
+        kinesis_handler(options, CONFIG)
 
 
 def configure_handler(options):

--- a/stream_alert_cli/terraform/cloudtrail.py
+++ b/stream_alert_cli/terraform/cloudtrail.py
@@ -35,6 +35,9 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     enabled_legacy = modules['cloudtrail'].get('enabled')
     cloudtrail_enabled = modules['cloudtrail'].get('enable_logging')
     kinesis_enabled = modules['cloudtrail'].get('enable_kinesis')
+    account_ids = list(set(
+        [config['global']['account']['aws_account_id']] +
+        modules['cloudtrail'].get('cross_account_ids', [])))
 
     # Allow for backwards compatilibity
     if enabled_legacy:
@@ -61,7 +64,7 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
 
     cluster_dict['module'][cloudtrail_module] = {
         'source': 'modules/tf_stream_alert_cloudtrail',
-        'account_id': config['global']['account']['aws_account_id'],
+        'account_ids': account_ids,
         'cluster': cluster_name,
         'prefix': config['global']['account']['prefix'],
         'enable_logging': cloudtrail_enabled,

--- a/stream_alert_cli/terraform/monitoring.py
+++ b/stream_alert_cli/terraform/monitoring.py
@@ -49,18 +49,24 @@ def generate_monitoring(cluster_name, cluster_dict, config):
 
     cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_monitoring',
-        'sns_topic_arn': sns_topic_arn
+        'sns_topic_arn': sns_topic_arn,
+        'kinesis_alarms_enabled': False,
+        'lambda_alarms_enabled': False
     }
 
     if monitoring_config.get('lambda_alarms_enabled', True):
-        cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)][
-            'lambda_functions'] = [
+        cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)].update({
+            'lambda_functions': [
                 '{}_{}_streamalert_rule_processor'.format(prefix, cluster_name),
                 '{}_{}_streamalert_alert_processor'.format(prefix, cluster_name)
-            ]
+            ],
+            'lambda_alarms_enabled': True
+        })
 
     if monitoring_config.get('kinesis_alarms_enabled', True):
-        cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)][
-            'kinesis_stream'] = '{}_{}_stream_alert_kinesis'.format(prefix, cluster_name)
+        cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)].update({
+            'kinesis_stream': '{}_{}_stream_alert_kinesis'.format(prefix, cluster_name),
+            'kinesis_alarms_enabled': True
+        })
 
     return True

--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -2,7 +2,6 @@
 resource "aws_cloudtrail" "streamalert" {
   name                          = "${var.prefix}.${var.cluster}.streamalert.cloudtrail"
   s3_bucket_name                = "${aws_s3_bucket.cloudtrail_bucket.id}"
-  s3_key_prefix                 = "cloudtrail"
   enable_log_file_validation    = true
   enable_logging                = "${var.enable_logging}"
   include_global_service_events = true
@@ -59,7 +58,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.prefix}.${var.cluster}.streamalert.cloudtrail/*",
+      "${formatlist("arn:aws:s3:::${var.prefix}.${var.cluster}.streamalert.cloudtrail/AWSLogs/%s/*", var.account_ids)}",
     ]
 
     principals {

--- a/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
@@ -1,5 +1,5 @@
-variable "account_id" {
-  type = "string"
+variable "account_ids" {
+  type = "list"
 }
 
 variable "cluster" {

--- a/terraform/modules/tf_stream_alert_s3_events/main.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/main.tf
@@ -21,7 +21,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 }
 
 resource "aws_iam_role_policy" "lambda_s3_permission" {
-  name = "InvokeFromS3Bucket${title(replace(var.bucket_id, ".", ""))}"
+  name = "S3GetObjectsFrom${title(replace(var.bucket_id, ".", ""))}"
   role = "${var.lambda_role_id}"
 
   policy = "${data.aws_iam_policy_document.s3_read_only.json}"

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -326,7 +326,7 @@ class TestTerraformGenerate(object):
         assert_equal(set(self.config['clusters']['advanced']['modules']['cloudtrail'].keys()),
                      {'enable_logging', 'enable_kinesis'})
         assert_equal(self.cluster_dict['module']['cloudtrail_advanced'], {
-            'account_id': '12345678910',
+            'account_ids': ['12345678910'],
             'cluster': 'advanced',
             'kinesis_arn': '${module.kinesis_advanced.arn}',
             'prefix': 'unit-testing',
@@ -363,7 +363,7 @@ class TestTerraformGenerate(object):
 
         assert_equal('cloudtrail_advanced' in self.cluster_dict['module'], True)
         assert_equal(self.cluster_dict['module']['cloudtrail_advanced'], {
-            'account_id': '12345678910',
+            'account_ids': ['12345678910'],
             'cluster': 'advanced',
             'existing_trail': False,
             'is_global_trail': False,

--- a/tests/unit/stream_alert_cli/terraform/test_monitoring.py
+++ b/tests/unit/stream_alert_cli/terraform/test_monitoring.py
@@ -34,7 +34,9 @@ def test_generate_cloudwatch_monitoring():
             'unit-testing_test_streamalert_rule_processor',
             'unit-testing_test_streamalert_alert_processor'
         ],
-        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis'
+        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis',
+        'lambda_alarms_enabled': True,
+        'kinesis_alarms_enabled': True
     }
 
     assert_true(result)
@@ -56,7 +58,9 @@ def test_generate_cloudwatch_monitoring_no_kinesis():
         'lambda_functions': [
             'unit-testing_test_streamalert_rule_processor',
             'unit-testing_test_streamalert_alert_processor'
-        ]
+        ],
+        'lambda_alarms_enabled': True,
+        'kinesis_alarms_enabled': False
     }
 
     assert_true(result)
@@ -75,7 +79,9 @@ def test_generate_cloudwatch_monitoring_no_lambda():
     expected_cloudwatch_tf = {
         'source': 'modules/tf_stream_alert_monitoring',
         'sns_topic_arn': 'arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring',
-        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis'
+        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis',
+        'lambda_alarms_enabled': False,
+        'kinesis_alarms_enabled': True
     }
 
     assert_true(result)
@@ -102,7 +108,9 @@ def test_generate_cloudwatch_monitoring_custom_sns():
             'unit-testing_test_streamalert_rule_processor',
             'unit-testing_test_streamalert_alert_processor'
         ],
-        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis'
+        'kinesis_stream': 'unit-testing_test_stream_alert_kinesis',
+        'lambda_alarms_enabled': True,
+        'kinesis_alarms_enabled': True
     }
 
     assert_true(result)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium

## Background

To enable cross-account delivery of CloudTrail logs via S3, you can modify a policy in an S3 bucket which allows the CloudTrail service to deliver logs into specific prefixes.

Also pushing misc changes to easily enable/disable kinesis events, fixing a bug in an S3 policy, and a small change in the monitoring Terraform module.

## Changes

* Support cross-account AWS Ids in CloudTrail
* S3 policy naming bug fix
* Explicitly add enabled kinesis/lambda alarms in monitoring module
* Kinesis CLI parser
* Updated tests

## Testing

* Deployed in a test AWS account
