### PR TITLE
[apps] gsuite app timestamp fix and schema update

### DIFF
--- a/app_integrations/apps/README.rst
+++ b/app_integrations/apps/README.rst
@@ -25,31 +25,30 @@ on ec2 instance
 .. code-block:: bash
 
   # Remove any previous caches
-  $ rm -rf ~/.cache/pip/
+  $ rm -rf $HOME/.cache/pip/
 
   # Create and source venv
-  $ virtualenv ~/venv
-  $ source ~/venv/bin/activate
+  $ virtualenv $HOME/venv
+  $ source $HOME/venv/bin/activate
 
   # Upgrade pip and setuptools (they are super old)
   $ pip install --upgrade pip setuptools
 
   # Make a temp build directory and temp pip install directory
-  $ mkdir ~/build_temp
-  $ mkdir ~/pip_temp
+  $ mkdir $HOME/build_temp $HOME/pip_temp
 
   # Install all of the dependencies to this directory
   # Replace the `boxsdk[jwt]==2.0.0a11` below with the desired package & version
-  $ python -c "import pip; pip.main(['install', 'boxsdk[jwt]==2.0.0a11', '--build', '~/build_temp/',  '--target', '~/pip_temp'])"
+  $ python -c "import pip; pip.main(['install', 'boxsdk[jwt]==2.0.0a11', '--build', '$HOME/build_temp/',  '--target', '$HOME/pip_temp'])"
 
   # Change into the install directory
-  $ cd ~/pip_temp
+  $ cd $HOME/pip_temp
 
   # Cleanup any pyc files
   $ find . -name '*.pyc' | xargs rm -rf
 
   # Zip it all up
-  $ zip -r pip.zip * .*
+  $ zip -r pip.zip .
 
   # Exit the ssh session
   $ exit

--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -29,8 +29,8 @@ class GSuiteReportsApp(AppIntegration):
 
     def __init__(self, config):
         super(GSuiteReportsApp, self).__init__(config)
-        self._last_event_timestamp = self._last_timestamp
         self._activities_service = None
+        self._last_event_timestamp = None
         self._next_page_token = None
 
     @classmethod
@@ -107,6 +107,10 @@ class GSuiteReportsApp(AppIntegration):
         """
         if not self._create_service():
             return False
+
+        # Cache the last event timestamp so it can be used for future requests
+        if not self._next_page_token:
+            self._last_event_timestamp = self._last_timestamp
 
         LOGGER.debug('Querying activities since %s for %s',
                      self._last_event_timestamp,

--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1092,14 +1092,27 @@
   },
   "gsuite:reports": {
     "schema": {
-      "kind": "string",
-      "id": {},
       "actor": {},
-      "ownerDomain": "string",
+      "etag": "string",
+      "events": [],
+      "id": {
+        "applicationName": "string",
+        "customerId": "string",
+        "time": "string",
+        "uniqueQualifier": "integer"
+      },
       "ipAddress": "string",
-      "events": []
+      "kind": "string",
+      "ownerDomain": "string"
     },
-    "parser": "json"
+    "parser": "json",
+    "configuration": {
+      "optional_top_level_keys": [
+        "etag",
+        "ipAddress",
+        "ownerDomain"
+      ]
+    }
   },
   "onelogin:events": {
     "schema": {

--- a/tests/integration/rules/gsuite/gsuite_admin.json
+++ b/tests/integration/rules/gsuite/gsuite_admin.json
@@ -2,38 +2,38 @@
   "records": [
     {
       "data": {
-        "kind": "audit#activity",
-        "id": {
-          "time": "2011-06-17T15:39:18.460Z",
-          "uniqueQualifier": "report's unique ID",
-          "applicationName": "admin",
-          "customerId": "C03az79cb"
-        },
         "actor": {
           "callerType": "USER",
           "email": "liz@example.com",
-          "profileId": "user's unique G Suite profile ID",
-          "key": "consumer key of requestor in OAuth 2LO requests"
+          "key": "consumer key of requestor in OAuth 2LO requests",
+          "profileId": "user's unique G Suite profile ID"
         },
-        "ownerDomain": "example.com",
-        "ipAddress": "user's IP address",
         "events": [
           {
-            "type": "GROUP_SETTINGS",
             "name": "CHANGE_GROUP_SETTING",
             "parameters": [
               {
-                "name": "SETTING_NAME",
-                "value": "WHO_CAN_JOIN",
+                "boolValue": "boolean value of parameter",
                 "intValue": "integer value of parameter",
-                "boolValue": "boolean value of parameter"
+                "name": "SETTING_NAME",
+                "value": "WHO_CAN_JOIN"
               }
-            ]
+            ],
+            "type": "GROUP_SETTINGS"
           }
-        ]
+        ],
+        "id": {
+          "applicationName": "admin",
+          "customerId": "C03az79cb",
+          "time": "2011-06-17T15:39:18.460Z",
+          "uniqueQualifier": "-1234567890987654321"
+        },
+        "ipAddress": "user's IP address",
+        "kind": "audit#activity",
+        "ownerDomain": "example.com"
       },
       "description": "G Suite Admin Report Log exmaple (validation only)",
-      "log": "gsuite:report",
+      "log": "gsuite:reports",
       "service": "stream_alert_app",
       "source": "prefix_cluster_gsuite_admin_sm-app-name_app",
       "trigger_rules": [],


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Discovered a pretty obscure bug that crashed the gsuite app on deploy with the following Traceback:
```
File "/var/task/app_integrations/apps/app_base.py", line 398, in do_gather
logs = self._gather_logs()
File "/var/task/app_integrations/apps/gsuite.py", line 120, in _gather_logs
pageToken=self._next_page_token
File "/var/task/googleapiclient/discovery.py", line 744, in method
for pvalue in pvalues:
TypeError: 'int' object is not iterable
```

## Changes

* Determined that the `startTime` parameter was getting passed a value of `0` and the google api client does not like integers much :)
* Moving the storing of the initial timestamp out of the init to avoid being set to 0.
* Updating `gsuite:reports` schema to include nested fields and updating test event to reflect real data (ie: `uniqueQualifier` is now an int).
* Updates to box dependencies readme to fix issues I noticed during testing.

## Testing

* Deployed changes and working as expected. All rule/unit tests passing.
