### PR TITLE
Add error handling

### DIFF
--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -155,7 +155,8 @@ class JSONParser(ParserBase):
                              'but received %s. Value: %s',
                              type(json_records[index]),
                              json_records[index])
-                return False
+                del json_records[index]
+                continue
             schema_match = False
             json_keys = set(json_records[index].keys())
             if json_keys == schema_keys:

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -150,6 +150,12 @@ class JSONParser(ParserBase):
         # Because elements are deleted off of json_records during
         # iteration, this block uses a reverse range.
         for index in reversed(range(len(json_records))):
+            if not isinstance(json_records[index], dict):
+                LOGGER.error('Skipping record. Expected type dict, '
+                             'but received %s. Value: %s',
+                             type(json_records[index]),
+                             json_records[index])
+                return False
             schema_match = False
             json_keys = set(json_records[index].keys())
             if json_keys == schema_keys:


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @ryandeivert 
size: small
resolves #648

## Background

Adds some simple error handling.  I was not able to get my instance of StreamAlert to fail in the same way it had previously, to retest this change, as now when I do:

```
aws kinesis put-record --stream-name test_prod_stream_alert_kinesis --partition-key 0 --data string_test
```
I get the error in the logs:

```
[ERROR]	2018-03-22T20:39:44.315Z	480fda82-041e-45f4-934b-4246aec7f9cd	Record does not match any defined schemas: <KinesisPayload valid:False log_source:None entity:test_prod_stream_alert_kinesis type:None record:None>
```
So that situation is being handled somewhere else, and I couldn't figure out how to put things back into the bad situation I was experiencing previously.

However, I did make this change, deploy this code, and ensure StreamAlert still functions correctly, so it looks like this should be harmless for normal operation.
