### PR TITLE
[tf][cli] vpc flow log support clusters & cross-account delivery

### DIFF
--- a/stream_alert_cli/terraform/flow_logs.py
+++ b/stream_alert_cli/terraform/flow_logs.py
@@ -28,6 +28,8 @@ def generate_flow_logs(cluster_name, cluster_dict, config):
         bool: Result of applying the flow_logs module
     """
     modules = config['clusters'][cluster_name]['modules']
+    account_id = config['global']['account']['aws_account_id']
+    cross_account_ids = modules['flow_logs'].get('cross_account_ids', []) + [account_id]
     flow_log_group_name_default = '{}_{}_streamalert_flow_logs'.format(
         config['global']['account']['prefix'],
         cluster_name
@@ -38,6 +40,8 @@ def generate_flow_logs(cluster_name, cluster_dict, config):
     if modules['flow_logs']['enabled']:
         cluster_dict['module']['flow_logs_{}'.format(cluster_name)] = {
             'source': 'modules/tf_stream_alert_flow_logs',
+            'cluster': cluster_name,
+            'cross_account_ids': cross_account_ids,
             'destination_stream_arn': '${{module.kinesis_{}.arn}}'.format(cluster_name),
             'flow_log_group_name': flow_log_group_name}
         for flow_log_input in ('vpcs', 'subnets', 'enis'):

--- a/terraform/modules/tf_stream_alert_flow_logs/iam.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/iam.tf
@@ -1,98 +1,126 @@
 // Allow flow logs to write to CloudWatch
 // http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html#flow-logs-iam
-
+// IAM Role: Clustered VPC Flow Log
 resource "aws_iam_role" "flow_log_role" {
-  name = "flow_log_role"
+  name = "stream_alert_${var.cluster}_flow_log_role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "vpc-flow-logs.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-} 
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.flow_log_assume_role_policy.json}"
 }
 
+// IAM Policy Doc: AssumeRole for VPC Flow Logs
+data "aws_iam_policy_document" "flow_log_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+// IAM Policy: CloudWatch Put Events
 resource "aws_iam_role_policy" "flow_log_write" {
-  name = "write_to_cloudwatch"
+  name = "CloudWatchPutEvents"
   role = "${aws_iam_role.flow_log_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}   
-EOF
+  policy = "${data.aws_iam_policy_document.flow_log_put_cloudwatch_logs.json}"
+}
+
+// IAM Policy Doc: CloudWatch Put Events
+data "aws_iam_policy_document" "flow_log_put_cloudwatch_logs" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 // Allow log subscription to write to Kinesis Stream
 // http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
-
+// IAM Role: Clustered CloudWatch Flow Log Role
 resource "aws_iam_role" "flow_log_subscription_role" {
-  name = "flow_log_subscription_role"
+  name = "stream_alert_${var.cluster}_flow_log_subscription_role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "logs.${var.region}.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-} 
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.cloudwatch_logs_assume_role_policy.json}"
 }
 
+// IAM Policy Doc: AssumeRole for CloudWatch Logs
+data "aws_iam_policy_document" "cloudwatch_logs_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+  }
+}
+
+// IAM Policy: Write to Kinesis
 resource "aws_iam_role_policy" "flow_logs_kinesis_wo" {
   name = "write_flow_logs_to_kinesis"
   role = "${aws_iam_role.flow_log_subscription_role.id}"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement" : [
-    {
-      "Action": [
-        "kinesis:PutRecord*",
-        "kinesis:DescribeStream",
-        "kinesis:ListStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${var.destination_stream_arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iam:PassRole",
-      "Resource": "${aws_iam_role.flow_log_subscription_role.arn}"
-    }
-  ]
+  policy = "${data.aws_iam_policy_document.flow_logs_put_kinesis_events.json}"
 }
-EOF
+
+// IAM Policy Doc: Write to Kinesis
+data "aws_iam_policy_document" "flow_logs_put_kinesis_events" {
+  statement {
+    actions = [
+      "kinesis:PutRecord*",
+      "kinesis:DescribeStream",
+      "kinesis:ListStreams",
+    ]
+
+    resources = [
+      "${var.destination_stream_arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:PassRole",
+    ]
+
+    resources = [
+      "${aws_iam_role.flow_log_subscription_role.arn}",
+    ]
+  }
+}
+
+// IAM Policy Doc: Allow Cross Account Flow Logs
+data "aws_iam_policy_document" "cross_account_subscription_filter" {
+  count = "${length(var.cross_account_ids) > 0 ? 1 : 0}"
+
+  statement {
+    effect = "Allow"
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "${var.cross_account_ids}",
+      ]
+    }
+
+    actions = [
+      "logs:PutSubscriptionFilter",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_destination.kinesis.arn}",
+    ]
+  }
 }

--- a/terraform/modules/tf_stream_alert_flow_logs/iam.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/iam.tf
@@ -31,12 +31,14 @@ resource "aws_iam_role_policy" "flow_log_write" {
 // IAM Policy Doc: CloudWatch Put Events
 data "aws_iam_policy_document" "flow_log_put_cloudwatch_logs" {
   statement {
+    effect = "Allow"
+
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
     ]
 
     resources = [
@@ -78,10 +80,12 @@ resource "aws_iam_role_policy" "flow_logs_kinesis_wo" {
 // IAM Policy Doc: Write to Kinesis
 data "aws_iam_policy_document" "flow_logs_put_kinesis_events" {
   statement {
+    effect = "Allow"
+
     actions = [
-      "kinesis:PutRecord*",
       "kinesis:DescribeStream",
       "kinesis:ListStreams",
+      "kinesis:PutRecord*",
     ]
 
     resources = [
@@ -90,6 +94,8 @@ data "aws_iam_policy_document" "flow_logs_put_kinesis_events" {
   }
 
   statement {
+    effect = "Allow"
+
     actions = [
       "iam:PassRole",
     ]
@@ -101,10 +107,11 @@ data "aws_iam_policy_document" "flow_logs_put_kinesis_events" {
 }
 
 // IAM Policy Doc: Allow Cross Account Flow Logs
-data "aws_iam_policy_document" "cross_account_subscription_filter" {
+data "aws_iam_policy_document" "cross_account_destination_policy" {
   count = "${length(var.cross_account_ids) > 0 ? 1 : 0}"
 
   statement {
+    sid    = "CrossAccountDestinationPolicy"
     effect = "Allow"
 
     principals = {

--- a/terraform/modules/tf_stream_alert_flow_logs/main.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/main.tf
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_log_destination" "kinesis" {
 resource "aws_cloudwatch_log_destination_policy" "kinesis" {
   count            = "${length(var.cross_account_ids) > 0 ? 1 : 0}"
   destination_name = "${aws_cloudwatch_log_destination.kinesis.name}"
-  access_policy    = "${data.aws_iam_policy_document.cross_account_subscription_filter.json}"
+  access_policy    = "${data.aws_iam_policy_document.cross_account_destination_policy.json}"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "flow_logs" {

--- a/terraform/modules/tf_stream_alert_flow_logs/main.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/main.tf
@@ -27,13 +27,31 @@ resource "aws_flow_log" "eni_flow_log" {
 }
 
 resource "aws_cloudwatch_log_group" "flow_log_group" {
-  name = "${var.flow_log_group_name}"
+  name              = "${var.flow_log_group_name}"
+  retention_in_days = "${var.log_retention}"
+}
+
+// Note: When creating cross-account log destinations,
+//       the log group and the destination must be in the same AWS region.
+//       However, the AWS resource that the destination points to can be 
+//       located in a different region.
+// Source: http://amzn.to/2zF7CS0
+resource "aws_cloudwatch_log_destination" "kinesis" {
+  name       = "stream_alert_${var.cluster}_log_destination"
+  role_arn   = "${aws_iam_role.flow_log_subscription_role.arn}"
+  target_arn = "${var.destination_stream_arn}"
+}
+
+resource "aws_cloudwatch_log_destination_policy" "kinesis" {
+  count            = "${length(var.cross_account_ids) > 0 ? 1 : 0}"
+  destination_name = "${aws_cloudwatch_log_destination.kinesis.name}"
+  access_policy    = "${data.aws_iam_policy_document.cross_account_subscription_filter.json}"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "flow_logs" {
-  name            = "${aws_cloudwatch_log_group.flow_log_group.name}_to_lambda"
+  name            = "${aws_cloudwatch_log_group.flow_log_group.name}_to_kinesis"
   log_group_name  = "${aws_cloudwatch_log_group.flow_log_group.name}"
   filter_pattern  = "${var.flow_log_filter}"
-  destination_arn = "${var.destination_stream_arn}"
-  role_arn        = "${aws_iam_role.flow_log_subscription_role.arn}"
+  destination_arn = "${aws_cloudwatch_log_destination.kinesis.arn}"
+  depends_on      = ["aws_cloudwatch_log_destination_policy.kinesis"]
 }

--- a/terraform/modules/tf_stream_alert_flow_logs/variables.tf
+++ b/terraform/modules/tf_stream_alert_flow_logs/variables.tf
@@ -1,24 +1,14 @@
+variable "cluster" {
+  type = "string"
+}
+
+variable "cross_account_ids" {
+  type    = "list"
+  default = []
+}
+
 variable "destination_stream_arn" {
   type = "string"
-}
-
-variable "region" {
-  type    = "string"
-  default = "us-east-1"
-}
-
-variable "flow_log_group_name" {
-  type = "string"
-}
-
-variable "vpcs" {
-  type    = "list"
-  default = []
-}
-
-variable "subnets" {
-  type    = "list"
-  default = []
 }
 
 variable "enis" {
@@ -28,4 +18,27 @@ variable "enis" {
 
 variable "flow_log_filter" {
   default = "[version, account, eni, source, destination, srcport, destport, protocol, packets, bytes, windowstart, windowend, action, flowlogstatus]"
+}
+
+variable "flow_log_group_name" {
+  type = "string"
+}
+
+variable "log_retention" {
+  default = 365
+}
+
+variable "region" {
+  type    = "string"
+  default = "us-east-1"
+}
+
+variable "subnets" {
+  type    = "list"
+  default = []
+}
+
+variable "vpcs" {
+  type    = "list"
+  default = []
 }


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

The VPC flow log Terraform module currently only creates a subscription filter within a single account.  In order to support cross account subscription filters, some IAM permissions needed to change.

## Changes

* Refactor to use IAM policy doc data resources
* Add an explicit cloudwatch log destination resource which allows us to grant cross account access
* Add an option in the `flow_logs` stream alert cluster module which accepts a list of `cross_account_ids`

## Testing

Deployed and verified by using two test accounts
