### PR TITLE
Threat intel error handling

### DIFF
--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -16,7 +16,7 @@ limitations under the License.
 import backoff
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 
 from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.backoff_handlers import (
@@ -58,10 +58,13 @@ class StreamIoc(object):
         self.is_ioc = kwargs.get('is_ioc', False)
 
 def exceptions_to_giveup(err):
-    """Function to decide if giveup backoff or not.
-    Give up backoff retries if DynamoDB IOC table doesn't exist.
-    """
-    return err.response['Error']['Code'] == 'AccessDeniedException'
+    """Function to decide if giveup backoff or not."""
+    error_code = {
+        'AccessDeniedException',
+        'ProvisionedThroughputExceededException',
+        'ResourceNotFoundException'
+    }
+    return err.response['Error']['Code'] in error_code
 
 class StreamThreatIntel(object):
     """Load intelligence from csv.gz files into a dictionary."""
@@ -158,7 +161,7 @@ class StreamThreatIntel(object):
                             value = value[original_key]
                     if value:
                         ioc_values.add(value)
-        return [StreamIoc(value=value, ioc_type=ioc_type, associated_record=record)
+        return [StreamIoc(value=value.lower(), ioc_type=ioc_type, associated_record=record)
                 for value in ioc_values]
 
     @classmethod
@@ -251,24 +254,40 @@ class StreamThreatIntel(object):
             query_values = []
             for ioc in subset:
                 if ioc.value not in query_values:
-                    query_values.append(ioc.value.lower())
+                    query_values.append(ioc.value)
 
             query_result = []
 
-            result, unprocesed_keys = self._query(query_values)
-            query_result.extend(result)
+            query_error_msg = 'An error occured while quering dynamodb table. Error is: %s'
+            try:
+                result, unprocesed_keys = self._query(query_values)
+                query_result.extend(result)
+            except ClientError as err:
+                LOGGER.error(query_error_msg, err.response)
+                return
+            except ParamValidationError as err:
+                LOGGER.error(query_error_msg, err)
+                return
 
             # If there are unprocessed keys, we will re-query once with unprocessed
             # keys only
             if unprocesed_keys:
                 deserializer = self._deserialize(unprocesed_keys[self._table]['Keys'])
                 query_values = [elem[PRIMARY_KEY] for elem in deserializer]
-                result, _ = self._query(query_values)
-                query_result.extend(result)
+                query_error_msg = 'An error occured while processing unprocesed_keys. Error is: %s'
+                try:
+                    result, _ = self._query(query_values)
+                    query_result.extend(result)
+                except ClientError as err:
+                    LOGGER.error(query_error_msg, err.response)
+                    return
+                except ParamValidationError as err:
+                    LOGGER.error(query_error_msg, err)
+                    return
 
             for value in ioc_collections:
                 for ioc in query_result:
-                    if value.value.lower() == ioc[PRIMARY_KEY]:
+                    if value.value == ioc[PRIMARY_KEY]:
                         value.sub_type = ioc[SUB_TYPE_KEY]
                         value.is_ioc = True
                         continue

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -305,6 +305,7 @@ class StreamThreatIntel(object):
         """
         result = []
         end = len(ioc_collections)
+        LOGGER.info('[Threat Inel] Rule Processor queries %d IOCs', end)
         for index in range(0, end, MAX_QUERY_CNT):
             result.append(ioc_collections[index:min(index+MAX_QUERY_CNT, end)])
         return result

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -263,10 +263,10 @@ class StreamThreatIntel(object):
                 result, unprocesed_keys = self._query(query_values)
                 query_result.extend(result)
             except ClientError as err:
-                LOGGER.error(query_error_msg, err.response)
+                LOGGER.exception(query_error_msg, err.response)
                 return
             except ParamValidationError as err:
-                LOGGER.error(query_error_msg, err)
+                LOGGER.exception(query_error_msg, err)
                 return
 
             # If there are unprocessed keys, we will re-query once with unprocessed
@@ -279,10 +279,10 @@ class StreamThreatIntel(object):
                     result, _ = self._query(query_values)
                     query_result.extend(result)
                 except ClientError as err:
-                    LOGGER.error(query_error_msg, err.response)
+                    LOGGER.exception(query_error_msg, err.response)
                     return
                 except ParamValidationError as err:
-                    LOGGER.error(query_error_msg, err)
+                    LOGGER.exception(query_error_msg, err)
                     return
 
             for value in ioc_collections:

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -469,8 +469,6 @@ class CLIConfig(object):
             self.config['global']['threat_intel']['dynamodb_table'] = \
                 threat_intel_info['dynamodb_table']
 
-        self.config['global']['threat_intel']['autoscale'] = threat_intel_info['autoscale']
-
         self.write()
 
         LOGGER_CLI.info('Threat Intel configuration successfully created')

--- a/tests/scripts/unit_tests.sh
+++ b/tests/scripts/unit_tests.sh
@@ -1,4 +1,7 @@
 #! /bin/bash
+if [ -f .coverage ]; then
+  rm .coverage
+fi
 nosetests tests/unit \
 --with-coverage \
 --cover-package=app_integrations \

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -129,10 +129,9 @@ class TestCLIConfig(object):
 
     @patch('logging.Logger.info')
     @patch('stream_alert_cli.config.CLIConfig.write')
-    def test_add_threat_intel_downloader_with_table_name(self, write_mock, log_mock):
+    def test_add_threat_intel_with_table_name(self, write_mock, log_mock):
         """CLI - Add Threat Intel config with default dynamodb table name"""
         threat_intel_info = {
-            'autoscale': True,
             'command': 'threat_intel',
             'debug': 'False',
             'dynamodb_table': 'my_ioc_table',
@@ -142,7 +141,6 @@ class TestCLIConfig(object):
         self.config.add_threat_intel(threat_intel_info)
 
         expected_config = {
-            'autoscale': True,
             'enabled': True,
             'dynamodb_table': 'my_ioc_table'
         }
@@ -153,10 +151,9 @@ class TestCLIConfig(object):
 
     @patch('logging.Logger.info')
     @patch('stream_alert_cli.config.CLIConfig.write')
-    def test_add_threat_intel_downloader_without_table_name(self, write_mock, log_mock):
+    def test_add_threat_intel_without_table_name(self, write_mock, log_mock):
         """CLI - Add Threat Intel config without dynamodb table name from cli"""
         threat_intel_info = {
-            'autoscale': True,
             'command': 'threat_intel',
             'debug': 'False',
             'subcommand': 'enable'
@@ -165,7 +162,6 @@ class TestCLIConfig(object):
         self.config.add_threat_intel(threat_intel_info)
 
         expected_config = {
-            'autoscale': True,
             'enabled': True,
             'dynamodb_table': 'unit-testing_streamalert_threat_intel_downloader'
         }

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -826,7 +826,7 @@ class TestStreamRules(object):
             """Testing dummy rule"""
             return True
 
-        mock_client('dynamodb').batch_get_item.return_value = MockDynamoDBClient.response()
+        mock_client.return_value = MockDynamoDBClient()
         toggled_config = self.config
         toggled_config['global']['threat_intel']['enabled'] = True
         toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=protected-access,no-self-use
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 from mock import patch
 from nose.tools import (
     assert_equal,
@@ -83,11 +83,56 @@ class TestStreamThreatIntel(object):
     @patch('boto3.client')
     def test_threat_detection(self, mock_client):
         """Threat Intel - Test threat_detection method"""
+        mock_client.return_value = MockDynamoDBClient()
         records = mock_normalized_records()
         threat_intel = StreamThreatIntel.load_from_config(self.config)
-        mock_client('dynamodb').batch_get_item.return_value = MockDynamoDBClient.response()
 
         assert_equal(len(threat_intel.threat_detection(records)), 2)
+
+    @patch('boto3.client')
+    def test_threat_detection_with_empty_ioc_value(self, mock_client):
+        """Threat Intel - Test threat_detection method with record contains empty/duplicated value"""
+        records = [
+            {
+                'account': 12345,
+                'region': '123456123456',
+                'detail': {
+                    'eventName': 'ConsoleLogin',
+                    'userIdentity': {
+                        'userName': 'alice',
+                        'accountId': '12345'
+                    },
+                    'sourceIPAddress': None,
+                    'recipientAccountId': '12345'
+                },
+                'source': '1.1.1.2',
+                'streamalert:normalization': {
+                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
+                    'usernNme': [['detail', 'userIdentity', 'userName']]
+                }
+            },
+            {
+                'domain': 'evil.com',
+                'pc_name': 'test-pc',
+                'date': 'Dec 1st, 2016',
+                'data': 'ABCDEF',
+                'streamalert:normalization': {
+                    'destinationDomain': [['domain']]
+                }
+            },
+            {
+                'domain': 'EVIL.com',
+                'pc_name': 'test-pc',
+                'date': 'Dec 1st, 2016',
+                'data': 'ABCDEF',
+                'streamalert:normalization': {
+                    'destinationDomain': [['domain']]
+                }
+            },
+        ]
+        mock_client.return_value = MockDynamoDBClient()
+        threat_intel = StreamThreatIntel.load_from_config(self.config)
+        assert_equal(len(threat_intel.threat_detection(records)), 3)
 
     def test_insert_ioc_info(self):
         """Threat Intel - Insert IOC info to a record"""
@@ -259,8 +304,8 @@ class TestStreamThreatIntel(object):
     @patch('boto3.client')
     def test_process_ioc(self, mock_client):
         """Threat Intel - Test private method process_ioc"""
+        mock_client.return_value = MockDynamoDBClient()
         threat_intel = StreamThreatIntel.load_from_config(self.config)
-        mock_client('dynamodb').batch_get_item.return_value = MockDynamoDBClient.response()
 
         ioc_collections = [
             StreamIoc(value='1.1.1.2', ioc_type='ip'),
@@ -275,9 +320,8 @@ class TestStreamThreatIntel(object):
     @patch('boto3.client')
     def test_process_ioc_with_unprocessed_keys(self, mock_client):
         """Threat Intel - Test private method process_ioc when response has UnprocessedKeys"""
+        mock_client.return_value = MockDynamoDBClient(unprocesed_keys=True)
         threat_intel = StreamThreatIntel.load_from_config(self.config)
-        mock_client('dynamodb').batch_get_item.return_value = \
-            MockDynamoDBClient.response(unprocesed_keys=True)
 
         ioc_collections = [
             StreamIoc(value='1.1.1.2', ioc_type='ip'),
@@ -309,8 +353,8 @@ class TestStreamThreatIntel(object):
     @patch('boto3.client')
     def test_query(self, mock_client):
         """Threat Intel - Test DynamoDB query method with batch_get_item"""
+        mock_client.return_value = MockDynamoDBClient()
         threat_intel = StreamThreatIntel.load_from_config(self.config)
-        mock_client('dynamodb').batch_get_item.return_value = MockDynamoDBClient.response()
 
         test_values = ['1.1.1.2', '2.2.2.2', 'evil.com', 'abcdef0123456789']
         result, unprocessed_keys = threat_intel._query(test_values)
@@ -319,14 +363,34 @@ class TestStreamThreatIntel(object):
         assert_equal(result[0], {'ioc_value': '1.1.1.2', 'sub_type': 'mal_ip'})
         assert_equal(result[1], {'ioc_value': 'evil.com', 'sub_type': 'c2_domain'})
 
+    @patch('boto3.client')
+    def test_query_with_empty_value(self, mock_client):
+        """Threat Intel - Test query value includes empty value"""
+        mock_client.return_value = MockDynamoDBClient()
+        threat_intel = StreamThreatIntel.load_from_config(self.config)
+
+        test_values = ['1.1.1.2', '', 'evil.com', 'abcdef0123456789']
+        result, unprocessed_keys = threat_intel._query(test_values)
+        assert_equal(len(result), 2)
+
+    @raises(ParamValidationError)
+    @patch('boto3.client')
+    def test_query_with_duplicated_value(self, mock_client):
+        """Threat Intel - Test query value includes dumplicated value"""
+        mock_client.return_value = MockDynamoDBClient()
+        threat_intel = StreamThreatIntel.load_from_config(self.config)
+
+        test_values = ['1.1.1.2', 'EVIL.com', 'evil.com', 'abcdef0123456789']
+        result, unprocessed_keys = threat_intel._query(test_values)
+
     @raises(ClientError)
     @patch('boto3.client')
     def test_query_with_exception(self, mock_client):
         """Threat Intel - Test DynamoDB query method with exception"""
-        mock_client('dynamodb').batch_get_item.return_value = \
-            MockDynamoDBClient.response(exception=True)
+        mock_client.return_value = MockDynamoDBClient(exception=True)
+        threat_intel = StreamThreatIntel.load_from_config(self.config)
 
-        self.threat_intel._query(['1.1.1.2'])
+        threat_intel._query(['1.1.1.2'])
 
     def test_deserialize(self):
         """Threat Intel - Test method to convert dynamodb types to python types"""

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -91,7 +91,7 @@ class TestStreamThreatIntel(object):
 
     @patch('boto3.client')
     def test_threat_detection_with_empty_ioc_value(self, mock_client):
-        """Threat Intel - Test threat_detection method with record contains empty/duplicated value"""
+        """Threat Intel - Test threat_detection with record contains empty/duplicated value"""
         records = [
             {
                 'account': 12345,
@@ -370,7 +370,7 @@ class TestStreamThreatIntel(object):
         threat_intel = StreamThreatIntel.load_from_config(self.config)
 
         test_values = ['1.1.1.2', '', 'evil.com', 'abcdef0123456789']
-        result, unprocessed_keys = threat_intel._query(test_values)
+        result, _ = threat_intel._query(test_values)
         assert_equal(len(result), 2)
 
     @raises(ParamValidationError)
@@ -381,7 +381,7 @@ class TestStreamThreatIntel(object):
         threat_intel = StreamThreatIntel.load_from_config(self.config)
 
         test_values = ['1.1.1.2', 'EVIL.com', 'evil.com', 'abcdef0123456789']
-        result, unprocessed_keys = threat_intel._query(test_values)
+        threat_intel._query(test_values)
 
     @raises(ClientError)
     @patch('boto3.client')


### PR DESCRIPTION
to: @ryandeivert or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves #539

## Background

Threat Intel Beta enables Rule Processor(s) to query a DynamoDB table where stores IOC data. In the implementation it doesn't have exception handling. This PR is to add exception handling for 
* ClientError
* ParamValidationError

## Changes
* Add error handling when querying dynamodb table.
* Make MockDynamoDBClient great (again). It includes raising more exceptions now.
* Enforce lowercase IOC value from first place.
* Add more test cases to catch errors.
* Remove `autoscale` setting from `threat_intel` and it is only available in `threat_intel_downloader`.  This bug was caused by careless Copy&Paste ;(

## Testing
* Unit test
```
./tests/scripts/unit_tests.sh
...
Ran 510 tests in 8.852s

OK
```
* Rule test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Tested it in AWS testing account, and it was passed.