### PR TITLE
[rule processor] explicitly close firehose connection

### DIFF
--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -286,3 +286,7 @@ class StreamAlertFirehose(object):
                 self._limit_record_size(record_batch)
                 for sized_batch in self._segment_records_by_size(record_batch):
                     self._firehose_request_helper(stream_name, sized_batch)
+
+        # explicitly close firehose client to resolve connection reset issue, suggested
+        # by AWS support team.
+        self._firehose_client._endpoint.http_session.close() #pylint: disable=protected-access


### PR DESCRIPTION
to: @jacknagz or @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves #478

## Background
AWS support suggests to explicitly close firehose connection to solve connection reset issue we encountered 1-2 times a day, approximately. The one line change is verified in internal environment and it does fix the issue.

## Changes

* Add one line to explicitly close firehose connection.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 529 tests in 7.423s

OK
```
