### PR TITLE
[output] Add Github output

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -13,6 +13,8 @@ Out of the box, StreamAlert supports:
 * **PagerDuty**
 * **Phantom**
 * **Slack**
+* **Jira**
+* **Github**
 
 StreamAlert can be extended to support any API. Creating a new output to send alerts to is easily accomplished through inheritance from the ``StreamOutputBase`` class. More on that in the `Adding Support for New Services`_ section below.
 

--- a/manage.py
+++ b/manage.py
@@ -109,7 +109,7 @@ Examples:
         '--service',
         choices=[
             'aws-firehose', 'aws-lambda', 'aws-s3', 'jira', 'pagerduty', 'pagerduty-v2',
-            'pagerduty-incident', 'phantom', 'slack'
+            'pagerduty-incident', 'phantom', 'slack', 'github'
         ],
         required=True,
         help=ARGPARSE_SUPPRESS)

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -1,0 +1,105 @@
+"""
+Copyright 2018-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from collections import OrderedDict
+import base64
+import json
+
+from stream_alert.alert_processor import LOGGER
+from stream_alert.alert_processor.outputs.output_base import (
+    OutputDispatcher,
+    OutputProperty,
+    OutputRequestFailure,
+    StreamAlertOutput
+)
+
+
+@StreamAlertOutput
+class GithubOutput(OutputDispatcher):
+    """GithubOutput handles all alert dispatching for Github"""
+    __service__ = 'github'
+
+    @classmethod
+    def get_user_defined_properties(cls):
+        """Get properties that must be assigned by the user when configuring a new Github output."""
+        return OrderedDict([
+            ('descriptor',
+             OutputProperty(description='a short and unique descriptor for this'
+                                        ' Github integration')),
+            ('repository',
+             OutputProperty(description='the repository for this integration '
+                                        'in the form :username/:repository',
+                            cred_requirement=True,
+                            mask_input=False)),
+            ('labels',
+             OutputProperty(description='a comma separated list of labels to '
+                                        'apply to issues when they are created',
+                            cred_requirement=True,
+                            mask_input=False)),
+            ('username',
+             OutputProperty(description='the username for this integration',
+                            cred_requirement=True,
+                            mask_input=False)),
+            ('access_token',
+             OutputProperty(description='the access token for the integration',
+                            cred_requirement=True,
+                            mask_input=True))
+        ])
+
+    @classmethod
+    def _get_default_properties(cls):
+        """Get the standard url used for Github API. This value the same for
+        everyone, so is hard-coded here and does not need to be configured by
+        the user
+
+        Returns:
+            dict: Contains various default items for this output (ie: url)
+        """
+        return {'api': 'https://api.github.com'}
+
+    def dispatch(self, **kwargs):
+        """Send alert to Github
+
+        Args:
+            **kwargs: consists of any combination of the following items:
+                descriptor (str): Service descriptor (ie: slack channel, pd integration)
+                rule_name (str): Name of the triggered rule
+                alert (dict): Alert relevant to the triggered rule
+        """
+        credentials = self._load_creds(kwargs['descriptor'])
+        if not credentials:
+            return self._log_status(False)
+
+        username_password = "{}:{}".format(credentials['username'],
+                                           credentials['access_token'])
+        encoded_credentials = base64.b64encode(username_password)
+        headers = {'Authorization': "Basic {}".format(encoded_credentials)}
+        url = '{}/repos/{}/issues'.format(credentials['api'],
+                                          credentials['repository'])
+
+        title = "StreamAlert: {}".format(kwargs['rule_name'])
+        body_template = "### Description\n{}\n\n### Event data\n\n```\n{}\n```"
+        body = body_template.format(kwargs['alert']['rule_description'],
+                                    json.dumps(kwargs['alert']['record'], indent=2))
+        issue = {'title': title, 'body': body, 'labels': credentials['labels'].split(',')}
+
+        LOGGER.debug('sending alert to Github repository %s', credentials['repository'])
+
+        try:
+            success = self._post_request_retry(url, issue, headers)
+        except OutputRequestFailure:
+            success = False
+
+        return self._log_status(success)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
@@ -1,0 +1,105 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=protected-access,attribute-defined-outside-init,no-self-use
+import base64
+from mock import patch
+from moto import mock_s3, mock_kms
+from nose.tools import assert_false, assert_true, assert_equal, assert_is_not_none
+
+from stream_alert.alert_processor.outputs.github import GithubOutput
+from stream_alert_cli.helpers import put_mock_creds
+from tests.unit.stream_alert_alert_processor import CONFIG, FUNCTION_NAME, KMS_ALIAS, REGION
+from tests.unit.stream_alert_alert_processor.helpers import (
+    get_alert,
+    remove_temp_secrets
+)
+
+
+@mock_s3
+@mock_kms
+@patch('stream_alert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS', 1)
+class TestGithubOutput(object):
+    """Test class for GithubOutput"""
+    DESCRIPTOR = 'unit_test_repo'
+    SERVICE = 'github'
+    CREDS = {'username': 'unit_test_user', 'access_token':
+             'unit_test_access_token', 'repository': 'unit_test_org/unit_test_repo',
+             'labels': 'label1,label2'}
+
+    def setup(self):
+        """Setup before each method"""
+        self._dispatcher = GithubOutput(REGION, FUNCTION_NAME, CONFIG)
+        remove_temp_secrets()
+        output_name = self._dispatcher.output_cred_name(self.DESCRIPTOR)
+        put_mock_creds(output_name, self.CREDS, self._dispatcher.secrets_bucket, REGION, KMS_ALIAS)
+
+    @patch('logging.Logger.info')
+    @patch('requests.post')
+    def test_dispatch_success(self, url_mock, log_mock):
+        """GithubOutput - Dispatch Success"""
+        url_mock.return_value.status_code = 200
+        url_mock.return_value.json.return_value = dict()
+
+        assert_true(self._dispatcher.dispatch(descriptor=self.DESCRIPTOR,
+                                              rule_name='rule_name',
+                                              alert=get_alert()))
+
+        assert_equal(url_mock.call_args[0][0],
+                     'https://api.github.com/repos/unit_test_org/unit_test_repo/issues')
+        assert_is_not_none(url_mock.call_args[1]['headers']['Authorization'])
+
+        credentials = url_mock.call_args[1]['headers']['Authorization'].split(' ')[-1]
+        decoded_username_password = base64.b64decode(credentials)
+        assert_equal(decoded_username_password, '{}:{}'.format(self.CREDS['username'],
+                                                               self.CREDS['access_token']))
+
+        log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
+
+    @patch('logging.Logger.info')
+    @patch('requests.post')
+    def test_dispatch_success_with_labels(self, url_mock, log_mock):
+        """GithubOutput - Dispatch Success with Labels"""
+        url_mock.return_value.status_code = 200
+        url_mock.return_value.json.return_value = dict()
+
+        assert_true(self._dispatcher.dispatch(descriptor=self.DESCRIPTOR,
+                                              rule_name='rule_name',
+                                              alert=get_alert()))
+
+        assert_equal(url_mock.call_args[1]['json']['labels'], ['label1', 'label2'])
+        log_mock.assert_called_with('Successfully sent alert to %s', self.SERVICE)
+
+    @patch('logging.Logger.error')
+    @patch('requests.post')
+    def test_dispatch_failure(self, url_mock, log_mock):
+        """GithubOutput - Dispatch Failure, Bad Request"""
+        json_error = {'message': 'error message', 'errors': ['error1']}
+        url_mock.return_value.json.return_value = json_error
+        url_mock.return_value.status_code = 400
+
+        assert_false(self._dispatcher.dispatch(descriptor=self.DESCRIPTOR,
+                                               rule_name='rule_name',
+                                               alert=get_alert()))
+        log_mock.assert_called_with('Failed to send alert to %s', self.SERVICE)
+
+    @patch('logging.Logger.error')
+    def test_dispatch_bad_descriptor(self, log_mock):
+        """GithubOutput - Dispatch Failure, Bad Descriptor"""
+        assert_false(self._dispatcher.dispatch(descriptor='bad_descriptor',
+                                               rule_name='rule_name',
+                                               alert=get_alert()))
+
+        log_mock.assert_called_with('Failed to send alert to %s', self.SERVICE)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -89,6 +89,7 @@ def test_output_loading():
         'aws-firehose',
         'aws-lambda',
         'aws-s3',
+        'github',
         'jira',
         'pagerduty',
         'pagerduty-v2',


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: medium
resolves: https://github.com/airbnb/streamalert/issues/586

## Background

Background issue for context: https://github.com/airbnb/streamalert/issues/586

## Changes

* Add a new `github` output which will create Github issues in the specified repository when alerts are generated.

## Testing
```
(streamalert) patrickod@C02T70ALHF1T [12:29:52] [~/src/streamalert]  [patrickod/add-github-output]
-> %  ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 533 tests in 13.391s

OK
(streamalert) patrickod@C02T70ALHF1T [12:33:13] [~/src/streamalert]  [patrickod/add-github-output]
-> %  ./tests/scripts/pylint.sh
Starting pylint script

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

(streamalert) patrickod@C02T70ALHF1T [12:34:11] [~/src/streamalert]  [patrickod/add-github-output]
-> %
```