### PR TITLE
Fix bugs introduced from #642

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -145,7 +145,7 @@ class OutputDispatcher(object):
     def __init__(self, region, account_id, prefix, config):
         self.region = region
         self.account_id = account_id
-        self.secrets_bucket = '{}_streamalert_secrets'.format(prefix)
+        self.secrets_bucket = '{}.streamalert.secrets'.format(prefix)
         self.config = config
 
     @staticmethod

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -418,7 +418,6 @@ def setup_mock_firehose_delivery_streams(config):
         create_delivery_stream(region, stream_name, prefix)
 
 
-@mock_dynamodb2
 def setup_mock_dynamodb_ioc_table(config):
     """Mock DynamoDB IOC table for rule testing
 
@@ -489,7 +488,6 @@ def setup_mock_dynamodb_ioc_table(config):
         TableName=table_name)
 
 
-@mock_dynamodb2
 def setup_mock_alerts_table(table_name):
     """Create a mock DynamoDB alerts table used by rule processor, alert processor, alert merger"""
     boto3.client('dynamodb').create_table(

--- a/tests/unit/stream_alert_alert_merger/test_main.py
+++ b/tests/unit/stream_alert_alert_merger/test_main.py
@@ -32,7 +32,6 @@ _ALERT_PROCESSOR = 'PREFIX_streamalert_alert_processor'
 _ALERT_PROCESSOR_TIMEOUT_SEC = 60
 
 
-@mock_dynamodb2
 class TestAlertTable(object):
     """Tests for merger/main.py:AlertTable"""
 
@@ -40,6 +39,9 @@ class TestAlertTable(object):
     def setup(self):
         """Alert Merger - Alert Table - Add mock alerts to the table"""
         # pylint: disable=attribute-defined-outside-init
+        self.dynamo_mock = mock_dynamodb2()
+        self.dynamo_mock.start()
+
         setup_mock_alerts_table(_ALERTS_TABLE)
         self.alert_table = main.AlertTable(_ALERTS_TABLE)
 
@@ -61,6 +63,10 @@ class TestAlertTable(object):
                         'key2': 'value2'
                     })
                 })
+
+    def teardown(self):
+        """Alert Merger - Teardown - Stop Mocks"""
+        self.dynamo_mock.stop()
 
     def test_paginate_multiple(self):
         """Alert Merger - Alert Table - Paginate Traverses Multiple Pages"""


### PR DESCRIPTION
to: @ryandeivert or @chunyong-lin 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

When syncing #642 internally, we found a couple of bugs related to rule testing. Namely:

- The output credentials bucket was not mocked correctly because it had the wrong name
- The mocks for the threat intel table and the alerts table conflict with each other 

## Changes

* Reverted name of the secrets bucket in the alert processor (`prefix.streamalert.secrets` is correct, not `prefix_streamalert_secrets`)
* Remove `@mock_dynamodb2` decorator from methods which setup mock tables, because the context is already mocked when those methods are called

## Testing

* Deployed this to a test account and tested the slack integration (to confirm output secrets are working as expected). Going forward, I'll make sure to test outputs with secrets when making large changes to the alert processor.
* Synced this branch internally and all tests pass
