### PR TITLE
[threat intel] avoid duplicating normalized records.

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -122,6 +122,7 @@ class StreamAlert(object):
 
             payload_with_normalized_records.extend(self._process_alerts(payload))
 
+        LOGGER.info('Got %d normalized records', len(payload_with_normalized_records))
         # Apply Threat Intel to normalized records in the end of Rule Processor invocation
         record_alerts = self._rule_engine.threat_intel_match(payload_with_normalized_records)
         self._alerts.extend(record_alerts)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
There is a bug that one normalized record may be added to normalized records list multiple time. It will cause memory outrage when processing records from S3 (normally there are 13k-14k records in one json file from S3).

## Changes

* Add a flag to indicate if the record has been added to normalized record list or not. 

## Testing

* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
-------------------------------------------------------------------------------------
TOTAL                                                    3020    117    96%
----------------------------------------------------------------------
Ran 513 tests in 12.522s

OK
```
