### PR TITLE
[tests] sped up some threat intel tests with nested function wrapping

### DIFF
--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -62,7 +62,7 @@ class TestStreamIoc(object):
         ioc.is_ioc = False
         assert_false(ioc.is_ioc)
 
-@patch.object(StreamThreatIntel, 'BACKOFF_MAX_RETRIES', 0)
+@patch.object(StreamThreatIntel, 'BACKOFF_MAX_RETRIES', 1)
 class TestStreamThreatIntel(object):
     """Test class for StreamThreatIntel"""
     @classmethod


### PR DESCRIPTION
to: @chunyong-lin @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

* Some unit tests for functions that use backoff are not able to properly mock the backoff attempts, resulting in sluggish unit tests.

## Changes

* Nesting a function that is currently an instance method so the decorator can properly have it's `max_tries` argument altered for tests.

## Testing

* Adjusted unit tests, now sped up by a few seconds.
