### PR TITLE
[output] Increasing backoff time between retries

### DIFF
--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -25,7 +25,7 @@
         "current_version": "$LATEST",
         "log_level": "info",
         "memory": 128,
-        "timeout": 10
+        "timeout": 60
       },
       "rule_processor": {
         "current_version": "$LATEST",

--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -46,7 +46,7 @@ def retry_on_exception(exceptions):
     """Decorator function to attempt retry based on passed exceptions"""
     def real_decorator(func):
         """Actual decorator to retry on exceptions"""
-        @backoff.on_exception(backoff.fibo,
+        @backoff.on_exception(backoff.expo,
                               exceptions, # This is a tuple with exceptions
                               max_tries=OutputDispatcher.MAX_RETRY_ATTEMPTS,
                               jitter=backoff.full_jitter,
@@ -133,7 +133,7 @@ class OutputDispatcher(object):
     __service__ = NotImplemented
 
     # How many times it will attempt to retry something failing using backoff
-    MAX_RETRY_ATTEMPTS = 3
+    MAX_RETRY_ATTEMPTS = 5
 
     # _DEFAULT_REQUEST_TIMEOUT indicates how long the requests library will wait before timing
     # out for both get and post requests. This applies to both connection and read timeouts

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -30,6 +30,7 @@ from tests.unit.stream_alert_alert_processor.helpers import get_alert, remove_te
 
 @mock_s3
 @mock_kms
+@patch('stream_alert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS', 1)
 class TestPagerDutyOutput(object):
     """Test class for PagerDutyOutput"""
     DESCRIPTOR = 'unit_test_pagerduty'
@@ -86,6 +87,7 @@ class TestPagerDutyOutput(object):
 
 @mock_s3
 @mock_kms
+@patch('stream_alert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS', 1)
 class TestPagerDutyOutputV2(object):
     """Test class for PagerDutyOutputV2"""
     DESCRIPTOR = 'unit_test_pagerduty-v2'

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -31,6 +31,7 @@ from tests.unit.stream_alert_alert_processor.helpers import (
 
 @mock_s3
 @mock_kms
+@patch('stream_alert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS', 1)
 class TestSlackOutput(object):
     """Test class for SlackOutput"""
     DESCRIPTOR = 'unit_test_channel'


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Backoff was added to handle retries for outputs when something goes wrong. The current code uses `backoff.fibo` (Fibonacci), as method to define how long to wait between attempts. Also the maximum number of attempts was 3. For PagerDuty it was not making much of a difference since the requests were still rate limited, as the wait was not that long.

By moving to `backoff.expo` (Exponential), we will increase more the wait from attempt to the next one and also the maximum number to attempts will be 5.

Here is a comparison between the two approaches, with a quick script:
```
$ python compare.py
Exponential
1
2
4
8
16

Fibonacci
1
1
2
3
5
```

## Changes

* Increased the timeout for default clusters.
* Changed the backoff behavior from `backoff.fibo` to backoff.expo` to increase the wait between attempts.
* Increased the maximum number of retries.
* Patched maximum number of retries for all outputs to avoid unnecessary delays in tests.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2803     99    96%
----------------------------------------------------------------------
Ran 494 tests in 9.749s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```