### PR TITLE
Fix read capacity overload issue

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -342,14 +342,16 @@ class StreamRules(object):
         and the rule itself to determine if a match occurs.
 
         Returns:
-            list: alerts
-
-            An alert is represented as a dictionary with the following keys:
-                rule_name: the name of the triggered rule
-                payload: the StreamPayload object
-                outputs: list of outputs to send to
+            (list): First return is a list of alerts.
+                An alert is represented as a dictionary with the following keys:
+                    rule_name: the name of the triggered rule
+                    payload: the StreamPayload object
+                    outputs: list of outputs to send to
+            (list): Second return is a list of payload instance with normalized records.
         """
         alerts = []
+        # store normalized records for future process in Threat Intel
+        normalized_records = []
         payload = copy(input_payload)
 
         rules = [rule_attrs for rule_attrs in self.__rules.values()
@@ -357,10 +359,7 @@ class StreamRules(object):
 
         if not rules:
             LOGGER.debug('No rules to process for %s', payload)
-            return alerts
-
-        # store normalized records for future process in Threat Intel
-        normalized_records = []
+            return alerts, normalized_records
 
         for record in payload.records:
             for rule in rules:
@@ -384,22 +383,42 @@ class StreamRules(object):
                     record_copy = record.copy()
                     record_copy[NORMALIZATION_KEY] = types_result
                     if self._threat_intel:
-                        normalized_records.append(record_copy)
+                        # An copy of payload which includes payload metadata.
+                        # The payload metadata includes log_source, type, service,
+                        # and entity. The meatdata will be returned to along with
+                        # normalized record for threat detection.
+                        payload_copy = copy(input_payload)
+                        payload_copy.pre_parsed_record = record_copy
+                        normalized_records.append(payload_copy)
                 else:
                     record_copy = record
                 # rule analysis
                 self.rule_analysis(record_copy, rule, payload, alerts)
 
-        # Apply the Threat Intelligence against normalized records
+        return alerts, normalized_records
+
+    def threat_intel_match(self, payload_with_normalized_records):
+        """Apply Threat Intelligence on normalized records
+
+        Args:
+            payload_with_normalized_records (list): A list of payload instances.
+                And it pre_parsed_record is replaced by normalized record. The
+                reason to pass a copy of payload into Threat Intelligence is because
+                alerts require to include payload metadata (payload.log_source,
+                payload.type, payload.service and payload.entity).
+
+        Returns:
+            (list): A list of alerts triggered by Threat Intelligence.
+        """
+        alerts = []
         if self._threat_intel:
-            ioc_records = self._threat_intel.threat_detection(normalized_records)
+            ioc_records = self._threat_intel.threat_detection(payload_with_normalized_records)
+            rules = [rule_attrs for rule_attrs in self.__rules.values()
+                     if rule_attrs.datatypes]
             if ioc_records:
                 for ioc_record in ioc_records:
                     for rule in rules:
-                        if not rule.datatypes:
-                            continue
-                        self.rule_analysis(ioc_record, rule, payload, alerts)
-
+                        self.rule_analysis(ioc_record.pre_parsed_record, rule, ioc_record, alerts)
         return alerts
 
     @staticmethod

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -176,7 +176,7 @@ class StreamRules(object):
                 interested in.
 
         Returns:
-            (dict): A dict of normalized_types with original key names
+            dict: A dict of normalized_types with original key names
 
         Example 1:
             datatypes=['defined_type1', 'defined_type2', 'not_defined_type']
@@ -206,7 +206,7 @@ class StreamRules(object):
             datatypes (list): Normalized types users interested in
 
         Returns:
-            (dict): A dict of normalized_types with original key names
+            dict: A dict of normalized_types with original key names
         """
         results = dict()
         for key, val in record.iteritems():
@@ -281,7 +281,7 @@ class StreamRules(object):
             rule (func): Rule function to process the record
 
         Returns:
-            (bool): The return function of the rule
+            bool: The return function of the rule
         """
         try:
             if rule.context:
@@ -342,12 +342,9 @@ class StreamRules(object):
         and the rule itself to determine if a match occurs.
 
         Returns:
-            (list): First return is a list of alerts.
-                An alert is represented as a dictionary with the following keys:
-                    rule_name: the name of the triggered rule
-                    payload: the StreamPayload object
-                    outputs: list of outputs to send to
-            (list): Second return is a list of payload instance with normalized records.
+            A tuple(list, list).
+                First return is a list of alerts.
+                Second return is a list of payload instance with normalized records.
         """
         alerts = []
         # store normalized records for future process in Threat Intel
@@ -383,9 +380,9 @@ class StreamRules(object):
                     record_copy = record.copy()
                     record_copy[NORMALIZATION_KEY] = types_result
                     if self._threat_intel:
-                        # An copy of payload which includes payload metadata.
+                        # A copy of payload which includes payload metadata.
                         # The payload metadata includes log_source, type, service,
-                        # and entity. The meatdata will be returned to along with
+                        # and entity. The metadata will be returned to along with
                         # normalized record for threat detection.
                         payload_copy = copy(input_payload)
                         payload_copy.pre_parsed_record = record_copy
@@ -408,7 +405,7 @@ class StreamRules(object):
                 payload.type, payload.service and payload.entity).
 
         Returns:
-            (list): A list of alerts triggered by Threat Intelligence.
+            list: A list of alerts triggered by Threat Intelligence.
         """
         alerts = []
         if self._threat_intel:
@@ -432,7 +429,7 @@ class StreamRules(object):
             alerts (list): A list of alerts which will be sent to alert processor.
 
         Returns:
-            (dict): A list of alerts.
+            dict: A list of alerts.
         """
         rule_result = StreamRules.process_rule(record, rule)
         if rule_result:
@@ -470,7 +467,7 @@ class StreamRules(object):
             alerts (list): A list of alerts which will be sent to alert processor.
 
         Returns:
-            (bool): Return True if both record and rule name exist in alerts list.
+            bool: Return True if both record and rule name exist in alerts list.
         """
         for exist_alert in alerts:
             if rule.rule_name == exist_alert['rule_name']:

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -87,10 +87,10 @@ class StreamThreatIntel(object):
         records contain malicious IOC(s).
 
         Args:
-            records (list): A list of the normalized records which are dictionaries.
+            records (list): A list of payload instance with normalized records.
 
         Returns:
-            (list): A list of records including IOC information.
+            (list): A list of payload instances including IOC information.
         """
         ioc_collections = []
         if not records:
@@ -106,7 +106,9 @@ class StreamThreatIntel(object):
         # IOC info will be inserted to the records if they contains malicious IOC(s)
         for ioc in ioc_collections:
             if ioc.is_ioc:
-                self._insert_ioc_info(ioc.associated_record, ioc.ioc_type, ioc.value)
+                self._insert_ioc_info(ioc.associated_record.pre_parsed_record,
+                                      ioc.ioc_type,
+                                      ioc.value)
 
         records_with_ioc = [ioc.associated_record for ioc in ioc_collections if ioc.is_ioc]
         return records_with_ioc
@@ -141,21 +143,21 @@ class StreamThreatIntel(object):
         """Instance method to extract IOC info from the record based on normalized keys
 
         Args:
-            record (dict): Normalized record.
+            record (dict): A list of payload instance with normalized records.
 
         Returns:
             (list): Return a list of StreamIoc instances.
         """
         ioc_values = set()
-        for datatype in record[NORMALIZATION_KEY]:
+        for datatype in record.pre_parsed_record[NORMALIZATION_KEY]:
             # Lookup mapped IOC type based on normalized CEF type from Class variable.
             ioc_type = self.__normalized_ioc_types_mapping.get(datatype, None)
 
             # A new StreamIoc instance will be created when normalized CEF type
             # has mapped IOC type.
             if ioc_type:
-                for original_keys in record[NORMALIZATION_KEY][datatype]:
-                    value = record
+                for original_keys in record.pre_parsed_record[NORMALIZATION_KEY][datatype]:
+                    value = record.pre_parsed_record
                     if isinstance(original_keys, list):
                         for original_key in original_keys:
                             value = value[original_key]
@@ -249,6 +251,7 @@ class StreamThreatIntel(object):
         Args:
             ioc_collections (list): A list of StreamIoc instances.
         """
+        LOGGER.debug('[Threat Inel] Rule Processor queries %d IOCs', len(ioc_collections))
         # Segment data before calling DynamoDB table with batch_get_item.
         for subset in self._segment(ioc_collections):
             query_values = []
@@ -305,7 +308,6 @@ class StreamThreatIntel(object):
         """
         result = []
         end = len(ioc_collections)
-        LOGGER.debug('[Threat Inel] Rule Processor queries %d IOCs', end)
         for index in range(0, end, MAX_QUERY_CNT):
             result.append(ioc_collections[index:min(index+MAX_QUERY_CNT, end)])
         return result

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -90,7 +90,7 @@ class StreamThreatIntel(object):
             records (list): A list of payload instance with normalized records.
 
         Returns:
-            (list): A list of payload instances including IOC information.
+            list: A list of payload instances including IOC information.
         """
         ioc_collections = []
         if not records:
@@ -146,7 +146,7 @@ class StreamThreatIntel(object):
             record (dict): A list of payload instance with normalized records.
 
         Returns:
-            (list): Return a list of StreamIoc instances.
+            list: Return a list of StreamIoc instances.
         """
         ioc_value_type_tuples = set()
         for datatype in record.pre_parsed_record[NORMALIZATION_KEY]:
@@ -222,10 +222,11 @@ class StreamThreatIntel(object):
             mapping_str (str): A qualified string has pattern 'normalized_type:ioc_type'
 
         Returns:
-            (bool): First return indicate if the string a qualifited string contains
+            A tuple(bool, str, str)
+            bool: First return indicate if the string a qualifited string contains
                 both normalized CEF type and IOC type.
-            (str): Second return is normalized type.
-            (str): Last return is IOC type.
+            str: Second return is normalized type.
+            str: Last return is IOC type.
         """
         normalized_type = None
         ioc_type = None
@@ -304,7 +305,7 @@ class StreamThreatIntel(object):
             ioc_collections (list): A list of StreamIoc instances
 
         Returns:
-            (list): List of subset of StreamIoc instances
+            list: List of subset of StreamIoc instances
         """
         result = []
         end = len(ioc_collections)
@@ -326,13 +327,14 @@ class StreamThreatIntel(object):
             values (list): A list of string which contains IOC values
 
         Returns:
-            First return (list): A list of dict returned from dynamodb
+            A tuple(list, dict)
+            list: A list of dict returned from dynamodb
                 table query, in the format of
                     [
                         {'sub_type': 'c2_domain', 'ioc_value': 'evil.com'},
                         {'sub_type': 'mal_ip', 'ioc_value': '1.1.1.2'},
                     ]
-            Second return (dict/None): A dict containing unprocesed keys.
+            dict: A dict containing unprocesed keys.
         """
         result = []
         query_keys = [{PRIMARY_KEY: {'S': ioc}} for ioc in values if ioc]
@@ -372,7 +374,7 @@ class StreamThreatIntel(object):
             dynamodb_data (list): Contains IOC info with DynamoDB types
 
         Returns:
-            (list): A list of Python dictionary type containing ioc_value and ioc_type
+            list: A list of Python dictionary type containing ioc_value and ioc_type
         """
         result = []
         if not dynamodb_data:

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -148,7 +148,7 @@ class StreamThreatIntel(object):
         Returns:
             (list): Return a list of StreamIoc instances.
         """
-        ioc_values = set()
+        ioc_value_type_tuples = set()
         for datatype in record.pre_parsed_record[NORMALIZATION_KEY]:
             # Lookup mapped IOC type based on normalized CEF type from Class variable.
             ioc_type = self.__normalized_ioc_types_mapping.get(datatype, None)
@@ -162,9 +162,9 @@ class StreamThreatIntel(object):
                         for original_key in original_keys:
                             value = value[original_key]
                     if value:
-                        ioc_values.add(value)
+                        ioc_value_type_tuples.add((value, ioc_type))
         return [StreamIoc(value=str(value).lower(), ioc_type=ioc_type, associated_record=record)
-                for value in ioc_values]
+                for value, ioc_type in ioc_value_type_tuples]
 
     @classmethod
     def load_from_config(cls, config):

--- a/tests/unit/conf/types.json
+++ b/tests/unit/conf/types.json
@@ -11,6 +11,10 @@
       "parent_md5",
       "expect_followon_w_md5",
       "md5"
+    ],
+    "sourceAddress:ioc_ip": [
+      "ipv4",
+      "local_ip"
     ]
   },
   "cloudwatch": {

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -167,56 +167,67 @@ def make_s3_raw_record(bucket, key):
     }
     return raw_record
 
-def mock_normalized_records():
+def mock_normalized_records(default_data=None):
     """Morck records which have been normalized"""
-    records = [
-        {
-            'account': 12345,
-            'region': '123456123456',
-            'detail': {
-                'eventName': 'ConsoleLogin',
-                'userIdentity': {
-                    'userName': 'alice',
-                    'accountId': '12345'
+    if not default_data:
+        default_data = [
+            {
+                'account': 12345,
+                'region': '123456123456',
+                'detail': {
+                    'eventName': 'ConsoleLogin',
+                    'userIdentity': {
+                        'userName': 'alice',
+                        'accountId': '12345'
+                    },
+                    'sourceIPAddress': '1.1.1.2',
+                    'recipientAccountId': '12345'
                 },
-                'sourceIPAddress': '1.1.1.2',
-                'recipientAccountId': '12345'
+                'source': '1.1.1.2',
+                'streamalert:normalization': {
+                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
+                    'usernNme': [['detail', 'userIdentity', 'userName']]
+                }
             },
-            'source': '1.1.1.2',
-            'streamalert:normalization': {
-                'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
-                'usernNme': [['detail', 'userIdentity', 'userName']]
+            {
+                'domain': 'evil.com',
+                'pc_name': 'test-pc',
+                'date': 'Dec 1st, 2016',
+                'data': 'ABCDEF',
+                'streamalert:normalization': {
+                    'destinationDomain': [['domain']]
+                }
+            },
+            {
+                'domain': 'evil2.com',
+                'pc_name': 'test-pc',
+                'date': 'Dec 1st, 2016',
+                'data': 'ABCDEF',
+                'streamalert:normalization': {
+                    'destinationDomain': [['domain']]
+                }
+            },
+            {
+                'process_md5': 'abcdef0123456789',
+                'server': 'test-server',
+                'date': 'Dec 2nd, 2016',
+                'data': 'Foo',
+                'streamalert:normalization': {
+                    'fileHash': [['process_md5']]
+                }
             }
-        },
-        {
-            'domain': 'evil.com',
-            'pc_name': 'test-pc',
-            'date': 'Dec 1st, 2016',
-            'data': 'ABCDEF',
-            'streamalert:normalization': {
-                'destinationDomain': [['domain']]
-            }
-        },
-        {
-            'domain': 'evil2.com',
-            'pc_name': 'test-pc',
-            'date': 'Dec 1st, 2016',
-            'data': 'ABCDEF',
-            'streamalert:normalization': {
-                'destinationDomain': [['domain']]
-            }
-        },
-        {
-            'process_md5': 'abcdef0123456789',
-            'server': 'test-server',
-            'date': 'Dec 2nd, 2016',
-            'data': 'Foo',
-            'streamalert:normalization': {
-                'fileHash': [['process_md5']]
-            }
-        }
-    ]
-    return records
+        ]
+
+    kinesis_payload = []
+    for record in default_data:
+        entity = 'unit_test_entity'
+        raw_record = make_kinesis_raw_record(entity, 'None')
+        payload = load_stream_payload('kinesis', entity, raw_record)
+        payload = payload.pre_parse().next()
+        payload.pre_parsed_record = record
+        kinesis_payload.append(payload)
+
+    return kinesis_payload
 
 class MockDynamoDBClient(object):
     """Helper mock class to act as dynamodb client"""

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -233,6 +233,7 @@ class MockDynamoDBClient(object):
     """Helper mock class to act as dynamodb client"""
     def __init__(self, **kwargs):
         self.exception = kwargs.get('exception', False)
+        self.has_unprocessed_keys = kwargs.get('unprocesed_keys', False)
 
     def batch_get_item(self, **kwargs):
         """Mock batch_get_item method and return mimicking dynamodb response
@@ -283,7 +284,7 @@ class MockDynamoDBClient(object):
                 'HTTPHeaders': {}
             }
         }
-        if kwargs.get('unprocesed_keys', False):
+        if self.has_unprocessed_keys:
             response['UnprocessedKeys'] = {
                 'test_table_name': {
                     'Keys': [

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -132,6 +132,7 @@ class TestStreamThreatIntel(object):
         ]
         mock_client.return_value = MockDynamoDBClient()
         threat_intel = StreamThreatIntel.load_from_config(self.config)
+        records = mock_normalized_records(records)
         assert_equal(len(threat_intel.threat_detection(records)), 3)
 
     def test_insert_ioc_info(self):
@@ -180,7 +181,7 @@ class TestStreamThreatIntel(object):
 
     def test_extract_ioc_from_record(self):
         """Threat Intel - Test extrac values from a record based on normalized keys"""
-        rec = {
+        records = [{
             'account': 12345,
             'region': '123456123456',
             'detail': {
@@ -200,10 +201,12 @@ class TestStreamThreatIntel(object):
                 'usernNme': [['detail', 'userIdentity', 'userName']]
             },
             'id': '12345'
-        }
-        result = self.threat_intel._extract_ioc_from_record(rec)
-        assert_equal(len(result), 1)
-        assert_equal(result[0].value, '1.1.1.2')
+        }]
+        records = mock_normalized_records(records)
+        for record in records:
+            result = self.threat_intel._extract_ioc_from_record(record)
+            assert_equal(len(result), 1)
+            assert_equal(result[0].value, '1.1.1.2')
 
     def test_from_config(self):
         """Threat Intel - Test load_config method"""

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -208,6 +208,44 @@ class TestStreamThreatIntel(object):
             assert_equal(len(result), 1)
             assert_equal(result[0].value, '1.1.1.2')
 
+        records = [{
+            'cb_server': 'cbserver',
+            'computer_name': 'DESKTOP-TESTING',
+            'direction': 'outbound',
+            'domain': 'evil.com',
+            'event_type': 'netconn',
+            'ipv4': '1.1.1.2',
+            'local_ip': '1.1.1.2',
+            'local_port': '57347',
+            'md5': 'ABCDEF0123456789ABCDEF0123456789',
+            'pid': '268',
+            'port': '50002',
+            'process_guid': '00003a07-0000-010c-01d3-766fd6eee995',
+            'process_path': 'bad_actor.exe',
+            'protocol': '6',
+            'remote_ip': '82.82.82.82',
+            'remote_port': '50002',
+            'sensor_id': '14855',
+            'timestamp': 1515151515,
+            'type': 'ingress.event.netconn',
+            'streamalert:normalization': {
+                'destinationAddress': [['remote_ip']],
+                'destinationDomain': [['domain']],
+                'fileHash': [['md5']],
+                'sourceAddress': [['ipv4'], ['local_ip']]
+            }
+        }]
+
+        records = mock_normalized_records(records)
+        for record in records:
+            results = self.threat_intel._extract_ioc_from_record(record)
+            assert_equal(len(results), 4)
+            assert_equal((results[0].value, results[0].ioc_type), ('1.1.1.2', 'ip'))
+            assert_equal((results[1].value, results[1].ioc_type), ('82.82.82.82', 'ip'))
+            assert_equal((results[2].value, results[2].ioc_type), ('evil.com', 'domain'))
+            assert_equal((results[3].value, results[3].ioc_type),
+                         ('abcdef0123456789abcdef0123456789', 'md5'))
+
     def test_from_config(self):
         """Threat Intel - Test load_config method"""
         test_config = {
@@ -319,6 +357,17 @@ class TestStreamThreatIntel(object):
         assert_true(ioc_collections[0].is_ioc)
         assert_false(ioc_collections[1].is_ioc)
         assert_true(ioc_collections[2].is_ioc)
+
+    @patch('boto3.client')
+    def test_process_ioc_with_clienterror(self, mock_client):
+        """Threat Intel - Test private method process_ioc"""
+        mock_client.return_value = MockDynamoDBClient(exception=True)
+        threat_intel = StreamThreatIntel.load_from_config(self.config)
+
+        ioc_collections = [
+            StreamIoc(value='1.1.1.2', ioc_type='ip')
+        ]
+        threat_intel._process_ioc(ioc_collections)
 
     @patch('boto3.client')
     def test_process_ioc_with_unprocessed_keys(self, mock_client):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: medium
resolves #531

## Background
[Threat Intel Beta PR](https://github.com/airbnb/streamalert/pull/507) is using DynamoDB table to store IOC. During deploy, we found Read Capacity Throttling issue when there are significant amount of log records processed by Rule Processor. 

This issue has been identified that threat intel should be called from rule processor handler, instead of in rules engine.
This [line](https://github.com/airbnb/streamalert/blob/master/stream_alert/rule_processor/rules_engine.py#L395) is called by every normalized record, so it doesn't take advantage of batch_get_item from DynamoDB.

### Solution:
Collect all normalized records and call threat_detection from Rule Processor's handler.

## Changes

* Call threat intel from StreamAlert `handler`, instead of in StreamRules `process`. This change also requires to return Payload metadata (`payload.log_source`, `payload.type`, `payload.service` and `payload.entity`) of each parsed record. These Payload metadata is needed when trigger the alerts.
* Add more test cases to guard that only one DynamoDB table query been called in one invocation with multiple events coming.
* Fix a bug about handling `ioc_type` incorrectly. The `ioc_type` doesn't match to `ioc_value` if there are multiple type of IOCs in a record. Also add a test case to catch this bug. 

## Testing
* Unit test
```
./tests/scripts/unit_tests.sh
...
-------------------------------------------------------------------------------------
TOTAL                                                    3013    117    96%
----------------------------------------------------------------------
Ran 513 tests in 12.082s

OK
```
* Rule test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Tested in AWS testing acount
