### PR TITLE
[athena] fix TypeError while delete messages from SQS

### DIFF
--- a/tests/unit/helpers/aws_mocks.py
+++ b/tests/unit/helpers/aws_mocks.py
@@ -106,3 +106,22 @@ class MockAthenaClient(object):
     def get_query_results(self, **kwargs):  # pylint: disable=unused-argument
         """Get the results of a executed query"""
         return {'ResultSet': {'Rows': [{'Data': self.results}] if self.results else []}}
+
+
+class MockSqsClient(object):
+    """Mock SQS client"""
+
+    def __init__(self, **kwargs):
+        self.region = kwargs.get('region')
+        self.failed = kwargs.get('failed')
+
+    def delete_message_batch(self, **kwargs): # pylint: disable=unused-argument
+        """Mock error handling in SQS delete_message_batch method"""
+        if self.failed:
+            return {'Failed': [{'Id': '1'}]}
+
+        return {'Successful': [{'foo': 'bar'}]}
+
+    def list_queues(self, **kwargs): # pylint: disable=unused-argument,no-self-use
+        """Mock list_queues method"""
+        return {'QueueUrls': ['url_foo', 'url_bar']}


### PR DESCRIPTION
to: @jacknagz or @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves #590 

## Background
We noticed there is Athena error due to `TypeError` while deleting messages from SQS. The root cause of `TypeError` is because of complicated list comprehension logic when first deletion failed. The list comprehension added extra list around pushed back messages. 

## Changes

* Break down complicated list comprehension to simpler ones.
* Add mock class for SQS client and add unit test case to reproduce error.
* Add a `max_retries` in backoff logic to make the code testable. 

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (60/60) Successful Tests
StreamAlertCLI [INFO]: (93/93) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 530 tests in 8.466s

OK
