### PR TITLE
fixing bug where unsupported types in logs would not fail classification

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -347,5 +347,6 @@ class StreamClassifier(object):
 
             else:
                 LOGGER.error('Unsupported schema type: %s', value)
+                return False
 
         return True


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves #676 

## Background

See #676

## Changes

* Fixing bug during classification that would not fail if an invalid 'type' was defined in a log schema.
* We should investigate how we could 'validate' this before it gets to this point in processing, since logs invalid log schemas are basically just burning processing time for every log.
