### PR TITLE
[threat intel] allow one record to be normalized multiple times

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -474,6 +474,13 @@ class StreamRules(object):
             if rule.rule_name == exist_alert['rule_name']:
                 record_copy = record.copy()
                 exist_alert_record_copy = exist_alert['record'].copy()
+                # Early return when two records are dumplicated.
+                if record_copy == exist_alert_record_copy:
+                    return True
+
+                # There is chance that there are different values in 'streamalert:normalization'
+                # or 'streamalert:ioc' fields. So do comparision again after removing
+                # two keys.
                 record_copy.pop(StreamThreatIntel.IOC_KEY, None)
                 record_copy.pop(NORMALIZATION_KEY, None)
                 exist_alert_record_copy.pop(StreamThreatIntel.IOC_KEY, None)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -351,9 +351,6 @@ class StreamRules(object):
             return alerts, normalized_records
 
         for record in payload.records:
-            # One record may be added to normalized records list multiple time due
-            # to each record is processed by all rules.
-            normalized_record_appended = False
             for rule in rules:
                 # subkey check
                 has_sub_keys = self.process_subkeys(record, payload.type, rule)
@@ -374,7 +371,7 @@ class StreamRules(object):
                 if types_result:
                     record_copy = record.copy()
                     record_copy[NORMALIZATION_KEY] = types_result
-                    if self._threat_intel and not normalized_record_appended:
+                    if self._threat_intel:
                         # A copy of payload which includes payload metadata.
                         # The payload metadata includes log_source, type, service,
                         # and entity. The metadata will be returned to along with
@@ -384,7 +381,6 @@ class StreamRules(object):
                         payload_copy.records = None
                         payload_copy.raw_record = None
                         normalized_records.append(payload_copy)
-                        normalized_record_appended = True
                 else:
                     record_copy = record
                 # rule analysis
@@ -477,11 +473,12 @@ class StreamRules(object):
         for exist_alert in alerts:
             if rule.rule_name == exist_alert['rule_name']:
                 record_copy = record.copy()
-                if StreamThreatIntel.IOC_KEY not in exist_alert['record']:
-                    record_copy.pop(StreamThreatIntel.IOC_KEY, None)
-                if NORMALIZATION_KEY not in exist_alert['record']:
-                    record_copy.pop(NORMALIZATION_KEY, None)
-                if record_copy == exist_alert['record']:
+                exist_alert_record_copy = exist_alert['record'].copy()
+                record_copy.pop(StreamThreatIntel.IOC_KEY, None)
+                record_copy.pop(NORMALIZATION_KEY, None)
+                exist_alert_record_copy.pop(StreamThreatIntel.IOC_KEY, None)
+                exist_alert_record_copy.pop(NORMALIZATION_KEY, None)
+                if record_copy == exist_alert_record_copy:
                     return True
 
         return False

--- a/stream_alert/rule_processor/threat_intel.py
+++ b/stream_alert/rule_processor/threat_intel.py
@@ -155,7 +155,6 @@ class StreamThreatIntel(object):
         for datatype in record.pre_parsed_record[NORMALIZATION_KEY]:
             # Lookup mapped IOC type based on normalized CEF type from Class variable.
             ioc_type = self.__normalized_ioc_types_mapping.get(datatype, None)
-
             # A new StreamIoc instance will be created when normalized CEF type
             # has mapped IOC type.
             if ioc_type:

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -336,5 +336,14 @@
     "configuration": {
       "json_regex_key": "message"
     }
+  },
+  "test_log_threat_intel_custom": {
+    "schema": {
+      "Field1": {},
+      "Field2": {},
+      "Field3": {},
+      "Field4": {}
+    },
+    "parser": "json"
   }
 }

--- a/tests/unit/conf/sources.json
+++ b/tests/unit/conf/sources.json
@@ -25,6 +25,11 @@
         "test_log_type_syslog"
       ]
     },
+    "test_stream_threat_intel": {
+      "logs": [
+        "test_log_threat_intel_custom"
+      ]
+    },
     "unit_test_default_stream": {
       "logs": [
         "unit_test_simple_log",

--- a/tests/unit/conf/types.json
+++ b/tests/unit/conf/types.json
@@ -55,5 +55,13 @@
       "owner",
       "invokedBy"
     ]
+  },
+  "test_log_threat_intel_custom": {
+    "fileHash:ioc_md5": [
+      "key2_md5"
+    ],
+    "sourceDomain:ioc_domain": [
+      "key3_source_domain"
+    ]
   }
 }

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -273,6 +273,10 @@ class MockDynamoDBClient(object):
                     {
                         'ioc_value': {'S': 'evil.com'},
                         'sub_type': {'S': 'c2_domain'}
+                    },
+                    {
+                        'ioc_value': {'S': 'md5-of-file'},
+                        'sub_type': {'S': 'test_file_hash'}
                     }
                 ]
             },

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -876,6 +876,67 @@ class TestStreamRules(object):
         alerts = new_rules_engine.threat_intel_match(records)
         assert_equal(len(alerts), 2)
 
+    @patch('boto3.client')
+    def test_process_allow_multi_around_normalization(self, mock_client):
+        """Rules Engine - Threat Intel is enabled run multi-round_normalization"""
+
+        @rule(datatypes=['fileHash'], outputs=['s3:sample_bucket'])
+        def match_file_hash(rec): # pylint: disable=unused-variable
+            """Testing dummy rule to match file hash"""
+            return 'streamalert:ioc' in rec and 'md5' in rec['streamalert:ioc']
+
+        @rule(datatypes=['fileHash', 'sourceDomain'], outputs=['s3:sample_bucket'])
+        def match_source_domain(rec): # pylint: disable=unused-variable
+            """Testing dummy rule to match source domain and file hash"""
+            return 'streamalert:ioc' in rec
+
+        mock_client.return_value = MockDynamoDBClient()
+        toggled_config = self.config
+        toggled_config['global']['threat_intel']['enabled'] = True
+        toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'
+
+        new_rules_engine = StreamRules(toggled_config)
+        kinesis_data = {
+            "Field1": {
+                "SubField1": {
+                    "key1": 17,
+                    "key2_md5": "md5-of-file",
+                    "key3_source_domain": "evil.com"
+                },
+                "SubField2": 1
+            },
+            "Field2": {
+                "Authentication": {}
+            },
+            "Field3": {},
+            "Field4": {}
+        }
+
+        kinesis_data = json.dumps(kinesis_data)
+        service, entity = 'kinesis', 'test_stream_threat_intel'
+        raw_record = make_kinesis_raw_record(entity, kinesis_data)
+        payload = load_and_classify_payload(toggled_config, service, entity, raw_record)
+        alerts, normalized_records = new_rules_engine.process(payload)
+
+        # Two testing rules are for threat intelligence matching. So no alert will be
+        # generated before threat intel takes effect.
+        assert_equal(len(alerts), 0)
+
+        # One record will be normalized twice by two different rules with different
+        # normalization keys. It should generate two alerts by two different rules
+        # from same record.
+        assert_equal(len(normalized_records), 2)
+        assert_equal(normalized_records[0].pre_parsed_record['streamalert:normalization'].keys(),
+                     ['fileHash'])
+        assert_equal(normalized_records[1].pre_parsed_record['streamalert:normalization'].keys(),
+                     ['fileHash', 'sourceDomain'])
+
+        # Pass normalized records to threat intel engine.
+        alerts_from_threat_intel = new_rules_engine.threat_intel_match(normalized_records)
+        assert_equal(len(alerts_from_threat_intel), 2)
+        assert_equal(alerts_from_threat_intel[0]['rule_name'], 'match_file_hash')
+        assert_equal(alerts_from_threat_intel[1]['rule_name'], 'match_source_domain')
+
     def test_rule_modify_context(self):
         """Rules Engine - Testing Context Modification"""
         @rule(logs=['test_log_type_json_nested_with_data'],

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -483,7 +483,7 @@ class TestStreamThreatIntel(object):
 
         test_values = ['1.1.1.2', '2.2.2.2', 'evil.com', 'abcdef0123456789']
         result, unprocessed_keys = threat_intel._query(test_values)
-        assert_equal(len(result), 2)
+        assert_equal(len(result), 3)
         assert_false(unprocessed_keys)
         assert_equal(result[0], {'ioc_value': '1.1.1.2', 'sub_type': 'mal_ip'})
         assert_equal(result[1], {'ioc_value': 'evil.com', 'sub_type': 'c2_domain'})
@@ -496,7 +496,7 @@ class TestStreamThreatIntel(object):
 
         test_values = ['1.1.1.2', '', 'evil.com', 'abcdef0123456789']
         result, _ = threat_intel._query(test_values)
-        assert_equal(len(result), 2)
+        assert_equal(len(result), 3)
 
     @raises(ParamValidationError)
     @patch('boto3.client')


### PR DESCRIPTION
to: @ryandeivert
cc: @airbnb/streamalert-maintainers
size: small
resolves #654 

## Background

Please see issue #654 where has example and detail.

## Changes

* Remove the flag which prevent a record to be normalized more than once.
* Refactor `check_alerts_duplication` to remove duplicated records.
* Add unit test case to reproduce issue and verify fix.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 556 tests in 9.120s

OK
```
