### PR TITLE
[apps] adding backoff to state saving in apps functions config

### DIFF
--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -329,7 +329,7 @@ class AppIntegrationPackage(LambdaPackage):
     package_files = {'app_integrations/__init__.py'}
     package_name = 'stream_alert_app'
     config_key = 'stream_alert_apps_config'
-    third_party_libs = {'boxsdk[jwt]==2.0.0a11', 'google-api-python-client', 'requests'}
+    third_party_libs = {'backoff', 'boxsdk[jwt]==2.0.0a11', 'google-api-python-client', 'requests'}
     precompiled_libs = {'boxsdk[jwt]==2.0.0a11'}
     version = apps_version
 

--- a/tests/unit/app_integrations/test_config.py
+++ b/tests/unit/app_integrations/test_config.py
@@ -26,6 +26,7 @@ from tests.unit.app_integrations.test_helpers import (
 )
 
 
+@patch.object(AppConfig, 'MAX_SAVE_TRIES', 1)
 class TestAppIntegrationConfig(object):
     """Test class for AppIntegrationConfig"""
 


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small
resolves #682

## Background

See #682, gist: rapid state saving can cause issues with SSM and will produce a `TooManyUpdates` error

## Changes

* Adding backoff to the `_save_state` function that will backoff on `ClientError` exceptions.
* The saving will be attempted 5 times and will then raise an exception.
* Adding `backoff` to app integration packaging requirements.

## Testing

Updating unit tests to patch new `MAX_SAVE_TRIES` class property, but no other test changes were required for this.
