### PR TITLE
Apply dynamodb autoscale

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1262,12 +1262,16 @@ Available Subcommands:
 
                               See the link in the Resources section below for more information.
     Optional Arguments:
-        --table_rcu        The DynamoDB table Read Capacity Unit.
-        --table_wcu        The DynamoDB table Write Capacity Unit.
-        --ioc_keys         The keys (list) of IOC stored in DynamoDB table.
-        --ioc_filters      Filters (list) applied while retrieving IOCs from Threat Feed.
-        --ioc_types        IOC types (list) are defined by the Threat Feed. IOC types can be
+        --table_rcu          The DynamoDB table Read Capacity Unit.
+        --table_wcu          The DynamoDB table Write Capacity Unit.
+        --ioc_keys           The keys (list) of IOC stored in DynamoDB table.
+        --ioc_filters        Filters (list) applied while retrieving IOCs from Threat Feed.
+        --ioc_types          IOC types (list) are defined by the Threat Feed. IOC types can be
                              different from different Threat Feeds.
+        --autoscale          Enable/disable DynamoDB table autoscale.
+        --min_read_capacity  Maximal read capacity when autoscale enabled.
+        --max_read_capacity  Mimimal read capacity when autoscale enabled.
+        --target_utilization Utilization remains at or near the setting level when autoscale enabled.
 
     manage.py threat_intel_downloader update-auth   Update API credentials to parameter store.
 

--- a/manage.py
+++ b/manage.py
@@ -1268,9 +1268,9 @@ Available Subcommands:
         --ioc_filters        Filters (list) applied while retrieving IOCs from Threat Feed.
         --ioc_types          IOC types (list) are defined by the Threat Feed. IOC types can be
                              different from different Threat Feeds.
-        --autoscale          Enable/disable DynamoDB table autoscale.
-        --min_read_capacity  Maximal read capacity when autoscale enabled.
-        --max_read_capacity  Mimimal read capacity when autoscale enabled.
+        --autoscale          (True/False) Enable/disable DynamoDB table autoscale.
+        --min_read_capacity  Maximal read capacity when autoscale enabled, default is 5.
+        --max_read_capacity  Mimimal read capacity when autoscale enabled, default is 5.
         --target_utilization Utilization remains at or near the setting level when autoscale enabled.
 
     manage.py threat_intel_downloader update-auth   Update API credentials to parameter store.
@@ -1377,6 +1377,25 @@ Examples:
         '--ioc_types',
         help=ARGPARSE_SUPPRESS,
         default=['domain', 'ip', 'md5']
+    )
+
+    ti_downloader_parser.add_argument(
+        '--autoscale',
+        help=ARGPARSE_SUPPRESS,
+        choices=['enable', 'disable'],
+        default='disable'
+    )
+
+    ti_downloader_parser.add_argument(
+        '--max_read_capacity', help=ARGPARSE_SUPPRESS, default=5
+    )
+
+    ti_downloader_parser.add_argument(
+        '--min_read_capacity', help=ARGPARSE_SUPPRESS, default=5
+    )
+
+    ti_downloader_parser.add_argument(
+        '--target_utilization', help=ARGPARSE_SUPPRESS, default=70
     )
 
     ti_downloader_parser.add_argument(

--- a/manage.py
+++ b/manage.py
@@ -1268,7 +1268,7 @@ Available Subcommands:
         --ioc_filters        Filters (list) applied while retrieving IOCs from Threat Feed.
         --ioc_types          IOC types (list) are defined by the Threat Feed. IOC types can be
                              different from different Threat Feeds.
-        --autoscale          (True/False) Enable/disable DynamoDB table autoscale.
+        --autoscale          Enable DynamoDB table read capacity autoscale.
         --min_read_capacity  Maximal read capacity when autoscale enabled, default is 5.
         --max_read_capacity  Mimimal read capacity when autoscale enabled, default is 5.
         --target_utilization Utilization remains at or near the setting level when autoscale enabled.
@@ -1382,8 +1382,8 @@ Examples:
     ti_downloader_parser.add_argument(
         '--autoscale',
         help=ARGPARSE_SUPPRESS,
-        choices=['enable', 'disable'],
-        default='disable'
+        default=False,
+        action='store_true'
     )
 
     ti_downloader_parser.add_argument(

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -503,7 +503,10 @@ class CLIConfig(object):
             'table_wcu': 10,
             'ioc_keys': [],
             'ioc_filters': [],
-            'ioc_types': []
+            'ioc_types': [],
+            'max_read_capacity': 5,
+            'min_read_capacity': 5,
+            'target_utilization': 70
         }
 
         if 'threat_intel_downloader_config' in self.config['lambda']:

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -469,6 +469,8 @@ class CLIConfig(object):
             self.config['global']['threat_intel']['dynamodb_table'] = \
                 threat_intel_info['dynamodb_table']
 
+        self.config['global']['threat_intel']['autoscale'] = threat_intel_info['autoscale']
+
         self.write()
 
         LOGGER_CLI.info('Threat Intel configuration successfully created')
@@ -485,6 +487,7 @@ class CLIConfig(object):
             (bool): Return True if writing settings of Lambda function successfully.
         """
         default_config = {
+            'autoscale': False,
             'enabled': True,
             'current_version': '$LATEST',
             'handler': 'stream_alert.threat_intel_downloader.main.handler',

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -519,10 +519,7 @@ class CLIConfig(object):
         # overwrite settings in conf/lambda.json for Threat Intel Downloader
         for key, value in ti_downloader_info.iteritems():
             if key in self.config['lambda']['threat_intel_downloader_config']:
-                if key == 'autoscale':
-                    self.config['lambda']['threat_intel_downloader_config'][key] = value == 'enable'
-                else:
-                    self.config['lambda']['threat_intel_downloader_config'][key] = value
+                self.config['lambda']['threat_intel_downloader_config'][key] = value
 
         self.write()
         return True

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -519,7 +519,10 @@ class CLIConfig(object):
         # overwrite settings in conf/lambda.json for Threat Intel Downloader
         for key, value in ti_downloader_info.iteritems():
             if key in self.config['lambda']['threat_intel_downloader_config']:
-                self.config['lambda']['threat_intel_downloader_config'][key] = value
+                if key == 'autoscale':
+                    self.config['lambda']['threat_intel_downloader_config'][key] = value == 'enable'
+                else:
+                    self.config['lambda']['threat_intel_downloader_config'][key] = value
 
         self.write()
         return True

--- a/stream_alert_cli/terraform/threat_intel_downloader.py
+++ b/stream_alert_cli/terraform/threat_intel_downloader.py
@@ -51,12 +51,13 @@ def generate_threat_intel_downloader(config):
         'monitoring_sns_topic': dlq_topic,
         'table_rcu': ti_downloader_config.get('table_rcu', '10'),
         'table_wcu': ti_downloader_config.get('table_wcu', '10'),
-        'ioc_keys': ti_downloader_config.get('ioc_keys'),
-        'ioc_filters': ti_downloader_config.get('ioc_filters'),
-        'ioc_types': ti_downloader_config.get('ioc_types'),
-        'autoscale': ti_downloader_config.get('autoscale'),
-        'max_read_capacity': ti_downloader_config.get('max_read_capacity'),
-        'min_read_capacity': ti_downloader_config.get('min_read_capacity'),
-        'target_utilization': ti_downloader_config.get('target_utilization')
+        'ioc_keys': ti_downloader_config.get('ioc_keys',
+                                             ['expiration_ts', 'itype', 'source', 'type', 'value']),
+        'ioc_filters': ti_downloader_config.get('ioc_filters', ['crowdstrike', '@airbnb.com']),
+        'ioc_types': ti_downloader_config.get('ioc_types', ['domain', 'ip', 'md5']),
+        'autoscale': ti_downloader_config.get('autoscale', False),
+        'max_read_capacity': ti_downloader_config.get('max_read_capacity', '5'),
+        'min_read_capacity': ti_downloader_config.get('min_read_capacity', '5'),
+        'target_utilization': ti_downloader_config.get('target_utilization', '70')
     }
     return ti_downloader_dict

--- a/stream_alert_cli/terraform/threat_intel_downloader.py
+++ b/stream_alert_cli/terraform/threat_intel_downloader.py
@@ -53,6 +53,7 @@ def generate_threat_intel_downloader(config):
         'table_wcu': ti_downloader_config.get('table_wcu', '10'),
         'ioc_keys': ti_downloader_config.get('ioc_keys'),
         'ioc_filters': ti_downloader_config.get('ioc_filters'),
-        'ioc_types': ti_downloader_config.get('ioc_types')
+        'ioc_types': ti_downloader_config.get('ioc_types'),
+        'autoscale': ti_downloader_config.get('autoscale')
     }
     return ti_downloader_dict

--- a/stream_alert_cli/terraform/threat_intel_downloader.py
+++ b/stream_alert_cli/terraform/threat_intel_downloader.py
@@ -54,6 +54,9 @@ def generate_threat_intel_downloader(config):
         'ioc_keys': ti_downloader_config.get('ioc_keys'),
         'ioc_filters': ti_downloader_config.get('ioc_filters'),
         'ioc_types': ti_downloader_config.get('ioc_types'),
-        'autoscale': ti_downloader_config.get('autoscale')
+        'autoscale': ti_downloader_config.get('autoscale'),
+        'max_read_capacity': ti_downloader_config.get('max_read_capacity'),
+        'min_read_capacity': ti_downloader_config.get('min_read_capacity'),
+        'target_utilization': ti_downloader_config.get('target_utilization')
     }
     return ti_downloader_dict

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -20,9 +20,9 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
 }
 
 // IAM Role: Application autoscalling role
-resource "aws_iam_role" "appautoscaling" {
+resource "aws_iam_role" "stream_alert_dynamodb_appautoscaling" {
   count              = "${var.autoscale ? 1 : 0}"
-  name               = "${var.prefix}_streamalert_appautoscaling"
+  name               = "${var.prefix}_streamalert_dynamodb_appautoscaling"
   assume_role_policy = "${data.aws_iam_policy_document.appautoscaling_assume_role_policy.json}"
 }
 
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "appautoscaling_assume_role_policy" {
 resource "aws_iam_role_policy" "appautoscaling_update_table" {
   count  = "${var.autoscale ? 1 : 0}"
   name   = "DynamoDBAppAutoscaleUpdateTablePolicy"
-  role   = "${aws_iam_role.appautoscaling.id}"
+  role   = "${aws_iam_role.stream_alert_dynamodb_appautoscaling.id}"
   policy = "${data.aws_iam_policy_document.appautoscaling_update_table.json}"
 }
 
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "appautoscaling_update_table" {
 resource "aws_iam_role_policy" "appautoscaling_cloudwatch_alarms" {
   count  = "${var.autoscale ? 1 : 0}"
   name   = "DynamoDBAppAutoscaleCloudWatchAlarmsPolicy"
-  role   = "${aws_iam_role.appautoscaling.id}"
+  role   = "${aws_iam_role.stream_alert_dynamodb_appautoscaling.id}"
   policy = "${data.aws_iam_policy_document.appautoscaling_cloudwatch_alarms.json}"
 }
 
@@ -101,7 +101,7 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = "${var.max_read_capacity}"
   min_capacity       = "${var.min_read_capacity}"
   resource_id        = "table/${var.prefix}_streamalert_threat_intel_downloader"
-  role_arn           = "${aws_iam_role.appautoscaling.arn}"
+  role_arn           = "${aws_iam_role.stream_alert_dynamodb_appautoscaling.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -10,7 +10,7 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
   }
 
   ttl {
-    attribute_name = "expiration_date"
+    attribute_name = "expiration_ts"
     enabled        = true
   }
 

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -98,8 +98,8 @@ data "aws_iam_policy_document" "appautoscaling_cloudwatch_alarms" {
 
 resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   count              = "${var.autoscale ? 1 : 0}"
-  max_capacity       = 100
-  min_capacity       = 5
+  max_capacity       = "${var.max_read_capacity}"
+  min_capacity       = "${var.min_read_capacity}"
   resource_id        = "table/${var.prefix}_streamalert_threat_intel_downloader"
   role_arn           = "${aws_iam_role.appautoscaling.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
@@ -119,7 +119,7 @@ resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
-    # Utilization remains at or near 70%
-    target_value = 70
+    # Utilization remains at or near 70% (default)
+    target_value = "${var.target_utilization}"
   }
 }

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -18,3 +18,80 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
     Name = "StreamAlert"
   }
 }
+
+// IAM Role: Application autoscalling role
+resource "aws_iam_role" "appautoscaling" {
+  name               = "${var.prefix}_streamalert_appautoscaling"
+  assume_role_policy = "${data.aws_iam_policy_document.appautoscaling_assume_role_policy.json}"
+}
+
+// IAM Policy Doc: Generic Application Autoscaling AssumeRole
+data "aws_iam_policy_document" "appautoscaling_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["application-autoscaling.amazonaws.com"]
+    }
+  }
+}
+
+// IAM Role Policy: Allow appautoscaling IAM role to autoscaling DynamoDB table
+resource "aws_iam_role_policy" "appautoscaling" {
+  name   = "DynamoDBAppAutoscalePolicy"
+  role   = "${aws_iam_role.appautoscaling.id}"
+  policy = "${data.aws_iam_policy_document.appautoscaling.json}"
+}
+
+// IAM Policy Doc: Allow autoscaling IAM role to send alarm to CloudWatch
+// and change table settings for autoscaling.
+data "aws_iam_policy_document" "appautoscaling" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:UpdateTable",
+      "cloudwatch:PutMetricAlarm",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:SetAlarmState",
+      "cloudwatch:DeleteAlarms",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.threat_intel_ioc.arn}",
+      "${aws_cloudwatch_log_group.threat_intel_downloader.arn}",
+    ]
+  }
+}
+
+resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
+  count              = "${var.autoscale ? 1 : 0}"
+  max_capacity       = 100
+  min_capacity       = 5
+  resource_id        = "${var.prefix}_streamalert_threat_intel_downloader"
+  role_arn           = "${aws_iam_role.appautoscaling.arn}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
+  count              = "${var.autoscale ? 1 : 0}"
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = "${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension}"
+  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_read_target.service_namespace}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    # Utilization remains at or near 70%
+    target_value = 70
+  }
+}

--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -21,12 +21,15 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
 
 // IAM Role: Application autoscalling role
 resource "aws_iam_role" "appautoscaling" {
+  count              = "${var.autoscale ? 1 : 0}"
   name               = "${var.prefix}_streamalert_appautoscaling"
   assume_role_policy = "${data.aws_iam_policy_document.appautoscaling_assume_role_policy.json}"
 }
 
 // IAM Policy Doc: Generic Application Autoscaling AssumeRole
 data "aws_iam_policy_document" "appautoscaling_assume_role_policy" {
+  count = "${var.autoscale ? 1 : 0}"
+
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -40,6 +43,7 @@ data "aws_iam_policy_document" "appautoscaling_assume_role_policy" {
 
 // IAM Role Policy: Allow appautoscaling IAM role to autoscaling DynamoDB table
 resource "aws_iam_role_policy" "appautoscaling" {
+  count  = "${var.autoscale ? 1 : 0}"
   name   = "DynamoDBAppAutoscalePolicy"
   role   = "${aws_iam_role.appautoscaling.id}"
   policy = "${data.aws_iam_policy_document.appautoscaling.json}"
@@ -48,6 +52,8 @@ resource "aws_iam_role_policy" "appautoscaling" {
 // IAM Policy Doc: Allow autoscaling IAM role to send alarm to CloudWatch
 // and change table settings for autoscaling.
 data "aws_iam_policy_document" "appautoscaling" {
+  count = "${var.autoscale ? 1 : 0}"
+
   statement {
     effect = "Allow"
 

--- a/terraform/modules/tf_threat_intel_downloader/variables.tf
+++ b/terraform/modules/tf_threat_intel_downloader/variables.tf
@@ -70,3 +70,7 @@ variable "ioc_types" {}
 variable "log_retention" {
   default = 14
 }
+
+variable "autoscale" {
+  default = false
+}

--- a/terraform/modules/tf_threat_intel_downloader/variables.tf
+++ b/terraform/modules/tf_threat_intel_downloader/variables.tf
@@ -74,3 +74,15 @@ variable "log_retention" {
 variable "autoscale" {
   default = false
 }
+
+variable "max_read_capacity" {
+  default = 5
+}
+
+variable "min_read_capacity" {
+  default = 5
+}
+
+variable "target_utilization" {
+  default = 70
+}

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -186,7 +186,10 @@ class TestCLIConfig(object):
             'memory': '128',
             'subcommand': 'enable',
             'timeout': '240',
-            'table_wcu': 25
+            'table_wcu': 25,
+            'max_read_capacity': 100,
+            'min_read_capacity': 5,
+            'target_utilization': 70
         }
         result = self.config.add_threat_intel_downloader(ti_downloader_info)
         assert_true(result)
@@ -209,7 +212,10 @@ class TestCLIConfig(object):
             ],
             'table_rcu': 10,
             'table_wcu': 25,
-            'timeout': '240'
+            'timeout': '240',
+            'max_read_capacity': 100,
+            'min_read_capacity': 5,
+            'target_utilization': 70
         }
         assert_equal(self.config['lambda']['threat_intel_downloader_config'], expected_config)
         write_mock.assert_called()

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -132,6 +132,7 @@ class TestCLIConfig(object):
     def test_add_threat_intel_downloader_with_table_name(self, write_mock, log_mock):
         """CLI - Add Threat Intel config with default dynamodb table name"""
         threat_intel_info = {
+            'autoscale': True,
             'command': 'threat_intel',
             'debug': 'False',
             'dynamodb_table': 'my_ioc_table',
@@ -141,6 +142,7 @@ class TestCLIConfig(object):
         self.config.add_threat_intel(threat_intel_info)
 
         expected_config = {
+            'autoscale': True,
             'enabled': True,
             'dynamodb_table': 'my_ioc_table'
         }
@@ -154,6 +156,7 @@ class TestCLIConfig(object):
     def test_add_threat_intel_downloader_without_table_name(self, write_mock, log_mock):
         """CLI - Add Threat Intel config without dynamodb table name from cli"""
         threat_intel_info = {
+            'autoscale': True,
             'command': 'threat_intel',
             'debug': 'False',
             'subcommand': 'enable'
@@ -162,6 +165,7 @@ class TestCLIConfig(object):
         self.config.add_threat_intel(threat_intel_info)
 
         expected_config = {
+            'autoscale': True,
             'enabled': True,
             'dynamodb_table': 'unit-testing_streamalert_threat_intel_downloader'
         }
@@ -175,6 +179,7 @@ class TestCLIConfig(object):
     def test_add_threat_intel_downloader(self, write_mock, log_mock):
         """CLI - Add Threat Intel Downloader config"""
         ti_downloader_info = {
+            'autoscale': True,
             'command': 'threat_intel_downloader',
             'debug': False,
             'interval': 'rate(1 day)',
@@ -186,6 +191,7 @@ class TestCLIConfig(object):
         result = self.config.add_threat_intel_downloader(ti_downloader_info)
         assert_true(result)
         expected_config = {
+            'autoscale': True,
             'enabled': True,
             'current_version': '$LATEST',
             'handler': 'stream_alert.threat_intel_downloader.main.handler',

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -179,7 +179,7 @@ class TestCLIConfig(object):
     def test_add_threat_intel_downloader(self, write_mock, log_mock):
         """CLI - Add Threat Intel Downloader config"""
         ti_downloader_info = {
-            'autoscale': True,
+            'autoscale': "enable",
             'command': 'threat_intel_downloader',
             'debug': False,
             'interval': 'rate(1 day)',

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -179,7 +179,7 @@ class TestCLIConfig(object):
     def test_add_threat_intel_downloader(self, write_mock, log_mock):
         """CLI - Add Threat Intel Downloader config"""
         ti_downloader_info = {
-            'autoscale': "enable",
+            'autoscale': True,
             'command': 'threat_intel_downloader',
             'debug': False,
             'interval': 'rate(1 day)',


### PR DESCRIPTION
to: @jacknagz @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: medium
resolves #536

## Background
[DynamoDB Auto Scaling](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html) is a useful feature when DynamoDB IOC table (built by `Threat Intel Downloader`) is processing large number of burst records by `batch_get` from Rule Processor(s). The auto scaling feature will automatically adjust Read capacity based on the traffic. 

Note: AWS DynamoDB Auto Scaling is also support Write Capacity. We don't support Write Capacity auto scaling right now, because,
* The Consumed Write Capacity is related low compared to Read Capacity.
* Write Capacity is more expensive than Read Capacity. With auto scaling it may generate unexpected cost. Right now, it is reasonable to throttle the Write Capacity than auto scaling. 

## Changes

* Add a new Assume Role for application autoscale service, as well as autoscale policy.
* Autoscale settings are variables and can be set via CLI.
* Correct TTL attribute name.

## Local Testing
* Rule test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Unit test
```
./tests/scripts/unit_tests.sh
...
-------------------------------------------------------------------------------------
TOTAL                                                    2955     41    99%
----------------------------------------------------------------------
Ran 503 tests in 8.498s

OK
```
## Testing in AWS testing account
* Toggle `autoscale` setting from CLI and `conf/lambda.json`
* Test event 1: 100 times(while loop) batch_get_item with 98 items, where includes 8 hits
  * Table autoscale settings
    * Max read capacity is set to 100
    * Min read capacity is set to 10
    * Utilization is set to 70%
  * After sending batch_get_item, table statistics is
  ```
  aws dynamodb describe-table --table-name my_testing_table_name --query "Table.
  [TableName,TableStatus,ProvisionedThroughput]"
  [
      "my_testing_table_name",
      "ACTIVE",
      {
          "NumberOfDecreasesToday": 0,
          "WriteCapacityUnits": 10,
          "LastIncreaseDateTime": 1513280911.803, (<=2017-12-14 19:48:31)
          "ReadCapacityUnits": 69
      }
  ]
  ```
  * Read Capacity Metrics
![test_event1](https://user-images.githubusercontent.com/21151436/34017683-8eb82ffc-e0db-11e7-9e9c-6251876b1203.png)
* Test event 2: 1000 times batch_get_item with 98 items, where includes 8 hits
  * Table autoscale settings
    * Max read capacity is set to **1000**
    * Min read capacity is set to 10
    * Utilization is set to 70%
  * After sending batch_get_item, table statistics is
  ```
  aws dynamodb describe-table --table-name my_testing_table_name --query 
  [
      "my_testing_table_name",
      "ACTIVE",
      {
          "NumberOfDecreasesToday": 0,
          "WriteCapacityUnits": 10,
          "LastIncreaseDateTime": 1513284222.211, (<=2017-12-14 20:43:42)
          "ReadCapacityUnits": 173
      }
  ]
  ```
  * Read Capacity Metrics
![test_event3](https://user-images.githubusercontent.com/21151436/34017823-1c051708-e0dc-11e7-86bb-b3aa69b616e3.png)

* Test event 3: Continually sending batch_get_item with 98 items, where includes 8 hits. Launch three processes to mimic three lambda functions doing query to IOC dynamodb table with 50 mins stress.
  * Table autoscale settings
    * Max read capacity is set to **1000**
    * Min read capacity is set to 10
    * Utilization is set to 70%
  * table statistics
  ```
  [
      "chunyong-my_testing_table_name",
      "ACTIVE",
      {
          "NumberOfDecreasesToday": 1,
          "WriteCapacityUnits": 10,
          "LastIncreaseDateTime": 1513290871.606,  (<=2017-12-14 22:34:31)
          "ReadCapacityUnits": 527,
          "LastDecreaseDateTime": 1513285537.587 
      }
  ]
  ```
  * Read Capacity Metrics
![test_event4](https://user-images.githubusercontent.com/21151436/34018000-fb0cfccc-e0dc-11e7-9eb3-678a9497e4b2.png)

