### PR TITLE
[threat intel] Add threat_intel flag in clusters' config

### DIFF
--- a/stream_alert/rule_processor/config.py
+++ b/stream_alert/rule_processor/config.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 import json
 import os
 
-CLUSTER = os.environ.get('CLUSTER', '')
 
 class ConfigError(Exception):
     """Exception class for config file errors"""
@@ -42,11 +41,12 @@ def load_config(conf_dir='conf/'):
             # Load current cluster config into memory for threat intel
             path = os.path.join(conf_dir, base_name)
             config['clusters'] = {}
-            if CLUSTER:
-                cluster_conf_path = '{}.json'.format(os.path.join(path, CLUSTER))
+            cluster = os.environ.get('CLUSTER', '')
+            if cluster:
+                cluster_conf_path = '{}.json'.format(os.path.join(path, cluster))
                 with open(cluster_conf_path) as data:
                     try:
-                        config['clusters'][CLUSTER] = json.load(data)
+                        config['clusters'][cluster] = json.load(data)
                     except ValueError:
                         raise ConfigError('Invalid JSON format for {}'.format(cluster_conf_path))
         else:

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
+
 import backoff
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
@@ -36,6 +38,8 @@ PROJECTION_EXPRESSION = '{},{}'.format(PRIMARY_KEY, SUB_TYPE_KEY)
 
 EXCEPTIONS_TO_BACKOFF = (ClientError,)
 BACKOFF_MAX_RETRIES = 3
+
+CLUSTER = os.environ.get('CLUSTER', '')
 
 class StreamIoc(object):
     """Class to store IOC info"""
@@ -178,6 +182,12 @@ class StreamThreatIntel(object):
         """
         if config.get('types'):
             cls._process_types_config(config['types'])
+
+        # Threat Intel will be disabled for the cluster if it is explicityly
+        # disabled in cluster config located in conf/clusters/ directory
+        if CLUSTER and not (config['clusters'][CLUSTER]['modules']['stream_alert']
+                            ['rule_processor'].get('enable_threat_intel', True)):
+            return False
 
         if (config.get('global')
                 and config['global'].get('threat_intel')

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -39,8 +39,6 @@ PROJECTION_EXPRESSION = '{},{}'.format(PRIMARY_KEY, SUB_TYPE_KEY)
 EXCEPTIONS_TO_BACKOFF = (ClientError,)
 BACKOFF_MAX_RETRIES = 3
 
-CLUSTER = os.environ.get('CLUSTER', '')
-
 class StreamIoc(object):
     """Class to store IOC info"""
     def __init__(self, **kwargs):
@@ -185,7 +183,8 @@ class StreamThreatIntel(object):
 
         # Threat Intel will be disabled for the cluster if it is explicitly
         # disabled in cluster config located in conf/clusters/ directory
-        if CLUSTER and not (config['clusters'][CLUSTER]['modules']['stream_alert']
+        cluster = os.environ.get('CLUSTER', '')
+        if cluster and not (config['clusters'][cluster]['modules']['stream_alert']
                             ['rule_processor'].get('enable_threat_intel', True)):
             return False
 

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -183,7 +183,7 @@ class StreamThreatIntel(object):
         if config.get('types'):
             cls._process_types_config(config['types'])
 
-        # Threat Intel will be disabled for the cluster if it is explicityly
+        # Threat Intel will be disabled for the cluster if it is explicitly
         # disabled in cluster config located in conf/clusters/ directory
         if CLUSTER and not (config['clusters'][CLUSTER]['modules']['stream_alert']
                             ['rule_processor'].get('enable_threat_intel', True)):

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -34,7 +34,8 @@ class SuppressNoise(logging.Filter):
             'Starting download from S3*',
             'Completed download in*',
             '*triggered an alert on log type*',
-            '*Firehose*'
+            '*Firehose*',
+            'Got * normalized records'
         )
 
         message = record.getMessage()

--- a/tests/unit/conf/clusters/test.json
+++ b/tests/unit/conf/clusters/test.json
@@ -30,6 +30,7 @@
       },
       "rule_processor": {
         "current_version": "$LATEST",
+        "enable_threat_intel": false,
         "memory": 128,
         "timeout": 25
       }

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -14,15 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=protected-access,no-self-use
+import os
 from botocore.exceptions import ClientError, ParamValidationError
 from mock import patch
 from nose.tools import (
     assert_equal,
     assert_false,
+    assert_is_instance,
     assert_true,
     raises,
 )
 
+from stream_alert.rule_processor import threat_intel as threat_intel_module
+from stream_alert.rule_processor import config as config_module
 from stream_alert.rule_processor.config import load_config
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel, StreamIoc
 from tests.unit.stream_alert_rule_processor.test_helpers import (
@@ -76,6 +80,10 @@ class TestStreamThreatIntel(object):
         self.config = load_config('tests/unit/conf')
         self.config['global']['threat_intel']['enabled'] = True
         self.threat_intel = StreamThreatIntel.load_from_config(self.config)
+        os.environ['CLUSTER'] = ''
+        # Force reload the threat_intel_module to trigger env var loading
+        reload(config_module)
+        reload(threat_intel_module)
 
     def teardown(self):
         StreamThreatIntel._StreamThreatIntel__normalized_types.clear() # pylint: disable=no-member
@@ -246,7 +254,7 @@ class TestStreamThreatIntel(object):
             assert_equal((results[3].value, results[3].ioc_type),
                          ('abcdef0123456789abcdef0123456789', 'md5'))
 
-    def test_from_config(self):
+    def test_load_from_config(self):
         """Threat Intel - Test load_config method"""
         test_config = {
             'global': {
@@ -301,6 +309,28 @@ class TestStreamThreatIntel(object):
             }
         }
         assert_equal(StreamThreatIntel.normalized_type_mapping(), expected_result)
+
+    def test_load_from_config_with_cluster_env(self):
+        """Threat Intel - Test load_from_config to read cluster env variable"""
+        with patch.dict('os.environ', {'CLUSTER': 'advanced'}):
+            reload(config_module)
+            reload(threat_intel_module)
+            config = load_config('tests/unit/conf')
+            config['global']['threat_intel']['enabled'] = True
+            threat_intel = StreamThreatIntel.load_from_config(config)
+            assert_is_instance(threat_intel, StreamThreatIntel)
+            assert_equal(threat_intel_module.CLUSTER, 'advanced')
+
+    def test_load_from_config_with_cluster_env_2(self):
+        """Threat Intel - Test load_from_config with threat intel disabled in cluster"""
+        with patch.dict('os.environ', {'CLUSTER': 'test'}):
+            reload(config_module)
+            reload(threat_intel_module)
+            config = load_config('tests/unit/conf')
+            config['global']['threat_intel']['enabled'] = True
+            threat_intel = StreamThreatIntel.load_from_config(config)
+            assert_false(isinstance(threat_intel, StreamThreatIntel))
+            assert_equal(threat_intel_module.CLUSTER, 'test')
 
     def test_process_types_config(self):
         """Threat Intel - Test process_types_config method"""


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
During internal deploy, we realized it will be super helpful if we support enable/disable threat_intel per cluster based. So users can have choice to enable threat intel on interested clusters or trying to avoid running threat intel against certain clusters. 

## Changes

* This PR is to add an explicitly disable flag for threat_intel feature based on clusters. In another words, even global threat_intel flag in conf/global.json is set to true, the cluster still can disable it by adding "enable_threat_intel": false, under rule_processor settings.
* If there is no enable_threat_intel flag in clusters' conf, it is default to True and global threat intel flag will take effect.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Unit testing
```
./tests/scripts/unit_tests.sh
...
TOTAL                                                    3037    119    96%
----------------------------------------------------------------------
Ran 516 tests in 12.293s

OK
