### PR TITLE
S3 Events Prefix/Suffix + Athena Bug Fixes

### DIFF
--- a/stream_alert/athena_partition_refresh/helpers.py
+++ b/stream_alert/athena_partition_refresh/helpers.py
@@ -49,17 +49,17 @@ def partition_statement(partitions, bucket, table_name):
     Returns:
         str: The ALTER TABLE statement to add the new partitions
     """
-    statement = 'ALTER TABLE {} ADD '.format(table_name)
+    statement = 'ALTER TABLE {} ADD IF NOT EXISTS '.format(table_name)
 
     for partition in sorted(partitions):
         parts = PARTITION_PARTS.match(partition)
         if not parts:
             continue
 
+        # The returned partition from the SHOW PARTITIONS command is dt=YYYY-MM-DD-HH,
+        # But when re-creating new partitions this value must be quoted
         statement += ('PARTITION ({partition}) '
                       'LOCATION \'s3://{bucket}/{table_name}/{year}/{month}/{day}/{hour}\' '.format(
-                          # The passed in partition is just dt=YYYY-MM-DD-HH, but we need to
-                          # quote the value of the partition when re-creating.
                           partition='dt = \'{}-{}-{}-{}\''.format(
                               parts.group('year'),
                               parts.group('month'),

--- a/stream_alert_cli/terraform/s3_events.py
+++ b/stream_alert_cli/terraform/s3_events.py
@@ -49,6 +49,7 @@ def generate_s3_events(cluster_name, cluster_dict, config):
             'source': 'modules/tf_stream_alert_s3_events',
             'lambda_function_arn': '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),
             'bucket_id': bucket_info['bucket_id'],
+            'notification_id': '{}_{}'.format(cluster_name, index),
             'enable_events': bucket_info.get('enable_events', True),
             'lambda_role_id': '${{module.stream_alert_{}.lambda_role_id}}'.format(cluster_name),
             'filter_prefix': bucket_info.get('filter_prefix', ''),

--- a/stream_alert_cli/terraform/s3_events.py
+++ b/stream_alert_cli/terraform/s3_events.py
@@ -28,6 +28,7 @@ def generate_s3_events(cluster_name, cluster_dict, config):
         bool: Result of applying the s3_events module
     """
     modules = config['clusters'][cluster_name]['modules']
+    prefix = config['global']['account']['prefix']
     s3_event_buckets = modules['s3_events']
 
     # Detect legacy and convert
@@ -38,19 +39,20 @@ def generate_s3_events(cluster_name, cluster_dict, config):
         LOGGER_CLI.info('Converting legacy S3 Events config')
         config.write()
 
-    for bucket_info in s3_event_buckets:
+    # Add each configured S3 bucket module
+    for index, bucket_info in enumerate(s3_event_buckets):
         if 'bucket_id' not in bucket_info:
             LOGGER_CLI.error('Config Error: Missing bucket_id key from s3_event configuration')
             return False
 
-        cluster_dict['module']['s3_events_{}'.format(bucket_info['bucket_id'].replace(
-            '.', '_'))] = {
-                'source': 'modules/tf_stream_alert_s3_events',
-                'lambda_function_arn':
-                '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),
-                'bucket_id': bucket_info['bucket_id'],
-                'enable_events': bucket_info.get('enable_events', True),
-                'lambda_role_id': '${{module.stream_alert_{}.lambda_role_id}}'.format(cluster_name)
-            }
+        cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, index)] = {
+            'source': 'modules/tf_stream_alert_s3_events',
+            'lambda_function_arn': '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),
+            'bucket_id': bucket_info['bucket_id'],
+            'enable_events': bucket_info.get('enable_events', True),
+            'lambda_role_id': '${{module.stream_alert_{}.lambda_role_id}}'.format(cluster_name),
+            'filter_prefix': bucket_info.get('filter_prefix', ''),
+            'filter_suffix': bucket_info.get('filter_suffix', '')
+        }
 
     return True

--- a/terraform/modules/tf_stream_alert_s3_events/main.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/main.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_permission" "allow_bucket" {
   function_name = "${var.lambda_function_arn}"
   principal     = "s3.amazonaws.com"
   source_arn    = "arn:aws:s3:::${var.bucket_id}"
-  qualifier     = "production"
+  qualifier     = "${var.lambda_function_alias}"
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
@@ -15,8 +15,10 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = "${var.bucket_id}"
 
   lambda_function {
-    lambda_function_arn = "${var.lambda_function_arn}:production"
+    lambda_function_arn = "${var.lambda_function_arn}:${var.lambda_function_alias}"
     events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "${var.filter_prefix}"
+    filter_suffix       = "${var.filter_suffix}"
   }
 }
 

--- a/terraform/modules/tf_stream_alert_s3_events/variables.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/variables.tf
@@ -1,9 +1,21 @@
 variable "bucket_id" {}
 
-variable "lambda_function_arn" {}
-
-variable "lambda_role_id" {}
-
 variable "enable_events" {
   default = true
 }
+
+variable "filter_prefix" {
+  default = ""
+}
+
+variable "filter_suffix" {
+  default = ""
+}
+
+variable "lambda_function_arn" {}
+
+variable "lambda_function_alias" {
+  default = "production"
+}
+
+variable "lambda_role_id" {}

--- a/terraform/modules/tf_stream_alert_s3_events/variables.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/variables.tf
@@ -19,3 +19,5 @@ variable "lambda_function_alias" {
 }
 
 variable "lambda_role_id" {}
+
+variable "notification_id" {}

--- a/tests/unit/conf/clusters/advanced.json
+++ b/tests/unit/conf/clusters/advanced.json
@@ -27,7 +27,9 @@
     },
     "s3_events": [
       {
-        "bucket_id": "unit-test-bucket.data"
+        "bucket_id": "unit-test-bucket.data",
+        "filter_prefix": "AWSLogs/123456789/CloudTrail/us-east-1/",
+        "filter_suffix": ".log"
       },
       {
         "bucket_id": "unit-test.cloudtrail.data",

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -409,7 +409,7 @@ class TestTerraformGenerate(object):
             'cloudwatch_monitoring_test',
             'kinesis_test',
             'kinesis_events_test',
-            's3_events_unit-test-bucket_legacy_data'
+            's3_events_unit-testing_test_0'
         }
 
         assert_equal(set(tf_cluster['module'].keys()), test_modules)
@@ -435,8 +435,8 @@ class TestTerraformGenerate(object):
             'kinesis_events_advanced',
             'flow_logs_advanced',
             'cloudtrail_advanced',
-            's3_events_unit-test-bucket_data',
-            's3_events_unit-test_cloudtrail_data'
+            's3_events_unit-testing_advanced_1',
+            's3_events_unit-testing_advanced_0'
         }
 
         assert_equal(set(tf_cluster['module'].keys()), advanced_modules)

--- a/tests/unit/stream_alert_cli/terraform/test_s3_events.py
+++ b/tests/unit/stream_alert_cli/terraform/test_s3_events.py
@@ -50,6 +50,7 @@ def test_generate_s3_events():
                 'source': 'modules/tf_stream_alert_s3_events',
                 'lambda_function_arn': '${module.stream_alert_advanced.lambda_arn}',
                 'bucket_id': 'unit-test-bucket.data',
+                'notification_id': 'advanced_0',
                 'enable_events': True,
                 'lambda_role_id': '${module.stream_alert_advanced.lambda_role_id}',
                 'filter_suffix': '.log',
@@ -60,6 +61,7 @@ def test_generate_s3_events():
                 'lambda_function_arn': '${module.stream_alert_advanced.lambda_arn}',
                 'bucket_id': 'unit-test.cloudtrail.data',
                 'enable_events': False,
+                'notification_id': 'advanced_1',
                 'lambda_role_id': '${module.stream_alert_advanced.lambda_role_id}',
                 'filter_suffix': '',
                 'filter_prefix': ''

--- a/tests/unit/stream_alert_cli/terraform/test_s3_events.py
+++ b/tests/unit/stream_alert_cli/terraform/test_s3_events.py
@@ -23,7 +23,7 @@ CONFIG = CLIConfig(config_path='tests/unit/conf')
 
 
 def test_generate_s3_events_legacy():
-    """CLI - Terraform S3 Events - Legacy"""
+    """CLI - Terraform - S3 Events - Legacy"""
     cluster_dict = _common.infinitedict()
     CONFIG['clusters']['test']['modules']['s3_events'] = {
         's3_bucket_id': 'unit-test-bucket.legacy.data'
@@ -40,25 +40,29 @@ def test_generate_s3_events_legacy():
 
 
 def test_generate_s3_events():
-    """CLI - Terraform S3 Events with Valid Buckets"""
+    """CLI - Terraform - S3 Events with Valid Buckets"""
     cluster_dict = _common.infinitedict()
     result = s3_events.generate_s3_events('advanced', cluster_dict, CONFIG)
 
     expected_config = {
         'module': {
-            's3_events_unit-test-bucket_data': {
+            's3_events_unit-testing_advanced_0': {
                 'source': 'modules/tf_stream_alert_s3_events',
                 'lambda_function_arn': '${module.stream_alert_advanced.lambda_arn}',
                 'bucket_id': 'unit-test-bucket.data',
                 'enable_events': True,
                 'lambda_role_id': '${module.stream_alert_advanced.lambda_role_id}',
+                'filter_suffix': '.log',
+                'filter_prefix': 'AWSLogs/123456789/CloudTrail/us-east-1/'
             },
-            's3_events_unit-test_cloudtrail_data': {
+            's3_events_unit-testing_advanced_1': {
                 'source': 'modules/tf_stream_alert_s3_events',
                 'lambda_function_arn': '${module.stream_alert_advanced.lambda_arn}',
                 'bucket_id': 'unit-test.cloudtrail.data',
                 'enable_events': False,
                 'lambda_role_id': '${module.stream_alert_advanced.lambda_role_id}',
+                'filter_suffix': '',
+                'filter_prefix': ''
             }
         }
     }
@@ -69,7 +73,7 @@ def test_generate_s3_events():
 
 @patch('stream_alert_cli.terraform.s3_events.LOGGER_CLI')
 def test_generate_s3_events_invalid_bucket(mock_logging):
-    """CLI - Terraform S3 Events with Missing Bucket Key"""
+    """CLI - Terraform - S3 Events with Missing Bucket Key"""
     cluster_dict = _common.infinitedict()
     CONFIG['clusters']['advanced']['modules']['s3_events'] = [{'wrong_key': 'my-bucket!!!'}]
     result = s3_events.generate_s3_events('advanced', cluster_dict, CONFIG)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers 
size: medium

## Background

When configuring S3 event notifications on CloudTrail buckets, having the ability to filter based on a S3 key prefix allows us to route processing to certain StreamAlert clusters.  This is especially useful when multiple accounts send CloudTrail into the same S3 Bucket.

## Changes

* Support `filter_prefix` and `filter_suffix` Terraform args to the s3 event notification resource
* Fix a couple bugs in Athena table creation

## Testing

* Verified in a test AWS account

