### PR TITLE
Rule context can be modified within rule

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -284,7 +284,10 @@ class StreamRules(object):
             (bool): The return function of the rule
         """
         try:
-            rule_result = rule.rule_function(record)
+            if rule.context:
+                rule_result = rule.rule_function(record, rule.context)
+            else:
+                rule_result = rule.rule_function(record)
         except Exception:  # pylint: disable=broad-except
             rule_result = False
             LOGGER.exception(

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -885,8 +885,6 @@ class TestStreamRules(object):
         # process payloads
         alerts = self.rules_engine.process(payload)
 
-        print alerts
-
         # alert tests
         assert_equal(alerts[0]['context']['assigned_user'], 'valid_user')
         assert_equal(alerts[0]['context']['assigned_policy'], 'valid_policy')


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Context was added to rules to be able to extract information from the rule record and be utilized after (for example, outputs). This code makes that alteration possible and adds test for it.

## Changes

* If context is used, it will be passed as argument of the rule.
* Test to verify the added code.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2951     94    97%
----------------------------------------------------------------------
Ran 501 tests in 8.074s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
