### PR TITLE
[Data Normalization] Fix memory exhausting issue

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -352,8 +352,6 @@ class StreamRules(object):
             return alerts, normalized_records
 
         for record in payload.records:
-            # One record may be added to normalized records list multiple time due
-            # to each record is processed by all rules.
             for rule in rules:
                 # subkey check
                 has_sub_keys = self.process_subkeys(record, payload.type, rule)
@@ -368,13 +366,15 @@ class StreamRules(object):
                 if rule.datatypes:
                     # When rule 'datatypes' option is defined, rules engine will
                     # apply data normalization to all the record.
-                    self._apply_normalization(record, normalized_records, rule, payload, alerts)
+                    record_copy = self._apply_normalization(record, normalized_records,
+                                                            rule, payload)
+                    self.rule_analysis(record_copy, rule, payload, alerts)
                 else:
                     self.rule_analysis(record, rule, payload, alerts)
 
         return alerts, normalized_records
 
-    def _apply_normalization(self, record, normalized_records, rule, payload, alerts):
+    def _apply_normalization(self, record, normalized_records, rule, payload):
         """Apply data normalization to current record
 
         Args:
@@ -414,7 +414,7 @@ class StreamRules(object):
             else:
                 record_copy = record
 
-        self.rule_analysis(record_copy, rule, payload, alerts)
+        return record_copy
 
     @staticmethod
     def _update_normalized_record(payload, record_copy, normalized_records):

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -32,6 +32,7 @@ RuleAttributes = namedtuple('Rule', ['rule_name',
                                      'req_subkeys',
                                      'context'])
 
+_IGNORE_KEYS = {StreamThreatIntel.IOC_KEY, NORMALIZATION_KEY}
 
 class StreamRules(object):
     """Container class for StreamAlert Rules
@@ -353,7 +354,6 @@ class StreamRules(object):
         for record in payload.records:
             # One record may be added to normalized records list multiple time due
             # to each record is processed by all rules.
-            normalized_record_appended = False
             for rule in rules:
                 # subkey check
                 has_sub_keys = self.process_subkeys(record, payload.type, rule)
@@ -365,33 +365,100 @@ class StreamRules(object):
                 if not matcher_result:
                     continue
 
-                types_result = None
                 if rule.datatypes:
-                    types_result = self.match_types(record,
-                                                    payload.normalized_types,
-                                                    rule.datatypes)
-
-                if types_result:
-                    record_copy = record.copy()
-                    record_copy[NORMALIZATION_KEY] = types_result
-                    if self._threat_intel and not normalized_record_appended:
-                        # A copy of payload which includes payload metadata.
-                        # The payload metadata includes log_source, type, service,
-                        # and entity. The metadata will be returned to along with
-                        # normalized record for threat detection.
-                        payload_copy = copy(input_payload)
-                        payload_copy.pre_parsed_record = record_copy
-                        payload_copy.records = None
-                        payload_copy.raw_record = None
-                        normalized_records.append(payload_copy)
-                        normalized_record_appended = True
+                    # When rule 'datatypes' option is defined, rules engine will
+                    # apply data normalization to all the record.
+                    self._apply_normalization(record, normalized_records, rule, payload, alerts)
                 else:
-                    record_copy = record
-                # rule analysis
-                self.rule_analysis(record_copy, rule, payload, alerts)
+                    self.rule_analysis(record, rule, payload, alerts)
 
         return alerts, normalized_records
 
+    def _apply_normalization(self, record, normalized_records, rule, payload, alerts):
+        """Apply data normalization to current record
+
+        Args:
+            record (dict): The parsed log w/wo data normalization.
+            normalized_records (list): Contains a list of payload objects which
+                have been normalized.
+            rule (namedtuple): Contains alerting logic.
+            payload (namedtuple): Contains parsed logs.
+            alerts (list): A list of triggered alerts.
+        """
+        normalized, normalized_payload = self._is_normalized(record,
+                                                             normalized_records,
+                                                             rule.datatypes)
+
+        record_copy = None
+        if normalized:
+            # If the record has been normalized, use normalized record copy
+            record_copy = normalized_payload.pre_parsed_record
+        else:
+            # If the record has been normalized, apply normalization logic to the record
+            # and insert normalization result to the record.
+            types_result = self.match_types(record,
+                                            payload.normalized_types,
+                                            rule.datatypes)
+
+            if types_result:
+                record_copy = record.copy()
+
+                # Insert normalization result to the record copy.
+                record_copy[NORMALIZATION_KEY] = types_result
+
+                if self._threat_intel:
+                    # If threat intel is enabled, add newly normalized record to
+                    # the list for future threat detection.
+                    self._update_normalized_record(payload, record_copy, normalized_records)
+
+            else:
+                record_copy = record
+
+        self.rule_analysis(record_copy, rule, payload, alerts)
+
+    @staticmethod
+    def _update_normalized_record(payload, record_copy, normalized_records):
+        """Add normalized record to a list for future theat detection
+
+        Args:
+            payload (namedtuple): Contains parsed logs.
+            record_copy (dict): Contains log data with normalization information.
+            normalized_records (list): Contains a list of payload objects
+                with normalized records.
+        """
+        # It is required to have payload 'log_source', 'type', 'service' and 'entity'
+        # information when analyzing record and triggering alert later. So here,
+        # we make a copy of payload and reset unneccessary fields ('record', 'raw_record')
+        payload_copy = copy(payload)
+        payload_copy.pre_parsed_record = record_copy
+        payload_copy.records = None
+        payload_copy.raw_record = None
+        normalized_records.append(payload_copy)
+
+    def _is_normalized(self, record, normalized_records, datatypes):
+        """Check if the current record has been normalized
+
+        A record may be normalized multiple time only by different set of data types.
+
+        Args:
+            record (dict): The parsed log w/wo data normalization.
+            normalized_records (list): Contains a list of payload objects
+                with normalized records.
+            datatypes (list): Normalized types defined in the Rule options.
+
+        Return:
+            bool: Return True if current record has been found in normalized records.
+            namedtuple: A payload object contains normalized record.
+        """
+        for payload in normalized_records:
+            if self._is_equal(record, payload.pre_parsed_record):
+                if set(datatypes) - set(payload.pre_parsed_record.get(NORMALIZATION_KEY)):
+                    continue
+                else:
+                    # if all datatypes have been normalized in a record, we should not do
+                    # again
+                    return True, payload
+        return False, None
 
 
     def threat_intel_match(self, payload_with_normalized_records):
@@ -432,7 +499,9 @@ class StreamRules(object):
         """
         rule_result = StreamRules.process_rule(record, rule)
         if rule_result:
-            if StreamRules.check_alerts_duplication(record, rule, alerts):
+            # when threat intel enabled, normalized records will be re-analyzed by
+            # all rules. Thus we need to check duplication.
+            if self._threat_intel and self.check_alerts_duplication(record, rule, alerts):
                 return
 
             alert_id = str(uuid.uuid4())  # Random unique alert ID
@@ -458,30 +527,42 @@ class StreamRules(object):
             alerts.append(alert)
 
     @staticmethod
-    def check_alerts_duplication(record, rule, alerts):
-        """The method to check if the record has been added to alerts list already.
+    def _is_equal(record1, record2):
+        """Check if two records are same excluding data normalization and threat intel information
 
-        The reason we need to do check alerts duplication is because original records
-        would be modified by inserting normalization or/and IOC information if there
-        exist. Threat Intel feature will process normalized records again and it
-        will result alert duplication.
+        Compare key set before comparing values for better performance.
+
+        Args:
+            record1/record2 (dict): The parsed log w/wo data normalization and
+            threat intel information.
+
+        Returns:
+            bool: Return True only when two records have same keys and values.
+        """
+        record1_keys = set(record1.keys()) - _IGNORE_KEYS
+        record2_keys = set(record2.keys()) - _IGNORE_KEYS
+
+        if record1_keys != record2_keys:
+            return False
+
+        return all(record1[key] == record2[key] for key in record1_keys)
+
+
+    def check_alerts_duplication(self, record, rule, alerts):
+        """ Check if the record has been triggerred an alert by the same rule
+
+        The reason we need to do the duplication is because the record might be
+        modified by inserting normalization or/and IOC information after data
+        normalization. Threat Intel feature will re-analyze normalized records.
 
         Args:
             record (dict): A parsed log with data.
             rule: Rule attributes.
             alerts (list): A list of alerts which will be sent to alert processor.
-
         Returns:
             bool: Return True if both record and rule name exist in alerts list.
         """
-        for exist_alert in alerts:
-            if rule.rule_name == exist_alert['rule_name']:
-                record_copy = record.copy()
-                if StreamThreatIntel.IOC_KEY not in exist_alert['record']:
-                    record_copy.pop(StreamThreatIntel.IOC_KEY, None)
-                if NORMALIZATION_KEY not in exist_alert['record']:
-                    record_copy.pop(NORMALIZATION_KEY, None)
-                if record_copy == exist_alert['record']:
-                    return True
 
-        return False
+        return any(self._is_equal(alert['record'], record)
+                   for alert in alerts
+                   if rule.rule_name == alert['rule_name'])

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -498,10 +498,7 @@ class TestStreamRules(object):
             """
             results = fetch_values_by_datatype(rec, 'sourceAddress')
 
-            for result in results:
-                if result == '1.1.1.2':
-                    return True
-            return False
+            return any(result == '1.1.1.2' for result in results)
 
         @rule(logs=['cloudwatch:test_match_types'],
               outputs=['s3:sample_bucket'],
@@ -517,10 +514,7 @@ class TestStreamRules(object):
             """
             results = fetch_values_by_datatype(rec, 'sourceAddress')
 
-            for result in results:
-                if result == '2.2.2.2':
-                    return True
-            return False
+            return any(result == '2.2.2.2' for result in results)
 
         kinesis_data_items = [
             {
@@ -875,6 +869,72 @@ class TestStreamRules(object):
         records = mock_normalized_records()
         alerts = new_rules_engine.threat_intel_match(records)
         assert_equal(len(alerts), 2)
+
+    @patch('boto3.client')
+    def test_process_allow_multi_around_normalization(self, mock_client):
+        """Rules Engine - Threat Intel is enabled run multi-round_normalization"""
+
+        @rule(datatypes=['fileHash'], outputs=['s3:sample_bucket'])
+        def match_file_hash(rec): # pylint: disable=unused-variable
+            """Testing dummy rule to match file hash"""
+            return 'streamalert:ioc' in rec and 'md5' in rec['streamalert:ioc']
+
+        @rule(datatypes=['fileHash'], outputs=['s3:sample_bucket'])
+        def match_file_hash_again(_): # pylint: disable=unused-variable
+            """Testing dummy rule to match file hash again"""
+            return False
+
+        @rule(datatypes=['fileHash', 'sourceDomain'], outputs=['s3:sample_bucket'])
+        def match_source_domain(rec): # pylint: disable=unused-variable
+            """Testing dummy rule to match source domain and file hash"""
+            return 'streamalert:ioc' in rec
+
+        mock_client.return_value = MockDynamoDBClient()
+        toggled_config = self.config
+        toggled_config['global']['threat_intel']['enabled'] = True
+        toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'
+
+        new_rules_engine = StreamRules(toggled_config)
+        kinesis_data = {
+            "Field1": {
+                "SubField1": {
+                    "key1": 17,
+                    "key2_md5": "md5-of-file",
+                    "key3_source_domain": "evil.com"
+                },
+                "SubField2": 1
+            },
+            "Field2": {
+                "Authentication": {}
+            },
+            "Field3": {},
+            "Field4": {}
+        }
+
+        kinesis_data = json.dumps(kinesis_data)
+        service, entity = 'kinesis', 'test_stream_threat_intel'
+        raw_record = make_kinesis_raw_record(entity, kinesis_data)
+        payload = load_and_classify_payload(toggled_config, service, entity, raw_record)
+        alerts, normalized_records = new_rules_engine.process(payload)
+
+        # Two testing rules are for threat intelligence matching. So no alert will be
+        # generated before threat intel takes effect.
+        assert_equal(len(alerts), 0)
+
+        # One record will be normalized twice by two different rules with different
+        # normalization keys. It should generate two alerts by two different rules
+        # from same record.
+        assert_equal(len(normalized_records), 2)
+        assert_equal(normalized_records[0].pre_parsed_record['streamalert:normalization'].keys(),
+                     ['fileHash'])
+        assert_equal(normalized_records[1].pre_parsed_record['streamalert:normalization'].keys(),
+                     ['fileHash', 'sourceDomain'])
+
+        # Pass normalized records to threat intel engine.
+        alerts_from_threat_intel = new_rules_engine.threat_intel_match(normalized_records)
+        assert_equal(len(alerts_from_threat_intel), 2)
+        assert_equal(alerts_from_threat_intel[0]['rule_name'], 'match_file_hash')
+        assert_equal(alerts_from_threat_intel[1]['rule_name'], 'match_source_domain')
 
     def test_rule_modify_context(self):
         """Rules Engine - Testing Context Modification"""


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: medium
resolves #654

## Background
The fix to allow one record to be normalized multiple times with **different set of datatypes** in PR #655 causes memory exhausting issue. We can reproduce the issue by profiling memory usage using library `memory_profile`.

The root cause of memory exhaustion is caused by one record is normalized multiple times with **same set of datatypes** and normalized records list is grown in linear speed when threat intel feature enabled. User may not notice the memory issue unless there are thousands records been normalized in one lambda invocation.

The solution is to check if a record has been normalized by the **same set of datatypes** or not. If so, use normalized information from existing normalized records, otherwise apply normalization to the record.

## Changes
* Extract Data Normalization and Threat Intel logic from `process` method.
* Check alert duplication.
* Add helper functions to prevent a record being normalized multiple times by the **same set of datatypes**.

## Testing
* Testing environment is locally:
  * A json file contains 7622 logs. Majority of logs are related to system processes. So the datatypes `command`, `fileHash` are heavily applied to normalize records.

* One record can  only be normalized once
  * the memory usage is 52.6MB
  * Generated 7622 normalized records
```
Line #    Mem usage    Increment   Line Contents
================================================
    68     85.8 MiB     85.8 MiB       @profile
    69                                 def run(self, event):
    70                                     """StreamAlert Lambda function handler.
  ...
   111                                         # Cache the log sources for this service and entity on the classifier
   112     87.0 MiB      0.0 MiB               if not self.classifier.load_sources(service, entity):
   113                                             continue
   114
   115                                         # Create the StreamPayload to use for encapsulating parsed info
   116     87.0 MiB      0.0 MiB               payload = load_stream_payload(service, entity, raw_record)
   117     87.0 MiB      0.0 MiB               if not payload:
   118                                             continue
   119
   120    120.6 MiB     33.6 MiB               payload_with_normalized_records.extend(self._process_alerts(payload))
   121
...
   159    121.2 MiB      0.0 MiB           if self._firehose_client:
   160    139.6 MiB     18.4 MiB               self._firehose_client.send()
...
   164    139.6 MiB      0.0 MiB           return self._failed_record_count == 0
```
  * After merge PR #655, one record can be normalized multiple time
    * The memory usage will be increased to 1,227.5 MB!! (1.2GB)
    * Generated 110,483 normalized records
```
Line #    Mem usage    Increment   Line Contents
================================================
    68     86.0 MiB     86.0 MiB       @profile
    69                                 def run(self, event):
...
    116     86.7 MiB      0.0 MiB               payload = load_stream_payload(service, entity, raw_record)
    117     86.7 MiB      0.0 MiB               if not payload:
    118                                             continue
    119
    120   1290.9 MiB   1204.2 MiB               payload_with_normalized_records.extend(self._process_alerts(payload))
...
    159   1297.4 MiB      0.0 MiB           if self._firehose_client:
    160   1314.2 MiB     16.8 MiB               self._firehose_client.send()
...
    164   1314.2 MiB      0.0 MiB           return self._failed_record_count == 0
```
* Apply current fix which is only allow a record to be normalized multiple times by the **different set of datatypes**
  * The memory usage looks reasonable, **143.4MB**
  * Generated 27,534 normalized records
```
Line #    Mem usage    Increment   Line Contents
================================================
    68     86.0 MiB     86.0 MiB       @profile
    69                                 def run(self, event):
...
   116     87.2 MiB      0.0 MiB               payload = load_stream_payload(service, entity, raw_record)
   117     87.2 MiB      0.0 MiB               if not payload:
   118                                             continue
   119
   120    212.6 MiB    125.5 MiB               payload_with_normalized_records.extend(self._process_alerts(payload))
...
   159    218.8 MiB      0.0 MiB           if self._firehose_client:
   160    230.6 MiB     11.8 MiB               self._firehose_client.send()
...
   164    230.6 MiB      0.0 MiB           return self._failed_record_count == 0
...

```
* Runtime profiling: No noticeable running time changed. 

