### PR TITLE
[tf] fix to address terraform support for cloudtrail event_selector

### DIFF
--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -7,6 +7,19 @@ resource "aws_cloudtrail" "streamalert" {
   enable_logging                = "${var.enable_logging}"
   include_global_service_events = true
   is_multi_region_trail         = "${var.is_global_trail}"
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type = "AWS::S3::Object"
+
+      values = [
+        "arn:aws:s3",
+      ]
+    }
+  }
 }
 
 // S3 bucket for CloudTrail output


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The new `terraform-provider-aws`[ added support for cloudtrail event_selector](https://github.com/terraform-providers/terraform-provider-aws/pull/2258). Attempting to apply the streamalert cloudtrail module attempts to overwrite the defaults:


## Changes

* Adding the `event_selector` to the cloudtrail module to keep the current setting from getting overwritten.
