### PR TITLE
Add dynamodb domain md5 mocking

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -396,6 +396,8 @@ class StreamRules(object):
             if ioc_records:
                 for ioc_record in ioc_records:
                     for rule in rules:
+                        if not rule.datatypes:
+                            continue
                         self.rule_analysis(ioc_record, rule, payload, alerts)
 
         return alerts

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -156,7 +156,8 @@ class StreamThreatIntel(object):
                     if isinstance(original_keys, list):
                         for original_key in original_keys:
                             value = value[original_key]
-                    ioc_values.add(value)
+                    if value:
+                        ioc_values.add(value)
         return [StreamIoc(value=value, ioc_type=ioc_type, associated_record=record)
                 for value in ioc_values]
 
@@ -250,7 +251,7 @@ class StreamThreatIntel(object):
             query_values = []
             for ioc in subset:
                 if ioc.value not in query_values:
-                    query_values.append(ioc.value)
+                    query_values.append(ioc.value.lower())
 
             query_result = []
 
@@ -312,7 +313,7 @@ class StreamThreatIntel(object):
             Second return (dict/None): A dict containing unprocesed keys.
         """
         result = []
-        query_keys = [{PRIMARY_KEY: {'S': ioc}} for ioc in values]
+        query_keys = [{PRIMARY_KEY: {'S': ioc}} for ioc in values if ioc]
         response = self.dynamodb.batch_get_item(
             RequestItems={
                 self._table: {

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -453,6 +453,10 @@ def setup_mock_dynamodb_ioc_table(config):
     """
     region = config['global']['account']['region']
     dynamodb_client = boto3.client('dynamodb', region_name=region)
+    table_name = 'test_table_name'
+    if (config['global'].get('threat_intel')
+            and config['global']['threat_intel'].get('dynamodb_table')):
+        table_name = config['global']['threat_intel']['dynamodb_table']
 
     dynamodb_client.create_table(
         AttributeDefinitions=[{
@@ -467,7 +471,7 @@ def setup_mock_dynamodb_ioc_table(config):
             'ReadCapacityUnits': 10,
             'WriteCapacityUnits': 10,
         },
-        TableName='test_table_name',
+        TableName=table_name,
     )
 
     dynamodb_client.put_item(
@@ -476,7 +480,25 @@ def setup_mock_dynamodb_ioc_table(config):
             'ioc_type': {'S': 'ip'},
             'sub_type': {'S': 'mal_ip'}
         },
-        TableName='test_table_name'
+        TableName=table_name
+    )
+
+    dynamodb_client.put_item(
+        Item={
+            'ioc_value': {'S': '0123456789abcdef0123456789abcdef'},
+            'ioc_type': {'S': 'md5'},
+            'sub_type': {'S': 'mal_md5'}
+        },
+        TableName=table_name
+    )
+
+    dynamodb_client.put_item(
+        Item={
+            'ioc_value': {'S': 'evil.com'},
+            'ioc_type': {'S': 'domain'},
+            'sub_type': {'S': 'c2_domain'}
+        },
+        TableName=table_name
     )
 
 def put_mock_s3_object(bucket, key, data, region):

--- a/stream_alert_cli/terraform/streamalert.py
+++ b/stream_alert_cli/terraform/streamalert.py
@@ -96,6 +96,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
             and config['global']['threat_intel'].get('dynamodb_table')):
         cluster_dict['module']['stream_alert_{}'.format(cluster_name)] \
             ['dynamodb_ioc_table'] = config['global']['threat_intel']['dynamodb_table']
+        cluster_dict['module']['stream_alert_{}'.format(cluster_name)] \
+            ['threat_intel_enabled'] = config['global']['threat_intel']['enabled']
     # Add Alert Processor output config from the loaded cluster file
     output_config = modules['stream_alert']['alert_processor'].get('outputs')
     if output_config:

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "streamalert_rule_processor_firehose" {
 
 // IAM Role Policy: Allow Rule Processor to read DynamoDB table (Threat Intel)
 resource "aws_iam_role_policy" "streamalert_rule_processor_dynamodb" {
+  count  = "${var.threat_intel_enabled ? 1 : 0}"
   name   = "ReadDynamodb"
   role   = "${aws_iam_role.streamalert_rule_processor_role.id}"
   policy = "${data.aws_iam_policy_document.streamalert_rule_processor_read_dynamodb.json}"

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -113,6 +113,10 @@ variable "rule_processor_metric_filters" {
 
 variable "sns_topic_arn" {}
 
+variable "threat_intel_enabled" {
+  default = false
+}
+
 variable "dynamodb_ioc_table" {
   default = "streamalert_threat_intel_ioc_table"
 }

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -241,6 +241,7 @@ class TestTerraformGenerate(object):
                     'cluster': 'test',
                     'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
                     'dynamodb_ioc_table': 'test_table_name',
+                    'threat_intel_enabled': False,
                     'rule_processor_enable_metrics': True,
                     'rule_processor_log_level': 'info',
                     'rule_processor_memory': 128,
@@ -278,6 +279,7 @@ class TestTerraformGenerate(object):
                     'cluster': 'advanced',
                     'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
                     'dynamodb_ioc_table': 'test_table_name',
+                    'threat_intel_enabled': False,
                     'rule_processor_enable_metrics': True,
                     'rule_processor_log_level': 'info',
                     'rule_processor_memory': 128,
@@ -299,6 +301,7 @@ class TestTerraformGenerate(object):
                 }
             }
         }
+
 
         assert_equal(self.cluster_dict['module']['stream_alert_advanced'],
                      expected_advanced_cluster['module']['stream_alert_advanced'])


### PR DESCRIPTION
to: @jacknagz or @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
* Add more dynamodb mocking which will be useful when doing rule testing while Threat Intel Beta is enabled. (Note, currently, Threat Intel Beta has issue, I am fixing now.) 
* Enforce IOC value check in lowercased. 
Also, this PR adds a conditional check to add read permission to IOC dynamodb table to Rule Process IAM role. 

## Testing
* Rule test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Unit test
```
./tests/scripts/unit_tests.sh
...
-------------------------------------------------------------------------------------
TOTAL                                                    2954     41    99%
----------------------------------------------------------------------
Ran 501 tests in 7.929s

OK
```
