### PR TITLE
[cli][bug] fixing lambda test arg that was incorrect

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -955,16 +955,6 @@ Example:
         action=UniqueSetAction,
         required=True)
 
-    # add the optional ability to test against a rule/set of rules
-    lambda_test_parser.add_argument(
-        '-r',
-        '--test-rules',
-        dest='rules',
-        nargs='+',
-        help=ARGPARSE_SUPPRESS,
-        action=UniqueSetAction,
-        default=set())
-
     test_filter_group = lambda_test_parser.add_mutually_exclusive_group(required=False)
 
     # add the optional ability to test against a rule/set of rules
@@ -972,6 +962,16 @@ Example:
         '-f',
         '--test-files',
         dest='files',
+        nargs='+',
+        help=ARGPARSE_SUPPRESS,
+        action=UniqueSetAction,
+        default=set())
+
+    # add the optional ability to test against a rule/set of rules
+    test_filter_group.add_argument(
+        '-r',
+        '--test-rules',
+        dest='rules',
         nargs='+',
         help=ARGPARSE_SUPPRESS,
         action=UniqueSetAction,

--- a/stream_alert_cli/terraform/athena.py
+++ b/stream_alert_cli/terraform/athena.py
@@ -29,7 +29,7 @@ def generate_athena(config):
     athena_dict = infinitedict()
     athena_config = config['lambda']['athena_partition_refresh_config']
 
-    data_buckets = list(set(athena_config['buckets']))
+    data_buckets = athena_config['buckets'].keys()
 
     prefix = config['global']['account']['prefix']
     database = athena_config.get('database_name', '{}_streamalert'.format(prefix))


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

A CLI argument for the `python manage.py lambda test -p rule` subcommand was improperly not part of the mutually exclusive group.

## Changes

* Fiing the -r/--test-rules and -f/--test-files arguments to be part of the same mutually exclusive group.

## Testing

Attempted to run the command with these args at the same time and received the expected error:
`manage.py lambda [subcommand] [options] test: error: argument -f/--test-files: not allowed with argument -r/--test-rules`
