### PR TITLE
[logs] update cb_watchlist_hit_binarys schema with opt keys.

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -779,7 +779,8 @@
       "product_version": "string",
       "server_added_timestamp": "string",
       "signed": "string",
-      "timestamp": "string"
+      "timestamp": "string",
+      "watchlists": []
     },
     "parser": "json",
     "configuration": {
@@ -823,7 +824,8 @@
         "digsig_issuer",
         "digsig_prog_name",
         "digsig_subject",
-        "legal_copyright"
+        "legal_copyright",
+        "watchlists"
       ]
     }
   },


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
Add new optional key `watchlists` to cb_watchlist_hit_binarys schema.

## Changes

* Add optional key watchlists to conf/logs.json

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 526 tests in 11.048s

OK
```
