### PR TITLE
[output] Backoff support for all PagerDuty related outputs

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -312,7 +312,7 @@ class OutputDispatcher(object):
         """
         @retry_on_exception(cls._catch_exceptions())
         def do_get_request():
-            """Decorator to perform the request with retry/backoff"""
+            """Decorated nested function to perform the request with retry/backoff"""
             resp = cls._get_request(url, params, headers, verify)
             success = cls._check_http_response(resp)
             if not success:
@@ -353,7 +353,7 @@ class OutputDispatcher(object):
         """
         @retry_on_exception(cls._catch_exceptions())
         def do_post_request():
-            """Decorator to perform the request with retry/backoff"""
+            """Decorated nested function to perform the request with retry/backoff"""
             resp = cls._post_request(url, data, headers, verify)
             success = cls._check_http_response(resp)
             if not success:

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -20,6 +20,7 @@ from stream_alert.alert_processor import LOGGER
 from stream_alert.alert_processor.outputs.output_base import (
     OutputDispatcher,
     OutputProperty,
+    OutputRequestFailure,
     StreamAlertOutput
 )
 
@@ -473,4 +474,5 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         resp = self._post_request(incidents_url, incident, self._headers, True)
         success = self._check_http_response(resp)
 
-        return self._log_status(success)
+        if not self._log_status(success):
+            raise OutputRequestFailure

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -90,7 +90,11 @@ class PagerDutyOutput(OutputDispatcher):
         resp = self._post_request(creds['url'], data, None, True)
         success = self._check_http_response(resp)
 
-        return self._log_status(success)
+        log_result = self._log_status(success)
+        if not log_result:
+            raise OutputRequestFailure
+
+        return log_result
 
 @StreamAlertOutput
 class PagerDutyOutputV2(OutputDispatcher):
@@ -167,7 +171,11 @@ class PagerDutyOutputV2(OutputDispatcher):
         resp = self._post_request(creds['url'], data, None, True)
         success = self._check_http_response(resp)
 
-        return self._log_status(success)
+        log_result = self._log_status(success)
+        if not log_result:
+            raise OutputRequestFailure
+
+        return log_result
 
 @StreamAlertOutput
 class PagerDutyIncidentOutput(OutputDispatcher):
@@ -474,5 +482,8 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         resp = self._post_request(incidents_url, incident, self._headers, True)
         success = self._check_http_response(resp)
 
-        if not self._log_status(success):
-            raise OutputRequestFailure
+        log_result = self._log_status(success)
+        if not log_result:
+            raise OutputRequestFailure()
+
+        return log_result

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -87,14 +87,12 @@ class PagerDutyOutput(OutputDispatcher):
             'client': 'StreamAlert'
         }
 
-        resp = self._post_request(creds['url'], data, None, True)
-        success = self._check_http_response(resp)
+        try:
+            success = self._post_request_retry(creds['url'], data, None, True)
+        except OutputRequestFailure:
+            success = False
 
-        log_result = self._log_status(success)
-        if not log_result:
-            raise OutputRequestFailure
-
-        return log_result
+        return self._log_status(success)
 
 @StreamAlertOutput
 class PagerDutyOutputV2(OutputDispatcher):
@@ -168,14 +166,12 @@ class PagerDutyOutputV2(OutputDispatcher):
             'client': 'StreamAlert'
         }
 
-        resp = self._post_request(creds['url'], data, None, True)
-        success = self._check_http_response(resp)
+        try:
+            success = self._post_request_retry(creds['url'], data, None, True)
+        except OutputRequestFailure:
+            success = False
 
-        log_result = self._log_status(success)
-        if not log_result:
-            raise OutputRequestFailure
-
-        return log_result
+        return self._log_status(success)
 
 @StreamAlertOutput
 class PagerDutyIncidentOutput(OutputDispatcher):
@@ -268,13 +264,12 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         params = {
             'query': '{}'.format(filter_str)
         }
-        resp = self._get_request(url, params, self._headers, False)
-
-        if not self._check_http_response(resp):
-            return False
-
-        response = resp.json()
-        if not response:
+        try:
+            resp = self._get_request_retry(url, params, self._headers, False)
+            response = resp.json()
+            if not response:
+                return False
+        except OutputRequestFailure:
             return False
 
         if not get_id:
@@ -364,13 +359,13 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             return dict()
 
         priorities_url = self._get_endpoint(self._base_url, self.PRIORITIES_ENDPOINT)
-        resp = self._get_request(priorities_url, {}, self._headers, False)
 
-        if not self._check_http_response(resp):
-            return dict()
-
-        response = resp.json()
-        if not response:
+        try:
+            resp = self._get_request_retry(priorities_url, {}, self._headers, False)
+            response = resp.json()
+            if not response:
+                return dict()
+        except OutputRequestFailure:
             return dict()
 
         priorities = response.get('priorities', [])
@@ -479,11 +474,10 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             }
         }
         incidents_url = self._get_endpoint(self._base_url, self.INCIDENTS_ENDPOINT)
-        resp = self._post_request(incidents_url, incident, self._headers, True)
-        success = self._check_http_response(resp)
 
-        log_result = self._log_status(success)
-        if not log_result:
-            raise OutputRequestFailure()
+        try:
+            success = self._post_request_retry(incidents_url, incident, self._headers, True)
+        except OutputRequestFailure:
+            success = False
 
-        return log_result
+        return self._log_status(success)

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -266,10 +266,11 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         }
         try:
             resp = self._get_request_retry(url, params, self._headers, False)
-            response = resp.json()
-            if not response:
-                return False
         except OutputRequestFailure:
+            return False
+
+        response = resp.json()
+        if not response:
             return False
 
         if not get_id:
@@ -362,10 +363,11 @@ class PagerDutyIncidentOutput(OutputDispatcher):
 
         try:
             resp = self._get_request_retry(priorities_url, {}, self._headers, False)
-            response = resp.json()
-            if not response:
-                return dict()
         except OutputRequestFailure:
+            return dict()
+
+        response = resp.json()
+        if not response:
             return dict()
 
         priorities = response.get('priorities', [])


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

There were some issues with the PagerDuty multiple APIs that was making StreamAlert to lose alerts becase the API access was being rate limited. With these changes the requests sent to the API will retry when a problem is detected, that way we can effectively mitigate the encountered rate limits, due to high volume alerts. 

## Changes

* Added changes to the base output class to add retry methods for both GET and POST requests. This way the support for backoff/retry can be progressively added in each single output without breaking existing code.
* Added specific support in PagerDuty outputs to use the backoff/retry code.
* Modified existing tests to support new approach.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                  2617     75    97%
----------------------------------------------------------------------
Ran 470 tests in 13.873s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
