### PR TITLE
[threat intel][tests] Make unit tests 1-2 seconds faster

### DIFF
--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -38,9 +38,6 @@ PRIMARY_KEY = 'ioc_value'
 SUB_TYPE_KEY = 'sub_type'
 PROJECTION_EXPRESSION = '{},{}'.format(PRIMARY_KEY, SUB_TYPE_KEY)
 
-EXCEPTIONS_TO_BACKOFF = (ClientError,)
-BACKOFF_MAX_RETRIES = 3
-
 class StreamIoc(object):
     """Class to store IOC info"""
     def __init__(self, **kwargs):
@@ -73,6 +70,9 @@ def exceptions_to_giveup(err):
 class StreamThreatIntel(object):
     """Load intelligence from csv.gz files into a dictionary."""
     IOC_KEY = 'streamalert:ioc'
+
+    EXCEPTIONS_TO_BACKOFF = (ClientError,)
+    BACKOFF_MAX_RETRIES = 3
 
     # Class variable stores Data Normalization types mapping.
     __normalized_types = {}

--- a/stream_alert/threat_intel_downloader/threat_stream.py
+++ b/stream_alert/threat_intel_downloader/threat_stream.py
@@ -43,6 +43,12 @@ class ThreatStream(object):
     _API_MAX_INDEX = 500000
     _PARAMETER_NAME = 'threat_intel_downloader_api_creds'
 
+    EXCEPTIONS_TO_BACKOFF = (requests.exceptions.Timeout,
+                             requests.exceptions.ConnectionError,
+                             requests.exceptions.ChunkedEncodingError,
+                             ThreatStreamRequestsError)
+    BACKOFF_MAX_RETRIES = 3
+
     def __init__(self, config):
         self.ioc_types = config['ioc_types']
         self.ioc_sources = config['ioc_filters']
@@ -81,13 +87,9 @@ class ThreatStream(object):
             LOGGER.error('API Creds Error')
             raise ThreatStreamCredsError('API Creds Error')
 
-    exceptions_to_backoff = (requests.exceptions.Timeout,
-                             requests.exceptions.ConnectionError,
-                             requests.exceptions.ChunkedEncodingError,
-                             ThreatStreamRequestsError)
     @backoff.on_exception(backoff.constant,
-                          exceptions_to_backoff,
-                          max_tries=3,
+                          EXCEPTIONS_TO_BACKOFF,
+                          max_tries=BACKOFF_MAX_RETRIES,
                           on_backoff=backoff_handler,
                           on_success=success_handler,
                           on_giveup=giveup_handler)

--- a/tests/unit/threat_intel_downloader/test_threat_stream.py
+++ b/tests/unit/threat_intel_downloader/test_threat_stream.py
@@ -38,6 +38,7 @@ from tests.unit.threat_intel_downloader.test_helpers import (
     mock_ssm_response
 )
 
+@patch.object(ThreatStream, 'BACKOFF_MAX_RETRIES', 0)
 class TestThreatStream(object):
     """Test class to test ThreatStream functionalities"""
     def __init__(self):


### PR DESCRIPTION
to: @chunyong-lin @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Backoff number of retries was set to 3 as default and that was making unit tests to slow down a bit. This should shave off 1-2 seconds from that time.

## Changes

* Patch `max_tries` in backoff to 0 for unit tests.
* Adding a class property for Threat Stream to avoid hardcoding `max_tries`.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
TOTAL                                                    3022    117    96%
----------------------------------------------------------------------
Ran 514 tests in 9.432s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```