### PR TITLE
[tf] Ignore .tf.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/build
 *.terraform/
 terraform.tfvars
 terraform/terraform.tfstate*
+*.tf.json
 
 # MacOS artifacts
 Thumbs.db


### PR DESCRIPTION
to: @austinbyers
cc: @airbnb/streamalert-maintainers
size: small
partially addresses #419 

## Background

Each deploy will generate all the `.tf.json` files, there is no need to store them in the repo. If you have stored those files in your repo, and each deploy updates them, this change will start ignoring them so you should consider doing a `git rm terraform/*.tf.json` to avoid keeping outdated files.

## Changes

* Ignore any file with extension`.tf.json`, since they are generated on deploy commands.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 545 tests in 9.224s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (61/61) Successful Tests
StreamAlertCLI [INFO]: (94/94) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```
