### PR TITLE
[athena] adding execution ID to logger output message in case of error

### DIFF
--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -224,7 +224,8 @@ class StreamAlertAthenaClient(object):
 
         if query_execution_result != 'SUCCEEDED':
             LOGGER.error(
-                'The query %s returned %s, exiting!',
+                'The query %s with execution ID %s returned %s, exiting!',
+                query_execution_resp['QueryExecutionId'],
                 kwargs['query'],
                 query_execution_result)
             return False, {}


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

We have no context on executions IDs if an error occurs. This adds it.

## Changes

* Logging execution ID to log error output.
