### PR TITLE
[threat intel] apply ip filter to only check public ip

### DIFF
--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -412,6 +412,8 @@ class StreamThreatIntel(object):
     def is_public_ip(ip_address):
         try:
             ip_addr = IPAddress(str(ip_address))
+            # We also need to filter multicast ip which is a private ip. For example,
+            # multicast ip '239.192.0.1', is a private ip.
             return ip_addr.is_unicast() and not ip_addr.is_private()
         except AddrFormatError:
             return False

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -19,6 +19,8 @@ import backoff
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError, ParamValidationError
+from netaddr import IPAddress
+from netaddr.core import AddrFormatError
 
 from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.backoff_handlers import (
@@ -164,6 +166,10 @@ class StreamThreatIntel(object):
                         for original_key in original_keys:
                             value = value[original_key]
                     if value:
+                        # Threat Intel will only check against public IP addresses
+                        # while processing IP IOCs.
+                        if ioc_type == 'ip' and not self.is_public_ip(value):
+                            continue
                         ioc_value_type_tuples.add((value, ioc_type))
         return [StreamIoc(value=str(value).lower(), ioc_type=ioc_type, associated_record=record)
                 for value, ioc_type in ioc_value_type_tuples]
@@ -401,3 +407,11 @@ class StreamThreatIntel(object):
     def normalized_type_mapping(cls):
         """Get normalized CEF types mapping to original keys from the records."""
         return cls.__normalized_types
+
+    @staticmethod
+    def is_public_ip(ip_address):
+        try:
+            ip_addr = IPAddress(str(ip_address))
+            return ip_addr.is_unicast() and not ip_addr.is_private()
+        except AddrFormatError:
+            return False

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -247,6 +247,57 @@ class TestStreamThreatIntel(object):
             assert_equal((results[3].value, results[3].ioc_type),
                          ('abcdef0123456789abcdef0123456789', 'md5'))
 
+    def test_extract_ioc_from_record_with_private_ip(self):
+        """Threat Intel - Test extrac values from a record based on normalized keys"""
+        records = [
+            {
+                'account': 12345,
+                'region': '123456123456',
+                'detail': {
+                    'eventType': 'AwsConsoleSignIn',
+                    'eventName': 'ConsoleLogin',
+                    'userIdentity': {
+                        'userName': 'alice',
+                        'type': 'Root',
+                        'principalId': '12345',
+                    },
+                    'sourceIPAddress': 'ec2.amazon.com',
+                    'recipientAccountId': '12345'
+                },
+                'source': 'ec2.amazon.com',
+                'streamalert:normalization': {
+                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
+                    'usernNme': [['detail', 'userIdentity', 'userName']]
+                },
+                'id': '12345'
+            },
+            {
+                'account': 12345,
+                'region': '123456123456',
+                'detail': {
+                    'eventType': 'AwsConsoleSignIn',
+                    'eventName': 'ConsoleLogin',
+                    'userIdentity': {
+                        'userName': 'alice',
+                        'type': 'Root',
+                        'principalId': '12345',
+                    },
+                    'sourceIPAddress': '192.168.1.2',
+                    'recipientAccountId': '12345'
+                },
+                'source': '192.168.1.2',
+                'streamalert:normalization': {
+                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
+                    'usernNme': [['detail', 'userIdentity', 'userName']]
+                },
+                'id': '12345'
+            }
+        ]
+        records = mock_normalized_records(records)
+        for record in records:
+            result = self.threat_intel._extract_ioc_from_record(record)
+            assert_equal(len(result), 0)
+
     def test_load_from_config(self):
         """Threat Intel - Test load_config method"""
         test_config = {

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -181,7 +181,7 @@ class TestStreamThreatIntel(object):
         assert_equal(rec_with_ioc_info['streamalert:ioc'], expected_results)
 
     def test_extract_ioc_from_record(self):
-        """Threat Intel - Test extrac values from a record based on normalized keys"""
+        """Threat Intel - Test extracting values from a record based on normalized keys"""
         records = [{
             'account': 12345,
             'region': '123456123456',
@@ -248,7 +248,7 @@ class TestStreamThreatIntel(object):
                          ('abcdef0123456789abcdef0123456789', 'md5'))
 
     def test_extract_ioc_from_record_with_private_ip(self):
-        """Threat Intel - Test extrac values from a record based on normalized keys"""
+        """Threat Intel - Test extracting values from a record based on normalized keys"""
         records = [
             {
                 'account': 12345,


### PR DESCRIPTION
to: @ryandeivert or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves 

## Background
When processing network related events, we will encounter the situation that many of the events are generated in the private subnet. It is totally not necessary to run Threat Intel against these private ip addresses. This PR proposes to filter out broadcast and private IP addresses. 

## Changes

* Use IPAddress class from `netaddr` lib.
* Add unit test cases. 

## Testing
* Performance scoping
Tested with 5466 cloudwatch events with IP filter, the IOC number is dropped to 2324, by 57%. It means the RC to DDB will be dropped by 57% based on the test events I have. 
* Rule Test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
* Unit test
```
./tests/scripts/unit_tests.sh
...
TOTAL                                                    3047    119    96%
----------------------------------------------------------------------
Ran 517 tests in 11.176s

OK
```
