### PR TITLE
[apps] safely handling single logs that exceed Lambda max input size

### DIFF
--- a/app_integrations/batcher.py
+++ b/app_integrations/batcher.py
@@ -93,6 +93,11 @@ class Batcher(object):
         payload = {'Records': [{'stream_alert_app': source_function, 'logs': logs}]}
         payload_json = json.dumps(payload, separators=(',', ':'))
         if len(payload_json) > MAX_LAMBDA_PAYLOAD_SIZE:
+            if len(logs) == 1:
+                LOGGER.error('Log payload size for single log exceeds input limit and will be '
+                             'dropped (%d > %d max).', len(payload_json), MAX_LAMBDA_PAYLOAD_SIZE)
+                return True
+
             LOGGER.debug('Log payload size for %d logs exceeds limit and will be '
                          'segmented (%d > %d max).', len(logs), len(payload_json),
                          MAX_LAMBDA_PAYLOAD_SIZE)

--- a/tests/unit/app_integrations/test_batcher.py
+++ b/tests/unit/app_integrations/test_batcher.py
@@ -73,6 +73,16 @@ class TestAppBatcher(object):
 
         assert_false(result)
 
+    @patch('logging.Logger.error')
+    def test_segment_and_send_one_over_max(self, log_mock):
+        """App Integration Batcher - Drop One Log Over Max Size"""
+        logs = [{'random_data': 'a' * 128000}]
+        assert_true(self.batcher._send_logs_to_stream_alert('duo_auth', logs))
+
+        log_mock.assert_called_with('Log payload size for single log exceeds input '
+                                    'limit and will be dropped (%d > %d max).',
+                                    128073, 128000)
+
     @patch('app_integrations.batcher.Batcher._send_logs_to_stream_alert')
     def test_segment_and_send(self, batcher_mock):
         """App Integration Batcher - Segment and Send Logs to StreamAlert"""


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

1) Observed bug where a single log that exceeds the max size we can send to lambda (128k) could cause a max recursion stack overflow:
```
maximum recursion depth exceeded in cmp: RuntimeError
Traceback (most recent call last):
File "/var/task/app_integrations/main.py", line 39, in handler
app.gather()
File "/var/task/app_integrations/apps/app_base.py", line 438, in gather
while (self._gather() + self._sleep_seconds() <
File "/var/task/app_integrations/apps/app_base.py", line 423, in _gather
exec_time = Decimal(timeit(do_gather, number=1))
File "/usr/lib64/python2.7/timeit.py", line 237, in timeit
return Timer(stmt, setup, timer).timeit(number)
File "/usr/lib64/python2.7/timeit.py", line 202, in timeit
timing = self.inner(it, self.timer)
File "/usr/lib64/python2.7/timeit.py", line 100, in inner
_func()
File "/var/task/app_integrations/apps/app_base.py", line 412, in do_gather
self._batcher.send_logs(self._config['function_name'], logs)
File "/var/task/app_integrations/batcher.py", line 58, in send_logs
self._segment_and_send(source_function, logs)
File "/var/task/app_integrations/batcher.py", line 79, in _segment_and_send
self._segment_and_send(source_function, subset)
File "/var/task/app_integrations/batcher.py", line 79, in _segment_and_send
self._segment_and_send(source_function, subset)
.....
File "/var/task/app_integrations/batcher.py", line 79, in _segment_and_send
self._segment_and_send(source_function, subset)
File "/var/task/app_integrations/batcher.py", line 79, in _segment_and_send
self._segment_and_send(source_function, subset)
```

2) Noticed a timeout exception from python `socket` that caused a crash. This is related to the gsuite app, and is a part of the google python api client.
```
timed out: timeout
Traceback (most recent call last):
File "/var/task/app_integrations/main.py", line 39, in handler
app.gather()
File "/var/task/app_integrations/apps/app_base.py", line 438, in gather
while (self._gather() + self._sleep_seconds() <
File "/var/task/app_integrations/apps/app_base.py", line 423, in _gather
exec_time = Decimal(timeit(do_gather, number=1))
File "/usr/lib64/python2.7/timeit.py", line 237, in timeit
return Timer(stmt, setup, timer).timeit(number)
File "/usr/lib64/python2.7/timeit.py", line 202, in timeit
timing = self.inner(it, self.timer)
File "/usr/lib64/python2.7/timeit.py", line 100, in inner
_func()
File "/var/task/app_integrations/apps/app_base.py", line 398, in do_gather
logs = self._gather_logs()
File "/var/task/app_integrations/apps/gsuite.py", line 108, in _gather_logs
if not self._create_service():
File "/var/task/app_integrations/apps/gsuite.py", line 89, in _create_service
resource = apiclient.discovery.build('admin', 'reports_v1', credentials=delegation)
File "/var/task/oauth2client/_helpers.py", line 133, in positional_wrapper
return wrapped(*args, **kwargs)
File "/var/task/googleapiclient/discovery.py", line 229, in build
requested_url, discovery_http, cache_discovery, cache)
File "/var/task/googleapiclient/discovery.py", line 276, in _retrieve_discovery_doc
resp, content = http.request(actual_url)
File "/var/task/httplib2/__init__.py", line 1659, in request
(response, content) = self._request(conn, authority, uri, request_uri, method, body, headers, redirections, cachekey)
File "/var/task/httplib2/__init__.py", line 1399, in _request
(response, content) = self._conn_request(conn, request_uri, method, body, headers)
File "/var/task/httplib2/__init__.py", line 1319, in _conn_request
conn.connect()
File "/var/task/httplib2/__init__.py", line 1065, in connect
sock.connect((self.host, self.port))
File "/usr/lib64/python2.7/socket.py", line 228, in meth
return getattr(self._sock,name)(*args)
timeout: timed out
```

## Changes

* Returning `True` and logging an error if there is a single log that exceeds max size and cannot be sent to AWS Lambda with an async call. This effectively skips single logs that are outside of the acceptable bounds for sending.
* Catching socket timeouts that could occur in the gsuite app and logging an error/returning.


## Other Changes

* Suppressing a noisy log message that prints a warning every time the gsuite app runs. This is part of the gsuite python api client. The warning is for something that is non-consequential and can be safely ignored.

## Testing

Adding a unit test to ensure single logs are being handled properly. All unit tests passing.
