### PR TITLE
[output] Fixes for mocks to test some outputs

### DIFF
--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -612,12 +612,12 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             return self._log_status(False)
 
         # Extract the json blob from the response, returned by self._post_request_retry
-        incident_data = incident.json()
-        if not incident_data:
+        incident_json = incident.json()
+        if not incident_json:
             return self._log_status(False)
 
         # Extract the incident id from the incident that was just created
-        incident_id = incident_data.get('incident', {}).get('id')
+        incident_id = incident_json.get('incident', {}).get('id')
 
         # Create alert to hold all the incident details
         event_data = events_v2_data(creds['integration_key'], **kwargs)


### PR DESCRIPTION
to: @ryandeivert @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Some changes were merged [here](https://github.com/airbnb/streamalert/pull/567) to the `pagerduty-incident` output which after testing with a wide set of rules, it needed some fixes to mock properly some added functionality.

## Changes

* Changes to `test.py` in order to mock properly the added code to `pagerduty-incident` output.
* Added the `integration_key` to the mocked credentials for `pagerduty-incident` output.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 521 tests in 14.749s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```