### PR TITLE
[output] Use service_name for PagerDuty Incidents

### DIFF
--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -222,8 +222,8 @@ class PagerDutyIncidentOutput(OutputDispatcher):
              OutputProperty(description='the token for this PagerDuty integration',
                             mask_input=True,
                             cred_requirement=True)),
-            ('service_key',
-             OutputProperty(description='the service key for this PagerDuty integration',
+            ('service_name',
+             OutputProperty(description='the service name for this PagerDuty integration',
                             mask_input=True,
                             cred_requirement=True)),
             ('escalation_policy',
@@ -464,7 +464,7 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             'details': kwargs['alert']['rule_description']
         }
         # We need to get the service id from the API
-        incident_service = self._service_verify(creds['service_key'])
+        incident_service = self._service_verify(creds['service_name'])
         incident = {
             'incident': {
                 'type': 'incident',

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -154,7 +154,7 @@ class TestPagerDutyIncidentOutput(object):
     SERVICE = 'pagerduty-incident'
     CREDS = {'api': 'https://api.pagerduty.com',
              'token': 'mocked_token',
-             'service_key': 'mocked_service_key',
+             'service_name': 'mocked_service_name',
              'escalation_policy': 'mocked_escalation_policy',
              'email_from': 'email@domain.com'}
 


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## ⚠️   Breaking Change ⚠️   

If you have already added `pagerduty-incident` as output, this will break things. Make sure you re-create the output using this new format.

## Background

PagerDuty Incidents output uses the name of a service to create a new incident. It was a bit confusing when creating a new output because other PagerDuty outputs use the `service_key` and that is the integration key.

## Changes

* Using `service_name` instead of `service_key` in incident creation.
* Modified current tests to reflect this change.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2820    100    96%
----------------------------------------------------------------------
Ran 496 tests in 7.831s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```