### PR TITLE
[apps] Extract all the returned content to avoid KeyError in JSON response

### DIFF
--- a/app_integrations/apps/app_base.py
+++ b/app_integrations/apps/app_base.py
@@ -316,13 +316,11 @@ class AppIntegration(object):
             bool: Indicator of whether or not this request was successful
         """
         success = response is not None and (200 <= response.status_code <= 299)
-
-        if response is not None and not success:
+        if not success:
             LOGGER.error('HTTP request failed for service \'%s\': [%d] %s',
                          self.type(),
                          response.status_code,
-                         response.json()['message'])
-
+                         response.content)
         return success
 
     @safe_timeout

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -150,7 +150,7 @@ class TestAppIntegration(object):
     @patch('logging.Logger.error')
     def test_check_http_response_bad(self, log_mock):
         """App Integration - Check HTTP Response, Failure"""
-        response = Mock(status_code=404, json=Mock(side_effect=[{'message': 'hey'}]))
+        response = Mock(status_code=404, content='hey')
 
         # Check to make sure this resulted in a return of False
         assert_false(self._app._check_http_response(response))
@@ -269,16 +269,16 @@ class TestAppIntegration(object):
         failed_message = 'something went wrong'
         requests_mock.return_value = Mock(
             status_code=404,
+            content=failed_message,
             json=Mock(return_value={'message': failed_message})
         )
+
         result, response = self._app._make_get_request('hostname', None, None)
         assert_false(result)
         assert_equal(response['message'], failed_message)
 
-        # The .json should be called on the response once, to get the error message
-        # and to check the response, to log the message. If it was called three times,
-        # it means `logs = response.json()['response']` is being called and should not be
-        assert_equal(requests_mock.return_value.json.call_count, 2)
+        # The .json should be called on the response once, to return the response.
+        assert_equal(requests_mock.return_value.json.call_count, 1)
 
     @patch('requests.get')
     def test_make_request_timeout(self, requests_mock):

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -97,15 +97,12 @@ class TestDuoApp(object):
         """DuoApp - Get Duo Logs, Bad Response"""
         requests_mock.return_value = Mock(
             status_code=404,
-            json=Mock(return_value={'message': 'something went wrong'})
-        )
+            content='something went wrong')
 
         assert_false(self._app._get_duo_logs('hostname', 'full_url'))
 
-        # The .json should be called on the response once, to get the error message
-        # and to check the response, to log the message. If it was called three times,
-        # it means `logs = response.json()['response']` is being called and should not be
-        assert_equal(requests_mock.return_value.json.call_count, 2)
+        # The .json should be called on the response once, to return the response.
+        assert_equal(requests_mock.return_value.json.call_count, 1)
 
     @patch('requests.get')
     def test_gather_logs(self, requests_mock):


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

In the function `_check_http_response` when a HTTP error is detected, the app base tries to grab the field `message` from the returned response JSON. This field may not exist and it generates the following error:
```
File "/var/task/app_integrations/apps/app_base.py", line 343, in _make_get_request
return self._check_http_response(response), response.json()
File "/var/task/app_integrations/apps/app_base.py", line 324, in _check_http_response
response.json()['message'])
KeyError: 'message'
```
This PR prevents that from happening by just grabbing the whole returned content, as it is done in the outputs code.

## Changes

* Getting `response.content` instead of specific fields (`message`) from the response.
* Modified existing tests to pass with the new code.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2779     99    96%
----------------------------------------------------------------------
Ran 489 tests in 10.114s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```