### PR TITLE
Add StreamAlert tag to Athena SQS queue

### DIFF
--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -42,6 +42,10 @@ resource "aws_sqs_queue" "streamalert_athena_data_bucket_notifications" {
 
   # Retain messages for one day
   message_retention_seconds = 86400
+
+  tags {
+    Name = "StreamAlert"
+  }
 }
 
 // SQS Queue Policy: Allow data buckets to send SQS messages


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @chunyong-lin 
size: small

## Changes

* Adds the "StreamAlert" tag to SQS, since SQS tagging support was added a few months ago

## Testing

* `terraform validate`
