### PR TITLE
Fork alerts to a Dynamo table

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -6,6 +6,10 @@
     "region": "us-east-1"
   },
   "infrastructure": {
+    "alerts_table": {
+      "read_capacity": 5,
+      "write_capacity": 5
+    },
     "monitoring": {
       "create_sns_topic": true
     }

--- a/stream_alert/rule_processor/alert_forward.py
+++ b/stream_alert/rule_processor/alert_forward.py
@@ -29,6 +29,7 @@ from stream_alert.rule_processor import LOGGER
 class AlertForwarder(object):
     """Sends alerts to the Alert Processor and the alerts Dynamo table."""
     # TODO: Do not send to Alert Processor after Alert Merger is implemented
+    BACKOFF_MAX_RETRIES = 6
 
     def __init__(self, env):
         """Initialize the Forwarder with the boto3 clients and resource names.
@@ -41,6 +42,9 @@ class AlertForwarder(object):
         self.client_lambda = boto3.client('lambda', region_name=self.env['lambda_region'])
         self.function = os.environ['ALERT_PROCESSOR']
         self.table = os.environ['ALERT_TABLE']
+
+        # Keep track of unprocessed items when retrying batch_write_item()
+        self.unprocessed_items = None
 
     def _send_to_lambda(self, alerts):
         """DEPRECATED: Invoke Alert Processor directly
@@ -104,7 +108,7 @@ class AlertForwarder(object):
             (dict) The constructed request for batch_write_item, containing <= 25 alerts.
                 Maps table name to a list of requests.
         """
-        for i in xrange(0, len(alerts), batch_size):
+        for i in range(0, len(alerts), batch_size):
             batch = alerts[i:i+batch_size]
             yield {
                 self.table: [
@@ -120,7 +124,9 @@ class AlertForwarder(object):
                                 'RuleDescription': {'S': alert['rule_description']},
                                 'Outputs': {'SS': alert['outputs']},
                                 # Compact JSON encoding (no extra spaces)
-                                'Record': {'S': json.dumps(alert['record'], separators=(',', ':'))}
+                                'Record': {'S': json.dumps(alert['record'], separators=(',', ':'))},
+                                # TODO: Remove TTL after alert merger is implemented
+                                'TTL': {'N': str(int(time.time()) + 7200)}  # 2 hour TTL
                             }
                         }
                     }
@@ -128,45 +134,54 @@ class AlertForwarder(object):
                 ]
             }
 
-    @backoff.on_exception(backoff.expo, ClientError, max_tries=5, jitter=backoff.full_jitter,
-                          on_backoff=backoff_handlers.backoff_handler,
-                          on_success=backoff_handlers.success_handler,
-                          on_giveup=backoff_handlers.giveup_handler)
-    def _batch_write(self, request_items, max_attempts=5):
+    def _batch_write(self):
         """Write a batch of alerts to Dynamo, retrying with exponential backoff for failed items.
 
-        Args:
-            request_items (dict): The generated RequestItems dict from _alert_batches().
-            max_attempts (int): Maximum number of times to retry UnprocessedItems.
-
         Returns:
-            (bool) True if the batch write was eventually successful, False otherwise.
+            (bool) True if *all* items were written successfully, False otherwise.
         """
-        for attempt in xrange(1, max_attempts + 1):
-            response = self.client_dynamo.batch_write_item(RequestItems=request_items)
+        @backoff.on_predicate(backoff.expo,
+                              max_tries=self.BACKOFF_MAX_RETRIES, jitter=backoff.full_jitter,
+                              on_backoff=backoff_handlers.backoff_handler,
+                              on_success=backoff_handlers.success_handler,
+                              on_giveup=backoff_handlers.giveup_handler)
+        @backoff.on_exception(backoff.expo, ClientError,
+                              max_tries=self.BACKOFF_MAX_RETRIES, jitter=backoff.full_jitter,
+                              on_backoff=backoff_handlers.backoff_handler,
+                              on_success=backoff_handlers.success_handler,
+                              on_giveup=backoff_handlers.giveup_handler)
+        def decorated_batch_write(cls):
+            """batch_write_item with the unprocessed_items from the AlertForwarder instance.
 
-            # If Dynamo experiences an internal error, unprocessed items are listed in the response.
-            # AWS recommends retrying unprocessed items in a loop with exponential backoff.
-            request_items = response['UnprocessedItems']
-            if request_items:
-                LOGGER.warn(
-                    'Batch write failed: %d alerts were not written (attempt %d/%d)',
-                    len(request_items[self.table]), attempt, max_attempts)
-                # Simple exponential backoff: Sleep 0.5, 1, 2, 4 and 8 seconds.
-                time.sleep(0.25 * 2 ** attempt)
-                attempt += 1
-            else:
-                return True
+            There are 2 different errors to handle here:
+                (1) If Dynamo is unresponsive, a boto ClientError will be raised.
+                (2) The batch_write_item operation can fail halfway through, in which case the
+                    unprocessed items are returned in the response. In this case, unprocessed items
+                    are stored in the class instance, and we return False.
+                    The backoff.on_predicate will automatically retry with any Falsey value, and
+                    batch_write will run again, but only with the remaining unprocessed items.
 
-        return False
+            Args:
+                cls (AlertForwarder): Instance of the AlertForwarder
+
+            Returns:
+                (bool) True if the batch write succeeded, False if there were UnprocessedItems.
+            """
+            response = cls.client_dynamo.batch_write_item(RequestItems=cls.unprocessed_items)
+            cls.unprocessed_items = response['UnprocessedItems']
+            return len(cls.unprocessed_items) == 0
+
+        return decorated_batch_write(self)
 
     def _send_to_dynamo(self, alerts):
         """Write alerts in batches to Dynamo."""
         for batch_num, batch in enumerate(self._alert_batches(alerts), start=1):
-            LOGGER.info('Sending batch #%d to Dynamo with %d alert(s)',
+            LOGGER.info('Sending batch %d to Dynamo with %d alert(s)',
                         batch_num, len(batch[self.table]))
-            if not self._batch_write(batch):
-                LOGGER.error('Unable to save alert batch %s', json.dumps(batch))
+            self.unprocessed_items = batch
+            if not self._batch_write():
+                LOGGER.error('Unable to save alert batch; unprocessed items remain: %s',
+                             json.dumps(self.unprocessed_items))
 
     def send_alerts(self, alerts):
         """Send alerts to the Alert Processor and to the alerts Dynamo table.
@@ -176,7 +191,8 @@ class AlertForwarder(object):
         """
         self._send_to_lambda(alerts)
 
-        # While we are testing this, exceptions should be logged but not raise errors.
+        # For now, don't blow up the rule processor if there is a problem sending to Dynamo.
+        # TODO: Remove/refine broad exception handling once tested.
         try:
             self._send_to_dynamo(alerts)
         except Exception:  # pylint: disable=broad-except

--- a/stream_alert/rule_processor/alert_forward.py
+++ b/stream_alert/rule_processor/alert_forward.py
@@ -48,7 +48,7 @@ class AlertForwarder(object):
         self.unprocessed_items = None
 
     def _send_to_lambda(self, alerts):
-        """DEPRECATED: Invoke Alert Processor directly
+        """Invoke Alert Processor directly
 
         Sends a message to the alert processor with the following JSON format:
             {
@@ -148,7 +148,7 @@ class AlertForwarder(object):
                               on_backoff=backoff_handlers.backoff_handler,
                               on_success=backoff_handlers.success_handler,
                               on_giveup=backoff_handlers.giveup_handler)
-        def decorated_batch_write(cls):
+        def decorated_batch_write(forwarder):
             """batch_write_item with the unprocessed_items from the AlertForwarder instance.
 
             There are 2 different errors to handle here:
@@ -160,14 +160,15 @@ class AlertForwarder(object):
                     batch_write will run again, but only with the remaining unprocessed items.
 
             Args:
-                cls (AlertForwarder): Instance of the AlertForwarder
+                forwarder (AlertForwarder): Instance of the AlertForwarder
 
             Returns:
                 (bool) True if the batch write succeeded, False if there were UnprocessedItems.
             """
-            response = cls.client_dynamo.batch_write_item(RequestItems=cls.unprocessed_items)
-            cls.unprocessed_items = response['UnprocessedItems']
-            return len(cls.unprocessed_items) == 0
+            response = forwarder.client_dynamo.batch_write_item(
+                RequestItems=forwarder.unprocessed_items)
+            forwarder.unprocessed_items = response['UnprocessedItems']
+            return len(forwarder.unprocessed_items) == 0
 
         return decorated_batch_write(self)
 

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -17,12 +17,12 @@ from logging import DEBUG as LOG_LEVEL_DEBUG
 import json
 
 from stream_alert.rule_processor import FUNCTION_NAME, LOGGER
+from stream_alert.rule_processor.alert_forward import AlertForwarder
 from stream_alert.rule_processor.classifier import StreamClassifier
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.rule_processor.rules_engine import StreamRules
-from stream_alert.rule_processor.sink import StreamSink
 from stream_alert.shared.metrics import MetricLogger
 
 
@@ -47,9 +47,9 @@ class StreamAlert(object):
         # Load the environment from the context arn
         self.env = load_env(context)
 
-        # Instantiate the sink here to handle sending the triggered alerts to the
+        # Instantiate the send_alerts here to handle sending the triggered alerts to the
         # alert processor
-        self.sinker = StreamSink(self.env)
+        self.alert_forwarder = AlertForwarder(self.env)
 
         # Instantiate a classifier that is used for this run
         self.classifier = StreamClassifier(config=self.config)
@@ -125,7 +125,7 @@ class StreamAlert(object):
         record_alerts = self._rule_engine.threat_intel_match(payload_with_normalized_records)
         self._alerts.extend(record_alerts)
         if record_alerts and self.enable_alert_processor:
-            self.sinker.sink(record_alerts)
+            self.alert_forwarder.send_alerts(record_alerts)
 
         MetricLogger.log_metric(FUNCTION_NAME,
                                 MetricLogger.TOTAL_RECORDS,
@@ -215,6 +215,6 @@ class StreamAlert(object):
             self._alerts.extend(record_alerts)
 
             if self.enable_alert_processor:
-                self.sinker.sink(record_alerts)
+                self.alert_forwarder.send_alerts(record_alerts)
 
         return payload_with_normalized_records

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -65,7 +65,7 @@ class StreamRules(object):
 
         A rule maps events (by `logs`) to a function that accepts an event
         and returns a boolean. If the function returns `True`, then the event is
-        passed on to the sink(s). If the function returns `False`, the event is
+        passed on to the alert forwarder. If the function returns `False`, the event is
         dropped.
         """
         def decorator(rule):

--- a/stream_alert/rule_processor/sink.py
+++ b/stream_alert/rule_processor/sink.py
@@ -22,6 +22,7 @@ import backoff
 import boto3
 from botocore.exceptions import ClientError
 
+from stream_alert.shared import backoff_handlers
 from stream_alert.rule_processor import LOGGER
 
 
@@ -126,7 +127,10 @@ class StreamSink(object):
                 ]
             }
 
-    @backoff.on_exception(backoff.expo, ClientError, max_tries=5, jitter=backoff.full_jitter)
+    @backoff.on_exception(backoff.expo, ClientError, max_tries=5, jitter=backoff.full_jitter,
+                          on_backoff=backoff_handlers.backoff_handler,
+                          on_success=backoff_handlers.success_handler,
+                          on_giveup=backoff_handlers.giveup_handler)
     def _batch_write(self, request_items, max_attempts=5):
         """Write a batch of alerts to Dynamo, retrying with exponential backoff for failed items.
 

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -55,6 +55,7 @@ class MetricLogger(object):
     TOTAL_S3_RECORDS = 'TotalS3Records'
     TOTAL_STREAM_ALERT_APP_RECORDS = 'TotalStreamAlertAppRecords'
     TRIGGERED_ALERTS = 'TriggeredAlerts'
+    UNPROCESSED_ALERTS = 'UnprocessedAlerts'
     FIREHOSE_RECORDS_SENT = 'FirehoseRecordsSent'
     FIREHOSE_FAILED_RECORDS = 'FirehoseFailedRecords'
 
@@ -83,6 +84,7 @@ class MetricLogger(object):
                                _default_value_lookup),
             TRIGGERED_ALERTS: (_default_filter.format(TRIGGERED_ALERTS),
                                _default_value_lookup),
+            UNPROCESSED_ALERTS: (_default_filter.format(UNPROCESSED_ALERTS), _default_value_lookup),
             FIREHOSE_RECORDS_SENT: (_default_filter.format(FIREHOSE_RECORDS_SENT),
                                     _default_value_lookup),
             FIREHOSE_FAILED_RECORDS: (_default_filter.format(FIREHOSE_FAILED_RECORDS),

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -163,12 +163,16 @@ def generate_main(**kwargs):
     # Setup Firehose Delivery Streams
     generate_firehose(config, main_dict, logging_bucket)
 
-    # Configure global resources like Firehose alert delivery
+    # Configure global resources like Firehose alert delivery and alerts table
     main_dict['module']['globals'] = {
         'source': 'modules/tf_stream_alert_globals',
         'account_id': config['global']['account']['aws_account_id'],
         'region': config['global']['account']['region'],
-        'prefix': config['global']['account']['prefix']
+        'prefix': config['global']['account']['prefix'],
+        'alerts_table_read_capacity': (
+            config['global']['infrastructure']['alerts_table']['read_capacity']),
+        'alerts_table_write_capacity': (
+            config['global']['infrastructure']['alerts_table']['write_capacity'])
     }
 
     # KMS Key and Alias creation

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -917,9 +917,10 @@ def stream_alert_test(options, config):
             options (namedtuple): CLI options (debug, processor, etc)
             context (namedtuple): A constructed aws context object
         """
-        # The Rule Processor sink is instantiated with the alert processor from the environment:
-        os.environ['ALERT_PROCESSOR'] = '{}_{}'.format(
-            config['global']['account']['prefix'], '_streamalert_alert_processor')
+        # The Rule Processor uses env variables to determine sink targets:
+        prefix = config['global']['account']['prefix']
+        os.environ['ALERT_PROCESSOR'] = '{}_streamalert_alert_processor'.format(prefix)
+        os.environ['ALERT_TABLE'] = '{}_streamalert_alerts'.format(prefix)
 
         if options.debug:
             # TODO(jack): Currently there is no (clean) way to set

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -917,7 +917,7 @@ def stream_alert_test(options, config):
             options (namedtuple): CLI options (debug, processor, etc)
             context (namedtuple): A constructed aws context object
         """
-        # The Rule Processor uses env variables to determine sink targets:
+        # The Rule Processor uses env variables to determine where alerts should be forwarded:
         prefix = config['global']['account']['prefix']
         os.environ['ALERT_PROCESSOR'] = '{}_streamalert_alert_processor'.format(prefix)
         os.environ['ALERT_TABLE'] = '{}_streamalert_alerts'.format(prefix)

--- a/terraform/modules/tf_lambda/iam.tf
+++ b/terraform/modules/tf_lambda/iam.tf
@@ -17,27 +17,11 @@ resource "aws_iam_role" "role" {
   assume_role_policy = "${data.aws_iam_policy_document.lambda_execution_policy.json}"
 }
 
-// Base permissions - Allow creating logs and publishing metrics
-data "aws_iam_policy_document" "logs_metrics_policy" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "cloudwatch:PutMetricData",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_role_policy" "logs_metrics_policy" {
-  count  = "${var.enabled}"
-  name   = "LogsAndMetrics"
-  role   = "${aws_iam_role.role.id}"
-  policy = "${data.aws_iam_policy_document.logs_metrics_policy.json}"
+// Attach write permissions for CloudWatch logs
+resource "aws_iam_role_policy_attachment" "logs_metrics_policy" {
+  count      = "${var.enabled}"
+  role       = "${aws_iam_role.role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 // Attach VPC policy (if applicable)

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -47,6 +47,21 @@ data "aws_iam_policy_document" "rule_processor_invoke_alert_proc" {
   }
 }
 
+// IAM Role Policy: Allow the Rule Processor to save alerts to dynamo.
+resource "aws_iam_role_policy" "save_alerts_to_dynamo" {
+  name   = "SaveAlertsToDynamo"
+  role   = "${aws_iam_role.streamalert_rule_processor_role.id}"
+  policy = "${data.aws_iam_policy_document.save_alerts_to_dynamo.json}"
+}
+
+data "aws_iam_policy_document" "save_alerts_to_dynamo" {
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:BatchWriteItem"]
+    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.prefix}_streamalert_alerts"]
+  }
+}
+
 // IAM Role Policy: Allow the Rule Processor to put data on Firehose
 resource "aws_iam_role_policy" "streamalert_rule_processor_firehose" {
   name = "FirehoseWriteData"

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -14,6 +14,7 @@ resource "aws_lambda_function" "streamalert_rule_processor" {
   environment {
     variables = {
       ALERT_PROCESSOR = "${var.prefix}_streamalert_alert_processor"
+      ALERT_TABLE     = "${var.prefix}_streamalert_alerts"
       CLUSTER         = "${var.cluster}"
       ENABLE_METRICS  = "${var.rule_processor_enable_metrics}"
       LOGGER_LEVEL    = "${var.rule_processor_log_level}"

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -4,3 +4,26 @@ module "alerts_firehose" {
   prefix     = "${var.prefix}"
   region     = "${var.region}"
 }
+
+// TODO: Autoscaling
+resource "aws_dynamodb_table" "alerts_table" {
+  name           = "${var.prefix}_streamalert_alerts"
+  read_capacity  = "${var.alerts_table_read_capacity}"
+  write_capacity = "${var.alerts_table_write_capacity}"
+  hash_key       = "RuleName"
+  range_key      = "Timestamp"
+
+  // Only the hash key and range key attributes need to be defined here.
+
+  attribute {
+    name = "RuleName"
+    type = "S"
+  }
+  attribute {
+    name = "Timestamp"
+    type = "S"
+  }
+  tags {
+    Name = "StreamAlert"
+  }
+}

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -19,10 +19,19 @@ resource "aws_dynamodb_table" "alerts_table" {
     name = "RuleName"
     type = "S"
   }
+
   attribute {
     name = "Timestamp"
     type = "S"
   }
+
+  // Enable expriation time while testing Dynamo table for alerts
+  // TODO: Remove TTL once Alert Merger is implemented
+  ttl {
+    attribute_name = "TTL"
+    enabled        = true
+  }
+
   tags {
     Name = "StreamAlert"
   }

--- a/terraform/modules/tf_stream_alert_globals/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/variables.tf
@@ -3,3 +3,7 @@ variable "account_id" {}
 variable "prefix" {}
 
 variable "region" {}
+
+variable "alerts_table_read_capacity" {}
+
+variable "alerts_table_write_capacity" {}

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -6,6 +6,10 @@
     "region": "us-west-1"
   },
   "infrastructure": {
+    "alerts_table": {
+      "read_capacity": 5,
+      "write_capacity": 5
+    },
     "monitoring": {
       "create_sns_topic": true
     }

--- a/tests/unit/stream_alert_rule_processor/test_alert_forward.py
+++ b/tests/unit/stream_alert_rule_processor/test_alert_forward.py
@@ -36,7 +36,7 @@ class TestAlertForwarder(object):
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
-        patcher = patch('stream_alert.rule_processor.alert_forward.boto3.client')
+        patcher = patch('boto3.client')
         cls.boto_mock = patcher.start()
         context = get_mock_context()
         env = load_env(context)

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -171,15 +171,15 @@ class TestStreamAlert(object):
             'Record does not match any defined schemas: %s\n%s')
         assert_equal(log_mock.call_args[0][2], '{"bad": "data"}')
 
-    @patch('stream_alert.rule_processor.sink.StreamSink.sink')
+    @patch('stream_alert.rule_processor.alert_forward.AlertForwarder.send_alerts')
     @patch('stream_alert.rule_processor.handler.StreamRules.process')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
-    def test_run_send_alerts(self, extract_mock, rules_mock, sink_mock):
+    def test_run_send_alerts(self, extract_mock, rules_mock, forwarder_mock):
         """StreamAlert Class - Run, Send Alert"""
         extract_mock.return_value = ('kinesis', 'unit_test_default_stream')
         rules_mock.return_value = (['success!!'], ['normalized_records'])
 
-        # Set send_alerts to true so the sink happens
+        # Set send_alerts to true so the send_alerts happens
         self.__sa_handler.enable_alert_processor = True
 
         # Swap out the alias so the logging occurs
@@ -187,7 +187,7 @@ class TestStreamAlert(object):
 
         self.__sa_handler.run(get_valid_event())
 
-        sink_mock.assert_called_with(['success!!'])
+        forwarder_mock.assert_called_with(['success!!'])
 
     @patch('logging.Logger.debug')
     @patch('stream_alert.rule_processor.handler.StreamRules.process')

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -48,7 +48,8 @@ class TestStreamAlert(object):
 
     @patch('stream_alert.rule_processor.handler.load_config',
            lambda: load_config('tests/unit/conf/'))
-    @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor'})
+    @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor',
+                             'ALERT_TABLE': 'unit-testing_streamalert_alerts'})
     def setup(self):
         """Setup before each method"""
         self.__sa_handler = StreamAlert(get_mock_context(), False)
@@ -267,7 +268,8 @@ class TestStreamAlert(object):
 
     @patch('stream_alert.rule_processor.threat_intel.StreamThreatIntel._query')
     @patch('stream_alert.rule_processor.threat_intel.StreamThreatIntel.load_from_config')
-    @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor'})
+    @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor',
+                             'ALERT_TABLE': 'unit-testing_streamalert_alerts'})
     def test_run_threat_intel_enabled(self, mock_threat_intel, mock_query): # pylint: disable=no-self-use
         """StreamAlert Class - Run SA when threat intel enabled"""
         @rule(datatypes=['sourceAddress'], outputs=['s3:sample_bucket'])

--- a/tests/unit/stream_alert_rule_processor/test_sink.py
+++ b/tests/unit/stream_alert_rule_processor/test_sink.py
@@ -13,11 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+# pylint: disable=protected-access
 from datetime import datetime
 import os
+import unittest
 
 from botocore.exceptions import ClientError
-from mock import patch
+from mock import ANY, call, patch
 from nose.tools import assert_equal
 
 from stream_alert.rule_processor.config import load_env
@@ -25,8 +27,12 @@ from stream_alert.rule_processor.sink import StreamSink
 from tests.unit.stream_alert_rule_processor.test_helpers import get_mock_context
 
 
-class TestStreamSink(object):
+@patch.dict(os.environ, {'CLUSTER': 'corp'})
+class TestStreamSink(unittest.TestCase):
     """Test class for StreamSink"""
+    ALERT_PROCESSOR = 'corp-prefix_streamalert_alert_processor'
+    ALERT_TABLE = 'corp-prefix_streamalert_alerts'
+
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
@@ -34,7 +40,8 @@ class TestStreamSink(object):
         cls.boto_mock = patcher.start()
         context = get_mock_context()
         env = load_env(context)
-        with patch.dict(os.environ, {'ALERT_PROCESSOR': 'corp-prefix_streamalert_alert_processor'}):
+        with patch.dict(os.environ, {'ALERT_PROCESSOR': cls.ALERT_PROCESSOR,
+                                     'ALERT_TABLE': cls.ALERT_TABLE}):
             cls.sinker = StreamSink(env)
 
     @classmethod
@@ -47,11 +54,7 @@ class TestStreamSink(object):
         """Teardown the class after each methods"""
         self.sinker.env['lambda_alias'] = 'development'
 
-    def test_streamsink_init(self):
-        """StreamSink - Init"""
-        assert_equal(self.sinker.function, 'corp-prefix_streamalert_alert_processor')
-
-    @patch('stream_alert.rule_processor.sink.LOGGER.exception')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
     def test_streamsink_sink_boto_error(self, log_mock):
         """StreamSink - Boto Error"""
 
@@ -63,13 +66,16 @@ class TestStreamSink(object):
 
         self.sinker.sink(['alert!!!'])
 
-        log_mock.assert_called_with('An error occurred while sending alert to '
-                                    '\'%s:production\'. Error is: %s. Alert: %s',
-                                    'corp-prefix_streamalert_alert_processor',
-                                    err_response,
-                                    '"alert!!!"')
+        log_mock.assert_has_calls([
+            call.exception(
+                'An error occurred while sending alert to \'%s:production\'. '
+                'Error is: %s. Alert: %s', self.ALERT_PROCESSOR,
+                err_response, '"alert!!!"'
+            ),
+            call.exception('Error saving alerts to Dynamo')
+        ])
 
-    @patch('stream_alert.rule_processor.sink.LOGGER.error')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
     def test_streamsink_sink_resp_error(self, log_mock):
         """StreamSink - Boto Response Error"""
         self.boto_mock.return_value.invoke.side_effect = [{
@@ -77,11 +83,12 @@ class TestStreamSink(object):
 
         self.sinker.sink(['alert!!!'])
 
-        log_mock.assert_called_with('Failed to send alert to \'%s\': %s',
-                                    'corp-prefix_streamalert_alert_processor',
-                                    '"alert!!!"')
+        log_mock.assert_has_calls([
+            call.error('Failed to send alert to \'%s\': %s', self.ALERT_PROCESSOR, '"alert!!!"'),
+            call.exception('Error saving alerts to Dynamo')
+        ])
 
-    @patch('stream_alert.rule_processor.sink.LOGGER.info')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
     def test_streamsink_sink_success(self, log_mock):
         """StreamSink - Successful Sink"""
         self.boto_mock.return_value.invoke.side_effect = [{
@@ -96,17 +103,131 @@ class TestStreamSink(object):
 
         self.sinker.sink(['alert!!!'])
 
-        log_mock.assert_called_with('Sent alert to \'%s\' with Lambda request ID \'%s\'',
-                                    'corp-prefix_streamalert_alert_processor',
-                                    'reqID')
+        log_mock.assert_has_calls([
+            call.info('Sent alert to \'%s\' with Lambda request ID \'%s\'',
+                      self.ALERT_PROCESSOR, 'reqID')
+        ])
 
-    @patch('stream_alert.rule_processor.sink.LOGGER.error')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
     def test_streamsink_sink_bad_obj(self, log_mock):
         """StreamSink - JSON Dump Bad Object"""
         bad_object = datetime.utcnow()
         self.sinker.sink([bad_object])
 
-        log_mock.assert_called_with(
-            'An error occurred while dumping alert to JSON: %s Alert: %s',
-            '\'datetime.datetime\' object has no attribute \'__dict__\'',
-            bad_object)
+        log_mock.assert_has_calls([
+            call.error('An error occurred while dumping alert to JSON: %s Alert: %s',
+                       '\'datetime.datetime\' object has no attribute \'__dict__\'', bad_object),
+            call.exception('Error saving alerts to Dynamo')
+        ])
+
+    @staticmethod
+    def _generate_alerts(count):
+        """Generate a list of alert dictionaries."""
+        return [
+            {
+                'record': '{"abc": 123}',
+                'rule_description': 'Desc{}'.format(i),
+                'rule_name': 'Rule{}'.format(i),
+                'outputs': ['aws-lambda:...', 'aws-s3:...']
+            }
+            for i in xrange(count)
+        ]
+
+    def test_alert_batches_single_alert(self):
+        """StreamSink - Alert Batching - Single Alert"""
+        alerts = self._generate_alerts(1)
+        result = list(self.sinker._alert_batches(alerts))
+
+        # Replace timestamp to allow for equality checking.
+        result[0][self.ALERT_TABLE][0]['PutRequest']['Item']['Timestamp']['S'] = 'now'
+
+        expected = [
+            {
+                self.ALERT_TABLE: [
+                    {
+                        'PutRequest': {
+                            'Item': {
+                                'RuleName': {'S': 'Rule0'},
+                                'Timestamp': {'S': 'now'},
+                                'Cluster': {'S': 'corp'},
+                                'RuleDescription': {'S': 'Desc0'},
+                                'Outputs': {'SS': ['aws-lambda:...', 'aws-s3:...']},
+                                'Record': {'S': '"{\\"abc\\": 123}"'}
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+        assert_equal(expected, result)
+
+    def test_alert_batches_max_batch(self):
+        """StreamSink - Alert Batching - Full Batch"""
+        alerts = self._generate_alerts(10)
+        result = list(self.sinker._alert_batches(alerts, batch_size=10))
+
+        assert_equal(1, len(result))  # There should be one batch.
+        assert_equal(10, len(result[0][self.ALERT_TABLE]))  # All 10 alerts should be in the batch.
+
+    def test_alert_batches_max_batch_plus_one(self):
+        """StreamSink - Alert Batching - Full Batch + 1"""
+        alerts = self._generate_alerts(11)
+        result = list(self.sinker._alert_batches(alerts, batch_size=10))
+
+        assert_equal(2, len(result))  # There should be 2 alert batches.
+        assert_equal(10, len(result[0][self.ALERT_TABLE]))  # 10 alerts in the first batch.
+        assert_equal(1, len(result[1][self.ALERT_TABLE]))  # 1 alert in the second batch.
+
+    @patch('stream_alert.rule_processor.sink.time')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
+    def test_dynamo_sink_unprocessed_alerts(self, log_mock, time_mock):
+        """StreamSink - Dynamo Sink - Retry unprocessed alerts"""
+
+        def mock_batch_write_item(**kwargs):
+            """Mock client_dynamo.batch_write_item to always return all items unprocessed."""
+            return {
+                'ResponseMetadata': {'HTTPStatusCode': 200},
+                'UnprocessedItems': {self.ALERT_TABLE: kwargs['RequestItems']}
+            }
+
+        self.sinker.client_dynamo.batch_write_item = mock_batch_write_item
+
+        self.sinker._sink_dynamo(self._generate_alerts(1))
+
+        batch_write_failed = 'Batch write failed: %d alerts were not written (attempt %d/%d)'
+        log_mock.assert_has_calls([
+            call.info('Sending batch #%d to Dynamo with %d alert(s)', 1, 1),
+            call.warn(batch_write_failed, 1, 1, 5),
+            call.warn(batch_write_failed, 1, 2, 5),
+            call.warn(batch_write_failed, 1, 3, 5),
+            call.warn(batch_write_failed, 1, 4, 5),
+            call.warn(batch_write_failed, 1, 5, 5),
+            call.error('Unable to save alert batch %s', ANY)
+        ])
+
+        time_mock.assert_has_calls([
+            call.sleep(0.5),
+            call.sleep(1),
+            call.sleep(2),
+            call.sleep(4),
+            call.sleep(8)
+        ])
+
+    @patch('stream_alert.rule_processor.sink.time')
+    @patch('stream_alert.rule_processor.sink.LOGGER')
+    def test_dynamo_sink_successful(self, log_mock, time_mock):
+        """StreamSink - Dynamo Sink - Successful"""
+
+        def mock_batch_write_item(**kwargs): # pylint: disable = unused-argument
+            """Mock client_dynamo.batch_write_item return successfully."""
+            return {
+                'ResponseMetadata': {'HTTPStatusCode': 200},
+                'UnprocessedItems': {}
+            }
+
+        self.sinker.client_dynamo.batch_write_item = mock_batch_write_item
+
+        self.sinker._sink_dynamo(self._generate_alerts(1))
+
+        log_mock.assert_has_calls([call.info('Sending batch #%d to Dynamo with %d alert(s)', 1, 1)])
+        time_mock.assert_not_called()


### PR DESCRIPTION
to: @jacknagz and @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: medium

## Background

In order to support alert merging (and more reliable alert delivery), we need to start keeping state about the alerts. We will do this with a Dynamo table that sits in between the Rule Processor and Alert Processor.

## Changes
This PR creates the new alerts table and forks all alerts to the table *in addition to the alert processor*, so we can test the alerts table in production. We will sever the rule processor - alert processor connection in a subsequent pull request after we verify that writing to the table is working as expected.

* Fixes a bug in the `tf_alert_processor_iam` module when the output lists are empty
* Replaces the `LogsAndMetrics` custom policy in the `tf_lambda` module with the managed `AWSLambdaBasicExecutionRole` policy
* Adds the alerts table to the `tf_globals` module, with capacity configurable in `conf/global.json`
* Changes and renames `sink.py` in the rule processor to write alerts in batches to Dynamo after sending them to Lambda.

## Testing

Deployed in a test account, alerts are sent to both the alert processor and Dynamo as expected. The Dynamo entry looks like this:

![screen shot 2018-02-28 at 2 58 31 pm](https://user-images.githubusercontent.com/3608925/36817966-f04aca8e-1c97-11e8-9347-ffc54d186563.png)
