### PR TITLE
[schema] adding cloudwatch control message schema and validation test

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -891,6 +891,24 @@
     },
     "parser": "json"
   },
+  "cloudwatch:control_message": {
+    "schema": {
+      "id": "string",
+      "message": "string",
+      "timestamp": "integer"
+    },
+    "parser": "json",
+    "configuration": {
+      "json_path": "logEvents[*]",
+      "envelope_keys": {
+        "logGroup": "string",
+        "logStream": "string",
+        "messageType": "string",
+        "owner": "string",
+        "subscriptionFilters": []
+      }
+    }
+  },
   "cloudwatch:events": {
     "schema": {
       "account": "string",

--- a/tests/integration/rules/cloudwatch/cloudwatch_control_message.json
+++ b/tests/integration/rules/cloudwatch/cloudwatch_control_message.json
@@ -1,0 +1,26 @@
+{
+  "records": [
+    {
+      "data": {
+        "messageType": "CONTROL_MESSAGE",
+        "owner": "CloudwatchLogs",
+        "logGroup": "",
+        "logStream": "",
+        "subscriptionFilters": [],
+        "logEvents": [
+          {
+            "id": "",
+            "timestamp": 1512601480749,
+            "message": "CWL CONTROL MESSAGE: Checking health of destination Kinesis stream."
+          }
+        ]
+      },
+      "description": "CloudWatch Control Message (validation only)",
+      "log": "cloudwatch:control_message",
+      "service": "kinesis",
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "trigger_rules": [],
+      "validate_schema_only": true
+    }
+  ]
+}


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Observed a failed parse for an incoming CloudWatch control message log.

## Changes

* Adding `cloudwatch:control_message` schema.

## Testing

* Adding validation test event for the new schema.
