### PR TITLE
[output] Mocking for rule processor testing

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -686,6 +686,10 @@ class AlertProcessorTester(object):
                     if 'phantom' in 'url':
                         return {'count': 0, 'data': []}
 
+                    elif 'api.pagerduty' in url:
+                        u_path = os.path.split(url)[1]
+                        return {u_path: [{'id': 1234}]}
+
                 # Default to returning an empty dict in case this was not implemented for a service
                 return dict()
 
@@ -767,8 +771,9 @@ class AlertProcessorTester(object):
             elif service == 'pagerduty-incident':
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'token': '247b97499078a015cc6c586bc0a92de6',
-                         'service_key': '247b97499078a015cc6c586bc0a92de6',
-                         'escalation_policy': '247b97499078a015cc6c586bc0a92de6'}
+                         'service_name': '247b97499078a015cc6c586bc0a92de6',
+                         'escalation_policy': '247b97499078a015cc6c586bc0a92de6',
+                         'email_from': 'blah@foo.bar'}
                 helpers.put_mock_creds(output_name, creds, self.secrets_bucket,
                                        'us-east-1', self.kms_alias)
 


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

When using the output `pagerduty-incident` and testing the processor, some mocking was missing.

## Changes

* Modified the mocked creds for `pagerduty-incident` output to reflect what the output is expecting.
* Modified the static method `_setup_requests_mocks` to be used with `pagerduty-incident` output. 

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    2951    103    97%
----------------------------------------------------------------------
Ran 501 tests in 7.947s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```