### PR TITLE
[apps] catching socket timeout in gsuite app (again)

### DIFF
--- a/app_integrations/apps/gsuite.py
+++ b/app_integrations/apps/gsuite.py
@@ -133,7 +133,7 @@ class GSuiteReportsApp(AppIntegration):
 
         try:
             results = activities_list.execute()
-        except apiclient.errors.HttpError:
+        except (apiclient.errors.Error, socket.timeout):
             LOGGER.exception('Failed to execute activities listing for %s', self.type())
             return False
 


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Noticed the following traceback for an exception that was not being caught in the GSuite app:
```
Traceback (most recent call last):
File "/var/task/app_integrations/main.py", line 39, in handler
app.gather()
File "/var/task/app_integrations/apps/app_base.py", line 438, in gather
while (self._gather() + self._sleep_seconds() <
File "/var/task/app_integrations/apps/app_base.py", line 423, in _gather
exec_time = Decimal(timeit(do_gather, number=1))
File "/usr/lib64/python2.7/timeit.py", line 237, in timeit
return Timer(stmt, setup, timer).timeit(number)
File "/usr/lib64/python2.7/timeit.py", line 202, in timeit
timing = self.inner(it, self.timer)
File "/usr/lib64/python2.7/timeit.py", line 100, in inner
_func()
File "/var/task/app_integrations/apps/app_base.py", line 398, in do_gather
logs = self._gather_logs()
File "/var/task/app_integrations/apps/gsuite.py", line 135, in _gather_logs
results = activities_list.execute()
File "/var/task/oauth2client/_helpers.py", line 133, in positional_wrapper
return wrapped(*args, **kwargs)
File "/var/task/googleapiclient/http.py", line 837, in execute
method=str(self.method), body=self.body, headers=self.headers)
File "/var/task/googleapiclient/http.py", line 163, in _retry_request
resp, content = http.request(uri, method, *args, **kwargs)
File "/var/task/oauth2client/transport.py", line 175, in new_request
redirections, connection_type)
File "/var/task/oauth2client/transport.py", line 282, in request
connection_type=connection_type)
File "/var/task/httplib2/__init__.py", line 1659, in request
(response, content) = self._request(conn, authority, uri, request_uri, method, body, headers, redirections, cachekey)
File "/var/task/httplib2/__init__.py", line 1399, in _request
(response, content) = self._conn_request(conn, request_uri, method, body, headers)
File "/var/task/httplib2/__init__.py", line 1319, in _conn_request
conn.connect()
File "/var/task/httplib2/__init__.py", line 1065, in connect
sock.connect((self.host, self.port))
File "/usr/lib64/python2.7/socket.py", line 228, in meth
return getattr(self._sock,name)(*args)
timeout: timed out
```

## Changes

* Adding `socket.timeout` to the tuple of exceptions to catch for the `activities_list.execute()` call.

## Testing

N/A
