### PR TITLE
Improve error message when a matcher fails to execute

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -157,7 +157,7 @@ class StreamRules(object):
                     matcher_result = matcher_function(record)
                 except Exception as err:  # pylint: disable=broad-except
                     matcher_result = False
-                    LOGGER.error('%s: %s', matcher_function.__name__, err.message)
+                    LOGGER.error('Matcher \'%s\' failed with error: %s', matcher_function.__name__, err.message)
                 if not matcher_result:
                     return False
             else:

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -157,7 +157,8 @@ class StreamRules(object):
                     matcher_result = matcher_function(record)
                 except Exception as err:  # pylint: disable=broad-except
                     matcher_result = False
-                    LOGGER.error('Matcher \'%s\' failed with error: %s', matcher_function.__name__, err.message)
+                    LOGGER.error('Matcher \'%s\' failed with error: %s',
+                                 matcher_function.__name__, err.message)
                 if not matcher_result:
                     return False
             else:


### PR DESCRIPTION
Improve the error message output to the user when a matcher fails to execute in
the rule_processor.

to: @airbnb/streamalert-maintainers
size: small

## Changes

* Improve the error message output when a matcher fails to execute in the rule processor lambda execution. 