### PR TITLE
[tf] Remove sort key from DynamoDB table.

### DIFF
--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -3,15 +3,9 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
   read_capacity  = "${var.table_rcu}"
   write_capacity = "${var.table_wcu}"
   hash_key       = "value"
-  range_key      = "type"
 
   attribute {
     name = "value"
-    type = "S"
-  }
-
-  attribute {
-    name = "type"
     type = "S"
   }
 


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
Remove sort key from DynamoDB table. It is not necessary to have sort key in DynamoDB table, since the primary key (hash key) will also be identical from each item in the table. The primary key in the DynamoDB table is the value of IOC. 

## Changes

* Remove `range_key` from terraform module, and it translates to `sort key` in DynamoDB table. 

## Testing
* Tested it in AWS testing account, and it was passed. 
