### PR TITLE
[athena] fixing when the create_table gets called

### DIFF
--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -115,17 +115,17 @@ def _terraform_init(config):
     if not run_command(['terraform', 'init']):
         return
 
-    # we need to manually create the streamalerts table since terraform does not support this
-    # See: https://github.com/terraform-providers/terraform-provider-aws/issues/1486
-    alerts_bucket = '{}.streamalerts'.format(config['global']['account']['prefix'])
-    create_table(None, alerts_bucket, 'alerts', config)
-
     # Use a named tuple to match the 'processor' attribute in the argparse options
     deploy_opts = namedtuple('DeployOptions', ['processor', 'clusters'])
 
     LOGGER_CLI.info('Deploying Lambda Functions')
 
     deploy(deploy_opts(['rule', 'alert', 'athena'], []), config)
+
+    # we need to manually create the streamalerts table since terraform does not support this
+    # See: https://github.com/terraform-providers/terraform-provider-aws/issues/1486
+    alerts_bucket = '{}.streamalerts'.format(config['global']['account']['prefix'])
+    create_table(None, alerts_bucket, 'alerts', config)
 
     LOGGER_CLI.info('Building Remainder Infrastructure')
     tf_runner(refresh=False)


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

* @austinbyers discovered an issue during initialization where the `alerts` table creation failed:
```
StreamAlertAthena [ERROR]: The query SHOW TABLES LIKE 'alerts'; returned FAILED, exiting!
StreamAlertAthena [ERROR]: The query CREATE EXTERNAL TABLE alerts (log_source string,log_type string,outputs array<string>,record string,rule_description string,rule_name string,source_entity string,source_service string)PARTITIONED BY (dt string)ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'LOCATION 's3://<prefix>.streamalerts/alerts/' returned FAILED, exiting!
StreamAlertCLI [ERROR]: The alerts table could not be created
```
* Thanks to Austin for proactively testing the fix :)

## Changes

* Changing when the `create_table` function is called so it happens after the initial infrastructure for athena is built.
