### PR TITLE
[output] Adding key to mocked request for api.pagerduty

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -688,7 +688,7 @@ class AlertProcessorTester(object):
 
                     elif 'api.pagerduty' in url:
                         u_path = os.path.split(url)[1]
-                        return {u_path: [{'id': 1234}]}
+                        return {u_path: [{'id': 1234, 'name': 'foobar'}]}
 
                 # Default to returning an empty dict in case this was not implemented for a service
                 return dict()


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

In order to patch `GET` and `POST` requests, `MagicMocks` are used for each different output. For the tests involving the `pagerduty-incident` output, a key was missing and was making all tests to fail.

## Changes

* Adding key `name` to the mocked response.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    3022    117    96%
----------------------------------------------------------------------
Ran 514 tests in 9.432s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
