### PR TITLE
Use context manager for Dynamo batch_write

### DIFF
--- a/stream_alert/rule_processor/alert_forward.py
+++ b/stream_alert/rule_processor/alert_forward.py
@@ -16,6 +16,7 @@ limitations under the License.
 from datetime import datetime
 import json
 import os
+import time
 
 import boto3
 from botocore.exceptions import ClientError
@@ -110,7 +111,9 @@ class AlertForwarder(object):
             'SourceService': alert['source_service'],
             'Outputs': set(alert['outputs']),
             # Compact JSON encoding (no extra spaces)
-            'Record': json.dumps(alert['record'], separators=(',', ':'))
+            'Record': json.dumps(alert['record'], separators=(',', ':')),
+            # TODO: Remove TTL after alert merger is implemented
+            'TTL': int(time.time()) + 7200  # 2 hour TTL
         }
 
     def _send_to_dynamo(self, alerts):

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -55,7 +55,6 @@ class MetricLogger(object):
     TOTAL_S3_RECORDS = 'TotalS3Records'
     TOTAL_STREAM_ALERT_APP_RECORDS = 'TotalStreamAlertAppRecords'
     TRIGGERED_ALERTS = 'TriggeredAlerts'
-    UNPROCESSED_ALERTS = 'UnprocessedAlerts'
     FIREHOSE_RECORDS_SENT = 'FirehoseRecordsSent'
     FIREHOSE_FAILED_RECORDS = 'FirehoseFailedRecords'
     NORMALIZED_RECORDS = 'NormalizedRecords'
@@ -87,7 +86,6 @@ class MetricLogger(object):
                                _default_value_lookup),
             TRIGGERED_ALERTS: (_default_filter.format(TRIGGERED_ALERTS),
                                _default_value_lookup),
-            UNPROCESSED_ALERTS: (_default_filter.format(UNPROCESSED_ALERTS), _default_value_lookup),
             FIREHOSE_RECORDS_SENT: (_default_filter.format(FIREHOSE_RECORDS_SENT),
                                     _default_value_lookup),
             FIREHOSE_FAILED_RECORDS: (_default_filter.format(FIREHOSE_FAILED_RECORDS),

--- a/stream_alert/shared/metrics.py
+++ b/stream_alert/shared/metrics.py
@@ -55,6 +55,7 @@ class MetricLogger(object):
     TOTAL_S3_RECORDS = 'TotalS3Records'
     TOTAL_STREAM_ALERT_APP_RECORDS = 'TotalStreamAlertAppRecords'
     TRIGGERED_ALERTS = 'TriggeredAlerts'
+    FAILED_DYNAMO_WRITES = 'FailedDynamoWrites'
     FIREHOSE_RECORDS_SENT = 'FirehoseRecordsSent'
     FIREHOSE_FAILED_RECORDS = 'FirehoseFailedRecords'
     NORMALIZED_RECORDS = 'NormalizedRecords'
@@ -86,6 +87,8 @@ class MetricLogger(object):
                                _default_value_lookup),
             TRIGGERED_ALERTS: (_default_filter.format(TRIGGERED_ALERTS),
                                _default_value_lookup),
+            FAILED_DYNAMO_WRITES: (_default_filter.format(FAILED_DYNAMO_WRITES),
+                                   _default_value_lookup),
             FIREHOSE_RECORDS_SENT: (_default_filter.format(FIREHOSE_RECORDS_SENT),
                                     _default_value_lookup),
             FIREHOSE_FAILED_RECORDS: (_default_filter.format(FIREHOSE_FAILED_RECORDS),

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -936,7 +936,7 @@ def stream_alert_test(options, config):
         # The Rule Processor uses env variables to determine where alerts should be forwarded:
         prefix = config['global']['account']['prefix']
         os.environ['ALERT_PROCESSOR'] = '{}_streamalert_alert_processor'.format(prefix)
-        os.environ['ALERT_TABLE'] = '{}_streamalert_alerts'.format(prefix)
+        os.environ['ALERTS_TABLE'] = '{}_streamalert_alerts'.format(prefix)
 
         if options.debug:
             # TODO(jack): Currently there is no (clean) way to set

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "streamalert_rule_processor" {
   environment {
     variables = {
       ALERT_PROCESSOR = "${var.prefix}_streamalert_alert_processor"
-      ALERT_TABLE     = "${var.prefix}_streamalert_alerts"
+      ALERTS_TABLE     = "${var.prefix}_streamalert_alerts"
       CLUSTER         = "${var.cluster}"
       ENABLE_METRICS  = "${var.rule_processor_enable_metrics}"
       LOGGER_LEVEL    = "${var.rule_processor_log_level}"

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -11,7 +11,7 @@ resource "aws_dynamodb_table" "alerts_table" {
   read_capacity  = "${var.alerts_table_read_capacity}"
   write_capacity = "${var.alerts_table_write_capacity}"
   hash_key       = "RuleName"
-  range_key      = "Timestamp"
+  range_key      = "AlertID"
 
   // Only the hash key and range key attributes need to be defined here.
 
@@ -20,7 +20,7 @@ resource "aws_dynamodb_table" "alerts_table" {
     type = "S"
   }
   attribute {
-    name = "Timestamp"
+    name = "AlertID"
     type = "S"
   }
   // Enable expriation time while testing Dynamo table for alerts

--- a/tests/unit/stream_alert_rule_processor/test_alert_forward.py
+++ b/tests/unit/stream_alert_rule_processor/test_alert_forward.py
@@ -149,7 +149,8 @@ class TestAlertForwarder(object):
             'SourceEntity': 'test_entity',
             'SourceService': 'test_service',
             'Outputs': {'out1:here', 'out2:there'},  # Duplicates are ignored
-            'Record': '{"key":"value"}'
+            'Record': '{"key":"value"}',
+            'TTL': ANY
         }
         assert_equal(expected, record)
 

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -49,7 +49,7 @@ class TestStreamAlert(object):
     @patch('stream_alert.rule_processor.handler.load_config',
            lambda: load_config('tests/unit/conf/'))
     @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor',
-                             'ALERT_TABLE': 'unit-testing_streamalert_alerts'})
+                             'ALERTS_TABLE': 'unit-testing_streamalert_alerts'})
     def setup(self):
         """Setup before each method"""
         self.__sa_handler = StreamAlert(get_mock_context(), False)
@@ -269,7 +269,7 @@ class TestStreamAlert(object):
     @patch('stream_alert.rule_processor.threat_intel.StreamThreatIntel._query')
     @patch('stream_alert.rule_processor.threat_intel.StreamThreatIntel.load_from_config')
     @patch.dict(os.environ, {'ALERT_PROCESSOR': 'unit-testing_streamalert_alert_processor',
-                             'ALERT_TABLE': 'unit-testing_streamalert_alerts'})
+                             'ALERTS_TABLE': 'unit-testing_streamalert_alerts'})
     def test_run_threat_intel_enabled(self, mock_threat_intel, mock_query): # pylint: disable=no-self-use
         """StreamAlert Class - Run SA when threat intel enabled"""
         @rule(datatypes=['sourceAddress'], outputs=['s3:sample_bucket'])


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

Batch writing in Dynamo is far easier than I previously thought, because boto3 provides a [context manager](http://boto3.readthedocs.io/en/latest/guide/dynamodb.html#batch-writing):

```python
with table.batch_writer() as batch:
    batch.put_item(Item={})
```

The batch writer automatically handles buffering and retrying items which failed to write. So we can remove a bunch of custom logic we added to do this.

## Changes

* Use `batch_writer()` for the alerts table instead of the underlying client
* Replace the `UnprocessedAlerts` custom metric with `FailedDynamoWrites`
* Rename `ALERT_TABLE` environment variable in the rule processor to `ALERTS_TABLE` (makes more sense to me - I kept naming variables "alerts_table")
* Change the alert as it appears in the Dynamo table
    * `AlertID` is the range key instead of `Timestamp` (which allows efficient lookup of a specific ruleName + alertID)
    * `Timestamp` renamed to `Created`
    * Add `LogSource`, `LogType`, `SourceEntity`, `SourceService` (these are keys present in the alert record but not yet saved to Dynamo)

## Testing

* Live test end-to-end! The alert in Dynamo now looks like this:

![screen shot 2018-03-16 at 2 44 50 pm](https://user-images.githubusercontent.com/3608925/37546119-afad1cb4-2928-11e8-9d40-46903b67fb38.png)

