### PR TITLE
[data-normalization] adding box ip_address to data normalization/threat intel

### DIFF
--- a/conf/types.json
+++ b/conf/types.json
@@ -1,4 +1,9 @@
 {
+  "box": {
+    "sourceAddress:ioc_ip": [
+      "ip_address"
+    ]
+  },
   "carbonblack": {
     "command": [
       "cmdline",


### PR DESCRIPTION
to: @mime-frame 
cc: @airbnb/streamalert-maintainers 
size: small
resolves N/A

## Background

Box admin event logs have an `ip_address` field that maps to the source address of where an event took place.

## Changes

* Adding the `sourceAddress:ioc_ip` --> `ip_address` mapping to the `types.json` file so we now have threat intelligence alerting on box admin event logs.

