### PR TITLE
Init Bug Fix, Check for Valid AWS Creds, Rollback by Cluster

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -160,6 +160,27 @@ def tf_runner(**kwargs):
 
     return True
 
+
+def check_credentials():
+    """Check for valid AWS credentials in environment variables
+
+    Returns:
+        bool: True any of the AWS env variables exist
+    """
+    aws_env_variables = [
+        'AWS_PROFILE', 'AWS_SHARED_CREDENTIALS_FILE', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'
+    ]
+    env_vars_exist = any([env_var in os.environ for env_var in aws_env_variables])
+
+    if not env_vars_exist:
+        LOGGER_CLI.error('No valid AWS Credentials found in your environment!')
+        LOGGER_CLI.error('Please follow the setup instructions here: '
+                         'https://www.streamalert.io/account.html')
+        return False
+
+    return True
+
+
 def _get_record_template(service):
     """Provides a pre-configured template that reflects incoming payload from a service
 

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -103,13 +103,17 @@ def _create_and_upload(function_name, config, cluster=None):
 def deploy(options, config):
     """Deploy new versions of all Lambda functions
 
+    Args:
+        options (namedtuple): ArgParsed command from the CLI
+        config (CLIConfig): Loaded StreamAlert config
+
     Steps:
-    - Build AWS Lambda deployment package
-    - Upload to S3
-    - Update lambda.json with uploaded package checksum and S3 key
-    - Publish new version
-    - Update each cluster's Lambda configuration with latest published version
-    - Run Terraform Apply
+        Build AWS Lambda deployment package
+        Upload to S3
+        Update lambda.json with uploaded package checksum and S3 key
+        Publish new version
+        Update each cluster's Lambda configuration with latest published version
+        Run Terraform Apply
     """
     # Terraform apply only to the module which contains our lambda functions
     deploy_targets = set()

--- a/stream_alert_cli/manage_lambda/handler.py
+++ b/stream_alert_cli/manage_lambda/handler.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from stream_alert_cli.helpers import check_credentials
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.manage_lambda.deploy import deploy
 from stream_alert_cli.manage_lambda.rollback import rollback
@@ -24,6 +25,9 @@ def lambda_handler(options, config):
     """Handle all Lambda CLI operations"""
 
     if options.subcommand == 'deploy':
+        # Check for valid credentials
+        if not check_credentials():
+            return
         # Make sure the Terraform code is up to date
         if not terraform_generate(config=config):
             return
@@ -31,6 +35,9 @@ def lambda_handler(options, config):
         deploy(options, config)
 
     elif options.subcommand == 'rollback':
+        # Check for valid credentials
+        if not check_credentials():
+            return
         # Make sure the Terraform code is up to date
         if not terraform_generate(config=config):
             return

--- a/stream_alert_cli/manage_lambda/rollback.py
+++ b/stream_alert_cli/manage_lambda/rollback.py
@@ -24,7 +24,7 @@ def rollback(options, config):
         Ignores if the production version is $LATEST
         Only rollsback if published version is greater than 1
     """
-    clusters = config.clusters()
+    clusters = options.clusters or config.clusters()
 
     if 'all' in options.processor:
         lambda_functions = {'rule_processor', 'alert_processor', 'athena_partition_refresh'}

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -45,7 +45,7 @@ def terraform_handler(options, config):
     if not terraform_check():
         return
     # Use a named tuple to match the 'processor' attribute in the argparse options
-    deploy_opts = namedtuple('DeployOptions', ['processor'])
+    deploy_opts = namedtuple('DeployOptions', ['processor', 'clusters'])
 
     # Plan and Apply our streamalert infrastructure
     if options.subcommand == 'build':
@@ -93,7 +93,7 @@ def terraform_handler(options, config):
 
         LOGGER_CLI.info('Deploying Lambda Functions')
         # deploy both lambda functions
-        deploy(deploy_opts(['rule', 'alert']), config)
+        deploy(deploy_opts(['rule', 'alert'], []), config)
         # create all remainder infrastructure
 
         LOGGER_CLI.info('Building Remainder Infrastructure')

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -19,7 +19,7 @@ import shutil
 import sys
 
 from stream_alert_cli.logger import LOGGER_CLI
-from stream_alert_cli.helpers import run_command, tf_runner, continue_prompt
+from stream_alert_cli.helpers import check_credentials, continue_prompt, run_command, tf_runner
 from stream_alert_cli.manage_lambda.deploy import deploy
 from stream_alert_cli.terraform.generate import terraform_generate
 
@@ -41,6 +41,10 @@ def terraform_handler(options, config):
     Args:
         options (namedtuple): Parsed arguments from manage.py
     """
+    # Check for valid credentials
+    if not check_credentials():
+        return
+
     # Verify terraform is installed
     if not terraform_check():
         return


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves #217 

## Background

The recent change to the `deploy` command (#520) caused the `init` steps to break.  While testing, I also discovered that we can add a simple check to avoid large stacktraces when AWS creds aren't loaded.

## Changes

* Since `clusters` is passed to the `deploy` method, we need to modify the one-off named tuple which mimics ArgParse to include a `clusters` attribute.
* Check for valid AWS creds by looking at the `os.environ` dictionary

## Testing

* Local pylinting + unit testing
* Also did test `deploy` and `terraform` commands
