### PR TITLE
[apps] utilizing delegation email for gsuite app

### DIFF
--- a/app_integrations/apps/box.py
+++ b/app_integrations/apps/box.py
@@ -113,6 +113,8 @@ class BoxApp(AppIntegration):
         else:
             params['created_after'] = self._last_timestamp
 
+        LOGGER.debug('Requesting events for %s', self.type())
+
         def _perform_request(allow_retry=True):
             try:
                 # Get the events using a make_request call with the box api. This is to

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -173,7 +173,7 @@ class GSuiteReportsApp(AppIntegration):
             'delegation_email':
                 {
                     'description': 'the service account user email to delegate access to',
-                    'format': re.compile(r'^[A-Za-z0-9-_.]+@[A-Za-z0-9-.]+\.[A-Za-z]{2,}$')
+                    'format': re.compile(r'^[A-Za-z0-9-_.+]+@[A-Za-z0-9-.]+\.[A-Za-z]{2,}$')
                 }
             }
 

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import json
+import re
 
-from apiclient import discovery, errors
+import apiclient
 from oauth2client.service_account import ServiceAccountCredentials
 
 from app_integrations import LOGGER
@@ -28,6 +29,7 @@ class GSuiteReportsApp(AppIntegration):
 
     def __init__(self, config):
         super(GSuiteReportsApp, self).__init__(config)
+        self._last_event_timestamp = self._last_timestamp
         self._activities_service = None
         self._next_page_token = None
 
@@ -82,9 +84,10 @@ class GSuiteReportsApp(AppIntegration):
         if not creds:
             return False
 
+        delegation = creds.create_delegated(self._config.auth['delegation_email'])
         try:
-            resource = discovery.build('admin', 'reports_v1', credentials=creds)
-        except errors.Error:
+            resource = apiclient.discovery.build('admin', 'reports_v1', credentials=delegation)
+        except apiclient.errors.Error:
             LOGGER.exception('Failed to build discovery service for %s', self.type())
             return False
 
@@ -105,32 +108,42 @@ class GSuiteReportsApp(AppIntegration):
         if not self._create_service():
             return False
 
+        LOGGER.debug('Querying activities since %s for %s',
+                     self._last_event_timestamp,
+                     self.type())
+        LOGGER.debug('Using next page token: %s', self._next_page_token)
+
         activities_list = self._activities_service.list(
             userKey='all',
             applicationName=self._type(),
-            startTime=self._last_timestamp,
-            pageToken=self._next_page_token if self._next_page_token else None
+            startTime=self._last_event_timestamp,
+            pageToken=self._next_page_token
         )
 
         try:
             results = activities_list.execute()
-        except errors.HttpError:
-            LOGGER.exception('Failed to execute activities listing')
+        except apiclient.errors.HttpError:
+            LOGGER.exception('Failed to execute activities listing for %s', self.type())
             return False
 
         if not results:
             LOGGER.error('No results received from the G Suite API request for %s', self.type())
             return False
 
-        self._next_page_token = results.get('nextPageToken')
-        self._more_to_poll = bool(self._next_page_token)
-
         activities = results.get('items', [])
         if not activities:
             LOGGER.info('No logs in response from G Suite API request for %s', self.type())
             return False
 
-        self._last_timestamp = activities[-1]['id']['time']
+        # The activity api returns logs in reverse chronological order, for some reason, and
+        # therefore the newest log will be first in the list. This should only be updated
+        # once during the first poll
+        if not self._next_page_token:
+            self._last_timestamp = activities[0]['id']['time']
+            LOGGER.debug('Caching last timestamp: %s', self._last_timestamp)
+
+        self._next_page_token = results.get('nextPageToken')
+        self._more_to_poll = bool(self._next_page_token)
 
         return activities
 
@@ -156,6 +169,11 @@ class GSuiteReportsApp(AppIntegration):
                     'description': ('the path on disk to the JSON formatted Google '
                                     'service account private key file'),
                     'format': keyfile_validator
+                },
+            'delegation_email':
+                {
+                    'description': 'the service account user email to delegate access to',
+                    'format': re.compile(r'^[A-Za-z0-9-_.]+@[A-Za-z0-9-.]+\.[A-Za-z]{2,}$')
                 }
             }
 

--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -307,9 +307,8 @@ class AppConfig(dict):
             )
         except ClientError as err:
             raise AppIntegrationStateError('Could not save current state to parameter '
-                                           'store with name \'{}\'. Error: '
-                                           '{}'.format(state_name,
-                                                       err.response['Error']['Message']))
+                                           'store with name \'{}\'. Response: '
+                                           '{}'.format(state_name, err.response))
 
     def _validate_config(self):
         """Validate the top level of the config to make sure it has all the right keys

--- a/tests/unit/app_integrations/test_helpers.py
+++ b/tests/unit/app_integrations/test_helpers.py
@@ -114,6 +114,7 @@ class MockSSMClient(object):
         elif app_type in {'gsuite', 'gsuite_admin', 'gsuite_drive',
                           'gsuite_login', 'gsuite_token'}:
             return {
+                'delegation_email': 'test@email.com',
                 'keyfile': {
                     'type': 'service_account',
                     'project_id': 'myapp-123456',


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

During testing of the GSuite streamalert app, it was found that the proper permissions were not being used by the app, resulting in the following error:
`HttpError: <HttpError 401 when requesting https://www.googleapis.com/admin/reports/v1/activity/users/all/applications/admin?alt=json returned "Access denied. You are not authorized to read activity records.">`

## Changes

* The GSuite app now uses a service account email to perform [domain-wide auth delegation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation#delegate_domain-wide_authority_to_your_service_account).
  * This email address must be provided during app configuration and will be save the parameter store along with the keyfile's data.
* Fixing bug where the incorrect last timestamp would be saved to the state.
  * The Google Admin SDK Reports API returns all logs in reverse chronological order (contrary to every other API I've seen or we support). Therefore, the _first_ log in the list of logs returned will have the most recent date and the _last_ log returned (after all pagination, etc) will be the oldest log.
  * The ideal fix for this would make sure ALL logs were retrieved before saving the timestamp, since this can now result in missed data if there are any errors. However, that's a significant refactor and we can limit the impact of this by setting a high AWS Lambda timeout and a low CloudWatch Scheduled Events interval.
* Adding additional debug log statements

### Other Changes
* Adding a debug logger statement to the box app so it's more clear when requests are happening.

## Testing

* Unit tests passing (`tests/scripts/unit_tests.sh`)
* Tested in scripted form locally.
