### PR TITLE
[output] Fix for PUT request bug

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -292,7 +292,7 @@ class OutputDispatcher(object):
         Returns:
             dict: Contains the http response object
         """
-        return requests.put(url, headers=headers, params=params,
+        return requests.put(url, headers=headers, json=params,
                             verify=verify, timeout=cls._DEFAULT_REQUEST_TIMEOUT)
 
     @classmethod

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -44,12 +44,11 @@ def events_v2_data(routing_key, with_record=True, **kwargs):
             dict: Contains JSON blob to be used as event
     """
     summary = 'StreamAlert Rule Triggered - {}'.format(kwargs['rule_name'])
-
-    details = {
-        'description': kwargs['alert']['rule_description']
-    }
+    details = OrderedDict()
+    details['description'] = kwargs['alert']['rule_description']
     if with_record:
         details['record'] = kwargs['alert']['record']
+
     payload = {
         'summary': summary,
         'source': kwargs['alert']['log_source'],


### PR DESCRIPTION
to: @austinbyers or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Following up #614, I forgot to add the actual fix for the issue, which uses the `json` parameter in requests instead of `params`. Also added some code to display the rule description first for alerts going to PagerDuty, which is better for people getting the alerts and not having to scroll down JSON data before knowing what actually fired.

## Changes

* `PUT` request uses `json` parameter in requests instead of `params`.
* Alert description will appear before record in PagerDuty alerts/incidents.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 545 tests in 9.224s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (61/61) Successful Tests
StreamAlertCLI [INFO]: (94/94) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
