### PR TITLE
[output] Backoff support in Jira output

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -254,7 +254,7 @@ class OutputDispatcher(object):
         """Log the status of sending the alerts
 
         Args:
-            success (bool): Indicates if the dispatching of alerts was successful
+            success (bool or dict): Indicates if the dispatching of alerts was successful
         """
         if success:
             LOGGER.info('Successfully sent alert to %s', cls.__service__)

--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -347,7 +347,7 @@ class OutputDispatcher(object):
             headers (dict): Dictionary containing request-specific header parameters
             verify (bool): Whether or not the server's SSL certificate should be verified
         Returns:
-            bool: Indicates whether the request was successful
+            dict: Contains the http response object
         Raises:
             OutputRequestFailure
         """
@@ -359,7 +359,7 @@ class OutputDispatcher(object):
             if not success:
                 raise OutputRequestFailure()
 
-            return success
+            return resp
         return do_post_request()
 
     @classmethod


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Backoff support allows to retry requests when something goes wrong.

## Changes

* Changed returned value in `_post_request_retry` from a boolean to the whole `requests.Response` object.
* Added support for backoff in jira output.
* Modified tests according to changes.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2793    103    96%
----------------------------------------------------------------------
Ran 490 tests in 10.049s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```