### PR TITLE
Add alert UUID and use it in SNS subject

### DIFF
--- a/rules/community/binaryalert/binaryalert_yara_match.py
+++ b/rules/community/binaryalert/binaryalert_yara_match.py
@@ -1,4 +1,4 @@
-"""Alert on destructive AWS API calls."""
+"""Alert on BinaryAlert YARA matches"""
 from stream_alert.rule_processor.rules_engine import StreamRules
 
 rule = StreamRules.rule

--- a/stream_alert/alert_processor/helpers.py
+++ b/stream_alert/alert_processor/helpers.py
@@ -31,6 +31,7 @@ def validate_alert(alert):
         return False
 
     alert_keys = {
+        'id',
         'record',
         'rule_name',
         'rule_description',
@@ -79,3 +80,20 @@ def validate_alert(alert):
             valid = False
 
     return valid
+
+
+def elide_string_middle(text, max_length):
+    """Replace the middle of the text with ellipses to shorten text to the desired length.
+
+    Args:
+        text (str): Text to shorten.
+        max_length (int): Maximum allowable length of the string.
+
+    Returns:
+        (str) The elided text, e.g. "Some really long tex ... the end."
+    """
+    if len(text) <= max_length:
+        return text
+
+    half_len = (max_length - 5) / 2  # Length of text on either side.
+    return '{} ... {}'.format(text[:half_len], text[-half_len:])

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -62,6 +62,7 @@ def run(alert, region, account_id, function_name, config):
             following structure:
 
             {
+                'id': uuid,
                 'record': record,
                 'rule_name': rule.rule_name,
                 'rule_description': rule.rule_function.__doc__,
@@ -84,7 +85,7 @@ def run(alert, region, account_id, function_name, config):
         LOGGER.error('Invalid alert format:\n%s', json.dumps(alert, indent=2))
         return
 
-    LOGGER.debug('Sending alert to outputs:\n%s', json.dumps(alert, indent=2))
+    LOGGER.info('Sending alert %s to outputs %s', alert['id'], alert['outputs'])
 
     # strip out unnecessary keys and sort
     alert = _sort_dict(alert)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -16,6 +16,7 @@ limitations under the License.
 from collections import namedtuple
 from copy import copy
 import json
+import uuid
 
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
@@ -443,10 +444,12 @@ class StreamRules(object):
             if StreamRules.check_alerts_duplication(record, rule, alerts):
                 return
 
-            LOGGER.info('Rule [%s] triggered an alert on log type [%s] from entity \'%s\' '
-                        'in service \'%s\'', rule.rule_name, payload.log_source,
+            alert_id = str(uuid.uuid4())  # Random unique alert ID
+            LOGGER.info('Rule [%s] triggered alert [%s] on log type [%s] from entity \'%s\' '
+                        'in service \'%s\'', rule.rule_name, alert_id, payload.log_source,
                         payload.entity, payload.service())
             alert = {
+                'id': alert_id,
                 'record': record,
                 'rule_name': rule.rule_name,
                 'rule_description': rule.rule_function.__doc__ or DEFAULT_RULE_DESCRIPTION,

--- a/tests/unit/stream_alert_alert_processor/helpers.py
+++ b/tests/unit/stream_alert_alert_processor/helpers.py
@@ -69,6 +69,7 @@ def get_alert(context=None):
         context(dict): context dictionary (None by default)
     """
     return {
+        'id': '79192344-4a6d-4850-8d06-9c3fef1060a4',
         'record': {
             'compressed_size': '9982',
             'timestamp': '1496947381.18',

--- a/tests/unit/stream_alert_alert_processor/test_helpers.py
+++ b/tests/unit/stream_alert_alert_processor/test_helpers.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from nose.tools import assert_false, assert_true
+from nose.tools import assert_equal, assert_false, assert_true
 
-from stream_alert.alert_processor.helpers import validate_alert
+from stream_alert.alert_processor.helpers import elide_string_middle, validate_alert
 from tests.unit.stream_alert_alert_processor.helpers import get_alert
 
 
@@ -100,3 +100,18 @@ def test_metadata_non_string_type():
 
     # Test with invalid metadata non-string value
     assert_false(validate_alert(invalid_metadata_non_string))
+
+
+def test_elide_string_middle():
+    """Alert Processor String Truncation"""
+    alphabet = 'abcdefghijklmnopqrstuvwxyz'
+
+    # String shortened
+    assert_equal('ab ... yz', elide_string_middle(alphabet, 10))
+    assert_equal('abcde ... vwxyz', elide_string_middle(alphabet, 15))
+    assert_equal('abcdefg ... tuvwxyz', elide_string_middle(alphabet, 20))
+    assert_equal('abcdefghij ... qrstuvwxyz', elide_string_middle(alphabet, 25))
+
+    # String unchanged
+    assert_equal(alphabet, elide_string_middle(alphabet, 26))
+    assert_equal(alphabet, elide_string_middle(alphabet, 50))

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -99,6 +99,7 @@ class TestStreamRules(object):
         alerts, _ = self.rules_engine.process(payload)
 
         alert_keys = {
+            'id',
             'record',
             'rule_name',
             'rule_description',
@@ -110,6 +111,7 @@ class TestStreamRules(object):
             'context'
         }
         assert_items_equal(alerts[0].keys(), alert_keys)
+        assert_is_instance(alerts[0]['id'], str)
         assert_is_instance(alerts[0]['record'], dict)
         assert_is_instance(alerts[0]['outputs'], list)
         assert_is_instance(alerts[0]['context'], dict)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers  @mime-frame 
size: small

## Background

We want to generate unique alert IDs to track them throughout their lifetime. For example, we can use them in the subject of messages sent via SNS

## Changes

* Adds alert UUID to alert dictionary
* Adds a subject to SNS messages with rule name + alert ID
* [unrelated] Fix BinaryAlert rule docstring

## Testing

* BuildKite CI
* Deploy to a test account - the SNS alert showed up in my inbox:

`binaryalert_yara_match triggered alert 091b1fd6-51f7-4be4-982e-9378b0af8cf6`
