### PR TITLE
[tf] Ignore DDB read_capacity change since we have autoscaling policy.

### DIFF
--- a/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
+++ b/terraform/modules/tf_threat_intel_downloader/dynamodb.tf
@@ -9,6 +9,13 @@ resource "aws_dynamodb_table" "threat_intel_ioc" {
     type = "S"
   }
 
+  # It is recommended to use lifecycle ignore_changes for read_capacity and/or
+  # write_capacity if there's autoscaling policy attached to the table. We have
+  # autoscaling policy for read_capacity
+  lifecycle {
+    ignore_changes = ["read_capacity"]
+  }
+
   ttl {
     attribute_name = "expiration_ts"
     enabled        = true


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
It is recommended to use lifecycle ignore_changes for read_capacity and/or write_capacity if there's autoscaling policy attached to the table. Otherwise, terraform will change `read_capacity` every time when you run it.  Also, we only apply autoscaling policy to `read_capacity`. Please refer to [terraform doc](https://www.terraform.io/docs/providers/aws/r/dynamodb_table.html) for more details. 

## Changes

* Add `read_capacity` to lifecycle ignore list in `aws_dynamodb_table` resource.

## Testing
* Terraform plan was successful.