### PR TITLE
[cli][tf] lambda tf module generation now expects the lambda config from caller

### DIFF
--- a/stream_alert_cli/manage_lambda/version.py
+++ b/stream_alert_cli/manage_lambda/version.py
@@ -110,7 +110,7 @@ class LambdaVersion(object):
             for function_name, app_info in self.config['clusters'][cluster]['modules'] \
                 ['stream_alert_apps'].iteritems():
                 # function_name follows format: '<prefix>_<cluster>_<service>_<app_name>_app'
-                new_version = self._publish(client, function_name, code_sha_256)
+                new_version = self._publish(client, function_name, app_info['source_current_hash'])
                 if not new_version:
                     continue
 

--- a/stream_alert_cli/terraform/alert_merger.py
+++ b/stream_alert_cli/terraform/alert_merger.py
@@ -37,7 +37,9 @@ def generate_alert_merger(config):
 
     # Set variables for the Lambda module
     result['module']['alert_merger_lambda'] = generate_lambda(
-        ALERT_MERGER_NAME, config,
+        '{}_streamalert_{}'.format(config['global']['account']['prefix'], ALERT_MERGER_NAME),
+        config['lambda']['alert_merger_config'],
+        config,
         environment={
             'ALERTS_TABLE': '{}_streamalert_alerts'.format(prefix),
             'ALERT_PROCESSOR': '{}_streamalert_alert_processor'.format(prefix),

--- a/stream_alert_cli/terraform/alert_processor.py
+++ b/stream_alert_cli/terraform/alert_processor.py
@@ -50,7 +50,12 @@ def generate_alert_processor(config):
 
     # Set variables for the Lambda module
     result['module']['alert_processor_lambda'] = generate_lambda(
-        ALERT_PROCESSOR_NAME, config,
-        environment={'ALERTS_TABLE': '{}_streamalert_alerts'.format(prefix)})
+        '{}_streamalert_{}'.format(config['global']['account']['prefix'], ALERT_PROCESSOR_NAME),
+        config['lambda']['alert_processor_config'],
+        config,
+        environment={
+            'ALERTS_TABLE': '{}_streamalert_alerts'.format(prefix)
+        }
+    )
 
     return result

--- a/stream_alert_cli/terraform/app_integrations.py
+++ b/stream_alert_cli/terraform/app_integrations.py
@@ -60,6 +60,6 @@ def generate_app_integrations(cluster_name, cluster_dict, config):
         # Format the lambda module with 'app_<app_name_<cluster>_lambda'
         cluster_dict['module']['{}_lambda'.format(module_prefix)] = generate_lambda(
             '{}_app'.format(func_prefix),
-            config,
-            cluster=cluster_name
+            config['clusters'][cluster_name]['modules']['stream_alert_apps'][function_name],
+            config
         )

--- a/tests/unit/stream_alert_cli/terraform/test_alert_processor.py
+++ b/tests/unit/stream_alert_cli/terraform/test_alert_processor.py
@@ -52,7 +52,7 @@ class TestAlertProcessor(unittest.TestCase):
                 'alert_processor_lambda': {
                     'alarm_actions': ['arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring'],
                     'aliased_version': '$LATEST',
-                    'description': 'StreamAlert Alert Processor',
+                    'description': 'Unit-Testing Streamalert Alert Processor',
                     'environment_variables': {
                         'ALERTS_TABLE': 'unit-testing_streamalert_alerts',
                         'ENABLE_METRICS': '0',
@@ -108,7 +108,7 @@ class TestAlertProcessor(unittest.TestCase):
                 },
                 'alert_processor_lambda': {
                     'aliased_version': '$LATEST',
-                    'description': 'StreamAlert Alert Processor',
+                    'description': 'Unit-Testing Streamalert Alert Processor',
                     'environment_variables': {
                         'ALERTS_TABLE': 'unit-testing_streamalert_alerts',
                         'ENABLE_METRICS': '0',


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Due to lambda configs living in different places in the conf directory, support is needs for accepting a lambda config from arbitrary places.

## Changes

* `tf_lambda` module generation now expects the lambda config to be passed from the caller

## Testing

Updating unit tests for how this affects the `description` for the function
