### PR TITLE
athena: added recursive schema support

### DIFF
--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -175,9 +175,9 @@ def _convert_to_athena_schema(log_schema):
 
     for key_name, key_type in log_schema.iteritems():
         key_name = '`{}`'.format(key_name)
-        if key_type = {}:
+        if key_type == {}:
             athena_schema[key_name] = SCHEMA_TYPE_MAPPING[dict]
-        elif key_type = []:
+        elif key_type == []:
             athena_schema[key_name] = SCHEMA_TYPE_MAPPING[list]
         elif isinstance(key_type, dict):
             athena_schema[key_name] = _convert_to_athena_schema(key_type)
@@ -275,8 +275,8 @@ def create_table(athena_client, options, config):
             if envelope_keys:
                 sanitized_envelope_key_schema = StreamAlertFirehose.sanitize_keys(envelope_keys)
                 # Note: this key is wrapped in backticks to be Hive compliant
-                athena_schema['`streamalert:envelope_keys`'] =
-                    _convert_to_athena_schema(sanitized_envelope_key_schema)
+                athena_schema['`streamalert:envelope_keys`'] = _convert_to_athena_schema(
+                    sanitized_envelope_key_schema)
 
         # Handle Schema overrides
         #   This is useful when an Athena schema needs to differ from the normal log schema

--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -170,45 +170,21 @@ def drop_all_tables(athena_client):
             LOGGER_CLI.info('Dropped %s', table)
 
 
-def _add_to_athena_schema(log_schema, athena_schema, root_key=''):
-    """Add sanitized schemas to the Athena table schema
-
-    Args:
-        log_schema (dict): The related StreamAlert log schema
-        athena_schema (dict): The Athena table schema to add to
-        root_key (str): The hierarchy where the schema should be added
-    """
-    # Setup the root_key dict
-    if root_key and not athena_schema.get(root_key):
-        athena_schema[root_key] = {}
+def _convert_to_athena_schema(log_schema):
+    athena_schema = {}
 
     for key_name, key_type in log_schema.iteritems():
-        # When using special characters in the beginning or end
-        # of a column name, they have to be wrapped in backticks
         key_name = '`{}`'.format(key_name)
-
-        special_key = None
-        # Transform the {} or [] into hashable types
-        if key_type == {}:
-            special_key = dict
-        elif key_type == []:
-            special_key = list
-        # Cast nested dict as a string for now
-        # TODO(jacknagz): support recursive schemas
+        if key_type = {}:
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[dict]
+        elif key_type = []:
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[list]
         elif isinstance(key_type, dict):
-            special_key = 'string'
-
-        # Account for envelope keys
-        if root_key:
-            if special_key is not None:
-                athena_schema[root_key][key_name] = SCHEMA_TYPE_MAPPING[special_key]
-            else:
-                athena_schema[root_key][key_name] = SCHEMA_TYPE_MAPPING[key_type]
+            athena_schema[key_name] = _convert_to_athena_schema(key_type)
         else:
-            if special_key is not None:
-                athena_schema[key_name] = SCHEMA_TYPE_MAPPING[special_key]
-            else:
-                athena_schema[key_name] = SCHEMA_TYPE_MAPPING[key_type]
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[key_type]
+
+    return athena_schema
 
 
 def _construct_create_table_statement(schema, table_name, bucket):
@@ -290,8 +266,7 @@ def create_table(athena_client, options, config):
         schema = dict(log_info['schema'])
         sanitized_schema = StreamAlertFirehose.sanitize_keys(schema)
 
-        athena_schema = {}
-        _add_to_athena_schema(sanitized_schema, athena_schema)
+        athena_schema = _convert_to_athena_schema(sanitized_schema)
 
         # Add envelope keys to Athena Schema
         configuration_options = log_info.get('configuration')
@@ -300,8 +275,8 @@ def create_table(athena_client, options, config):
             if envelope_keys:
                 sanitized_envelope_key_schema = StreamAlertFirehose.sanitize_keys(envelope_keys)
                 # Note: this key is wrapped in backticks to be Hive compliant
-                _add_to_athena_schema(sanitized_envelope_key_schema, athena_schema,
-                                      '`streamalert:envelope_keys`')
+                athena_schema['`streamalert:envelope_keys`'] =
+                    _convert_to_athena_schema(sanitized_envelope_key_schema)
 
         # Handle Schema overrides
         #   This is useful when an Athena schema needs to differ from the normal log schema

--- a/stream_alert_cli/athena/helpers.py
+++ b/stream_alert_cli/athena/helpers.py
@@ -40,10 +40,13 @@ def to_athena_schema(log_schema):
     for key_name, key_type in log_schema.iteritems():
         key_name = '`{}`'.format(key_name)
         if key_type == {}:
+            # For empty dicts
             athena_schema[key_name] = SCHEMA_TYPE_MAPPING[dict]
         elif key_type == []:
+            # For empty array
             athena_schema[key_name] = SCHEMA_TYPE_MAPPING[list]
         elif isinstance(key_type, dict):
+            # For recursion
             athena_schema[key_name] = to_athena_schema(key_type)
         else:
             athena_schema[key_name] = SCHEMA_TYPE_MAPPING[key_type]

--- a/stream_alert_cli/athena/helpers.py
+++ b/stream_alert_cli/athena/helpers.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# How to map log schema types to Athena/Hive types
+SCHEMA_TYPE_MAPPING = {
+    'string': 'string',
+    'integer': 'bigint',
+    'boolean': 'boolean',
+    'float': 'decimal(10,3)',
+    dict: 'map<string, string>',
+    list: 'array<string>'
+}
+
+def to_athena_schema(log_schema):
+    """Convert streamalert log schema to athena schema"""
+
+    athena_schema = {}
+
+    for key_name, key_type in log_schema.iteritems():
+        key_name = '`{}`'.format(key_name)
+        if key_type == {}:
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[dict]
+        elif key_type == []:
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[list]
+        elif isinstance(key_type, dict):
+            athena_schema[key_name] = to_athena_schema(key_type)
+        else:
+            athena_schema[key_name] = SCHEMA_TYPE_MAPPING[key_type]
+
+    return athena_schema

--- a/stream_alert_cli/athena/helpers.py
+++ b/stream_alert_cli/athena/helpers.py
@@ -24,8 +24,16 @@ SCHEMA_TYPE_MAPPING = {
     list: 'array<string>'
 }
 
+
 def to_athena_schema(log_schema):
-    """Convert streamalert log schema to athena schema"""
+    """Convert streamalert log schema to athena schema
+
+    Args:
+        log_schema (dict): StreamAlert log schema object.
+
+    Returns:
+        athena_schema (dict): Equivalent Athena schema used for generating create table statement
+    """
 
     athena_schema = {}
 

--- a/tests/unit/stream_alert_cli/athena/test_handler.py
+++ b/tests/unit/stream_alert_cli/athena/test_handler.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from nose.tools import assert_equal
+
+from stream_alert_cli.config import CLIConfig
+
+from stream_alert_cli.athena import handler
+
+CONFIG = CLIConfig(config_path='tests/unit/conf')
+
+
+def test_generate_athena_schema_simple():
+    """CLI - Generate Athena schema: simple"""
+
+    log_schema = CONFIG['logs']['unit_test_simple_log']['schema']
+    athena_schema = handler._convert_to_athena_schema(log_schema)
+
+    expected_athena_schema = {
+        '`unit_key_01`': 'bigint',
+        '`unit_key_02`': 'string'
+    }
+
+    assert_equal(athena_schema, expected_athena_schema)
+
+
+def test_generate_athena_schema_special_key():
+    """CLI - Generate Athena schema: special key"""
+
+    log_schema = CONFIG['logs']['test_log_type_json']['schema']
+    athena_schema = handler._convert_to_athena_schema(log_schema)
+
+    expected_athena_schema = {
+        '`key1`': 'array<string>',
+        '`key2`': 'string',
+        '`key3`': 'bigint',
+        '`key9`': 'boolean',
+        '`key10`': 'map<string, string>',
+        '`key11`': 'decimal(10,3)'
+    }
+
+    assert_equal(athena_schema, expected_athena_schema)
+
+
+def test_generate_athena_schema_nested():
+    """CLI - Generate Athena schema: nested"""
+
+    log_schema = CONFIG['logs']['test_log_type_json_nested_with_data']['schema']
+    athena_schema = handler._convert_to_athena_schema(log_schema)
+
+    expected_athena_schema = {
+        '`date`': 'string',
+        '`unixtime`': 'bigint',
+        '`host`': 'string',
+        '`application`': 'string',
+        '`environment`': 'string',
+        '`data`': {
+            '`category`': 'string',
+            '`type`': 'bigint',
+            '`source`': 'string'
+        }
+    }
+
+    assert_equal(athena_schema, expected_athena_schema)

--- a/tests/unit/stream_alert_cli/athena/test_handler.py
+++ b/tests/unit/stream_alert_cli/athena/test_handler.py
@@ -17,7 +17,7 @@ from nose.tools import assert_equal
 
 from stream_alert_cli.config import CLIConfig
 
-from stream_alert_cli.athena import handler
+from stream_alert_cli.athena import helpers
 
 CONFIG = CLIConfig(config_path='tests/unit/conf')
 
@@ -26,7 +26,7 @@ def test_generate_athena_schema_simple():
     """CLI - Generate Athena schema: simple"""
 
     log_schema = CONFIG['logs']['unit_test_simple_log']['schema']
-    athena_schema = handler._convert_to_athena_schema(log_schema)
+    athena_schema = helpers.to_athena_schema(log_schema)
 
     expected_athena_schema = {
         '`unit_key_01`': 'bigint',
@@ -40,7 +40,7 @@ def test_generate_athena_schema_special_key():
     """CLI - Generate Athena schema: special key"""
 
     log_schema = CONFIG['logs']['test_log_type_json']['schema']
-    athena_schema = handler._convert_to_athena_schema(log_schema)
+    athena_schema = helpers.to_athena_schema(log_schema)
 
     expected_athena_schema = {
         '`key1`': 'array<string>',
@@ -58,7 +58,7 @@ def test_generate_athena_schema_nested():
     """CLI - Generate Athena schema: nested"""
 
     log_schema = CONFIG['logs']['test_log_type_json_nested_with_data']['schema']
-    athena_schema = handler._convert_to_athena_schema(log_schema)
+    athena_schema = helpers.to_athena_schema(log_schema)
 
     expected_athena_schema = {
         '`date`': 'string',


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: medium
resolves #<related-issue-goes-here>

## Background

Nested log schema is not supported when creating tables in Athena.

## Changes

* Added recursive support when converting log schema to Athena schema.

## Testing

```
15:00 $ ./tests/scripts/pylint.sh
Starting pylint script

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
15:01 $ ./tests/scripts/unit_tests.sh
...
CLI - Generate Athena schema: simple ... ok (0.0003s)
CLI - Generate Athena schema: special key ... ok (0.0003s)
CLI - Generate Athena schema: nested ... ok (0.0002s)
...
Ran 521 tests in 66.392s

OK
```
