### PR TITLE
small optimization to avoid multiple recursive calls

### DIFF
--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -350,9 +350,7 @@ class StreamThreatIntel(object):
                               on_backoff=backoff_handler,
                               on_success=success_handler,
                               on_giveup=giveup_handler)
-        def _query(values):
-            result = []
-            query_keys = [{PRIMARY_KEY: {'S': ioc}} for ioc in values if ioc]
+        def _query(query_keys):
             response = self.dynamodb.batch_get_item(
                 RequestItems={
                     self._table: {
@@ -362,12 +360,15 @@ class StreamThreatIntel(object):
                 },
             )
 
+            result = []
             if response.get('Responses'):
                 result.extend(self._deserialize(response['Responses'].get(self._table)))
 
             return result, response.get('UnprocessedKeys')
 
-        return _query(values)
+        query_keys = [{PRIMARY_KEY: {'S': ioc}} for ioc in values if ioc]
+
+        return _query(query_keys)
 
     @staticmethod
     def _deserialize(dynamodb_data):


### PR DESCRIPTION
to: @austinbyers or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Identified a function that used backoff that does recursive record sanitization. If the function ever backs-off, this would result in unnecessary calls to sanitize keys.

## Changes

* Moving the record dumping and sanitization to outside of the backed-off function.
* Changing another small instance of something similar in the threat_intel module.

## Testing

Unit tests passing, etc