### PR TITLE
removing unnecessary output that is now required by default

### DIFF
--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -1,7 +1,4 @@
 {
-  "aws-firehose": {
-    "alerts": "<prefix>_streamalert_alert_delivery"
-  },
   "aws-lambda": {
     "sample-lambda": "function-name:qualifier"
   },


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: v small

## Changes

Just removing an old config option that is no longer necessary, as it is a hard-coded required output.

