### PR TITLE
[apps] adding support for suppressing state saves if no change occurred

### DIFF
--- a/app_integrations/config.py
+++ b/app_integrations/config.py
@@ -65,10 +65,13 @@ class AppConfig(dict):
             LOGGER.error('Current state cannot be saved with value \'%s\'', value)
             return
 
+        # Cache the old value to see if the new value differs
+        current_value = self.get(key)
+
         dict.__setitem__(self, key, value)
 
         # If this is a key related to the state config, save the state in parameter store
-        if key in self._state_keys():
+        if key in self._state_keys() and current_value != value:
             self._save_state()
 
     @staticmethod

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -195,6 +195,24 @@ class TestAppIntegrationConfig(object):
         """AppIntegrationConfig - Check If Success"""
         assert_false(self._config.is_success)
 
+    @patch('app_integrations.config.AppConfig._save_state')
+    def test_suppress_state_save_no_change(self, save_mock):
+        """AppIntegrationConfig - Suppress Save State on No Change"""
+        # Try to mark with success more than once
+        self._config.mark_success()
+        self._config.mark_success()
+
+        save_mock.assert_called_once()
+
+    @patch('app_integrations.config.AppConfig._save_state')
+    def test_suppress_state_save(self, save_mock):
+        """AppIntegrationConfig - Save State on Change"""
+        # Try to mark with failure followed by success
+        self._config.mark_failure()
+        self._config.mark_success()
+
+        assert_equal(save_mock.call_count, 2)
+
     def test_scrub_auth_info(self):
         """AppIntegrationConfig - Scrub Auth Info"""
         auth_key = '{}_auth'.format(FUNCTION_NAME)


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves #524 

## Background

See #524. The gist: a race condition can cause the state to not get written to SSM Parameter Store if the state parameter is already in the process of being updated.

## Changes

* Will only save the remote state if the value of the local state has changed since it's previous value.

## Testing

* Adding two unit tests to ensure that:
  1) The remote state _is_ updated if the current value is being changed.
  2) The remote state is _not_ update if the current value is the same as the new value being set.
