### PR TITLE
[lambda][alert] fixing small bug where method should be classmethod

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -303,7 +303,8 @@ class OutputDispatcher(object):
         """
         pass
 
-    def output_cred_name(self, descriptor):
+    @classmethod
+    def output_cred_name(cls, descriptor):
         """Formats the output name for this credential by combining the service
         and the descriptor.
 
@@ -313,7 +314,7 @@ class OutputDispatcher(object):
         Returns:
             str: Formatted credential name (ie: slack_ryandchannel)
         """
-        cred_name = str(self.__service__)
+        cred_name = str(cls.__service__)
 
         # should descriptor be enforced in all rules?
         if descriptor:


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: v small
resolves N/A

## Background

Discovered a small bug when configuring a new output via the cli where an instance method needed to be converted to a classmethod. Traceback:
```
Traceback (most recent call last):
  File "manage.py", line 1239, in <module>
    main()
  File "manage.py", line 1234, in main
    cli_runner(options)
  File "/repos/streamalert/stream_alert_cli/runner.py", line 49, in cli_runner
    configure_output(options)
  File "/repos/streamalert/stream_alert_cli/runner.py", line 134, in configure_output
    secrets_key = output.output_cred_name(props['descriptor'].value)
TypeError: unbound method output_cred_name() must be called with SlackOutput instance as first argument (got str instance instead)
```

## Changes

* Converting instance method to class method and verifying adding new outputs now works as expected.

## Testing

* Deployed in test AWS account in verify end to end alerting.
