### PR TITLE
[output] Fix for alert processor cli and pagerduty incidents

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -858,7 +858,9 @@ class AlertProcessorTester(object):
                 output_name = '{}/{}'.format(service, descriptor)
                 creds = {'token': '247b97499078a015cc6c586bc0a92de6',
                          'service_name': '247b97499078a015cc6c586bc0a92de6',
+                         'service_id': 'SERVICEID123',
                          'escalation_policy': '247b97499078a015cc6c586bc0a92de6',
+                         'escalation_policy_id': 'POLICYID123',
                          'email_from': 'blah@foo.bar',
                          'integration_key': '247b97499078a015cc6c586bc0a92de6'}
                 helpers.put_mock_creds(output_name, creds, self.secrets_bucket,


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Related to https://github.com/airbnb/streamalert/pull/652, this is needed for testing alerts using the new format of the PagerDuty output and storing the service and escalation policies IDs.

## Changes

* Adding mocked `service_id` and `escalation_policy_id` in the alert processor CLI tests.

## Testing

```
$ rm .coverage && ./tests/scripts/unit_tests.sh
...
----------------------------------------------------------------------
Ran 555 tests in 10.902s

OK

$ ./tests/scripts/pylint.sh

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ python manage.py lambda test --processor rule all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```