### PR TITLE
[metrics] getting a more accurate processed record count in rp handler

### DIFF
--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -199,7 +199,7 @@ class TestPagerDutyIncidentOutput(object):
 
     @patch('requests.get')
     def test_check_exists_no_get_id(self, get_mock):
-        """Check Exists No Get Id - PagerDutyIncidentOutput"""
+        """PagerDutyIncidentOutput - Check Exists No Get Id"""
         # /check
         get_mock.return_value.status_code = 200
         json_check = {'check': [{'id': 'checked_id'}]}

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-# pylint: disable=protected-access
+# pylint: disable=protected-access,attribute-defined-outside-init
 import base64
 import json
 import logging
@@ -44,9 +44,6 @@ rule = StreamRules.rule
 
 class TestStreamAlert(object):
     """Test class for StreamAlert class"""
-
-    def __init__(self):
-        self.__sa_handler = None
 
     @patch('stream_alert.rule_processor.handler.load_config',
            lambda: load_config('tests/unit/conf/'))
@@ -130,6 +127,14 @@ class TestStreamAlert(object):
         passed = self.__sa_handler.run(get_valid_event())
 
         assert_true(passed)
+
+    @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
+    def test_run_alert_count(self, extract_mock):
+        """StreamAlert Class - Run, Check Count With 4 Logs"""
+        count = 4
+        extract_mock.return_value = ('kinesis', 'unit_test_default_stream')
+        self.__sa_handler.run(get_valid_event(count))
+        assert_equal(self.__sa_handler._processed_record_count, count)
 
     @patch('logging.Logger.debug')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves #527 

## Background

See #527. Metrics should track the records for the processed payload, not the incoming 'records' array.

## Changes

* Using a instance property to track the total records from each processed payload.
* This value is then logged at the end of processing as the total records metric.

## Testing

* Adding unit test to check for tracking the proper processed log count.