### PR TITLE
[threat_intel_downloader] filtering part2

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1482,13 +1482,13 @@ Available Subcommands:
 
                               See the link in the Resources section below for more information.
     Optional Arguments:
-        --table_rcu          The DynamoDB table Read Capacity Unit.
-        --table_wcu          The DynamoDB table Write Capacity Unit.
+        --table_rcu          The DynamoDB table Read Capacity Unit. Default is 10.
+        --table_wcu          The DynamoDB table Write Capacity Unit. Default is 10.
         --ioc_keys           The keys (list) of IOC stored in DynamoDB table.
         --ioc_filters        Filters (list) applied while retrieving IOCs from Threat Feed.
         --ioc_types          IOC types (list) are defined by the Threat Feed. IOC types can be
                              different from different Threat Feeds.
-        --autoscale          Enable DynamoDB table read capacity autoscale.
+        --excluded_sub_types Sub ioc types want to excluded. Default it will exclude 'bot_ip', 'brute_ip', 'scan_ip', 'spam_ip', 'tor_ip'.
         --min_read_capacity  Maximal read capacity when autoscale enabled, default is 5.
         --max_read_capacity  Mimimal read capacity when autoscale enabled, default is 5.
         --target_utilization Utilization remains at or near the setting level when autoscale enabled.

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -473,9 +473,10 @@ class CLIConfig(object):
         if not threat_intel_info:
             return
 
+        prefix = self.config['global']['account']['prefix']
         default_config = {
             'enabled': True,
-            'dynamodb_table': 'PREFIX_GOES_HERE_streamalert_threat_intel_downloader'
+            'dynamodb_table': '{}_streamalert_threat_intel_downloader'.format(prefix)
         }
 
         if 'threat_intel' not in self.config['global']:
@@ -505,6 +506,7 @@ class CLIConfig(object):
         Returns:
             (bool): Return True if writing settings of Lambda function successfully.
         """
+        prefix = self.config['global']['account']['prefix']
         default_config = {
             'autoscale': False,
             'enabled': True,
@@ -513,7 +515,7 @@ class CLIConfig(object):
             'interval': 'rate(1 day)',
             'log_level': 'info',
             'memory': '128',
-            'source_bucket': 'PREFIX_GOES_HERE.streamalert.source',
+            'source_bucket': '{}.streamalert.source'.format(prefix),
             'source_current_hash': '<auto_generated>',
             'source_object_key': '<auto_generated>',
             'third_party_libraries': ['requests'],
@@ -523,6 +525,7 @@ class CLIConfig(object):
             'ioc_keys': [],
             'ioc_filters': [],
             'ioc_types': [],
+            'excluded_sub_types': [],
             'max_read_capacity': 5,
             'min_read_capacity': 5,
             'target_utilization': 70

--- a/stream_alert_cli/terraform/threat_intel_downloader.py
+++ b/stream_alert_cli/terraform/threat_intel_downloader.py
@@ -55,6 +55,7 @@ def generate_threat_intel_downloader(config):
                                              ['expiration_ts', 'itype', 'source', 'type', 'value']),
         'ioc_filters': ti_downloader_config.get('ioc_filters', ['crowdstrike', '@airbnb.com']),
         'ioc_types': ti_downloader_config.get('ioc_types', ['domain', 'ip', 'md5']),
+        'excluded_sub_types': ti_downloader_config.get('excluded_sub_types'),
         'max_read_capacity': ti_downloader_config.get('max_read_capacity', '5'),
         'min_read_capacity': ti_downloader_config.get('min_read_capacity', '5'),
         'target_utilization': ti_downloader_config.get('target_utilization', '70')

--- a/terraform/modules/tf_threat_intel_downloader/variables.tf
+++ b/terraform/modules/tf_threat_intel_downloader/variables.tf
@@ -67,6 +67,8 @@ variable "ioc_keys" {}
 
 variable "ioc_types" {}
 
+variable "excluded_sub_types" {}
+
 variable "log_retention" {
   default = 14
 }

--- a/tests/unit/stream_alert_cli/test_config.py
+++ b/tests/unit/stream_alert_cli/test_config.py
@@ -199,9 +199,10 @@ class TestCLIConfig(object):
             'ioc_filters': [],
             'ioc_keys': [],
             'ioc_types': [],
+            'excluded_sub_types': [],
             'log_level': 'info',
             'memory': '128',
-            'source_bucket': 'PREFIX_GOES_HERE.streamalert.source',
+            'source_bucket': 'unit-testing.streamalert.source',
             'source_current_hash': '<auto_generated>',
             'source_object_key': '<auto_generated>',
             'third_party_libraries': [


### PR DESCRIPTION
to: @strcrzy 
cc: @airbnb/streamalert-maintainers
size: small
resolves: N/A

## Background
This PR is a follow-up to PR #684 which supports exclusive filtering in *threat_intel_downloader*. Add *excluded_sub_types* setting to *threat_intel_downloader* terraform module so that *excluded_sub_types* setting will be written to `conf/lambda.json` under *threat_intel_downloader*.

Also, this PR corrects prefix when generate default config for *threat_intel* and *threat_intel_downloader* lambda functions. So users don't manually update them. 

## Testing
* Deploy changes to AWS testing account was successful.
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
StreamAlertCLI [INFO]: Completed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 617 tests in 11.313s

OK
```
