### PR TITLE
Assign Kinesis Users to a Group, and Make User Creation Optional

### DIFF
--- a/docs/source/kinesis.rst
+++ b/docs/source/kinesis.rst
@@ -49,12 +49,13 @@ Kinesis Streams settings for each cluster:
 Options
 ~~~~~~~
 
-=============  =========  ===========
-Key            Required   Description
--------------  ---------  -----------
-``retention``  ``Yes``    The data record retention period of your stream.
-``shards``     ``Yes``    A shard provides a fixed unit of capacity to your stream.
-=============  =========  ===========
+===============    =========  ===========
+Key                Required   Description
+---------------    ---------  -----------
+``retention``      ``Yes``    The data record retention period of your stream.
+``shards``         ``Yes``    A shard provides a fixed unit of capacity to your stream.
+``create_user``    ``No``     A boolean to enable/disable user creation for the Kinesis stream.  This is true by default.
+===============    =========  ===========
 
 Scaling
 ~~~~~~~

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -28,7 +28,7 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
         bool: Result of applying the kinesis module
     """
     prefix = config['global']['account']['prefix']
-    config_modules = config['clusters'][cluster_name]['modules']
+    kinesis_module = config['clusters'][cluster_name]['modules']['kinesis']['streams']
 
     shard_level_metrics = config['global']['infrastructure']['monitoring'].get(
         'shard_level_metrics', [])
@@ -40,9 +40,10 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
         'cluster_name': cluster_name,
         'prefix': config['global']['account']['prefix'],
         'stream_name': '{}_{}_stream_alert_kinesis'.format(prefix, cluster_name),
-        'shards': config_modules['kinesis']['streams']['shards'],
         'shard_level_metrics': shard_level_metrics,
-        'retention': config_modules['kinesis']['streams']['retention']
+        'shards': kinesis_module['shards'],
+        'retention': kinesis_module['retention'],
+        'create_user': kinesis_module.get('create_user', True)
     }
 
     return True

--- a/terraform/modules/tf_stream_alert_kinesis_streams/iam.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/iam.tf
@@ -1,0 +1,57 @@
+// IAM User: stream_alert user for systems to send data to the stream
+resource "aws_iam_user" "stream_alert" {
+  count = "${var.create_user ? 1 : 0}"
+  name  = "${var.prefix}_${var.cluster_name}_stream_alert_user"
+  path  = "/streamalert/"
+}
+
+// IAM Group: stream_alert clustered group
+resource "aws_iam_group" "stream_alert" {
+  count = "${var.create_user ? 1 : 0}"
+  name  = "${var.prefix}_${var.cluster_name}_stream_alert_users"
+  path  = "/"
+}
+
+// IAM Group Membership: Assign stream_alert user to group
+resource "aws_iam_group_membership" "stream_alert" {
+  count = "${var.create_user ? 1 : 0}"
+  name  = "stream-alert-kinesis-user-membership"
+
+  users = [
+    "${aws_iam_user.stream_alert.name}",
+  ]
+
+  group = "${aws_iam_group.stream_alert.name}"
+}
+
+// IAM Group Policy: Allow users in the group to PutRecords to Kinesis
+resource "aws_iam_group_policy" "stream_alert_kinesis_put_records" {
+  count = "${var.create_user ? 1 : 0}"
+  name  = "KinesisPutRecords"
+  group = "${aws_iam_group.stream_alert.id}"
+
+  policy = "${data.aws_iam_policy_document.stream_alert_writeonly.json}"
+}
+
+// IAM Access Key: credentials for the above user
+resource "aws_iam_access_key" "stream_alert" {
+  count = "${var.create_user ? var.access_key_count : 0}"
+  user  = "${aws_iam_user.stream_alert.name}"
+}
+
+// IAM Policy Doc: allow the stream_alert user to write to the generated Kinesis Stream
+data "aws_iam_policy_document" "stream_alert_writeonly" {
+  count = "${var.create_user ? 1 : 0}"
+
+  statement {
+    actions = [
+      "kinesis:PutRecord*",
+      "kinesis:DescribeStream",
+      "kinesis:ListStreams",
+    ]
+
+    resources = [
+      "${aws_kinesis_stream.stream_alert_stream.arn}",
+    ]
+  }
+}

--- a/terraform/modules/tf_stream_alert_kinesis_streams/iam.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/iam.tf
@@ -26,10 +26,9 @@ resource "aws_iam_group_membership" "stream_alert" {
 
 // IAM Group Policy: Allow users in the group to PutRecords to Kinesis
 resource "aws_iam_group_policy" "stream_alert_kinesis_put_records" {
-  count = "${var.create_user ? 1 : 0}"
-  name  = "KinesisPutRecords"
-  group = "${aws_iam_group.stream_alert.id}"
-
+  count  = "${var.create_user ? 1 : 0}"
+  name   = "KinesisPutRecords"
+  group  = "${aws_iam_group.stream_alert.id}"
   policy = "${data.aws_iam_policy_document.stream_alert_writeonly.json}"
 }
 
@@ -45,9 +44,9 @@ data "aws_iam_policy_document" "stream_alert_writeonly" {
 
   statement {
     actions = [
-      "kinesis:PutRecord*",
       "kinesis:DescribeStream",
       "kinesis:ListStreams",
+      "kinesis:PutRecord*",
     ]
 
     resources = [

--- a/terraform/modules/tf_stream_alert_kinesis_streams/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/main.tf
@@ -11,38 +11,3 @@ resource "aws_kinesis_stream" "stream_alert_stream" {
     Cluster = "${var.cluster_name}"
   }
 }
-
-// IAM User: stream_alert user for systems to send data to the stream
-resource "aws_iam_user" "stream_alert" {
-  name = "${var.prefix}_${var.cluster_name}_stream_alert_user"
-  path = "/streamalert/"
-}
-
-// IAM Access Key: credentials for the above user
-resource "aws_iam_access_key" "stream_alert" {
-  count = "${var.access_key_count}"
-  user  = "${aws_iam_user.stream_alert.name}"
-}
-
-// IAM Policy Doc: allow the stream_alert user to write to the generated Kinesis Stream
-data "aws_iam_policy_document" "stream_alert_writeonly" {
-  statement {
-    actions = [
-      "kinesis:PutRecord*",
-      "kinesis:DescribeStream",
-      "kinesis:ListStreams",
-    ]
-
-    resources = [
-      "${aws_kinesis_stream.stream_alert_stream.arn}",
-    ]
-  }
-}
-
-// IAM Policy Attach: associate the above policy with the stream_alert user
-resource "aws_iam_user_policy" "kinesis_writeonly" {
-  name = "kinesis_writeonly"
-  user = "${aws_iam_user.stream_alert.name}"
-
-  policy = "${data.aws_iam_policy_document.stream_alert_writeonly.json}"
-}

--- a/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_streams/variables.tf
@@ -6,6 +6,10 @@ variable "account_id" {}
 
 variable "cluster_name" {}
 
+variable "create_user" {
+  default = true
+}
+
 variable "prefix" {}
 
 variable "region" {}

--- a/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
+++ b/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
@@ -26,6 +26,7 @@ def test_kinesis_streams():
     result = kinesis_streams.generate_kinesis_streams('advanced',
                                                       cluster_dict,
                                                       CONFIG)
+
     expected_result = {
         'module': {
             'kinesis_advanced': {
@@ -37,7 +38,8 @@ def test_kinesis_streams():
                 'cluster_name': 'advanced',
                 'stream_name': 'unit-testing_advanced_stream_alert_kinesis',
                 'shards': 1,
-                'retention': 24
+                'retention': 24,
+                'create_user': True
             }
         }
     }


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

It's general best practice to not directly assign user policies, and instead assign them to groups.  This change applies this best practice, and also creates the ability to optionally create the user.  In some instances, data is delivered to Lambda in other ways (CloudWatch events, S3 notifications, etc)

## Changes

* Create a clustered stream_alert group
* Assign Kinesis users to this group
* Assign the Kinesis WriteOnly policy to this group
* Add a variable to optionally create users/groups

## Testing

* Local CI testing
* Deployed the change on an existing cluster, no users or access keys were deleted
* Deployed the change with `"create_user": false`
