### PR TITLE
S3Payload Ignore Empty Files, NormalizedRecords Metric

### DIFF
--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -120,7 +120,11 @@ class StreamAlert(object):
 
             payload_with_normalized_records.extend(self._process_alerts(payload))
 
-        LOGGER.info('Got %d normalized records', len(payload_with_normalized_records))
+        # Log normalized records metric
+        MetricLogger.log_metric(FUNCTION_NAME,
+                                MetricLogger.NORMALIZED_RECORDS,
+                                len(payload_with_normalized_records))
+
         # Apply Threat Intel to normalized records in the end of Rule Processor invocation
         record_alerts = self._rule_engine.threat_intel_match(payload_with_normalized_records)
         self._alerts.extend(record_alerts)

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -58,6 +58,7 @@ class MetricLogger(object):
     TRIGGERED_ALERTS = 'TriggeredAlerts'
     FIREHOSE_RECORDS_SENT = 'FirehoseRecordsSent'
     FIREHOSE_FAILED_RECORDS = 'FirehoseFailedRecords'
+    NORMALIZED_RECORDS = 'NormalizedRecords'
 
     _default_filter = '{{ $.metric_name = "{}" }}'
     _default_value_lookup = '$.metric_value'
@@ -72,6 +73,8 @@ class MetricLogger(object):
         ALERT_PROCESSOR_NAME: {},   # Placeholder for future alert processor metrics
         ATHENA_PARTITION_REFRESH_NAME: {},  # Placeholder for future athena processor metrics
         RULE_PROCESSOR_NAME: {
+            NORMALIZED_RECORDS: (_default_filter.format(NORMALIZED_RECORDS),
+                                 _default_value_lookup),
             FAILED_PARSES: (_default_filter.format(FAILED_PARSES),
                             _default_value_lookup),
             S3_DOWNLOAD_TIME: (_default_filter.format(S3_DOWNLOAD_TIME),

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -143,17 +143,16 @@ def make_sns_raw_record(topic_name, sns_data):
     return raw_record
 
 
-def make_s3_raw_record(bucket, key):
+def make_s3_raw_record(bucket, key, size=100):
     """Helper for creating the s3 raw record"""
-    # size = len(s3_data)
-    raw_record = {
+    return {
         's3': {
             'configurationId': 'testConfigRule',
             'object': {
                 'eTag': '0123456789abcdef0123456789abcdef',
                 'sequencer': '0A1B2C3D4E5F678901',
                 'key': key,
-                'size': 100
+                'size': size
             },
             'bucket': {
                 'arn': 'arn:aws:s3:::mybucket',
@@ -165,7 +164,7 @@ def make_s3_raw_record(bucket, key):
         },
         'awsRegion': 'us-east-1'
     }
-    return raw_record
+
 
 def mock_normalized_records(default_data=None):
     """Morck records which have been normalized"""


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers @chunyong-lin 
size: small

## Background

Currently when the rule processor receives S3 event notifications, it will still try and download the file, but instead pre processing should just exit at this point.  I have also added a quick metric for NormalizedRecords

## Changes

* Ignore empty S3 files
* Add NormalizedRecords metric
* Update tests

## Testing

Local CI
