### PR TITLE
Speed up deploys with -auto-approve

### DIFF
--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -129,7 +129,7 @@ def tf_runner(action='apply', refresh=True, auto_approve=False, targets=None):
         LOGGER_CLI.info('Destroying infrastructure')
         tf_command.append('-force={}'.format(str(auto_approve).lower()))
     else:
-        LOGGER_CLI.info('{} changes'.format('Applying' if auto_approve else 'Planning'))
+        LOGGER_CLI.info('%s changes', 'Applying' if auto_approve else 'Planning')
         tf_command.append('-auto-approve={}'.format(str(auto_approve).lower()))
 
     if targets:

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -107,7 +107,7 @@ def tf_runner(action='apply', refresh=True, auto_approve=False, targets=None):
 
     Resolves modules with `terraform get` before continuing.
 
-    Kwargs:
+    Args:
         action (str): Terraform action ('apply' or 'destroy').
         refresh (bool): If True, Terraform will refresh its state before applying the change.
         auto_approve (bool): If True, Terraform will *not* prompt the user for approval.

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -22,7 +22,6 @@ import random
 import re
 from StringIO import StringIO
 import subprocess
-import sys
 import zipfile
 import zlib
 
@@ -39,6 +38,7 @@ from moto import (
 
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
+
 
 def run_command(runner_args, **kwargs):
     """Helper function to run commands with error handling.
@@ -102,62 +102,40 @@ def continue_prompt(message=''):
     return response == 'yes'
 
 
-def tf_runner(**kwargs):
+def tf_runner(action='apply', refresh=True, auto_approve=False, targets=None):
     """Terraform wrapper to build StreamAlert infrastructure.
 
-    Steps:
-        - resolve modules with `terraform get`
-        - run `terraform plan` for the given targets
-        - if plan is successful and user confirms prompt,
-          then the infrastructure is applied
+    Resolves modules with `terraform get` before continuing.
 
-    kwargs:
-        targets: a list of Terraform targets
-        action: 'apply' or 'destroy'
+    Kwargs:
+        action (str): Terraform action ('apply' or 'destroy').
+        refresh (bool): If True, Terraform will refresh its state before applying the change.
+        auto_approve (bool): If True, Terraform will *not* prompt the user for approval.
+        targets (list): Optional list of affected targets.
+            If not specified, Terraform will run against all of its resources.
 
     Returns:
         bool: True if the terraform command was successful
     """
-    targets = kwargs.get('targets', [])
-    action = kwargs.get('action', None)
-    tf_action_index = 1  # The index to the terraform 'action'
-
-    var_files = {'conf/lambda.json'}
-    tf_opts = ['-var-file=../{}'.format(x) for x in var_files]
-    tf_targets = ['-target={}'.format(x) for x in targets]
-    tf_command = ['terraform', 'plan'] + tf_opts + tf_targets
-    if action == 'destroy':
-        tf_command.append('-destroy')
-
     LOGGER_CLI.debug('Resolving Terraform modules')
     if not run_command(['terraform', 'get'], quiet=True):
         return False
 
-    LOGGER_CLI.info('Planning infrastructure')
-    if not run_command(tf_command):
-        return False
-
-    if not continue_prompt():
-        sys.exit(1)
+    tf_command = ['terraform', action, '-var-file=../conf/lambda.json',
+                  '-refresh={}'.format(str(refresh).lower())]
 
     if action == 'destroy':
+        # Terraform destroy has a '-force' flag instead of '-auto-approve'
         LOGGER_CLI.info('Destroying infrastructure')
-        tf_command[tf_action_index] = action
-        tf_command.remove('-destroy')
-        tf_command.append('-force')
-
-    elif action:
-        tf_command[tf_action_index] = action
-
+        tf_command.append('-force={}'.format(str(auto_approve).lower()))
     else:
-        LOGGER_CLI.info('Creating infrastructure')
-        tf_command[tf_action_index] = 'apply'
-        tf_command.append('-refresh=false')
+        LOGGER_CLI.info('{} changes'.format('Applying' if auto_approve else 'Planning'))
+        tf_command.append('-auto-approve={}'.format(str(auto_approve).lower()))
 
-    if not run_command(tf_command):
-        return False
+    if targets:
+        tf_command.extend('-target={}'.format(x) for x in targets)
 
-    return True
+    return run_command(tf_command)
 
 
 def check_credentials():
@@ -450,6 +428,7 @@ def setup_mock_firehose_delivery_streams(config):
         prefix = '{}/'.format(log_type)
         create_delivery_stream(region, stream_name, prefix)
 
+
 @mock_dynamodb2
 def setup_mock_dynamodb_ioc_table(config):
     """Mock DynamoDB IOC table for rule testing
@@ -506,6 +485,7 @@ def setup_mock_dynamodb_ioc_table(config):
         },
         TableName=table_name
     )
+
 
 def put_mock_s3_object(bucket, key, data, region):
     """Create a mock AWS S3 object for testing
@@ -597,6 +577,7 @@ def get_context_from_config(cluster, config):
 
     return context
 
+
 def user_input(requested_info, mask, input_restrictions):
     """Prompt user for requested information
 
@@ -617,7 +598,6 @@ def user_input(requested_info, mask, input_restrictions):
 
         # Restrict having spaces or colons in items (applies to things like
         # descriptors, etc)
-        valid_response = False
         if isinstance(input_restrictions, re._pattern_type):
             valid_response = input_restrictions.match(response)
             if not valid_response:

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -150,4 +150,4 @@ def deploy(options, config):
         return
 
     # Apply the changes to the Lambda aliases
-    helpers.tf_runner(targets=deploy_targets)
+    helpers.tf_runner(targets=deploy_targets, refresh=False, auto_approve=True)

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -84,7 +84,7 @@ def terraform_handler(options, config):
             'aws_kms_alias.stream_alert_secrets'
         ]
         if not tf_runner(targets=init_targets):
-            LOGGER_CLI.error('An error occured while running StreamAlert init')
+            LOGGER_CLI.error('An error occurred while running StreamAlert init')
             sys.exit(1)
 
         # generate the main.tf with remote state enabled
@@ -101,7 +101,7 @@ def terraform_handler(options, config):
         # create all remainder infrastructure
 
         LOGGER_CLI.info('Building Remainder Infrastructure')
-        tf_runner()
+        tf_runner(refresh=False)
 
     elif options.subcommand == 'clean':
         if not continue_prompt(message='Are you sure you want to clean all Terraform files?'):
@@ -109,6 +109,7 @@ def terraform_handler(options, config):
         terraform_clean(config)
 
     elif options.subcommand == 'destroy':
+        # Ask for approval here since multiple Terraform commands may be necessary
         if not continue_prompt(message='Are you sure you want to destroy?'):
             sys.exit(1)
 
@@ -126,7 +127,7 @@ def terraform_handler(options, config):
                     targets.extend(
                         ['module.{}_{}'.format(target, cluster) for cluster in config.clusters()])
 
-            tf_runner(targets=targets, action='destroy')
+            tf_runner(action='destroy', auto_approve=True, targets=targets)
             return
 
         # Migrate back to local state so Terraform can successfully
@@ -138,7 +139,7 @@ def terraform_handler(options, config):
             return
 
         # Destroy all of the infrastructure
-        if not tf_runner(action='destroy'):
+        if not tf_runner(action='destroy', auto_approve=True):
             return
 
         # Remove old Terraform files


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers 
size: small
resolves #194  (supersedes #359)

## Background

Two separate issues unnecessarily slow down StreamAlert deploys:

- Most Terraform operations are implemented as a `plan` followed by an `apply` after user confirmation. This requires Terraform to parse the config and walk its graph twice. The built-in `-auto-approve=false` accomplishes the same plan + user confirmation, but faster (because Terraform is only invoked once)
- There are some cases (e.g. `lambda deploy`) where we unnecessarily refresh between Terraform commands

## Changes

* `tf_runner` accepts 4 keyword arguments: `action`, `refresh`, `auto_approve`, and `targets`
* `-auto-approve=false` is used instead of requesting user confirmation ourselves. Besides speed, this has another benefit: the user need not approve empty changes when Terraform is up to date
* Applying the Lambda alias update after a Lambda deploy now uses `refresh=False` and `auto_approve=True` 
* The final Terraform build during `./manage.py terraform init` uses `refresh=False`

## Testing
For each command, I tested with the old and new deploy process with 3 clusters with the default configurations.

* `./manage.py terraform init` - 190 seconds down to 145 seconds (23.7% faster)
* `./manage.py lambda deploy` - 57 seconds down to 37 seconds (35% faster)
* `./manage.py terraform destroy` - unchanged
