### PR TITLE
[output] Backoff support in slack output

### DIFF
--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from stream_alert.alert_processor.outputs.output_base import (
     OutputDispatcher,
     OutputProperty,
+    OutputRequestFailure,
     StreamAlertOutput
 )
 
@@ -223,7 +224,9 @@ class SlackOutput(OutputDispatcher):
 
         slack_message = self._format_message(kwargs['rule_name'], kwargs['alert'])
 
-        resp = self._post_request(creds['url'], slack_message)
-        success = self._check_http_response(resp)
+        try:
+            success = self._post_request_retry(creds['url'], slack_message)
+        except OutputRequestFailure:
+            success = False
 
         return self._log_status(success)


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Backoff support allows to retry requests when something goes wrong.

## Changes

* Added support for backoff in slack output.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2793    103    96%
----------------------------------------------------------------------
Ran 490 tests in 10.049s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```