### PR TITLE
[test] Ignore B108 hardcorded_tmp_directory check in Bandit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,13 @@ exclude: venv,tests
 
 # Skip the following tests:
 #
+# - [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
+#   Severity: Medium   Confidence: Medium
+#       In Lambda, /tmp is explicitly where local files must be stored
 # - [B404:blacklist] Consider possible security implications associated with subprocess module.
 #   Severity: Low   Confidence: High
 #       There are other warnings specific to subprocess calls (e.g. B603, B607)
-skips: B404
+skips: B108,B404
 
 [yapf]
 COLUMN_LIMIT=100


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background

Ignore B108 hardcorded_tmp_directory check in Bandit. In Lambda, /tmp is explicitly where local files must be stored.

## Changes

* Update `setup.cfg` to ignore B108 security checking in Bandit.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
Ran 529 tests in 8.046s

OK
