### PR TITLE
Deploy by Cluster, Batch Size Param, and More

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1002,6 +1002,8 @@ Available Options:
     --target                                   The Terraform module name to apply.
                                                Valid options: stream_alert, kinesis, kinesis_events,
                                                cloudtrail, monitoring, and s3_events.
+    --cluster                                  The StreamAlert cluster(s) to apply to.
+
 Examples:
 
     manage.py terraform init
@@ -1038,6 +1040,11 @@ Examples:
             'athena', 'cloudwatch_monitoring', 'cloudtrail', 'flow_logs', 'kinesis',
             'kinesis_events', 'stream_alert', 's3_events', 'threat_intel_downloader'
         ],
+        help=ARGPARSE_SUPPRESS,
+        nargs='+')
+
+    tf_parser.add_argument(
+        '--cluster',
         help=ARGPARSE_SUPPRESS,
         nargs='+')
 

--- a/manage.py
+++ b/manage.py
@@ -976,6 +976,11 @@ def _add_default_lambda_args(lambda_parser):
         action=UniqueSetAction,
         required=True)
 
+    lambda_parser.add_argument(
+        '--cluster',
+        help=ARGPARSE_SUPPRESS,
+        nargs='+')
+
     # Allow verbose output for the CLI with the --debug option
     lambda_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
 

--- a/manage.py
+++ b/manage.py
@@ -977,7 +977,7 @@ def _add_default_lambda_args(lambda_parser):
         required=True)
 
     lambda_parser.add_argument(
-        '--cluster',
+        '--clusters',
         help=ARGPARSE_SUPPRESS,
         nargs='+')
 
@@ -1007,7 +1007,7 @@ Available Options:
     --target                                   The Terraform module name to apply.
                                                Valid options: stream_alert, kinesis, kinesis_events,
                                                cloudtrail, monitoring, and s3_events.
-    --cluster                                  The StreamAlert cluster(s) to apply to.
+    --clusters                                  The StreamAlert cluster(s) to apply to.
 
 Examples:
 
@@ -1049,7 +1049,9 @@ Examples:
         nargs='+')
 
     tf_parser.add_argument(
-        '--cluster',
+        '--clusters',
+        action=UniqueSetAction,
+        default=set(),
         help=ARGPARSE_SUPPRESS,
         nargs='+')
 

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -118,7 +118,7 @@ def deploy(options, config):
         processors = options.processor
 
     for processor in processors:
-        package, targets = _create_and_upload(processor, config, options.cluster)
+        package, targets = _create_and_upload(processor, config, options.clusters)
         # Continue if the package isn't enabled
         if not all([package, targets]):
             continue

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -86,10 +86,13 @@ def _create_and_upload(function_name, config, cluster=None):
             config['lambda'].get('threat_intel_downloader_config', False))}
 
     if not package_mapping[function_name].enabled:
-        return None, None
+        return False, False
 
     package = package_mapping[function_name].package_class(config=config)
-    package.create_and_upload()
+    success = package.create_and_upload()
+
+    if not success:
+        sys.exit(1)
 
     return package, package_mapping[function_name].targets
 

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -13,19 +13,85 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from collections import namedtuple
 import sys
 
-from app_integrations import __version__ as apps_version
-from stream_alert import __version__ as current_version
-from stream_alert.threat_intel_downloader import __version__ as ti_downloader_version
 from stream_alert_cli import helpers
-from stream_alert_cli.manage_lambda.package import (AlertProcessorPackage,
-                                                    AthenaPackage,
-                                                    AppIntegrationPackage,
-                                                    RuleProcessorPackage,
-                                                    ThreatIntelDownloaderPackage)
+from stream_alert_cli.manage_lambda import package as stream_alert_packages
 from stream_alert_cli.terraform.generate import terraform_generate
 from stream_alert_cli.version import LambdaVersion
+
+
+PackageMap = namedtuple('package_attrs', ['package_class', 'targets', 'enabled'])
+
+
+def _publish_version(packages, config):
+    """Publish production Lambda versions
+
+    Args:
+        packages (list of LambdaPackage classes)
+
+    Returns:
+        bool: Result of Lambda version publishing
+    """
+    global_packages = {'athena_partition_refresh', 'threat_intel_downloader'}
+
+    for package in packages:
+        if package.package_name in global_packages:
+            published = LambdaVersion(
+                config=config, package=package, clustered_deploy=False).publish_function()
+        else:
+            published = LambdaVersion(
+                config=config, package=package).publish_function()
+        if not published:
+            return False
+
+    return True
+
+
+def _create_and_upload(function_name, config, cluster=None):
+    """
+    Args:
+        function_name: The name of the function to create and upload
+        config (CLIConfig): The loaded StreamAlert config
+        cluster (string): The cluster to deploy to
+
+    Returns:
+        tuple (LambdaPackage, set): The created Lambda package and the set of Terraform targets
+    """
+    clusters = cluster or config.clusters()
+
+    package_mapping = {
+        'alert': PackageMap(
+            stream_alert_packages.AlertProcessorPackage,
+            {'module.stream_alert_{}'.format(cluster) for cluster in clusters},
+            True),
+        'apps': PackageMap(
+            stream_alert_packages.AppIntegrationPackage,
+            {'module.app_{}_{}'.format(app_name, cluster)
+             for cluster, info in config['clusters'].iteritems()
+             for app_name in info['modules'].get('stream_alert_apps', {})},
+            config['lambda'].get('stream_alert_apps_config', False)),
+        'athena': PackageMap(
+            stream_alert_packages.AthenaPackage,
+            {'module.stream_alert_athena'},
+            config['lambda'].get('athena_partition_refresh_config', False)),
+        'rule': PackageMap(
+            stream_alert_packages.RuleProcessorPackage,
+            {'module.stream_alert_{}'.format(cluster) for cluster in clusters},
+            True),
+        'threat_intel_downloader': PackageMap(
+            stream_alert_packages.ThreatIntelDownloaderPackage,
+            {'module.threat_intel_downloader'},
+            config['lambda'].get('threat_intel_downloader_config', False))}
+
+    if not package_mapping[function_name].enabled:
+        return None, None
+
+    package = package_mapping[function_name].package_class(config=config)
+    package.create_and_upload()
+
+    return package, package_mapping[function_name].targets
 
 
 def deploy(options, config):
@@ -39,119 +105,34 @@ def deploy(options, config):
     - Update each cluster's Lambda configuration with latest published version
     - Run Terraform Apply
     """
-    processor = options.processor
     # Terraform apply only to the module which contains our lambda functions
-    targets = set()
+    deploy_targets = set()
     packages = []
 
-    def _publish_version(packages):
-        """Publish Lambda versions"""
-        for package in packages:
-            if package.package_name in {'athena_partition_refresh', 'threat_intel_downloader'}:
-                published = LambdaVersion(
-                    config=config, package=package, clustered_deploy=False).publish_function()
-            else:
-                published = LambdaVersion(config=config, package=package).publish_function()
-            if not published:
-                return False
-
-        return True
-
-    def _deploy_rule_processor():
-        """Create Rule Processor package and publish versions"""
-        rule_package = RuleProcessorPackage(config=config, version=current_version)
-        rule_package.create_and_upload()
-        return rule_package
-
-    def _deploy_alert_processor():
-        """Create Alert Processor package and publish versions"""
-        alert_package = AlertProcessorPackage(config=config, version=current_version)
-        alert_package.create_and_upload()
-        return alert_package
-
-    def _deploy_athena_partition_refresh():
-        """Create Athena Partition Refresh package and publish"""
-        athena_package = AthenaPackage(config=config, version=current_version)
-        athena_package.create_and_upload()
-        return athena_package
-
-    def _deploy_apps_function():
-        """Create app integration package and publish versions"""
-        app_integration_package = AppIntegrationPackage(config=config, version=apps_version)
-        app_integration_package.create_and_upload()
-        return app_integration_package
-
-    def _deploy_threat_intel_downloader():
-        """Create Threat Intel downloader package and publish version"""
-        threat_intel_package = ThreatIntelDownloaderPackage(
-            config=config,
-            version=ti_downloader_version
-        )
-        threat_intel_package.create_and_upload()
-        return threat_intel_package
-
-    if 'all' in processor:
-        targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
-
-        targets.update({
-            'module.app_{}_{}'.format(app_name, cluster)
-            for cluster, info in config['clusters'].iteritems()
-            for app_name in info['modules'].get('stream_alert_apps', {})
-        })
-
-        packages.append(_deploy_rule_processor())
-        packages.append(_deploy_alert_processor())
-        packages.append(_deploy_apps_function())
-
-        # Only include the Athena function if it exists and is enabled
-        athena_config = config['lambda'].get('athena_partition_refresh_config')
-        if athena_config and athena_config.get('enabled', False):
-            targets.add('module.stream_alert_athena')
-            packages.append(_deploy_athena_partition_refresh())
-
+    if 'all' in options.processor:
+        processors = {'alert', 'athena', 'apps', 'rule', 'threat_intel_downloader'}
     else:
+        processors = options.processor
 
-        if 'rule' in processor:
-            targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
+    for processor in processors:
+        package, targets = _create_and_upload(processor, config, options.cluster)
+        # Continue if the package isn't enabled
+        if not all([package, targets]):
+            continue
 
-            packages.append(_deploy_rule_processor())
-
-        if 'alert' in processor:
-            targets.update({'module.stream_alert_{}'.format(x) for x in config.clusters()})
-
-            packages.append(_deploy_alert_processor())
-
-        if 'apps' in processor:
-
-            targets.update({
-                'module.app_{}_{}'.format(app_name, cluster)
-                for cluster, info in config['clusters'].iteritems()
-                for app_name in info['modules'].get('stream_alert_apps', {})
-            })
-
-            packages.append(_deploy_apps_function())
-
-        if 'athena' in processor:
-            targets.add('module.stream_alert_athena')
-
-            packages.append(_deploy_athena_partition_refresh())
-
-        if 'threat_intel_downloader' in processor:
-            targets.add('module.threat_intel_downloader')
-            packages.append(_deploy_threat_intel_downloader())
+        packages.append(package)
+        deploy_targets.update(targets)
 
     # Regenerate the Terraform configuration with the new S3 keys
     if not terraform_generate(config=config):
         return
 
     # Run Terraform: Update the Lambda source code in $LATEST
-    if not helpers.tf_runner(targets=targets):
+    if not helpers.tf_runner(targets=deploy_targets):
         sys.exit(1)
 
-    # TODO(jack) write integration test to verify newly updated function
-
     # Publish a new production Lambda version
-    if not _publish_version(packages):
+    if not _publish_version(packages, config):
         return
 
     # Regenerate the Terraform configuration with the new Lambda versions
@@ -159,4 +140,4 @@ def deploy(options, config):
         return
 
     # Apply the changes to the Lambda aliases
-    helpers.tf_runner(targets=targets)
+    helpers.tf_runner(targets=deploy_targets)

--- a/stream_alert_cli/manage_lambda/handler.py
+++ b/stream_alert_cli/manage_lambda/handler.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.manage_lambda.deploy import deploy
 from stream_alert_cli.manage_lambda.rollback import rollback
 from stream_alert_cli.test import stream_alert_test
@@ -26,13 +27,16 @@ def lambda_handler(options, config):
         # Make sure the Terraform code is up to date
         if not terraform_generate(config=config):
             return
+        LOGGER_CLI.info('Deploying: %s', ' '.join(options.processor))
         deploy(options, config)
 
     elif options.subcommand == 'rollback':
         # Make sure the Terraform code is up to date
         if not terraform_generate(config=config):
             return
+        LOGGER_CLI.info('Rolling back: %s', ' '.join(options.processor))
         rollback(options, config)
 
     elif options.subcommand == 'test':
+        LOGGER_CLI.info('Testing: %s', ' '.join(options.processor))
         stream_alert_test(options, config)

--- a/stream_alert_cli/manage_lambda/version.py
+++ b/stream_alert_cli/manage_lambda/version.py
@@ -38,11 +38,9 @@ class LambdaVersion(object):
         Keyword Args:
             config (CLIConfig): Loaded StreamAlert CLI Config
             package (LambdaPackage): The created Lambda Package
-            clustered_deploy (bool): Identifies cluster based Lambdas
         """
         self.config = kwargs['config']
         self.package = kwargs['package']
-        self.clustered_deploy = kwargs.get('clustered_deploy', True)
 
     @staticmethod
     def _version_helper(**kwargs):
@@ -140,6 +138,7 @@ class LambdaVersion(object):
                 LOGGER_CLI.info('Published version %s for %s',
                                 new_version, function_name)
                 self.config['lambda'][self.package.config_key]['current_version'] = new_version
+
         self.config.write()
 
         return True
@@ -156,10 +155,18 @@ class LambdaVersion(object):
 
         return new_version
 
-    def publish_function(self):
-        """Main Publish Function method"""
-        if self.clustered_deploy:
-            for cluster in self.config.clusters():
+    def publish_function(self, **kwargs):
+        """Main Publish Function method
+
+        Keyword Args:
+            clustered_deploy (bool): Identifies cluster based Lambdas
+            clusters (list): The list of clusters to deploy to
+        """
+        clustered_deploy = kwargs.get('clustered_deploy', True)
+        clusters = kwargs.get('clusters', []) or self.config.clusters()
+
+        if clustered_deploy:
+            for cluster in clusters:
                 if not self._publish_helper(cluster=cluster):
                     return False
         else:

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -32,9 +32,7 @@ def terraform_check():
     prereqs_message = ('Terraform not found! Please install and add to '
                        'your $PATH:\n'
                        '\t$ export PATH=$PATH:/usr/local/terraform/bin')
-    return run_command(['terraform', 'version'],
-                       error_message=prereqs_message,
-                       quiet=True)
+    return run_command(['terraform', 'version'], error_message=prereqs_message, quiet=True)
 
 
 def terraform_handler(options, config):
@@ -76,12 +74,9 @@ def terraform_handler(options, config):
         # build init infrastructure
         LOGGER_CLI.info('Building Initial Infrastructure')
         init_targets = [
-            'aws_s3_bucket.lambda_source',
-            'aws_s3_bucket.logging_bucket',
-            'aws_s3_bucket.stream_alert_secrets',
-            'aws_s3_bucket.terraform_remote_state',
-            'aws_s3_bucket.streamalerts',
-            'aws_kms_key.stream_alert_secrets',
+            'aws_s3_bucket.lambda_source', 'aws_s3_bucket.logging_bucket',
+            'aws_s3_bucket.stream_alert_secrets', 'aws_s3_bucket.terraform_remote_state',
+            'aws_s3_bucket.streamalerts', 'aws_kms_key.stream_alert_secrets',
             'aws_kms_alias.stream_alert_secrets'
         ]
         if not tf_runner(targets=init_targets):
@@ -124,8 +119,8 @@ def terraform_handler(options, config):
                 elif target == 'threat_intel_downloader':
                     targets.append('module.threat_intel_downloader')
                 else:
-                    targets.extend(['module.{}_{}'.format(target, cluster)
-                                    for cluster in config.clusters()])
+                    targets.extend(
+                        ['module.{}_{}'.format(target, cluster) for cluster in config.clusters()])
 
             tf_runner(targets=targets, action='destroy')
             return
@@ -151,27 +146,34 @@ def terraform_handler(options, config):
 
 
 def terraform_build(options, config):
-    """Run Terraform with an optional set of targets
+    """Run Terraform with an optional set of targets and clusters
 
     Args:
         options (namedtuple): Parsed arguments from manage.py
     """
-    # Generate Terraform files
     if not terraform_generate(config=config):
         return
-    # Target is for terraforming a specific streamalert module.
-    # This value is passed as a list
-    if options.target == ['athena']:
-        tf_runner(targets=['module.stream_alert_athena'])
-    elif options.target == ['threat_intel_downloader']:
-        tf_runner(targets=['module.threat_intel_downloader'])
-    elif options.target:
-        targets = ['module.{}_{}'.format(target, cluster)
-                   for cluster in config.clusters()
-                   for target in options.target]
-        tf_runner(targets=targets)
-    else:
-        tf_runner()
+
+    # Define the set of custom targets to apply
+    tf_runner_targets = set()
+    # If resource are not clustered, it is most likely required to
+    # fall in the custom mapping below:
+    custom_module_mapping = {
+        'athena': 'module.stream_alert_athena',
+        'threat_intel_downloader': 'module.threat_intel_downloader'
+    }
+    clusters = set(options.cluster or config.clusters())
+
+    if options.target:
+        tf_runner_targets.update({
+            'module.{}_{}'.format(target, cluster)
+            for cluster in clusters for target in options.target
+        })
+        for name, _ in custom_module_mapping.iteritems():
+            if name in options.target:
+                tf_runner_targets.add(custom_module_mapping[name])
+
+    tf_runner(targets=tf_runner_targets)
 
 
 def terraform_clean(config):
@@ -179,12 +181,8 @@ def terraform_clean(config):
     LOGGER_CLI.info('Cleaning Terraform files')
 
     cleanup_files = ['{}.tf.json'.format(cluster) for cluster in config.clusters()]
-    cleanup_files.extend([
-        'athena.tf.json',
-        'main.tf.json',
-        'terraform.tfstate',
-        'terraform.tfstate.backup'
-    ])
+    cleanup_files.extend(
+        ['athena.tf.json', 'main.tf.json', 'terraform.tfstate', 'terraform.tfstate.backup'])
     for tf_file in cleanup_files:
         file_to_remove = 'terraform/{}'.format(tf_file)
         if not os.path.isfile(file_to_remove):
@@ -201,17 +199,14 @@ def terraform_status(config):
     for cluster, region in config['clusters'].items():
         print '\n======== {} ========'.format(cluster)
         print 'Region: {}'.format(region)
-        print ('Alert Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
-               '\n\tProd Version: {}').format(
-                   config['alert_processor_lambda_config'][cluster][0],
-                   config['alert_processor_lambda_config'][cluster][1],
-                   config['alert_processor_versions'][cluster])
-        print ('Rule Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
-               '\n\tProd Version: {}').format(
-                   config['rule_processor_lambda_config'][cluster][0],
-                   config['rule_processor_lambda_config'][cluster][1],
-                   config['rule_processor_versions'][cluster])
+        print('Alert Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
+              '\n\tProd Version: {}').format(config['alert_processor_lambda_config'][cluster][0],
+                                             config['alert_processor_lambda_config'][cluster][1],
+                                             config['alert_processor_versions'][cluster])
+        print('Rule Processor Lambda Settings: \n\tTimeout: {}\n\tMemory: {}'
+              '\n\tProd Version: {}').format(config['rule_processor_lambda_config'][cluster][0],
+                                             config['rule_processor_lambda_config'][cluster][1],
+                                             config['rule_processor_versions'][cluster])
         print 'Kinesis settings: \n\tShards: {}\n\tRetention: {}'.format(
             config['kinesis_streams_config'][cluster][0],
-            config['kinesis_streams_config'][cluster][1]
-        )
+            config['kinesis_streams_config'][cluster][1])

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -162,14 +162,14 @@ def terraform_build(options, config):
         'athena': 'module.stream_alert_athena',
         'threat_intel_downloader': 'module.threat_intel_downloader'
     }
-    clusters = set(options.cluster or config.clusters())
+    clusters = set(options.clusters or config.clusters())
 
     if options.target:
         tf_runner_targets.update({
             'module.{}_{}'.format(target, cluster)
             for cluster in clusters for target in options.target
         })
-        for name, _ in custom_module_mapping.iteritems():
+        for name in custom_module_mapping:
             if name in options.target:
                 tf_runner_targets.add(custom_module_mapping[name])
 

--- a/stream_alert_cli/terraform/kinesis_events.py
+++ b/stream_alert_cli/terraform/kinesis_events.py
@@ -27,11 +27,14 @@ def generate_kinesis_events(cluster_name, cluster_dict, config):
     Returns:
         bool: Result of applying the kinesis_events module
     """
-    kinesis_events_enabled = bool(
-        config['clusters'][cluster_name]['modules']['kinesis_events']['enabled'])
+    cluster_config = config['clusters'][cluster_name]['modules']
+    kinesis_events_enabled = bool(cluster_config['kinesis_events']['enabled'])
+    batch_size = cluster_config['kinesis_events'].get('batch_size', 100)
+
     # Kinesis events module
     cluster_dict['module']['kinesis_events_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_events',
+        'batch_size': batch_size,
         'lambda_production_enabled': kinesis_events_enabled,
         'lambda_role_id': '${{module.stream_alert_{}.lambda_role_id}}'.format(cluster_name),
         'lambda_function_arn': '${{module.stream_alert_{}.lambda_arn}}'.format(cluster_name),

--- a/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
@@ -4,11 +4,15 @@ variable "access_key_count" {
 
 variable "account_id" {}
 
-variable "region" {}
-
 variable "cluster_name" {}
 
 variable "prefix" {}
+
+variable "region" {}
+
+variable "retention" {
+  default = 24
+}
 
 variable "stream_name" {
   default = "stream_alert_stream"
@@ -16,10 +20,6 @@ variable "stream_name" {
 
 variable "shards" {
   default = 1
-}
-
-variable "retention" {
-  default = 24
 }
 
 // Default values for shard_level_metrics

--- a/tests/unit/stream_alert_cli/terraform/test_kinesis_events.py
+++ b/tests/unit/stream_alert_cli/terraform/test_kinesis_events.py
@@ -23,14 +23,13 @@ CONFIG = CLIConfig(config_path='tests/unit/conf')
 def test_kinesis_events():
     """CLI - Terraform Generate Kinesis Events"""
     cluster_dict = _common.infinitedict()
-    result = kinesis_events.generate_kinesis_events('advanced',
-                                                    cluster_dict,
-                                                    CONFIG)
+    result = kinesis_events.generate_kinesis_events('advanced', cluster_dict, CONFIG)
 
     expected_result = {
         'module': {
             'kinesis_events_advanced': {
                 'source': 'modules/tf_stream_alert_kinesis_events',
+                'batch_size': 100,
                 'lambda_production_enabled': True,
                 'lambda_role_id': '${module.stream_alert_advanced.lambda_role_id}',
                 'lambda_function_arn': '${module.stream_alert_advanced.lambda_arn}',

--- a/tests/unit/stream_alert_cli/test_version.py
+++ b/tests/unit/stream_alert_cli/test_version.py
@@ -18,7 +18,7 @@ from mock import patch
 from nose.tools import assert_equal, assert_true, assert_false, nottest
 
 from stream_alert_cli.manage_lambda.package import AthenaPackage, RuleProcessorPackage
-from stream_alert_cli.version import LambdaVersion
+from stream_alert_cli.manage_lambda.version import LambdaVersion
 from tests.unit.helpers.aws_mocks import MockLambdaClient
 from tests.unit.helpers.base import basic_streamalert_config, MockCLIConfig
 
@@ -37,7 +37,6 @@ def test_publish_helper_clustered():
     package = RuleProcessorPackage(config=config)
     publish = LambdaVersion(
         config=config,
-        clustered_deploy=True,
         package=package
     )
     result = publish._publish_helper(cluster='prod')
@@ -56,7 +55,6 @@ def test_publish_helper():
     package = AthenaPackage(config=config)
     publish = LambdaVersion(
         config=config,
-        clustered_deploy=False,
         package=package
     )
     result = publish._publish_helper()
@@ -70,7 +68,6 @@ def test_version_helper():
     package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
-        clustered_deploy=False,
         package=package
     )
     current_version = 10
@@ -85,13 +82,12 @@ def test_version_helper():
     assert_equal(result, current_version + 1)
 
 
-@patch('stream_alert_cli.version.LOGGER_CLI')
+@patch('stream_alert_cli.manage_lambda.version.LOGGER_CLI')
 def test_version_helper_error(mock_logging):
     """CLI - Publish Helper Raises Error"""
     package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
-        clustered_deploy=False,
         package=package
     )
     current_version = 10

--- a/tests/unit/stream_alert_cli/test_version.py
+++ b/tests/unit/stream_alert_cli/test_version.py
@@ -34,10 +34,7 @@ def test_publish_clustered():
 def test_publish_helper_clustered():
     """CLI - Publish Clustered Function"""
     config = MockCLIConfig(config=basic_streamalert_config())
-    package = RuleProcessorPackage(
-        version='1.0',
-        config=config
-    )
+    package = RuleProcessorPackage(config=config)
     publish = LambdaVersion(
         config=config,
         clustered_deploy=True,
@@ -56,10 +53,7 @@ def test_publish_helper_clustered():
 def test_publish_helper():
     """CLI - Publish Athena Function"""
     config = MockCLIConfig(config=basic_streamalert_config())
-    package = AthenaPackage(
-        version='1.0',
-        config=config
-    )
+    package = AthenaPackage(config=config)
     publish = LambdaVersion(
         config=config,
         clustered_deploy=False,
@@ -73,10 +67,7 @@ def test_publish_helper():
 
 def test_version_helper():
     """CLI - Publish Helper"""
-    package = AthenaPackage(
-        version='1.0',
-        config=basic_streamalert_config()
-    )
+    package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
         clustered_deploy=False,
@@ -97,10 +88,7 @@ def test_version_helper():
 @patch('stream_alert_cli.version.LOGGER_CLI')
 def test_version_helper_error(mock_logging):
     """CLI - Publish Helper Raises Error"""
-    package = AthenaPackage(
-        version='1.0',
-        config=basic_streamalert_config()
-    )
+    package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
         clustered_deploy=False,


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: medium
resolves #434 

## Background

When building new clusters, or deploying in the event of an infrastructure based issue, having the ability to deploy by cluster greatly decreases the time necessary to make changes.  This PR focuses on refactoring to make this possible, and also adds features for supporting batch size, and more.

## Changes

* Add the ability to deploy and publish versions by cluster
* Support the `all` option in the deployment process for optional Lambdas
* Do not deploy if S3 package upload fails
* `yapf` on `stream_alert_cli/config.py`
* Update unit tests accordingly

## Testing

* Deploy the rule processor
* Deploy all (enabled) processors
* Deploy by cluster
* Terraform build specific cluster
