### PR TITLE
[cli] cluster based shard level metrics

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -7,8 +7,7 @@
   },
   "infrastructure": {
     "monitoring": {
-      "create_sns_topic": true,
-      "shard_level_metrics": []
+      "create_sns_topic": true
     }
   },
   "terraform": {

--- a/stream_alert_cli/terraform/kinesis_streams.py
+++ b/stream_alert_cli/terraform/kinesis_streams.py
@@ -29,9 +29,7 @@ def generate_kinesis_streams(cluster_name, cluster_dict, config):
     """
     prefix = config['global']['account']['prefix']
     kinesis_module = config['clusters'][cluster_name]['modules']['kinesis']['streams']
-
-    shard_level_metrics = config['global']['infrastructure']['monitoring'].get(
-        'shard_level_metrics', [])
+    shard_level_metrics = kinesis_module.get('shard_level_metrics', [])
 
     cluster_dict['module']['kinesis_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert_kinesis_streams',

--- a/tests/unit/conf/clusters/advanced.json
+++ b/tests/unit/conf/clusters/advanced.json
@@ -19,6 +19,9 @@
     "kinesis": {
       "streams": {
         "retention": 24,
+        "shard_level_metrics": [
+          "IncomingBytes"
+        ],
         "shards": 1
       }
     },

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -7,8 +7,7 @@
   },
   "infrastructure": {
     "monitoring": {
-      "create_sns_topic": true,
-      "shard_level_metrics": []
+      "create_sns_topic": true
     }
   },
   "terraform": {

--- a/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
+++ b/tests/unit/stream_alert_cli/terraform/test_kinesis_streams.py
@@ -32,7 +32,7 @@ def test_kinesis_streams():
             'kinesis_advanced': {
                 'source': 'modules/tf_stream_alert_kinesis_streams',
                 'account_id': '12345678910',
-                'shard_level_metrics': [],
+                'shard_level_metrics': ["IncomingBytes"],
                 'region': 'us-west-1',
                 'prefix': 'unit-testing',
                 'cluster_name': 'advanced',


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Shard level metrics should be clustered

## Changes

* Read the `shard_level_metrics` config option from the cluster and not the global config

## Testing

Unit tests
