### PR TITLE
adding logic to perform basic rule statistics

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -955,6 +955,38 @@ Example:
         action=UniqueSetAction,
         required=True)
 
+    # flag to run additional stats during testing
+    lambda_test_parser.add_argument(
+        '-s',
+        '--stats',
+        action='store_true',
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # Validate the provided repitition value
+    def _validate_repitition(val):
+        """Make sure the input is between 1 and 1000"""
+        err = ('Invalid repitition value [{}]. Must be an integer between 1 '
+               'and 1000').format(val)
+        try:
+            count = int(val)
+        except TypeError:
+            raise lambda_test_parser.error(err)
+
+        if not 1 <= count <= 1000:
+            raise lambda_test_parser.error(err)
+
+        return count
+
+    # flag to run these tests a given number of times
+    lambda_test_parser.add_argument(
+        '-n',
+        '--repeat',
+        default=1,
+        type=_validate_repitition,
+        help=ARGPARSE_SUPPRESS
+    )
+
     test_filter_group = lambda_test_parser.add_mutually_exclusive_group(required=False)
 
     # add the optional ability to test against a rule/set of rules

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -23,6 +23,7 @@ from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.shared import stats
 from stream_alert.shared.metrics import MetricLogger
 
 
@@ -154,6 +155,12 @@ class StreamAlert(object):
 
         if self._firehose_client:
             self._firehose_client.send()
+
+        # Only log rule info here if this is not running tests
+        # During testing, this gets logged at the end and printing here could be confusing
+        # since stress testing calls this method multiple times
+        if self.env['lambda_alias'] != 'development':
+            stats.print_rule_stats(True)
 
         return self._failed_record_count == 0
 

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -21,6 +21,7 @@ from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 from stream_alert.shared import NORMALIZATION_KEY, resources
 from stream_alert.shared.alert import Alert
+from stream_alert.shared.stats import time_rule
 
 
 RuleAttributes = namedtuple('Rule', ['rule_name',
@@ -281,17 +282,20 @@ class StreamRules(object):
         Returns:
             bool: The return function of the rule
         """
-        try:
-            if rule.context:
-                rule_result = rule.rule_function(record, rule.context)
-            else:
-                rule_result = rule.rule_function(record)
-        except Exception:  # pylint: disable=broad-except
-            rule_result = False
-            LOGGER.exception(
-                'Encountered error with rule: %s',
-                rule.rule_function.__name__)
-        return rule_result
+        @time_rule(rule_name=rule.rule_function.__name__)
+        def _run():
+            try:
+                if rule.context:
+                    rule_result = rule.rule_function(record, rule.context)
+                else:
+                    rule_result = rule.rule_function(record)
+            except Exception:  # pylint: disable=broad-except
+                rule_result = False
+                LOGGER.exception(
+                    'Encountered error with rule: %s',
+                    rule.rule_function.__name__)
+            return rule_result
+        return _run()
 
     @staticmethod
     def process_subkeys(record, payload_type, rule):


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

There is often the need for more insight into how long a rule takes to run. This could help us  understand any performance impact caused by rules.

## Changes (v1?)

* Adding a `time_rule` decorator to use on rule functions.
* Adding a cli `--stats` flag for use during `manage.py lamdba test ...`
* Adding a cli `--repeat` flag that can repeat a test n number of times.
* A new `RuleStatistic` class is now used for tracking rule processing time and call count.

Statistic output will be similar to:
```
duo_bypass_code_create_non_auto_generated                  0.05602837 ms       6 calls      0.00933806 avg
cloudtrail_security_group_ingress_anywhere                 0.05793571 ms      10 calls      0.00579357 avg
duo_bypass_code_create_non_expiring                        0.05817413 ms       6 calls      0.00969569 avg
cloudtrail_put_object_acl_public                           0.08058548 ms      10 calls      0.00805855 avg
duo_bypass_code_create_unlimited_use                       0.08106232 ms       6 calls      0.01351039 avg
right_to_left_character                                    0.25558472 ms      60 calls      0.00425975 avg
```

## Testing

I will add unit tests for this in a future PR.
