### PR TITLE
[athena] fixing athena results bucket tag name

### DIFF
--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -29,7 +29,7 @@ resource "aws_s3_bucket" "athena_results_bucket" {
   force_destroy = false
 
   tags {
-    Name = "${var.results_bucket}"
+    Name = "StreamAlert"
   }
 
   versioning {


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The athena results bucket was using the name of the bucket as the tag when it should be using `StreamAlert`. This is mostly for billing tracking purposes.

## Changes

* Changing the `Name` resource tag to `StreamAlert`
