### PR TITLE
[helpers] check for valid ips before executing in_network

### DIFF
--- a/helpers/base.py
+++ b/helpers/base.py
@@ -136,12 +136,15 @@ def in_network(ip_address, cidrs):
     """Check that an ip_address is within a set of CIDRs
 
     Args:
-        ip_address (netaddr.IPAddress): IP address to check
+        ip_address (str or netaddr.IPAddress): IP address to check
         cidrs (set): String CIDRs
 
     Returns:
         Boolean representing if the given IP is within any CIDRs
     """
+    if not valid_ip(ip_address):
+        return False
+
     for cidr in cidrs:
         try:
             network = IPNetwork(cidr)

--- a/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
@@ -80,6 +80,16 @@ def test_valid_ip():
     assert_equal(base.valid_ip(test_ip_invalid), False)
 
 
+def test_in_network_invalid_ip():
+    """Helpers - In Network - Invalid IP"""
+    assert_false(base.in_network('a string that is not an ip', {'10.0.100.0/24'}))
+
+
+def test_in_network_invalid_cidr():
+    """Helpers - In Network - Invalid CIDR"""
+    assert_false(base.in_network('127.0.0.1', {'not a cidr'}))
+
+
 def test_in_network():
     """Helpers - In Network"""
     cidrs = {


### PR DESCRIPTION
to: @ryandeivert 
cc:  @airbnb/streamalert-maintainers
size: small

## Background

Force the ip check `in_network` prior to execution

## Changes

* Use the `valid_ip` helper before running `in_network`

## Testing

Unit testing
