### PR TITLE
[tf] reduce cloudwatch log retention to 14 days

### DIFF
--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -3,7 +3,7 @@ variable "account_id" {
 }
 
 variable "cloudwatch_log_retention" {
-  default = 60
+  default = 14
 }
 
 variable "cluster" {

--- a/terraform/modules/tf_stream_alert_app/main.tf
+++ b/terraform/modules/tf_stream_alert_app/main.tf
@@ -64,5 +64,5 @@ resource "aws_cloudwatch_event_target" "stream_alert_app_lambda_target" {
 // Log Retention Policy: StreamAlert App function
 resource "aws_cloudwatch_log_group" "stream_alert_app" {
   name              = "/aws/lambda/${var.function_prefix}_app"
-  retention_in_days = 60
+  retention_in_days = 14
 }

--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -125,7 +125,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 // Log Retention Policy
 resource "aws_cloudwatch_log_group" "athena" {
   name              = "/aws/lambda/${var.prefix}_streamalert_athena_partition_refresh"
-  retention_in_days = 60
+  retention_in_days = 14
 }
 
 // CloudWatch metric filters for the athena partition refresh function

--- a/terraform/modules/tf_stream_alert_globals/alerts_firehose/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/alerts_firehose/variables.tf
@@ -9,7 +9,7 @@ variable "buffer_interval" {
 }
 
 variable "cloudwatch_log_retention" {
-  default = 30
+  default = 14
 }
 
 variable "compression_format" {


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

CloudWatch log search performance depends on how many log streams exist within a log group.  This PR is an attempt to make searching quicker by lowering the amount of log streams retained in a single group.

## Changes

* Reduce cloudwatch log retention for Athena, Rule Processor, Apps, and Firehose

## Testing

None
