### PR TITLE
[cli][bug] removing bad update to athena lambda config

### DIFF
--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -273,9 +273,10 @@ def create_table(table, bucket, config, schema_override=None):
         return
 
     # Update the CLI config
-    config['lambda']['athena_partition_refresh_config'] \
-          ['buckets'][bucket] = sanitized_table_name
-    config.write()
+    if (table != 'alerts' and
+            bucket not in config['lambda']['athena_partition_refresh_config']['buckets']):
+        config['lambda']['athena_partition_refresh_config']['buckets'][bucket] = 'data'
+        config.write()
 
     LOGGER_CLI.info('The %s table was successfully created!', sanitized_table_name)
 


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The athena lambda config used to require different bucket/refresh type information for various tables that were created. Now only bucket names and whether they are for data or alerts is required.

## Changes

* Removing some code that would overwrite the existing bucket entry when creating a new table.
* This only adds new buckets if they don't already exist, and sets them as 'data' buckets.
* Buckets are needed in this dict so s3 event notifications to the athena partition refresh function get configured properly for the buckets.