### PR TITLE
[Athena] Add debug message for issue 590

### DIFF
--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -492,6 +492,10 @@ class StreamAlertSQSClient(object):
             # Pop processed records from the list to be deleted
             message_batch = [self.processed_messages.pop() for _ in range(batch)]
 
+            # This debug info should be removed when Issue #590 is fixed.
+            # https://github.com/airbnb/streamalert/issues/590
+            LOGGER.debug('The messages to be deleted: \n%s', message_batch)
+
             # Try to delete the batch
             resp = self.sqs_client.delete_message_batch(
                 QueueUrl=self.athena_sqs_url,
@@ -504,7 +508,8 @@ class StreamAlertSQSClient(object):
                 self.deleted_messages += len(resp['Successful'])
             # Handle failure deletion
             if resp.get('Failed'):
-                LOGGER.error('Failed to delete the following (%d) messages:\n%s',
+                LOGGER.error(('Failed to delete the messages with following (%d) '
+                              'error messages:\n%s'),
                              len(resp['Failed']), json.dumps(resp['Failed']))
                 # Add the failed messages back to the processed_messages attribute
                 # to be retried via backoff


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
Issue #590 is caused by unexpected messages format from SQS queue which are supposed to be in the format of `[dict(), dict(), ...]`. However, Athena received unexpected messages in the format of `[list(), list(), ...]` which results `TypeError: list indices must be integers, not str`. 

In order to fix the issue completely, I would like to get the unexpected messages so that we can add reasonable unit test to reproduce the issue.

## Changes

* Add a new debug message to log `message_batch` which are the message to be deleted.
* Update error message to reflect failed response messages. 

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 529 tests in 8.139s

OK
```
