### PR TITLE
[tf] add table for storing rule information

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -22,7 +22,7 @@
     },
     "rules_table": {
       "read_capacity": 20,
-      "write_capacity": 2
+      "write_capacity": 5
     }
   },
   "terraform": {

--- a/conf/global.json
+++ b/conf/global.json
@@ -19,6 +19,10 @@
     },
     "monitoring": {
       "create_sns_topic": true
+    },
+    "rules_table": {
+      "read_capacity": 20,
+      "write_capacity": 2
     }
   },
   "terraform": {

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -173,7 +173,11 @@ def generate_main(**kwargs):
         'alerts_table_read_capacity': (
             config['global']['infrastructure']['alerts_table']['read_capacity']),
         'alerts_table_write_capacity': (
-            config['global']['infrastructure']['alerts_table']['write_capacity'])
+            config['global']['infrastructure']['alerts_table']['write_capacity']),
+        'rules_table_read_capacity': (
+            config['global']['infrastructure']['rules_table']['read_capacity']),
+        'rules_table_write_capacity': (
+            config['global']['infrastructure']['rules_table']['write_capacity'])
     }
 
     # KMS Key and Alias creation

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -48,7 +48,7 @@ RESTRICTED_CLUSTER_NAMES = ('main', 'athena')
 TERRAFORM_VERSIONS = {'application': '~> 0.10.6', 'provider': {'aws': '~> 1.11.0'}}
 
 
-def generate_s3_bucket(**kwargs):
+def generate_s3_bucket(bucket, logging, **kwargs):
     """Generate an S3 Bucket dict
 
     Keyword Args:
@@ -62,34 +62,26 @@ def generate_s3_bucket(**kwargs):
     Returns:
         dict: S3 bucket Terraform dict to be used in clusters/main.tf.json
     """
-    bucket_name = kwargs.get('bucket')
-    acl = kwargs.get('acl', 'private')
-    logging_bucket = kwargs.get('logging')
-    logging = {
-        'target_bucket': logging_bucket,
-        'target_prefix': '{}/'.format(bucket_name)
-    }
-    force_destroy = kwargs.get('force_destroy', True)
-    versioning = kwargs.get('versioning', True)
-    lifecycle_rule = kwargs.get('lifecycle_rule')
-
-    bucket = {
-        'bucket': bucket_name,
-        'acl': acl,
-        'force_destroy': force_destroy,
+    s3_bucket = {
+        'bucket': bucket,
+        'acl': kwargs.get('acl', 'private'),
+        'force_destroy': kwargs.get('force_destroy', True),
         'versioning': {
-            'enabled': versioning
+            'enabled': kwargs.get('versioning', True)
         },
-        'logging': logging
+        'logging': {
+            'target_bucket': logging,
+            'target_prefix': '{}/'.format(bucket)
+        }
     }
-
+    lifecycle_rule = kwargs.get('lifecycle_rule')
     if lifecycle_rule:
-        bucket['lifecycle_rule'] = lifecycle_rule
+        s3_bucket['lifecycle_rule'] = lifecycle_rule
 
-    return bucket
+    return s3_bucket
 
 
-def generate_main(**kwargs):
+def generate_main(config, init=False):
     """Generate the main.tf.json Terraform dict
 
     Keyword Args:
@@ -99,8 +91,6 @@ def generate_main(**kwargs):
     Returns:
         dict: main.tf.json Terraform dict
     """
-    init = kwargs.get('init')
-    config = kwargs['config']
     main_dict = infinitedict()
 
     # Configure provider along with the minimum version
@@ -151,8 +141,8 @@ def generate_main(**kwargs):
         ),
         'logging_bucket': generate_s3_bucket(
             bucket=logging_bucket,
-            acl='log-delivery-write',
             logging=logging_bucket,
+            acl='log-delivery-write',
             lifecycle_rule=logging_bucket_lifecycle
         ),
         'streamalerts': generate_s3_bucket(
@@ -253,7 +243,7 @@ def generate_outputs(cluster_name, cluster_dict, config):
     return True
 
 
-def generate_cluster(**kwargs):
+def generate_cluster(config, cluster_name):
     """Generate a StreamAlert cluster file.
 
     Keyword Args:
@@ -263,9 +253,6 @@ def generate_cluster(**kwargs):
     Returns:
         dict: generated Terraform cluster dictionary
     """
-    config = kwargs.get('config')
-    cluster_name = kwargs.get('cluster_name')
-
     modules = config['clusters'][cluster_name]['modules']
     cluster_dict = infinitedict()
 
@@ -341,7 +328,7 @@ def terraform_generate(config, init=False):
     LOGGER_CLI.debug('Generating cluster file: main.tf.json')
     with open('terraform/main.tf.json', 'w') as tf_file:
         json.dump(
-            generate_main(init=init, config=config),
+            generate_main(config, init=init),
             tf_file,
             indent=2,
             sort_keys=True
@@ -358,7 +345,7 @@ def terraform_generate(config, init=False):
                 'Rename cluster "main" or "athena" to something else!')
 
         LOGGER_CLI.debug('Generating cluster file: %s.tf.json', cluster)
-        cluster_dict = generate_cluster(cluster_name=cluster, config=config)
+        cluster_dict = generate_cluster(config=config, cluster_name=cluster)
         if not cluster_dict:
             LOGGER_CLI.error(
                 'An error was generated while creating the %s cluster', cluster)
@@ -376,7 +363,7 @@ def terraform_generate(config, init=False):
     generate_global_lambda_settings(
         config,
         config_name='athena_partition_refresh_config',
-        config_generate_func=generate_athena,
+        generate_func=generate_athena,
         tf_tmp_file='terraform/athena.tf.json',
         message='Removing old Athena Terraform file'
     )
@@ -385,7 +372,7 @@ def terraform_generate(config, init=False):
     generate_global_lambda_settings(
         config,
         config_name='threat_intel_downloader_config',
-        config_generate_func=generate_threat_intel_downloader,
+        generate_func=generate_threat_intel_downloader,
         tf_tmp_file='terraform/ti_downloader.tf.json',
         message='Removing old Threat Intel Downloader Terraform file'
     )
@@ -394,7 +381,7 @@ def terraform_generate(config, init=False):
     generate_global_lambda_settings(
         config,
         config_name='alert_processor_config',
-        config_generate_func=generate_alert_processor,
+        generate_func=generate_alert_processor,
         tf_tmp_file='terraform/alert_processor.tf.json',
         message='Removing old Alert Processor Terraform file'
     )
@@ -403,7 +390,7 @@ def terraform_generate(config, init=False):
     generate_global_lambda_settings(
         config,
         config_name='alert_merger_config',
-        config_generate_func=generate_alert_merger,
+        generate_func=generate_alert_merger,
         tf_tmp_file='terraform/alert_merger.tf.json',
         message='Removing old Alert Merger Terraform file'
     )
@@ -411,7 +398,7 @@ def terraform_generate(config, init=False):
     return True
 
 
-def generate_global_lambda_settings(config, **kwargs):
+def generate_global_lambda_settings(config, config_name, generate_func, tf_tmp_file, message):
     """Generate settings for global Lambda functions
 
     Args:
@@ -423,15 +410,16 @@ def generate_global_lambda_settings(config, **kwargs):
         tf_tmp_file (str): filename of terraform file, generated by CLI.
         message (str): Message will be logged by LOGGER.
     """
-    config_name = kwargs.get('config_name')
-    tf_tmp_file = kwargs.get('tf_tmp_file')
-    if config_name and config['lambda'].get(config_name) and tf_tmp_file:
-        if config['lambda'][config_name].get('enabled', True):
-            generated_config = kwargs.get('config_generate_func')(config=config)
-            if generated_config:
-                with open(tf_tmp_file, 'w') as tf_file:
-                    json.dump(generated_config, tf_file, indent=2, sort_keys=True)
-        else:
-            if os.path.isfile(tf_tmp_file):
-                LOGGER_CLI.info(kwargs.get('message'))
-                os.remove(tf_tmp_file)
+    if not config['lambda'].get(config_name):
+        LOGGER_CLI.error('Config for \'%s\' not in lambda.json', config_name)
+        return
+
+    if config['lambda'][config_name].get('enabled', True):
+        generated_config = generate_func(config=config)
+        if generated_config:
+            with open(tf_tmp_file, 'w') as tf_file:
+                json.dump(generated_config, tf_file, indent=2, sort_keys=True)
+    else:
+        if os.path.isfile(tf_tmp_file):
+            LOGGER_CLI.info(message)
+            os.remove(tf_tmp_file)

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -27,3 +27,20 @@ resource "aws_dynamodb_table" "alerts_table" {
     Name = "StreamAlert"
   }
 }
+
+// DynamoDB table to store some rule information
+resource "aws_dynamodb_table" "rules_table" {
+  name           = "${var.prefix}_streamalert_rules"
+  read_capacity  = "${var.rules_table_read_capacity}"
+  write_capacity = "${var.rules_table_write_capacity}"
+  hash_key       = "RuleName"
+
+  attribute {
+    name = "RuleName"
+    type = "S"
+  }
+
+  tags {
+    Name = "StreamAlert"
+  }
+}

--- a/terraform/modules/tf_stream_alert_globals/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/variables.tf
@@ -7,3 +7,7 @@ variable "region" {}
 variable "alerts_table_read_capacity" {}
 
 variable "alerts_table_write_capacity" {}
+
+variable "rules_table_read_capacity" {}
+
+variable "rules_table_write_capacity" {}

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -12,6 +12,10 @@
     },
     "monitoring": {
       "create_sns_topic": true
+    },
+    "rules_table": {
+      "read_capacity": 5,
+      "write_capacity": 5
     }
   },
   "terraform": {

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -83,12 +83,7 @@ class TestTerraformGenerate(object):
 
     def test_generate_main(self):
         """CLI - Terraform Generate Main"""
-        init = False
-
-        tf_main = generate.generate_main(
-            config=self.config,
-            init=init
-        )
+        tf_main = generate.generate_main(config=self.config, init=False)
 
         tf_main_expected = {
             'provider': {
@@ -215,10 +210,7 @@ class TestTerraformGenerate(object):
                 'cloudwatch'
             ]
         }
-        tf_main = generate.generate_main(
-            config=self.config,
-            init=False
-        )
+        tf_main = generate.generate_main(config=self.config, init=False)
 
         generated_modules = tf_main['module']
         expected_kinesis_modules = {

--- a/tests/unit/stream_alert_cli/test_version.py
+++ b/tests/unit/stream_alert_cli/test_version.py
@@ -63,8 +63,8 @@ def test_publish_helper():
     assert_true(result)
 
 
-def test_version_helper():
-    """CLI - Publish Helper"""
+def test_publish():
+    """CLI - Publish"""
     package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
@@ -72,19 +72,18 @@ def test_version_helper():
     )
     current_version = 10
     fake_client = MockLambdaClient('athena', current_version=current_version)
-    result = publish._version_helper(
+    result = publish._publish(
         client=fake_client,
         function_name='test',
-        code_sha_256='12345',
-        date='2017-01-01'
+        code_sha_256='12345'
     )
 
     assert_equal(result, current_version + 1)
 
 
 @patch('stream_alert_cli.manage_lambda.version.LOGGER_CLI')
-def test_version_helper_error(mock_logging):
-    """CLI - Publish Helper Raises Error"""
+def test_publish_error(mock_logging):
+    """CLI - Publish, Raises Error"""
     package = AthenaPackage(basic_streamalert_config())
     publish = LambdaVersion(
         config=basic_streamalert_config(),
@@ -94,11 +93,10 @@ def test_version_helper_error(mock_logging):
     fake_client = MockLambdaClient('athena',
                                    current_version=current_version,
                                    throw_exception=True)
-    result = publish._version_helper(
+    result = publish._publish(
         client=fake_client,
         function_name='test',
-        code_sha_256='12345',
-        date='2017-01-01'
+        code_sha_256='12345'
     )
 
     assert_false(result)


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

We need to begin storing some general information related to rules to enable staging/promotion/etc. This is the beginning of changes to enable that.

## Changes

* Creating `rules_tables` DynamoDB table in terraform with a hash key of `RuleName`
* Updating terraform generation for read/write capacity for this table.
* General cleanup of some generation code where kwargs is unnecessary and/or being abused.

## Incoming

* Another PR is incoming that will actually add information to this table upon deploy.

## Testing

Updating unit tests for new `rules_table` settings.
