### PR TITLE
Firehose Table Creation Bug Fixes

### DIFF
--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -212,8 +212,29 @@ class StreamAlertFirehose(object):
                         record_batch_size,
                         stream_name)
 
-    @staticmethod
-    def _load_enabled_log_sources(firehose_config, log_sources):
+    def _firehose_log_name(self, log_name):
+        """Convert conventional log names into Firehose delievery stream names
+
+        Args:
+            log_name: The name of the log from logs.json
+
+        Returns
+            str: Converted name which corresponds to a Firehose Delievery Stream
+        """
+        return re.sub(self.SPECIAL_CHAR_REGEX, '_', log_name)
+
+    def enabled_log_source(self, log_source_name):
+        """Check that the incoming record is an enabled log source for Firehose
+
+        Args:
+            log_source_name (str): The log source of the record
+
+        Returns:
+            bool: Whether or not the log source is enabled to send to Firehose
+        """
+        return self._firehose_log_name(log_source_name) in self.enabled_logs
+
+    def _load_enabled_log_sources(self, firehose_config, log_sources):
         """Load and expand all declared and enabled Firehose log sources
 
         Args:
@@ -229,7 +250,7 @@ class StreamAlertFirehose(object):
 
             # Expand to all subtypes
             if len(enabled_log_parts) == 1:
-                expanded_logs = [log_name.replace(':', '_') for log_name
+                expanded_logs = [self._firehose_log_name(log_name) for log_name
                                  in log_sources
                                  if log_name.split(':')[0] == enabled_log_parts[0]]
                 # If the list comprehension is Falsey, it means no matching logs
@@ -243,20 +264,9 @@ class StreamAlertFirehose(object):
                 if enabled_log not in log_sources:
                     LOGGER.error('Enabled Firehose log %s not declared in logs.json', enabled_log)
 
-                enabled_logs.add('_'.join(enabled_log_parts))
+                enabled_logs.add(self._firehose_log_name('_'.join(enabled_log_parts)))
 
         return enabled_logs
-
-    def enabled_log_source(self, log_source_name):
-        """Check that the incoming record is an enabled log source for Firehose
-
-        Args:
-            log_source_name (str): The log source of the record
-
-        Returns:
-            bool: Whether or not the log source is enabled to send to Firehose
-        """
-        return log_source_name.replace(':', '_') in self.enabled_logs
 
     def send(self):
         """Send all classified records to a respective Firehose Delivery Stream"""
@@ -267,7 +277,7 @@ class StreamAlertFirehose(object):
         # in a specific prefix in S3.
         for log_type, records in self.categorized_payloads.iteritems():
             # This same substitution method is used when naming the Delivery Streams
-            formatted_log_type = log_type.replace(':', '_')
+            formatted_log_type = self._firehose_log_name(log_type)
 
             # Process each record batch in the categorized payload set
             for record_batch in self._segment_records_by_count(records, self.MAX_BATCH_COUNT):

--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -212,7 +212,7 @@ class StreamAlertFirehose(object):
                         record_batch_size,
                         stream_name)
 
-    def _firehose_log_name(self, log_name):
+    def firehose_log_name(self, log_name):
         """Convert conventional log names into Firehose delievery stream names
 
         Args:
@@ -232,7 +232,7 @@ class StreamAlertFirehose(object):
         Returns:
             bool: Whether or not the log source is enabled to send to Firehose
         """
-        return self._firehose_log_name(log_source_name) in self.enabled_logs
+        return self.firehose_log_name(log_source_name) in self.enabled_logs
 
     def _load_enabled_log_sources(self, firehose_config, log_sources):
         """Load and expand all declared and enabled Firehose log sources
@@ -250,7 +250,7 @@ class StreamAlertFirehose(object):
 
             # Expand to all subtypes
             if len(enabled_log_parts) == 1:
-                expanded_logs = [self._firehose_log_name(log_name) for log_name
+                expanded_logs = [self.firehose_log_name(log_name) for log_name
                                  in log_sources
                                  if log_name.split(':')[0] == enabled_log_parts[0]]
                 # If the list comprehension is Falsey, it means no matching logs
@@ -264,7 +264,7 @@ class StreamAlertFirehose(object):
                 if enabled_log not in log_sources:
                     LOGGER.error('Enabled Firehose log %s not declared in logs.json', enabled_log)
 
-                enabled_logs.add(self._firehose_log_name('_'.join(enabled_log_parts)))
+                enabled_logs.add(self.firehose_log_name('_'.join(enabled_log_parts)))
 
         return enabled_logs
 
@@ -277,7 +277,7 @@ class StreamAlertFirehose(object):
         # in a specific prefix in S3.
         for log_type, records in self.categorized_payloads.iteritems():
             # This same substitution method is used when naming the Delivery Streams
-            formatted_log_type = self._firehose_log_name(log_type)
+            formatted_log_type = self.firehose_log_name(log_type)
 
             # Process each record batch in the categorized payload set
             for record_batch in self._segment_records_by_count(records, self.MAX_BATCH_COUNT):

--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -30,6 +30,7 @@ SCHEMA_TYPE_MAPPING = {
 }
 MAX_QUERY_LENGTH = 262144
 
+
 def create_database(athena_client):
     """Create the 'streamalert' Athena database
 
@@ -73,14 +74,15 @@ def rebuild_partitions(athena_client, options, config):
     sa_firehose = StreamAlertFirehose(config['global']['account']['region'],
                                       config['global']['infrastructure']['firehose'],
                                       config['logs'])
-    sanitized_table_name = sa_firehose._firehose_log_name(options.table_name)
+    sanitized_table_name = sa_firehose.firehose_log_name(options.table_name)
 
     if options.type == 'data':
         # Get the current set of partitions
         partition_success, partitions = athena_client.run_athena_query(
             query='SHOW PARTITIONS {}'.format(sanitized_table_name), database='streamalert')
         if not partition_success:
-            LOGGER_CLI.error('An error occured when loading partitions for %s', sanitized_table_name)
+            LOGGER_CLI.error('An error occured when loading partitions for %s',
+                             sanitized_table_name)
             return
 
         unique_partitions = athena_helpers.unique_values_from_query(partitions)
@@ -217,7 +219,7 @@ def create_table(athena_client, options, config):
             LOGGER_CLI.error('Missing command line argument --table_name')
             return
 
-        sanitized_table_name = sa_firehose._firehose_log_name(options.table_name)
+        sanitized_table_name = sa_firehose.firehose_log_name(options.table_name)
 
         if sanitized_table_name not in sa_firehose.enabled_logs:
             LOGGER_CLI.error('Table name %s missing from configuration or '


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

While creating Athena tables for CarbonBlack log types, I discovered a bug in how the CLI converts the log name format to the Athena format.  Athena tables can only have underscores in them, so all other special characters need to be converted.

## Changes

* Fix a bug when looking up schemas for log names containing special characters
* Pylint fixes

## Testing

Local test suite
