### PR TITLE
[cli] adding support for alert table rebuilding

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1240,10 +1240,8 @@ Required Arguments:
 
     -b/--bucket                        The name of the S3 bucket to be used for Athena
                                          query results.
-    -n/--table-name                    The name of the Athena table to create
-    -t/--table-type                    The type of table being created. This must be one of:
-                                         alert
-                                         data
+    -n/--table-name                    The name of the Athena table to create. This must be a
+                                         type of log defined in logs.json
 
 Optional Arguments:
 
@@ -1256,8 +1254,7 @@ Examples:
 
     manage.py athena create-table \\
       --bucket s3.bucket.name \\
-      --table-name my_athena_table \\
-      --table-type data
+      --table-name my_athena_table
 
 """.format(version))
     athena_create_table_parser = athena_subparsers.add_parser(
@@ -1307,10 +1304,8 @@ Required Arguments:
 
     -b/--bucket                        The name of the S3 bucket to be used for Athena
                                          query results.
-    -n/--table-name                    The name of the Athena table to create
-    -t/--table-type                    The type of table being rebuilt. This can be one of:
-                                         alert
-                                         data
+    -n/--table-name                    The name of the Athena table to create. This must be
+                                         either a type of log defined in logs.json or 'alerts'
 
 Optional Arguments:
 
@@ -1320,8 +1315,7 @@ Examples:
 
     manage.py athena rebuild-partitions \\
       --bucket s3.bucket.name \\
-      --table-name my_athena_table \\
-      --table-type data
+      --table-name my_athena_table
 
 """.format(version))
     athena_rebuild_parser = athena_subparsers.add_parser(
@@ -1373,12 +1367,6 @@ def _add_default_athena_args(athena_parser):
 
     athena_parser.add_argument(
         '-b', '--bucket',
-        help=ARGPARSE_SUPPRESS,
-        required=True)
-
-    athena_parser.add_argument(
-        '-t', '--table-type',
-        choices=['data', 'alert'],
         help=ARGPARSE_SUPPRESS,
         required=True)
 

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -34,6 +34,41 @@ from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
 
 
+SCHEMA_TYPE_LOOKUP = {
+    bool: 'boolean',
+    float: 'float',
+    int: 'integer',
+    str: 'string',
+    dict: dict(),
+    list: list()
+}
+
+
+def record_to_schema(record, recursive=False):
+    """Take a record and return a schema that corresponds to it's keys/value types
+
+    Args:
+        record (dict): The record to generate a schema for
+        recursive (bool): True if sub-dictionaries should be recursed
+
+    Returns:
+        dict: A new record that reflects the original keys with values that reflect
+            the types of the original values
+    """
+    if not isinstance(record, dict):
+        return
+
+    result = {}
+    for key, value in record.iteritems():
+        # only worry about recursion for dicts, not lists
+        if recursive and isinstance(value, dict):
+            result[key] = record_to_schema(value, recursive)
+        else:
+            result[key] = SCHEMA_TYPE_LOOKUP.get(type(value), 'string')
+
+    return result
+
+
 def run_command(runner_args, **kwargs):
     """Helper function to run commands with error handling.
 

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -47,6 +47,8 @@ SCHEMA_TYPE_LOOKUP = {
 def record_to_schema(record, recursive=False):
     """Take a record and return a schema that corresponds to it's keys/value types
 
+    This generates a log schema that is compatible with schemas in conf/logs.json
+
     Args:
         record (dict): The record to generate a schema for
         recursive (bool): True if sub-dictionaries should be recursed

--- a/stream_alert_cli/terraform/handler.py
+++ b/stream_alert_cli/terraform/handler.py
@@ -125,7 +125,7 @@ def _terraform_init(config):
     # we need to manually create the streamalerts table since terraform does not support this
     # See: https://github.com/terraform-providers/terraform-provider-aws/issues/1486
     alerts_bucket = '{}.streamalerts'.format(config['global']['account']['prefix'])
-    create_table(None, alerts_bucket, 'alerts', config)
+    create_table('alerts', alerts_bucket, config)
 
     LOGGER_CLI.info('Building Remainder Infrastructure')
     tf_runner(refresh=False)

--- a/tests/unit/stream_alert_cli/test_helpers.py
+++ b/tests/unit/stream_alert_cli/test_helpers.py
@@ -18,7 +18,13 @@ import json
 from stream_alert_cli import helpers
 
 from mock import mock_open, patch
-from nose.tools import assert_equal, assert_false, assert_is_none, assert_items_equal
+from nose.tools import (
+    assert_equal,
+    assert_false,
+    assert_is_instance,
+    assert_is_none,
+    assert_items_equal
+)
 
 
 def test_load_test_file_list():
@@ -95,3 +101,59 @@ def test_get_rules_from_test_events():
             returned_rules = helpers.get_rules_from_test_events('fake/path')
 
         assert_items_equal(rules, returned_rules)
+
+
+def test_record_to_schema_no_recurse():
+    """CLI - Helpers - Record to Schema, Non-recursive"""
+
+    record = {
+        'dict': {
+            'boolean': False,
+            'integer': 123
+        },
+        'list': [],
+        'string': 'this is a string',
+        'float': 1234.56,
+        'integer': 1234,
+        'boolean': True
+    }
+
+    result = helpers.record_to_schema(record, recursive=False)
+
+    assert_is_instance(result['dict'], dict)
+    assert_is_instance(result['list'], list)
+    assert_equal(result['string'], 'string')
+    assert_equal(result['float'], 'float')
+    assert_equal(result['integer'], 'integer')
+    assert_equal(result['boolean'], 'boolean')
+    # Check to make no recursion occurred
+    assert_equal(len(result['dict']), 0)
+
+
+def test_record_to_schema_recurse():
+    """CLI - Helpers - Record to Schema, Recursive"""
+
+    record = {
+        'dict': {
+            'boolean': False,
+            'integer': 123
+        },
+        'list': [],
+        'string': 'this is a string',
+        'float': 1234.56,
+        'integer': 1234,
+        'boolean': True
+    }
+
+    result = helpers.record_to_schema(record, recursive=True)
+
+    assert_is_instance(result['dict'], dict)
+    assert_is_instance(result['list'], list)
+    assert_equal(result['string'], 'string')
+    assert_equal(result['float'], 'float')
+    assert_equal(result['integer'], 'integer')
+    assert_equal(result['boolean'], 'boolean')
+    # Check to make recursion occurred
+    assert_equal(len(result['dict']), 2)
+    assert_equal(result['dict']['boolean'], 'boolean')
+    assert_equal(result['dict']['integer'], 'integer')

--- a/tests/unit/stream_alert_cli/test_helpers.py
+++ b/tests/unit/stream_alert_cli/test_helpers.py
@@ -18,13 +18,7 @@ import json
 from stream_alert_cli import helpers
 
 from mock import mock_open, patch
-from nose.tools import (
-    assert_equal,
-    assert_false,
-    assert_is_instance,
-    assert_is_none,
-    assert_items_equal
-)
+from nose.tools import assert_equal, assert_false, assert_is_none, assert_items_equal
 
 
 def test_load_test_file_list():
@@ -118,16 +112,18 @@ def test_record_to_schema_no_recurse():
         'boolean': True
     }
 
+    expected_result = {
+        'dict': {},
+        'list': [],
+        'string': 'string',
+        'float': 'float',
+        'integer': 'integer',
+        'boolean': 'boolean'
+    }
+
     result = helpers.record_to_schema(record, recursive=False)
 
-    assert_is_instance(result['dict'], dict)
-    assert_is_instance(result['list'], list)
-    assert_equal(result['string'], 'string')
-    assert_equal(result['float'], 'float')
-    assert_equal(result['integer'], 'integer')
-    assert_equal(result['boolean'], 'boolean')
-    # Check to make no recursion occurred
-    assert_equal(len(result['dict']), 0)
+    assert_equal(result, expected_result)
 
 
 def test_record_to_schema_recurse():
@@ -145,15 +141,19 @@ def test_record_to_schema_recurse():
         'boolean': True
     }
 
+    expected_result = {
+        'dict': {
+            'boolean': 'boolean',
+            'integer': 'integer'
+        },
+        'list': [],
+        'string': 'string',
+        'float': 'float',
+        'integer': 'integer',
+        'boolean': 'boolean'
+    }
+
+
     result = helpers.record_to_schema(record, recursive=True)
 
-    assert_is_instance(result['dict'], dict)
-    assert_is_instance(result['list'], list)
-    assert_equal(result['string'], 'string')
-    assert_equal(result['float'], 'float')
-    assert_equal(result['integer'], 'integer')
-    assert_equal(result['boolean'], 'boolean')
-    # Check to make recursion occurred
-    assert_equal(len(result['dict']), 2)
-    assert_equal(result['dict']['boolean'], 'boolean')
-    assert_equal(result['dict']['integer'], 'integer')
+    assert_equal(result, expected_result)


### PR DESCRIPTION
to: @austinbyers
cc: @airbnb/streamalert-maintainers
size: small

## Background

The CLI currently lacks the ability to rebuild the athena 'alerts' table. This abstracts away the differentiators between 'data' tables and the 'alerts' table so the same code can be used for rebuilding both.

**NOTE**: This PR is currently being compared to @austinbyers `austin-alert-class` branch since it is dependent on some of his changes. Once his PR merges, I will switch this to compare against master.

## Changes

* Updating athena cli code to handle refreshing both 'data' and 'alerts' table types.
* This uses @austinbyers `Alert` class to determine the most up-to-date set of keys and value types in an alert and transforms that into a schema that reflects said keys/values.
* Removing '--table-type' requirement from athena cli commands since it can be deduced from the '--table-name' instead

## Testing

* Adding tests for simple `record_to_schema` helper function that was added.
