### PR TITLE
[data-normalization] adding gsuite ipAddress to data normalization/threat intel

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -144,6 +144,11 @@
       "user"
     ]
   },
+  "gsuite": {
+    "sourceAddress:ioc_ip": [
+      "ipAddress"
+    ]
+  },
   "onelogin": {
     "sourceAddress:ioc_ip": [
       "ipaddr",


### PR DESCRIPTION
to: @mime-frame 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

G Suite Admin SDK Report logs have an `ipAddress` field that maps to the source address of where an event took place.

## Changes

* Adding the `sourceAddress` --> `ipAddress` mapping to the `types.json` file so we can get threat intelligence alerting on gsuite logs.

