### PR TITLE
[output] Reducing the PagerDuty API requests per alert

### DIFF
--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -880,11 +880,11 @@ class TestStreamRules(object):
         """Rules Engine - Testing Context Modification"""
         @rule(logs=['test_log_type_json_nested_with_data'],
               outputs=['s3:sample_bucket'],
-              context={'assigned_user': 'not_set', 'assigned_policy': 'not_set2'})
+              context={'assigned_user': 'not_set', 'assigned_policy_id': 'not_set2'})
         def modify_context_test(rec, context): # pylint: disable=unused-variable
             """Modify context rule"""
             context['assigned_user'] = 'valid_user'
-            context['assigned_policy'] = 'valid_policy'
+            context['assigned_policy_id'] = 'valid_policy_id'
             return rec['application'] == 'web-app'
 
         kinesis_data = json.dumps({
@@ -910,4 +910,4 @@ class TestStreamRules(object):
 
         # alert tests
         assert_equal(alerts[0]['context']['assigned_user'], 'valid_user')
-        assert_equal(alerts[0]['context']['assigned_policy'], 'valid_policy')
+        assert_equal(alerts[0]['context']['assigned_policy_id'], 'valid_policy_id')


### PR DESCRIPTION
to: @ryandeivert or @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

When using the PagerDuty output `PagerDutyIncidentOutput`, the target service and default escalation policy were stored by name, making the output to generate 2 extra requests to the API, to verify those items (and retrieve both IDs). If those IDs are provided when creating the output, we no longer need to verify them and less API calls will be needed. In environments where there is a large number of alerts generated per hour, saving 2-3 API calls per alert helps to avoid API throttling.

## Changes

* Storing service ID and escalation policy ID as part of the output, it saves 2-3 requests per alert to the API.
* Modified unit tests accordingly.
* Context will contain now the policy ID to be assigned to.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 555 tests in 10.902s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```