### PR TITLE
[output] Adding support to add notes to incidents

### DIFF
--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -536,6 +536,35 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         # Verify escalation policy, return tuple
         return 'escalation_policy', self._policy_verify(policy_to_assign, self._escalation_policy)
 
+    def _add_incident_note(self, incident_id, note):
+        """Method to add a text note to the provided incident id
+
+        Args:
+            incident_id (str): ID of the incident to add the note to
+
+        Returns:
+            str: ID of the note after being added to the incident or False if it fails
+        """
+        notes_path = '{}/{}/notes'.format(self.INCIDENTS_ENDPOINT, incident_id)
+        incident_notes_url = self._get_endpoint(self._base_url, notes_path)
+        data = {
+            'note': {
+                'content': note
+            }
+        }
+        try:
+            resp = self._post_request_retry(incident_notes_url, data, self._headers, True)
+        except OutputRequestFailure:
+            return False
+
+        response = resp.json()
+        if not response:
+            return False
+
+        note_rec = response.get('note', {})
+
+        return note_rec.get('id', False)
+
     def dispatch(self, **kwargs):
         """Send incident to Pagerduty Incidents API v2
         Keyword Args:

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -429,6 +429,50 @@ class TestPagerDutyIncidentOutput(object):
         assert_equal(assigned_value['id'], 'verified_policy_id')
         assert_equal(assigned_value['type'], 'escalation_policy_reference')
 
+    @patch('requests.post')
+    def test_add_note_incident_success(self, post_mock):
+        """PagerDutyIncidentOutput - Add Note to Incident Success"""
+        post_mock.return_value.status_code = 200
+        json_note = {'note': {'id': 'created_note_id'}}
+        post_mock.return_value.json.return_value = json_note
+
+        note_id = self._dispatcher._add_incident_note('incident_id', 'this is the note')
+
+        assert_equal(note_id, 'created_note_id')
+
+    @patch('requests.post')
+    def test_add_note_incident_fail(self, post_mock):
+        """PagerDutyIncidentOutput - Add Note to Incident Fail"""
+        post_mock.return_value.status_code = 200
+        json_note = {'note': {'not_id': 'created_note_id'}}
+        post_mock.return_value.json.return_value = json_note
+
+        note_id = self._dispatcher._add_incident_note('incident_id', 'this is the note')
+
+        assert_false(note_id)
+
+    @patch('requests.post')
+    def test_add_note_incident_bad_request(self, post_mock):
+        """PagerDutyIncidentOutput - Add Note to Incident Bad Request"""
+        post_mock.return_value.status_code = 400
+        json_note = {'note': {'id': 'created_note_id'}}
+        post_mock.return_value.json.return_value = json_note
+
+        note_id = self._dispatcher._add_incident_note('incident_id', 'this is the note')
+
+        assert_false(note_id)
+
+    @patch('requests.post')
+    def test_add_note_incident_no_response(self, post_mock):
+        """PagerDutyIncidentOutput - Add Note to Incident No Response"""
+        post_mock.return_value.status_code = 200
+        json_note = {}
+        post_mock.return_value.json.return_value = json_note
+
+        note_id = self._dispatcher._add_incident_note('incident_id', 'this is the note')
+
+        assert_false(note_id)
+
     @patch('requests.get')
     def test_item_verify_fail(self, get_mock):
         """PagerDutyIncidentOutput - Item Verify Fail"""


### PR DESCRIPTION
to: @ryandeivert or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

When creating incidents it may be helpful to add a note with a bit of context of what has happened or an action taken. This adds support for creating a note to a given incident.

This is just adding the functionality and the unit tests, there will be an upcoming PR to add this to the `pagerduty-incidents` output.

## Changes

* Added ability to create a text note given an incident id.
* Added unit tests for the code.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 533 tests in 9.331s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
