### PR TITLE
Bug fix: Slack rule name in message

### DIFF
--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -223,7 +223,7 @@ class SlackOutput(OutputDispatcher):
         if not creds:
             return self._log_status(False, descriptor)
 
-        slack_message = self._format_message(alert.rule_description, alert)
+        slack_message = self._format_message(alert.rule_name, alert)
 
         try:
             success = self._post_request_retry(creds['url'], slack_message)


### PR DESCRIPTION
to: @ryandeivert 
cc: @jacknagz 
size: tiny

## Background

#666 introduced a bug in the Slack output: the rule name (which appears at the beginning of the slack message) was accidentally replaced with the rule description, leading to Slack messages which were hard to read.

## Changes

* Revert https://github.com/airbnb/streamalert/commit/943e6ccf12fb198093a85823de84f2bae22b8f39#diff-d23b5ca88d24a7ca4a9150e246c621afR226

## Testing

- Slack message in test account returned to correct format
- Manually reviewed all other output changes in #666 (again) to make sure a similar bug didn't happen elsewhere
