### PR TITLE
[output] catch requests timeout exceptions

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -19,6 +19,7 @@ import json
 import os
 import tempfile
 import requests
+from requests.exceptions import Timeout as ReqTimeout
 import urllib3
 
 import backoff
@@ -266,7 +267,7 @@ class OutputDispatcher(object):
     @classmethod
     def _catch_exceptions(cls):
         """Classmethod that returns a tuple of the exceptions to catch"""
-        default_exceptions = (OutputRequestFailure,)
+        default_exceptions = (OutputRequestFailure, ReqTimeout)
         exceptions = cls._get_exceptions_to_catch()
         if not exceptions:
             return default_exceptions

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -16,6 +16,8 @@ limitations under the License.
 # pylint: disable=abstract-class-instantiated,protected-access,attribute-defined-outside-init
 import os
 
+from requests.exceptions import Timeout as ReqTimeout
+
 from mock import Mock, patch
 from moto import mock_kms, mock_s3
 from nose.tools import (
@@ -214,7 +216,7 @@ class TestOutputDispatcher(object):
         """OutputDispatcher - Catch Non Default Exceptions"""
         exceptions = self._dispatcher._catch_exceptions()
 
-        assert_equal(exceptions, (OutputRequestFailure, ValueError))
+        assert_equal(exceptions, (OutputRequestFailure, ReqTimeout, ValueError))
 
     @patch.object(OutputDispatcher,
                   '_get_exceptions_to_catch', Mock(return_value=(ValueError, TypeError)))
@@ -222,11 +224,11 @@ class TestOutputDispatcher(object):
         """OutputDispatcher - Catch Non Default Exceptions Tuple"""
         exceptions = self._dispatcher._catch_exceptions()
 
-        assert_equal(exceptions, (OutputRequestFailure, ValueError, TypeError))
+        assert_equal(exceptions, (OutputRequestFailure, ReqTimeout, ValueError, TypeError))
 
     @patch.object(OutputDispatcher, '_get_exceptions_to_catch', Mock(return_value=()))
     def test_catch_exceptions_default(self):
         """OutputDispatcher - Catch Default Exceptions"""
         exceptions = self._dispatcher._catch_exceptions()
 
-        assert_equal(exceptions, (OutputRequestFailure,))
+        assert_equal(exceptions, (OutputRequestFailure, ReqTimeout))


### PR DESCRIPTION
to: @ryandeivert or @javuto 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
During an internal triage, I found out we need to catch ReadTimeout and ConnectTimeout while sending [requests post request](https://github.com/airbnb/streamalert/blob/master/stream_alert/alert_processor/outputs/output_base.py#L398). [requests.execptions.Timeout](http://docs.python-requests.org/en/master/_modules/requests/exceptions/) will catch both `ReadTimeout` and `ConnectTimeout`.

## Changes

* Add `requests.exceptions.Timeout` to default exceptions in output base class
* Update unit test cases. 

## Testing
* Unit test
```
./tests/scripts/unit_tests.sh
...
Ran 548 tests in 9.324s

OK
```
* Rule test
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (61/61) Successful Tests
StreamAlertCLI [INFO]: (33/33) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```