### PR TITLE
Trusted Advisor support

### DIFF
--- a/matchers/matchers.py
+++ b/matchers/matchers.py
@@ -20,3 +20,7 @@ matcher = StreamRules.matcher()
 @matcher
 def guard_duty(record):
     return record['detail-type'] == 'GuardDuty Finding'
+
+@matcher
+def trusted_advisor(record):
+    return record['source'] == 'aws.trustedadvisor'

--- a/rules/community/trustedadvisor/trusted_advisor.py
+++ b/rules/community/trustedadvisor/trusted_advisor.py
@@ -1,0 +1,48 @@
+"""Alert on Trusted Advisor"""
+from stream_alert.rule_processor.rules_engine import StreamRules
+
+rule = StreamRules.rule
+disable = StreamRules.disable()
+
+
+@rule(logs=['cloudwatch:events'],
+      matchers=['trusted_advisor'],
+      outputs=['slack:sample-channel'])
+def trusted_advisor(rec):
+    """
+    author:         spiper
+    description:    Alert on Trusted Advisor events.
+                    Note that these will only go to CloudWatch events if you
+                    have a Business support contract or better for the account.
+    playbook:       Depends on the alert. Some of these are misconfigurations,
+                    some are warnings that you are approaching limits, and some
+                    and critical alerts that need to be responded to (such as
+                    access keys being pushed to github).
+    testing:        Create an S3 bucket with a random name and no contents,
+                    and make it publicly read-able.
+    """
+    detail = rec['detail']
+    check_name = detail.get('check-name', '')
+
+    # Ignore checks that tell us things are OK
+    if detail.get('status', '') == 'OK':
+        return False
+
+    # The check are somewhat documented at: https://aws.amazon.com/premiumsupport/ta-iam/
+
+    # Known checks to alert on
+    if check_name == 'Security Groups - Specific Ports Unrestricted':
+        return True
+    if check_name == 'MFA on Root Account':
+        return True
+    if check_name == 'IAM Password Policy':
+        return True
+    if check_name == 'AWS CloudTrail Logging':
+        return True
+    if check_name == 'Exposed Access Keys':
+        return True
+    if check_name == 'Amazon Route 53 MX Resource Record Sets and Sender Policy Framework':
+        return True
+
+    # Ignore everything else
+    return False

--- a/tests/integration/rules/trustedadvisor/trusted_advisor.json
+++ b/tests/integration/rules/trustedadvisor/trusted_advisor.json
@@ -1,0 +1,39 @@
+{
+  "records": [
+    {
+      "data": {
+        "version": "0",
+        "id": "1234abcd-ab12-123a-123a-1234567890ab",
+        "detail-type": "Trusted Advisor Check Item Refresh Notification",
+        "source": "aws.trustedadvisor",
+        "account": "123456789012",
+        "time": "2018-01-12T19:38:24Z",
+        "region": "us-east-1",
+        "resources": [],
+        "detail": {
+          "check-name": "Exposed Access Keys",
+          "check-item-detail": {
+            "Case ID": "12345678-1234-1234-abcd-1234567890ab",
+            "Usage (USD per Day)": "0",
+            "User Name (IAM or Root)": "my-username",
+            "Deadline": "1440453299248",
+            "Access Key ID": "AKIAIOSFODNN7EXAMPLE",
+            "Time Updated": "1440021299248",
+            "Fraud Type": "Exposed",
+            "Location": "www.example.com"
+          },
+          "status": "ERROR",
+          "resource_id": "",
+          "uuid": "aa12345f-55c7-498e-b7ac-123456789012"
+        }
+      },
+      "description": "Trusted Advisor alert for key exposed",
+      "log": "cloudwatch:events",
+      "service": "kinesis",
+      "source": "prefix_cluster1_stream_alert_kinesis",
+      "trigger_rules": [
+        "trusted_advisor"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves #618

Trusted Advisor events go to CloudWatch Events.  This rule is similar to the recent GuardDuty rule in https://github.com/airbnb/streamalert/pull/594

There are dozens of Trusted Advisor events, so this filters on just a few of the more important security ones, otherwise you will be flooded with hundreds regularly as Trusted Advisor tries to save you a few pennies.