### PR TITLE
[threat_intel_downloader] Update key names for the IOCs stored in DB table

### DIFF
--- a/stream_alert/threat_intel_downloader/threat_stream.py
+++ b/stream_alert/threat_intel_downloader/threat_stream.py
@@ -40,7 +40,7 @@ class ThreatStream(object):
     _IOC_STATUS = 'active'
     # max IOC objects received from one API call, default is 0 (equal to 1000)
     _API_MAX_LIMIT = 1000
-    _API_MAX_INDEX = 1000000
+    _API_MAX_INDEX = 500000
     _PARAMETER_NAME = 'threat_intel_downloader_api_creds'
 
     def __init__(self, config):
@@ -258,8 +258,8 @@ class ThreatStream(object):
                 for ioc in intelligence:
                     batch.put_item(
                         Item={
-                            'value': ioc['value'],
-                            'type': ioc['type'],
+                            'ioc_value': ioc['value'],
+                            'ioc_type': ioc['type'],
                             'sub_type': ioc['itype'],
                             'source': ioc['source'],
                             'expiration_ts': ioc['expiration_ts']

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -2,10 +2,10 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
   name           = "${var.prefix}_streamalert_threat_intel_downloader"
   read_capacity  = "${var.table_rcu}"
   write_capacity = "${var.table_wcu}"
-  hash_key       = "value"
+  hash_key       = "ioc_value"
 
   attribute {
-    name = "value"
+    name = "ioc_value"
     type = "S"
   }
 

--- a/tests/unit/threat_intel_downloader/test_threat_stream.py
+++ b/tests/unit/threat_intel_downloader/test_threat_stream.py
@@ -193,9 +193,9 @@ class TestThreatStream(object):
                 Item={
                     'expiration_ts': 1512000062,
                     'source': 'test_source',
-                    'type': 'domain',
+                    'ioc_type': 'domain',
                     'sub_type': 'c2_domain',
-                    'value': 'malicious_domain2.com'
+                    'ioc_value': 'malicious_domain2.com'
                 }
             ),
             call().Table().batch_writer().__exit__(None, None, None)


### PR DESCRIPTION
to: @austinbyers  
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
DynamoDB has a list of [reserved words](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html), e.g. `value`, `type`. AWS document mention `The following keywords are reserved for use by DynamoDB. Do not use any of these words as attribute names in expressions.` 
Sadly, I am using `value` and `type` as attribute names in DynamoDB table. Table will be created correctly, however, it requires special handling when we want to query the table. 
So we just avoid to use these reserved words. 

## Changes

* change attribute names in DynamoDB IOC table. 

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (59/59) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Unit testing
```
./tests/scripts/unit_tests.sh
Ran 496 tests in 7.310s

OK
```
* Linting
```
./tests/scripts/pylint.sh
Starting pylint script

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```
* Test in AWS testing account, and it was passed. 