### PR TITLE
[logs] change repo_id to string in ghe schema

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1172,7 +1172,7 @@
       "org": "string",
       "org_id": {},
       "repo": "string",
-      "repo_id": "integer",
+      "repo_id": "string",
       "user": "string",
       "user_id": "string"
     },


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
We noticed the value of `repo_id` can be empty in log coming from GHE when the event is to deletion a repository. Change type of `repo_id` to string, so that the rule classifier will handle empty value properly.

## Changes

* Change type of `repo_id` to string in GHE schema.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 529 tests in 8.475s

OK
```
