### PR TITLE
[outputs] PagerDuty Incident rich content

### DIFF
--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -156,7 +156,8 @@ class TestPagerDutyIncidentOutput(object):
              'token': 'mocked_token',
              'service_name': 'mocked_service_name',
              'escalation_policy': 'mocked_escalation_policy',
-             'email_from': 'email@domain.com'}
+             'email_from': 'email@domain.com',
+             'integration_key': 'mocked_key'}
 
     def setup(self):
         """Setup before each method"""

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -148,6 +148,8 @@ class TestPagerDutyOutputV2(object):
 @mock_s3
 @mock_kms
 @patch('stream_alert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS', 1)
+@patch('stream_alert.alert_processor.outputs.pagerduty.PagerDutyIncidentOutput.BACKOFF_MAX', 0)
+@patch('stream_alert.alert_processor.outputs.pagerduty.PagerDutyIncidentOutput.BACKOFF_TIME', 0)
 class TestPagerDutyIncidentOutput(object):
     """Test class for PagerDutyIncidentOutput"""
     DESCRIPTOR = 'unit_test_pagerduty-incident'
@@ -181,7 +183,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_check_exists_get_id(self, get_mock):
         """PagerDutyIncidentOutput - Check Exists Get ID"""
-        # /check
+        # GET /check
         get_mock.return_value.status_code = 200
         json_check = {'check': [{'id': 'checked_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -201,7 +203,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_check_exists_no_get_id(self, get_mock):
         """PagerDutyIncidentOutput - Check Exists No Get Id"""
-        # /check
+        # GET /check
         get_mock.return_value.status_code = 200
         json_check = {'check': [{'id': 'checked_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -232,7 +234,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_policy_verify_success_no_default(self, get_mock):
         """PagerDutyIncidentOutput - Policy Verify Success (No Default)"""
-        # /escalation_policies
+        # GET /escalation_policies
         get_mock.return_value.status_code = 200
         json_check = {'escalation_policies': [{'id': 'good_policy_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -244,7 +246,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_policy_verify_success_default(self, get_mock):
         """PagerDutyIncidentOutput - Policy Verify Success (Default)"""
-        # /escalation_policies
+        # GET /escalation_policies
         type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200])
         json_check_bad = {'no_escalation_policies': [{'id': 'bad_policy_id'}]}
         json_check_good = {'escalation_policies': [{'id': 'good_policy_id'}]}
@@ -257,7 +259,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_policy_verify_fail_default(self, get_mock):
         """PagerDutyIncidentOutput - Policy Verify Fail (Default)"""
-        # /not_escalation_policies
+        # GET /not_escalation_policies
         type(get_mock.return_value).status_code = PropertyMock(side_effect=[400, 400])
         json_check_bad = {'escalation_policies': [{'id': 'bad_policy_id'}]}
         json_check_bad_default = {'escalation_policies': [{'id': 'good_policy_id'}]}
@@ -268,7 +270,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_policy_verify_fail_no_default(self, get_mock):
         """PagerDutyIncidentOutput - Policy Verify Fail (No Default)"""
-        # /not_escalation_policies
+        # GET /not_escalation_policies
         get_mock.return_value.status_code = 200
         json_check = {'not_escalation_policies': [{'not_id': 'verified_policy_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -278,7 +280,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_service_verify_success(self, get_mock):
         """PagerDutyIncidentOutput - Service Verify Success"""
-        # /services
+        # GET /services
         get_mock.return_value.status_code = 200
         json_check = {'services': [{'id': 'verified_service_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -299,7 +301,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_item_verify_success(self, get_mock):
         """PagerDutyIncidentOutput - Item Verify Success"""
-        # /items
+        # GET /items
         get_mock.return_value.status_code = 200
         json_check = {'items': [{'id': 'verified_item_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -312,7 +314,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_item_verify_no_get_id_success(self, get_mock):
         """PagerDutyIncidentOutput - Item Verify No Get Id Success"""
-        # /items
+        # GET /items
         get_mock.return_value.status_code = 200
         json_check = {'items': [{'id': 'verified_item_id'}]}
         get_mock.return_value.json.return_value = json_check
@@ -323,7 +325,7 @@ class TestPagerDutyIncidentOutput(object):
     def test_priority_verify_success(self, get_mock):
         """PagerDutyIncidentOutput - Priority Verify Success"""
         priority_name = 'priority_name'
-        # /priorities
+        # GET /priorities
         get_mock.return_value.status_code = 200
         json_check = {'priorities': [{'id': 'verified_priority_id', 'name': priority_name}]}
         get_mock.return_value.json.return_value = json_check
@@ -337,7 +339,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_priority_verify_fail(self, get_mock):
         """PagerDutyIncidentOutput - Priority Verify Fail"""
-        # /priorities
+        # GET /priorities
         get_mock.return_value.status_code = 404
 
         context = {'incident_priority': 'priority_name'}
@@ -348,7 +350,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_priority_verify_empty(self, get_mock):
         """PagerDutyIncidentOutput - Priority Verify Empty"""
-        # /priorities
+        # GET /priorities
         get_mock.return_value.status_code = 200
         json_check = {}
         get_mock.return_value.json.return_value = json_check
@@ -361,7 +363,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_priority_verify_not_found(self, get_mock):
         """PagerDutyIncidentOutput - Priority Verify Not Found"""
-        # /priorities
+        # GET /priorities
         get_mock.return_value.status_code = 200
         json_check = {'priorities': [{'id': 'verified_priority_id', 'name': 'not_priority_name'}]}
         get_mock.return_value.json.return_value = json_check
@@ -374,7 +376,7 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_priority_verify_invalid(self, get_mock):
         """PagerDutyIncidentOutput - Priority Verify Invalid"""
-        # /priorities
+        # GET /priorities
         get_mock.return_value.status_code = 200
         json_check = {'not_priorities': [{'id': 'verified_priority_id', 'name': 'priority_name'}]}
         get_mock.return_value.json.return_value = json_check
@@ -440,18 +442,30 @@ class TestPagerDutyIncidentOutput(object):
         assert_false(item_verified)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_good_user(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_good_user(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success, Good User"""
-        # /users, /users, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        # GET /users, /users, /services
         json_user = {'users': [{'id': 'valid_user_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, json_user, json_service]
 
-        # /incidents
+        # GET /incidents
+        json_lookup = {'incidents': [{'id': 'incident_id'}]}
+
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.side_effect = [json_user, json_user,
+                                                  json_service, json_lookup]
+
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         ctx = {'pagerduty-incident': {'assigned_user': 'valid_user'}}
 
@@ -462,19 +476,31 @@ class TestPagerDutyIncidentOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_good_policy(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_good_policy(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success, Good Policy"""
-         # /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+         # GET /users, /escalation_policies, /services
         json_user = {'users': [{'id': 'user_id'}]}
         json_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
 
-        # /incidents
+        # GET /incidents
+        json_lookup = {'incidents': [{'id': 'incident_id'}]}
+
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.side_effect = [json_user, json_policy,
+                                                  json_service, json_lookup]
+
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         ctx = {'pagerduty-incident': {'assigned_policy': 'valid_policy'}}
 
@@ -485,21 +511,31 @@ class TestPagerDutyIncidentOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_with_priority(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_with_priority(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success With Priority"""
-         # /priorities, /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200, 200])
+         # GET /priorities, /users, /escalation_policies, /services
         json_user = {'users': [{'id': 'user_id'}]}
         json_priority = {'priorities': [{'id': 'priority_id', 'name': 'priority_name'}]}
         json_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, json_priority,
-                                                  json_policy, json_service]
 
-        # /incidents
+        # GET /incidents
+        json_lookup = {'incidents': [{'id': 'incident_id'}]}
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.side_effect = [json_user, json_priority,
+                                                  json_policy, json_service, json_lookup]
+
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         ctx = {
             'pagerduty-incident': {
@@ -515,21 +551,32 @@ class TestPagerDutyIncidentOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_bad_user(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_bad_user(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success, Bad User"""
-        # /users, /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200, 200])
+        # GET /users, /users, /escalation_policies, /services
         json_user = {'users': [{'id': 'user_id'}]}
         json_not_user = {'not_users': [{'id': 'user_id'}]}
         json_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, json_not_user,
-                                                  json_policy, json_service]
 
-        # /incidents
+        # GET /incidents
+        json_lookup = {'incidents': [{'id': 'incident_id'}]}
+
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.side_effect = [json_user, json_not_user, json_policy,
+                                                  json_service, json_lookup]
+
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         ctx = {'pagerduty-incident': {'assigned_user': 'invalid_user'}}
 
@@ -540,19 +587,31 @@ class TestPagerDutyIncidentOutput(object):
         log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_no_context(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_no_context(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success, No Context"""
-        # /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        # GET /users, /escalation_policies, /services
         json_user = {'users': [{'id': 'user_id'}]}
         json_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, json_policy, json_service]
 
-        # /incidents
+        # GET /incidents
+        json_lookup = {'incidents': [{'id': 'incident_id'}]}
+
+        get_mock.return_value.status_code = 200
+        get_mock.return_value.json.side_effect = [json_user, json_policy,
+                                                  json_service, json_lookup]
+
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         assert_true(self._dispatcher.dispatch(descriptor=self.DESCRIPTOR,
                                               rule_name='rule_name',
@@ -565,12 +624,14 @@ class TestPagerDutyIncidentOutput(object):
     @patch('requests.get')
     def test_dispatch_failure_bad_everything(self, get_mock, post_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Failure: No User, Bad Policy, Bad Service"""
-        # /users, /users, /escalation_policies, /services
+        # GET /users, /users, /escalation_policies, /services
         type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 400, 400, 400])
-        json_user = {'users': [{'id': 'user_id'}]}
-        get_mock.return_value.json.side_effect = [json_user, dict(), dict(), dict()]
 
-        # /incidents
+        # Only set the return_value here since there will only be one successful call
+        # that makes it to the point of calling the .json() method
+        get_mock.return_value.json.return_value = {'users': [{'id': 'user_id'}]}
+
+        # POST /incidents
         post_mock.return_value.status_code = 400
 
         assert_false(self._dispatcher.dispatch(descriptor=self.DESCRIPTOR,
@@ -580,21 +641,29 @@ class TestPagerDutyIncidentOutput(object):
         log_mock.assert_called_with('Failed to send alert to %s', self.SERVICE)
 
     @patch('logging.Logger.info')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.get')
-    def test_dispatch_success_bad_policy(self, get_mock, post_mock, log_mock):
+    def test_dispatch_success_bad_policy(self, get_mock, post_mock, put_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Success, Bad Policy"""
-        # /users, /escalation_policies, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 400, 200, 200])
+        # GET /users, /escalation_policies, /escalation_policies, /services
+        get_mock.return_value.status_code = 200
         json_user = {'users': [{'id': 'user_id'}]}
-        json_bad_policy = dict()
+        json_bad_policy = {'not_escalation_policies': [{'id': 'other_policy_id'}]}
         json_good_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}
+        json_lookup = {'incidents': [{'id': 'existing_incident_id'}]}
         get_mock.return_value.json.side_effect = [json_user, json_bad_policy,
-                                                  json_good_policy, json_service]
+                                                  json_good_policy, json_service, json_lookup]
 
-        # /incidents
+        # POST /incidents, /v2/enqueue
         post_mock.return_value.status_code = 200
+        json_incident = {'incident': {'id': 'incident_id'}}
+        json_event = {'dedup_key': 'returned_dedup_key'}
+        post_mock.return_value.json.side_effect = [json_incident, json_event]
+
+        # PUT /incidents/indicent_id
+        put_mock.return_value.status_code = 200
 
         ctx = {'pagerduty-incident': {'assigned_policy': 'valid_policy'}}
 
@@ -610,7 +679,7 @@ class TestPagerDutyIncidentOutput(object):
     def test_dispatch_bad_dispatch(self, get_mock, post_mock, log_mock):
         """PagerDutyIncidentOutput - Dispatch Failure, Bad Request"""
         # /users, /escalation_policies, /services
-        type(get_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
+        get_mock.return_value.status_code = 200
         json_user = {'users': [{'id': 'user_id'}]}
         json_policy = {'escalation_policies': [{'id': 'policy_id'}]}
         json_service = {'services': [{'id': 'service_id'}]}


### PR DESCRIPTION
to: @ryandeivert @mime-frame 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

PagerDuty REST API v2 allows to create incidents and assign them to a specific user from the PagerDuty account. That allows alerts to be able to be assigned when they are created. The problem is that the API does not allow to have any JSON object data, like the PagerDuty Events API v2. With this code, we are able to utilize the incident creation capabilities and also have a rich content by merging alerts/events created with the Events API v2.

## Changes

* Added PUT requests support to the output base class.
* Added capability to create events and merge them with the created incidents.
* Modified unit tests to test new capabilities.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 518 tests in 11.193s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
