### PR TITLE
[output] Adding support for assign priority to incidents

### DIFF
--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -347,6 +347,9 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             dict: JSON object be used in the API call, containing the priority id
                   and the priority reference, empty if it fails or it does not exist
         """
+        if not context:
+            return dict()
+
         priority_name = context.get('incident_priority', False)
         if not priority_name:
             return dict()
@@ -442,9 +445,7 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             rule_context = rule_context.get(self.__service__, {})
 
         # Use the priority provided in the context, use it or the incident will be low priority
-        incident_priority = {}
-        if rule_context:
-            incident_priority = self._priority_verify(rule_context)
+        incident_priority = self._priority_verify(rule_context)
 
         # Incident assignment goes in this order:
         #  Provided user -> provided policy -> default policy

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -325,7 +325,9 @@ class TestPagerDutyIncidentOutput(object):
         json_check = {'priorities': [{'id': 'verified_priority_id', 'name': priority_name}]}
         get_mock.return_value.json.return_value = json_check
 
-        priority_verified = self._dispatcher._priority_verify(priority_name)
+        context = {'incident_priority': priority_name}
+
+        priority_verified = self._dispatcher._priority_verify(context)
         assert_equal(priority_verified['id'], 'verified_priority_id')
         assert_equal(priority_verified['type'], 'priority_reference')
 
@@ -335,8 +337,10 @@ class TestPagerDutyIncidentOutput(object):
         # /priorities
         get_mock.return_value.status_code = 404
 
-        priority_not_verified = self._dispatcher._priority_verify('some_priority')
-        assert_false(priority_not_verified)
+        context = {'incident_priority': 'priority_name'}
+
+        priority_not_verified = self._dispatcher._priority_verify(context)
+        assert_equal(priority_not_verified, dict())
 
     @patch('requests.get')
     def test_priority_verify_empty(self, get_mock):
@@ -346,8 +350,10 @@ class TestPagerDutyIncidentOutput(object):
         json_check = {}
         get_mock.return_value.json.return_value = json_check
 
-        priority_not_verified = self._dispatcher._priority_verify('some_priority')
-        assert_false(priority_not_verified)
+        context = {'incident_priority': 'priority_name'}
+
+        priority_not_verified = self._dispatcher._priority_verify(context)
+        assert_equal(priority_not_verified, dict())
 
     @patch('requests.get')
     def test_priority_verify_not_found(self, get_mock):
@@ -357,8 +363,10 @@ class TestPagerDutyIncidentOutput(object):
         json_check = {'priorities': [{'id': 'verified_priority_id', 'name': 'not_priority_name'}]}
         get_mock.return_value.json.return_value = json_check
 
-        priority_not_verified = self._dispatcher._priority_verify('some_priority')
-        assert_false(priority_not_verified)
+        context = {'incident_priority': 'priority_name'}
+
+        priority_not_verified = self._dispatcher._priority_verify(context)
+        assert_equal(priority_not_verified, dict())
 
     @patch('requests.get')
     def test_priority_verify_invalid(self, get_mock):
@@ -368,8 +376,10 @@ class TestPagerDutyIncidentOutput(object):
         json_check = {'not_priorities': [{'id': 'verified_priority_id', 'name': 'priority_name'}]}
         get_mock.return_value.json.return_value = json_check
 
-        priority_not_verified = self._dispatcher._priority_verify('some_priority')
-        assert_false(priority_not_verified)
+        context = {'incident_priority': 'priority_name'}
+
+        priority_not_verified = self._dispatcher._priority_verify(context)
+        assert_equal(priority_not_verified, dict())
 
     @patch('requests.get')
     def test_incident_assignment_user(self, get_mock):


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

New output to use PagerDuty Incidents was added [here](https://github.com/airbnb/streamalert/pull/467). Incidents will be created with a low priority by default, unless specified.

## Changes

* Added support to specify a valid priority name in the context.
* Added testing code.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                  2573     73    97%
----------------------------------------------------------------------
Ran 470 tests in 8.373s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
