### PR TITLE
[core] reworking rule functionality to be class-based

### DIFF
--- a/matchers/matchers.py
+++ b/matchers/matchers.py
@@ -13,9 +13,8 @@ You can also supply multiple matchers for many common scenarios:
       matchers=['prod', 'pci'], outputs=['pagerduty:sample-integration'])
 """
 # from helpers.base import in_set, last_hour
-from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.shared.rule import matcher
 
-matcher = StreamRules.matcher()
 
 @matcher
 def guard_duty(record):

--- a/matchers/matchers.py
+++ b/matchers/matchers.py
@@ -12,7 +12,6 @@ You can also supply multiple matchers for many common scenarios:
 @rule('root_logins', logs=['osquery:differential'],
       matchers=['prod', 'pci'], outputs=['pagerduty:sample-integration'])
 """
-# from helpers.base import in_set, last_hour
 from stream_alert.shared.rule import matcher
 
 

--- a/rules/community/binaryalert/binaryalert_yara_match.py
+++ b/rules/community/binaryalert/binaryalert_yara_match.py
@@ -1,7 +1,5 @@
 """Alert on BinaryAlert YARA matches"""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['binaryalert'])

--- a/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
+++ b/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
@@ -1,8 +1,5 @@
 """Alert on destructive AWS API calls."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
-disable = StreamRules.disable()
+from stream_alert.shared.rule import rule
 
 _CRITICAL_EVENTS = {
     # VPC Flow Logs (~netflow)

--- a/rules/community/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.py
+++ b/rules/community/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.py
@@ -1,8 +1,6 @@
 """Alert on calls made without MFA that may be attempting to abuse a flawed enforcement policy"""
-from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.shared.rule import rule
 
-rule = StreamRules.rule
-disable = StreamRules.disable()
 
 _IAM_ACTIONS = {
     'CreateUser',

--- a/rules/community/cloudtrail/cloudtrail_network_acl_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_network_acl_ingress_anywhere.py
@@ -1,7 +1,5 @@
 """Alert on AWS Network ACLs that allow ingress from anywhere."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(

--- a/rules/community/cloudtrail/cloudtrail_put_bucket_acl.py
+++ b/rules/community/cloudtrail/cloudtrail_put_bucket_acl.py
@@ -1,7 +1,5 @@
 """Alert on dangerous S3 bucket ACLs."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 _DENIED_ACLS = {
     'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',

--- a/rules/community/cloudtrail/cloudtrail_put_object_acl_public.py
+++ b/rules/community/cloudtrail/cloudtrail_put_object_acl_public.py
@@ -1,8 +1,7 @@
 """Identifies new S3 object ACLs that grant access to the public."""
 from helpers.base import data_has_value_from_substring_list
-from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.shared.rule import rule
 
-rule = StreamRules.rule
 
 _PUBLIC_ACLS = {
     'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',

--- a/rules/community/cloudtrail/cloudtrail_root_account_usage.py
+++ b/rules/community/cloudtrail/cloudtrail_root_account_usage.py
@@ -1,7 +1,5 @@
 """Alert when root AWS credentials are used."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(

--- a/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
+++ b/rules/community/cloudtrail/cloudtrail_security_group_ingress_anywhere.py
@@ -1,8 +1,6 @@
 """Alert on AWS Security Groups that allow ingress from anywhere."""
 from helpers.base import get_keys
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_auto_generated.py
@@ -1,8 +1,6 @@
 """Alert when a DUO bypass code is artisanly crafted and not auto-generated."""
 from helpers.base import safe_json_loads
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['duo:administrator'])

--- a/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_non_expiring.py
@@ -1,8 +1,6 @@
 """Alert when a DUO bypass code is created that is non-expiring."""
 from helpers.base import safe_json_loads
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['duo:administrator'])

--- a/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
+++ b/rules/community/duo_administrator/duo_bypass_code_create_unlimited_use.py
@@ -1,8 +1,6 @@
 """Alert when a DUO bypass code is created that has unlimited use."""
 from helpers.base import safe_json_loads
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['duo:administrator'])

--- a/rules/community/duo_authentication/duo_anonymous_ip_failure.py
+++ b/rules/community/duo_authentication/duo_anonymous_ip_failure.py
@@ -1,7 +1,5 @@
 """Alert on any Duo auth logs marked as a failure due to an Anonymous IP."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['duo:authentication'])

--- a/rules/community/duo_authentication/duo_fraud.py
+++ b/rules/community/duo_authentication/duo_fraud.py
@@ -1,7 +1,5 @@
 """Alert on any Duo auth logs marked as fraud."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['duo:authentication'])

--- a/rules/community/github/github_disable_dismiss_stale_pull_request_approvals.py
+++ b/rules/community/github/github_disable_dismiss_stale_pull_request_approvals.py
@@ -1,7 +1,5 @@
 """Github setting 'Dismiss stale pull request approvals' was disabled for a repo."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_disable_protect_this_branch.py
+++ b/rules/community/github/github_disable_protect_this_branch.py
@@ -1,7 +1,5 @@
 """Github setting 'Protect this branch' was disabled for a repo."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_disable_required_pull_request_reviews.py
+++ b/rules/community/github/github_disable_required_pull_request_reviews.py
@@ -1,7 +1,5 @@
 """Github 'Require pull request reviews before merging' was disabled for a repo."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_disable_required_status_checks.py
+++ b/rules/community/github/github_disable_required_status_checks.py
@@ -1,7 +1,5 @@
 """Github 'required status checks' was disabled for a repo."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_disable_two_factor_requirement_org.py
+++ b/rules/community/github/github_disable_two_factor_requirement_org.py
@@ -1,7 +1,5 @@
 """Github two-factor authentication requirement was disabled for an org."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_disable_two_factor_requirement_user.py
+++ b/rules/community/github/github_disable_two_factor_requirement_user.py
@@ -1,7 +1,5 @@
 """Github two-factor authentication requirement was disabled for a user."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_oauth_application_create.py
+++ b/rules/community/github/github_oauth_application_create.py
@@ -1,7 +1,5 @@
 """An OAuth application was registered within Github."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_site_admin_action.py
+++ b/rules/community/github/github_site_admin_action.py
@@ -1,7 +1,5 @@
 """A Github site admin tool/action was used."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/github/github_site_admin_user_promotion.py
+++ b/rules/community/github/github_site_admin_user_promotion.py
@@ -1,7 +1,5 @@
 """A Github Enterprise user account was promoted to a site admin."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['ghe:general'])

--- a/rules/community/guardduty/guard_duty_all.py
+++ b/rules/community/guardduty/guard_duty_all.py
@@ -1,8 +1,5 @@
 """Alert on GuardDuty"""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
-disable = StreamRules.disable()
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['cloudwatch:events'], matchers=['guard_duty'])

--- a/rules/community/mitre_attack/defense_evasion/multi/obfuscated_files_or_information/right_to_left_character.py
+++ b/rules/community/mitre_attack/defense_evasion/multi/obfuscated_files_or_information/right_to_left_character.py
@@ -1,8 +1,6 @@
 """Detection of the right to left override unicode character U+202E in filename or process name."""
 from helpers.base import fetch_values_by_datatype
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(datatypes=['command', 'filePath', 'processPath', 'fileName'])

--- a/rules/community/onelogin/onelogin_events_assumed_role.py
+++ b/rules/community/onelogin/onelogin_events_assumed_role.py
@@ -1,7 +1,5 @@
 """Alert on the OneLogin event that a user has assumed the role of someone else."""
-from stream_alert.rule_processor.rules_engine import StreamRules
-
-rule = StreamRules.rule
+from stream_alert.shared.rule import rule
 
 
 @rule(logs=['onelogin:events'])

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -22,7 +22,7 @@ from stream_alert.rule_processor.classifier import StreamClassifier
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
 from stream_alert.rule_processor.payload import load_stream_payload
-from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import stats
 from stream_alert.shared.metrics import MetricLogger
 
@@ -59,7 +59,7 @@ class StreamAlert(object):
 
         # Create an instance of the StreamRules class that gets cached in the
         # StreamAlert class as an instance property
-        self._rule_engine = StreamRules(self.config)
+        self._rules_engine = RulesEngine(self.config)
 
         # Firehose client attribute
         self._firehose_client = None
@@ -123,7 +123,7 @@ class StreamAlert(object):
                                 len(payload_with_normalized_records))
 
         # Apply Threat Intel to normalized records in the end of Rule Processor invocation
-        record_alerts = self._rule_engine.threat_intel_match(payload_with_normalized_records)
+        record_alerts = self._rules_engine.threat_intel_match(payload_with_normalized_records)
         self._alerts.extend(record_alerts)
         if record_alerts:
             self.alert_forwarder.send_alerts(record_alerts)
@@ -197,7 +197,7 @@ class StreamAlert(object):
                 record.log_source,
                 record.entity)
 
-            record_alerts, normalized_records = self._rule_engine.process(record)
+            record_alerts, normalized_records = self._rules_engine.run(record)
 
             payload_with_normalized_records.extend(normalized_records)
 

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -347,7 +347,7 @@ class RulesEngine(object):
             return
 
         # Combine the required alert outputs with the ones for this rule
-        all_outputs = self._required_outputs_set.union(set(rule.outputs or []))
+        all_outputs = self._required_outputs_set.union(rule.outputs_set)
         alert = Alert(
             rule.rule_name, record, all_outputs,
             cluster=os.environ['CLUSTER'],
@@ -356,7 +356,7 @@ class RulesEngine(object):
             log_type=payload.type,
             merge_by_keys=rule.merge_by_keys,
             merge_window=timedelta(minutes=rule.merge_window_mins),
-            rule_description=rule.rule_function.__doc__,
+            rule_description=rule.description,
             source_entity=payload.entity,
             source_service=payload.service()
         )

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -348,14 +348,15 @@ class RulesEngine(object):
 
         # Combine the required alert outputs with the ones for this rule
         all_outputs = self._required_outputs_set.union(set(rule.outputs or []))
-
         alert = Alert(
             rule.rule_name, record, all_outputs,
             cluster=os.environ['CLUSTER'],
             context=rule.context,
             log_source=str(payload.log_source),
             log_type=payload.type,
-            rule_description=rule.func.__doc__,
+            merge_by_keys=rule.merge_by_keys,
+            merge_window=timedelta(minutes=rule.merge_window_mins),
+            rule_description=rule.rule_function.__doc__,
             source_entity=payload.entity,
             source_service=payload.service()
         )

--- a/stream_alert/shared/alert.py
+++ b/stream_alert/shared/alert.py
@@ -40,7 +40,6 @@ class Alert(object):
         'source_entity', 'source_service', 'staged'
     }
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
-    DEFAULT_RULE_DESCRIPTION = 'No rule description provided'
 
     def __init__(self, rule_name, record, outputs, **kwargs):
         """Create a new Alert with a random ID and timestamped now.
@@ -100,7 +99,7 @@ class Alert(object):
         self.merge_by_keys = kwargs.get('merge_by_keys') or []
         self.merge_window = kwargs.get('merge_window') or timedelta(minutes=0)
         self.outputs_sent = kwargs.get('outputs_sent') or set()
-        self.rule_description = kwargs.get('rule_description') or self.DEFAULT_RULE_DESCRIPTION
+        self.rule_description = kwargs.get('rule_description') or None
         self.source_entity = kwargs.get('source_entity') or None
         self.source_service = kwargs.get('source_service') or None
         self.staged = kwargs.get('staged') or False

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -1,0 +1,118 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from stream_alert.shared import LOGGER
+from stream_alert.shared.stats import time_rule
+
+LOADED_MATCHERS = {}
+
+
+class RuleInvalid(Exception):
+    """Exeception to raise for any errors with invalid rules"""
+
+
+def rule(**opts):
+    """Register a rule that evaluates records"""
+    def decorator(rule_func):
+        """Rule decorator logic that returns instance of Rule"""
+        return Rule(rule_func, **opts)
+    return decorator
+
+
+def disable(rule_instance):
+    """Disables a rule from being run by removing it from the internal rules dict"""
+    Rule.disable(rule_instance.rule_name)
+    return rule_instance
+
+
+def matcher(matcher_func):
+    """Registers a matcher to be used with rules
+
+    Matchers are rules which allow you to extract common logic
+    into helper functions. Each rule can contain multiple matchers.
+    """
+    if matcher_func.__name__ in LOADED_MATCHERS:
+        raise ValueError('matcher already defined: {}'.format(matcher_func.__name__))
+    LOADED_MATCHERS[matcher_func.__name__] = matcher_func
+    return matcher_func
+
+
+class Rule(object):
+    """Rule class to handle processing"""
+    _rules = {}
+
+    def __init__(self, func, **kwargs):
+        self.func = func
+        self.rule_name = func.__name__
+        self.logs = kwargs.get('logs')
+        self.outputs = kwargs.get('outputs')
+        self.matchers = kwargs.get('matchers')
+        self.datatypes = kwargs.get('datatypes')
+        self.req_subkeys = kwargs.get('req_subkeys')
+        self.context = kwargs.get('context', {})
+        self.disabled = False
+
+        if not (self.logs or self.datatypes):
+            raise RuleInvalid(
+                "Invalid rule [{}] - rule must have either 'logs' "
+                "or 'datatypes' declared'".format(self.rule_name)
+            )
+
+        if self.rule_name in Rule._rules:
+            raise RuleInvalid('Rule [{}] already defined'.format(self.rule_name))
+
+        Rule._rules[self.rule_name] = self
+
+    @time_rule
+    def process(self, rec):
+        """Process will call this rule's function on the passed record
+
+        Args:
+            rec (dict): Record that this rule should be run against
+
+        Returns:
+            bool: True if this rule triggers for the passed record, False otherwise
+        """
+        try:
+            if self.context:
+                return self.func(rec, self.context)
+
+            return self.func(rec)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception('Encountered error with rule: %s', self.rule_name)
+
+        return False
+
+    @classmethod
+    def disable(cls, name):
+        cls._rules[name].disabled = True
+
+    @classmethod
+    def rule_names(cls):
+        return Rule._rules.keys()
+
+    @classmethod
+    def get_rule(cls, rule_name):
+        return Rule._rules.get(rule_name)
+
+    @classmethod
+    def rules_with_datatypes(cls):
+        return [item for item in Rule._rules.values()
+                if item.datatypes and not item.disabled]
+
+    @classmethod
+    def rules_for_log_type(cls, log_type):
+        return [item for item in Rule._rules.values()
+                if (item.logs is None or log_type in item.logs) and not item.disabled]

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -42,10 +42,12 @@ class Rule(object):
     def __init__(self, func, **kwargs):
         self.func = func
         self.rule_name = func.__name__
-        self.logs = kwargs.get('logs')
-        self.outputs = kwargs.get('outputs')
-        self.matchers = kwargs.get('matchers')
         self.datatypes = kwargs.get('datatypes')
+        self.logs = kwargs.get('logs')
+        self.matchers = kwargs.get('matchers')
+        self.merge_by_keys = kwargs.get('merge_by_keys')
+        self.merge_window_mins = kwargs.get('merge_window_mins') or 0
+        self.outputs = kwargs.get('outputs')
         self.req_subkeys = kwargs.get('req_subkeys')
         self.initial_context = kwargs.get('context')
         self.context = None

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -91,7 +91,8 @@ class Rule(object):
         self.matchers = kwargs.get('matchers')
         self.datatypes = kwargs.get('datatypes')
         self.req_subkeys = kwargs.get('req_subkeys')
-        self.context = kwargs.get('context', {})
+        self.initial_context = kwargs.get('context')
+        self.context = None
         self.disabled = False
 
         if not (self.logs or self.datatypes):
@@ -140,7 +141,11 @@ class Rule(object):
             bool: True if this rule triggers for the passed record, False otherwise
         """
         try:
-            if self.context:
+            # The initial_context object must be copied. This avoids
+            # bleed over from other runs of the rule using the same
+            # context object
+            if self.initial_context is not None:
+                self.context = self.initial_context.copy()
                 return self.func(record, self.context)
 
             return self.func(record)

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -75,6 +75,16 @@ class Rule(object):
 
         Rule._rules[self.rule_name] = self
 
+    def __str__(self):
+        return '<Rule: {}; outputs: {}; disabled: {}>'.format(
+            self.rule_name,
+            self.outputs,
+            self.disabled
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
     @time_rule
     def process(self, rec):
         """Process will call this rule's function on the passed record

--- a/stream_alert/shared/stats.py
+++ b/stream_alert/shared/stats.py
@@ -64,20 +64,15 @@ def time_me(func):
     return timed
 
 
-def time_rule(func=None, rule_name=None):
+def time_rule(rule_func):
     """Timing decorator for specifically timing a rule function"""
-    if not func:
-        def partial(inner):
-            return time_rule(inner, rule_name)
-        return partial
-
-    def timed(*args, **kw):
+    def timed(self, *args, **kwargs):
         """Wrapping function"""
         time_start = time.time()
-        result = func(*args, **kw)
+        result = rule_func(self, *args, **kwargs)
         time_end = time.time()
 
-        RULE_STATS[rule_name] += RuleStatistic((time_end - time_start) * 1000)
+        RULE_STATS[self.rule_name] += RuleStatistic((time_end - time_start) * 1000)
 
         return result
 

--- a/tests/unit/app_integrations/test_apps/test_app_base.py
+++ b/tests/unit/app_integrations/test_apps/test_app_base.py
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use
-from mock import Mock, patch
-
 from botocore.exceptions import ClientError
+from mock import Mock, patch
 from nose.tools import (
     assert_equal,
     assert_false,

--- a/tests/unit/app_integrations/test_apps/test_box.py
+++ b/tests/unit/app_integrations/test_apps/test_box.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method,attribute-defined-outside-init
 import json
-from mock import Mock, mock_open, patch
 
 from boxsdk.exception import BoxException
+from mock import Mock, mock_open, patch
 from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true
 from requests.exceptions import ConnectionError, Timeout
 

--- a/tests/unit/app_integrations/test_apps/test_duo.py
+++ b/tests/unit/app_integrations/test_apps/test_duo.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method
 from mock import Mock, patch
-
 from nose.tools import assert_equal, assert_false, assert_items_equal, raises
 import requests
 

--- a/tests/unit/app_integrations/test_apps/test_gsuite.py
+++ b/tests/unit/app_integrations/test_apps/test_gsuite.py
@@ -18,10 +18,9 @@ import json
 import socket
 import ssl
 
-from mock import Mock, mock_open, patch
-
 import apiclient
 import oauth2client
+from mock import Mock, mock_open, patch
 from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true, raises
 
 from app_integrations.apps.gsuite import GSuiteReportsApp

--- a/tests/unit/app_integrations/test_apps/test_onelogin.py
+++ b/tests/unit/app_integrations/test_apps/test_onelogin.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use
 from mock import Mock, patch
-
 from nose.tools import assert_equal, assert_false, assert_items_equal
 
 from app_integrations.apps.onelogin import OneLoginApp

--- a/tests/unit/app_integrations/test_apps/test_salesforce.py
+++ b/tests/unit/app_integrations/test_apps/test_salesforce.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use,abstract-method,attribute-defined-outside-init
-
 from requests.exceptions import Timeout
 from mock import Mock, patch
 from nose.tools import (

--- a/tests/unit/app_integrations/test_main.py
+++ b/tests/unit/app_integrations/test_main.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 # pylint: disable=protected-access
 from mock import call, patch
-
 from nose.tools import assert_equal, raises
 
 import app_integrations

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 # pylint: disable=protected-access,attribute-defined-outside-init,no-self-use
 import base64
+
 from mock import patch
 from moto import mock_s3, mock_kms
 from nose.tools import assert_false, assert_true, assert_equal, assert_is_not_none

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -16,8 +16,6 @@ limitations under the License.
 # pylint: disable=abstract-class-instantiated,protected-access,attribute-defined-outside-init
 import os
 
-from requests.exceptions import Timeout as ReqTimeout
-
 from mock import Mock, patch
 from moto import mock_kms, mock_s3
 from nose.tools import (
@@ -27,6 +25,7 @@ from nose.tools import (
     assert_is_none,
     assert_items_equal
 )
+from requests.exceptions import Timeout as ReqTimeout
 
 from stream_alert.alert_processor.outputs.output_base import (
     OutputDispatcher,

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 # pylint: disable=protected-access,attribute-defined-outside-init,no-self-use
 from collections import Counter, OrderedDict
+
 from mock import patch
 from moto import mock_s3, mock_kms
 from nose.tools import assert_equal, assert_false, assert_true, assert_set_equal

--- a/tests/unit/stream_alert_cli/test_helpers.py
+++ b/tests/unit/stream_alert_cli/test_helpers.py
@@ -15,10 +15,10 @@ limitations under the License.
 """
 import json
 
-from stream_alert_cli import helpers
-
 from mock import mock_open, patch
 from nose.tools import assert_equal, assert_false, assert_is_none, assert_items_equal
+
+from stream_alert_cli import helpers
 
 
 def test_load_test_file_list():

--- a/tests/unit/stream_alert_rule_processor/test_config.py
+++ b/tests/unit/stream_alert_rule_processor/test_config.py
@@ -13,9 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-# command: nosetests -v -s tests/unit/
-# specific test: nosetests -v -s tests/unit/file.py:TestStreamPayload.test_name
-
 # pylint: disable=protected-access
 from mock import mock_open, patch
 from nose.tools import assert_equal, raises, nottest

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -31,7 +31,7 @@ import boto3
 
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.handler import load_config, StreamAlert
-from stream_alert.rule_processor.rules_engine import StreamRules
+from stream_alert.shared.rule import rule
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 from stream_alert.shared.alert import Alert
 from tests.unit.stream_alert_rule_processor.test_helpers import (
@@ -40,8 +40,6 @@ from tests.unit.stream_alert_rule_processor.test_helpers import (
     get_valid_event,
     make_kinesis_raw_record,
 )
-
-rule = StreamRules.rule
 
 
 @mock_dynamodb2
@@ -125,7 +123,7 @@ class TestStreamAlert(object):
         )
 
     @patch('stream_alert.rule_processor.alert_forward.AlertForwarder.send_alerts')
-    @patch('stream_alert.rule_processor.handler.StreamRules.process')
+    @patch('stream_alert.rule_processor.handler.RulesEngine.run')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
     def test_run_with_alert(self, extract_mock, rules_mock, alerts_mock):
         """StreamAlert Class - Run, With Alert"""
@@ -177,7 +175,7 @@ class TestStreamAlert(object):
         assert_equal(log_mock.call_args[0][2], '{"bad": "data"}')
 
     @patch('stream_alert.rule_processor.alert_forward.AlertForwarder.send_alerts')
-    @patch('stream_alert.rule_processor.handler.StreamRules.process')
+    @patch('stream_alert.rule_processor.handler.RulesEngine.run')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
     def test_run_send_alerts(self, extract_mock, rules_mock, forwarder_mock):
         """StreamAlert Class - Run, Send Alert"""
@@ -193,7 +191,7 @@ class TestStreamAlert(object):
 
     @patch('logging.Logger.debug')
     @patch('stream_alert.rule_processor.alert_forward.AlertForwarder.send_alerts')
-    @patch('stream_alert.rule_processor.handler.StreamRules.process')
+    @patch('stream_alert.rule_processor.handler.RulesEngine.run')
     @patch('stream_alert.rule_processor.handler.StreamClassifier.extract_service_and_entity')
     def test_run_debug_log_alert(self, extract_mock, rules_mock, alerts_mock, log_mock):
         """StreamAlert Class - Run, Debug Log Alert"""

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -31,9 +31,9 @@ import boto3
 
 from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.handler import load_config, StreamAlert
-from stream_alert.shared.rule import rule
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 from stream_alert.shared.alert import Alert
+from stream_alert.shared.rule import rule
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     convert_events_to_kinesis,
     get_mock_context,

--- a/tests/unit/stream_alert_rule_processor/test_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_helpers.py
@@ -18,7 +18,6 @@ import json
 
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError, ParamValidationError
-
 from mock import Mock
 
 from stream_alert.rule_processor.classifier import StreamClassifier

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -30,7 +30,7 @@ from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.parsers import get_parser
 from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import NORMALIZATION_KEY
-from stream_alert.shared.rule import disable, LOADED_MATCHERS, matcher, rule, Rule
+from stream_alert.shared.rule import disable, matcher, Matcher, rule, Rule
 
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     get_mock_context,
@@ -61,7 +61,7 @@ class TestRulesEngine(object):
     def setup(self):
         """Setup before each method"""
         # Clear out the cached matchers and rules to avoid conflicts with production code
-        LOADED_MATCHERS.clear()  # pylint: disable=no-member
+        Matcher._matchers.clear()
         Rule._rules.clear()
         self.config = load_config('tests/unit/conf')
         self.config['global']['threat_intel']['enabled'] = False
@@ -78,13 +78,13 @@ class TestRulesEngine(object):
         def minimal_rule(rec):  # pylint: disable=unused-variable
             return rec['unixtime'] == 1483139547
 
-        @rule(matchers=['foobar', 'prod'],
+        @rule(matchers=['prod'],
               logs=['test_log_type_json_nested_with_data'],
               outputs=['pagerduty:sample_integration'])
         def chef_logs(rec):  # pylint: disable=unused-variable
             return rec['application'] == 'chef'
 
-        @rule(matchers=['foobar', 'prod'],
+        @rule(matchers=['prod'],
               logs=['test_log_type_json_nested_with_data'],
               outputs=['pagerduty:sample_integration'])
         def test_nest(rec):  # pylint: disable=unused-variable

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=no-self-use,protected-access
-from collections import namedtuple
 import json
 import os
 
@@ -29,8 +28,9 @@ from nose.tools import (
 
 from stream_alert.rule_processor.config import load_config, load_env
 from stream_alert.rule_processor.parsers import get_parser
-from stream_alert.rule_processor.rules_engine import RuleAttributes, StreamRules
+from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import NORMALIZATION_KEY
+from stream_alert.shared.rule import disable, LOADED_MATCHERS, matcher, rule, Rule
 
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     get_mock_context,
@@ -41,14 +41,10 @@ from tests.unit.stream_alert_rule_processor.test_helpers import (
 )
 from helpers.base import fetch_values_by_datatype
 
-rule = StreamRules.rule
-matcher = StreamRules.matcher()
-disable = StreamRules.disable()
-
 
 @patch.dict(os.environ, {'CLUSTER': ''})
-class TestStreamRules(object):
-    """Test class for StreamRules"""
+class TestRulesEngine(object):
+    """Test class for RulesEngine"""
     @classmethod
     def setup_class(cls):
         """Setup the class before any methods"""
@@ -65,37 +61,17 @@ class TestStreamRules(object):
     def setup(self):
         """Setup before each method"""
         # Clear out the cached matchers and rules to avoid conflicts with production code
-        StreamRules._StreamRules__matchers.clear()  # pylint: disable=no-member
-        StreamRules._StreamRules__rules.clear()  # pylint: disable=no-member
+        LOADED_MATCHERS.clear()  # pylint: disable=no-member
+        Rule._rules.clear()
         self.config = load_config('tests/unit/conf')
         self.config['global']['threat_intel']['enabled'] = False
-        self.rules_engine = StreamRules(self.config)
-
-    @patch('stream_alert.rule_processor.rules_engine.LOGGER.exception')
-    def test_bad_rule(self, log_mock):
-        """Rules Engine - Process Bad Rule Function"""
-        bad_rule = namedtuple('BadRule', 'rule_function')
-
-        def bad_rule_function(_):
-            """A simple function that will raise an exception"""
-            raise AttributeError('This rule raises an error')
-
-        test_rule = bad_rule(bad_rule_function)
-
-        self.rules_engine.process_rule({}, test_rule)
-
-        log_mock.assert_called_with('Encountered error with rule: %s',
-                                    'bad_rule_function')
+        self.rules_engine = RulesEngine(self.config)
 
     def test_basic_rule_matcher_process(self):
         """Rules Engine - Basic Rule/Matcher"""
         @matcher
         def prod(rec):  # pylint: disable=unused-variable
             return rec['environment'] == 'prod'
-
-        @rule()
-        def incomplete_rule(_):  # pylint: disable=unused-variable
-            return True
 
         @rule(logs=['test_log_type_json_nested_with_data'],
               outputs=['s3:sample_bucket'])
@@ -133,7 +109,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # check alert output
         assert_equal(len(alerts), 3)
@@ -157,9 +133,9 @@ class TestStreamRules(object):
                 'us-east' in rec['awsRegion'] and
                 'AWS' in rec['requestParameters']['program']
             )
-        rule_attrs = RuleAttributes(
+        rule_attrs = Rule(
+            cloudtrail_us_east_logs,
             rule_name='cloudtrail_us_east_logs',
-            rule_function=cloudtrail_us_east_logs,
             matchers=[],
             datatypes=[],
             logs=['test_log_type_json_nested'],
@@ -246,12 +222,12 @@ class TestStreamRules(object):
 
         valid_record = [
             rec for rec in parsed_result if rec['requestParameters'] is not None][0]
-        valid_subkey_check = StreamRules.process_subkeys(valid_record, 'json', rule_attrs)
+        valid_subkey_check = RulesEngine.process_subkeys(valid_record, 'json', rule_attrs)
         assert_true(valid_subkey_check)
 
         invalid_record = [
             rec for rec in parsed_result if rec['requestParameters'] is None][0]
-        invalid_subkey_check = StreamRules.process_subkeys(invalid_record, 'json', rule_attrs)
+        invalid_subkey_check = RulesEngine.process_subkeys(invalid_record, 'json', rule_attrs)
         assert_false(invalid_subkey_check)
 
     def test_process_subkeys(self):
@@ -298,7 +274,7 @@ class TestStreamRules(object):
             raw_record = make_kinesis_raw_record(entity, kinesis_data)
             payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
-            alerts.extend(self.rules_engine.process(payload)[0])
+            alerts.extend(self.rules_engine.run(payload)[0])
 
         # check alert output
         assert_equal(len(alerts), 2)
@@ -328,7 +304,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # alert tests
         assert_equal(len(alerts), 1)
@@ -356,7 +332,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # alert tests
         assert_equal(len(alerts), 1)
@@ -383,7 +359,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # alert tests
         assert_equal(len(alerts), 0)
@@ -426,7 +402,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # alert tests
         assert_equal(len(alerts), 2)
@@ -497,7 +473,7 @@ class TestStreamRules(object):
             raw_record = make_kinesis_raw_record(entity, kinesis_data)
             payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
-            alerts.extend(self.rules_engine.process(payload)[0])
+            alerts.extend(self.rules_engine.run(payload)[0])
 
         # check alert output
         assert_equal(len(alerts), 2)
@@ -515,7 +491,7 @@ class TestStreamRules(object):
             'username': [['sub_key1']],
             'ipv4': [['sub_key2']]
         }
-        StreamRules.update(results, parent_key, nested_results)
+        RulesEngine.update(results, parent_key, nested_results)
         expected_results = {
             'username': [['key2', 'sub_key1']],
             'ipv4': [['key1'], ['key2', 'sub_key2']]
@@ -533,7 +509,7 @@ class TestStreamRules(object):
             'username': [['sub_key1', 'sub_key11']],
             'type': [['sub_key2']]
         }
-        StreamRules.update(results, parent_key, nested_results)
+        RulesEngine.update(results, parent_key, nested_results)
         expected_results = {
             'username': [['key2', 'sub_key1', 'sub_key11']],
             'type': [['key4'], ['key2', 'sub_key2']],
@@ -564,7 +540,7 @@ class TestStreamRules(object):
             'ipv4': ['destination', 'source', 'sourceIPAddress']
         }
         datatypes = ['account', 'ipv4', 'region']
-        results = StreamRules.match_types_helper(
+        results = RulesEngine.match_types_helper(
             record,
             normalized_types,
             datatypes
@@ -599,7 +575,7 @@ class TestStreamRules(object):
             'userName': ['userName', 'owner', 'invokedBy']
         }
         datatypes = ['account', 'ipv4', 'region', 'userName']
-        results = StreamRules.match_types_helper(
+        results = RulesEngine.match_types_helper(
             record,
             normalized_types,
             datatypes
@@ -670,41 +646,13 @@ class TestStreamRules(object):
             raw_record = make_kinesis_raw_record(entity, kinesis_data)
             payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
-            alerts.extend(self.rules_engine.process(payload)[0])
+            alerts.extend(self.rules_engine.run(payload)[0])
 
         assert_equal(len(alerts), 3)
         rule_names = ['no_logs_has_datatypes',
                       'has_logs_no_datatypes',
                       'has_logs_datatypes']
         assert_items_equal([alerts[i].rule_name for i in range(3)], rule_names)
-
-    def test_process_required_logs(self):
-        """Rules Engine - Logs is required when no datatypes defined"""
-        @rule(outputs=['s3:sample_bucket'])
-        def match_ipaddress(): # pylint: disable=unused-variable
-            """Testing rule to detect matching IP address"""
-            return True
-
-        kinesis_data_items = [
-            {
-                'account': 123456,
-                'region': '123456123456',
-                'source': '1.1.1.2',
-                'detail': {
-                    'eventName': 'ConsoleLogin',
-                    'sourceIPAddress': '1.1.1.2',
-                    'recipientAccountId': '654321'
-                }
-            }
-        ]
-
-        for data in kinesis_data_items:
-            kinesis_data = json.dumps(data)
-            service, entity = 'kinesis', 'test_kinesis_stream'
-            raw_record = make_kinesis_raw_record(entity, kinesis_data)
-            payload = load_and_classify_payload(self.config, service, entity, raw_record)
-
-            assert_false(self.rules_engine.process(payload)[0])
 
     def test_reset_normalized_types(self):
         """Rules Engine - Normalized types should be reset after each iteration"""
@@ -755,7 +703,7 @@ class TestStreamRules(object):
             raw_record = make_kinesis_raw_record(entity, kinesis_data)
             payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
-            alerts.extend(self.rules_engine.process(payload)[0])
+            alerts.extend(self.rules_engine.run(payload)[0])
 
         assert_equal(len(alerts), 3)
         for alert in alerts:
@@ -778,7 +726,7 @@ class TestStreamRules(object):
         toggled_config['global']['threat_intel']['enabled'] = True
         toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'
 
-        new_rules_engine = StreamRules(toggled_config)
+        new_rules_engine = RulesEngine(toggled_config)
         kinesis_data_items = [
             {
                 'account': 123456,
@@ -798,7 +746,7 @@ class TestStreamRules(object):
             raw_record = make_kinesis_raw_record(entity, kinesis_data)
             payload = load_and_classify_payload(toggled_config, service, entity, raw_record)
 
-            assert_equal(len(new_rules_engine.process(payload)[0]), 1)
+            assert_equal(len(new_rules_engine.run(payload)[0]), 1)
 
     @patch('boto3.client')
     def test_threat_intel_match(self, mock_client):
@@ -814,7 +762,7 @@ class TestStreamRules(object):
         toggled_config['global']['threat_intel']['enabled'] = True
         toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'
 
-        new_rules_engine = StreamRules(toggled_config)
+        new_rules_engine = RulesEngine(toggled_config)
         records = mock_normalized_records()
         alerts = new_rules_engine.threat_intel_match(records)
         assert_equal(len(alerts), 2)
@@ -843,7 +791,7 @@ class TestStreamRules(object):
         toggled_config['global']['threat_intel']['enabled'] = True
         toggled_config['global']['threat_intel']['dynamodb_table'] = 'test_table_name'
 
-        new_rules_engine = StreamRules(toggled_config)
+        new_rules_engine = RulesEngine(toggled_config)
         kinesis_data = {
             "Field1": {
                 "SubField1": {
@@ -864,7 +812,7 @@ class TestStreamRules(object):
         service, entity = 'kinesis', 'test_stream_threat_intel'
         raw_record = make_kinesis_raw_record(entity, kinesis_data)
         payload = load_and_classify_payload(toggled_config, service, entity, raw_record)
-        alerts, normalized_records = new_rules_engine.process(payload)
+        alerts, normalized_records = new_rules_engine.run(payload)
 
         # Two testing rules are for threat intelligence matching. So no alert will be
         # generated before threat intel takes effect.
@@ -915,7 +863,7 @@ class TestStreamRules(object):
         payload = load_and_classify_payload(self.config, service, entity, raw_record)
 
         # process payloads
-        alerts, _ = self.rules_engine.process(payload)
+        alerts, _ = self.rules_engine.run(payload)
 
         # alert tests
         assert_equal(alerts[0].context['assigned_user'], 'valid_user')

--- a/tests/unit/stream_alert_shared/test_backoff_handlers.py
+++ b/tests/unit/stream_alert_shared/test_backoff_handlers.py
@@ -15,12 +15,12 @@ limitations under the License.
 """
 from mock import Mock, patch
 
-
 from stream_alert.shared.backoff_handlers import (
     backoff_handler,
     giveup_handler,
     success_handler
 )
+
 
 def _get_details(with_wait=False):
     """Return a details dict that conforms to what the backoff handlers expected

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -1,0 +1,155 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=no-self-use,protected-access
+from mock import patch
+
+from stream_alert.shared import rule
+
+from nose.tools import assert_equal, raises
+
+
+class TestRule(object):
+    """TestRule class"""
+    def setup(self):
+        rule.Rule._rules.clear()
+
+    def teardown(self):
+        rule.Rule._rules.clear()
+
+    @staticmethod
+    def _create_rule_helper(rule_name, options=None):
+
+        if not options:
+            options = {'logs': ['log_type_01']}
+
+        # Create a rule from this code block, injecting the rule name
+        custom_rule = """
+@rule.rule(**options)
+def {}(_):
+    return False
+""".format(rule_name)
+
+        exec custom_rule #pylint: disable=exec-used
+
+    def test_rule_valid(self):
+        """Rule - Create Valid Rule"""
+        self._create_rule_helper('test_rule')
+        assert_equal(rule.Rule._rules.keys(), ['test_rule'])
+
+    @raises(rule.RuleInvalid)
+    def test_rule_invalid(self):
+        """Rule - Create Rule, Missing Args"""
+        # Rules must either have `logs` or `datatypes` defined
+        self._create_rule_helper('test_rule', {'outputs': ['fake_output']})
+
+    @raises(rule.RuleInvalid)
+    def test_rule_exists(self):
+        """Rule - Create Rule, Rule Already Exists"""
+        # Rules must either have `logs` or `datatypes` defined
+        self._create_rule_helper('test_rule')
+        self._create_rule_helper('test_rule')
+
+    def test_rule_disable(self):
+        """Rule - Disabled Rule"""
+        @rule.disable
+        @rule.rule(logs=['log_type'])
+        def test_rule_disabled(_): #pylint: disable=unused-variable
+            return False
+
+        assert_equal(rule.Rule._rules['test_rule_disabled'].disabled, True)
+
+    def test_rule_to_string(self):
+        """Rule - String Representation"""
+        def test_rule(_):
+            pass
+        test_rule = rule.Rule(test_rule, outputs=['foo'], logs=['bar'])
+        assert_equal(str(test_rule), '<Rule: test_rule; outputs: [\'foo\']; disabled: False>')
+
+    @patch('logging.Logger.exception')
+    def test_rule_process_exception(self, log_mock):
+        """Rule - Process, Exeception"""
+        def test_rule(_):
+            return 1/0 == 0
+        test_rule = rule.Rule(test_rule, logs=['bar'])
+        result = test_rule.process(None)
+        log_mock.assert_called_with('Encountered error with rule: %s', 'test_rule')
+        assert_equal(result, False)
+
+    def test_rule_process(self):
+        """Rule - Process, Valid"""
+        def test_rule(_):
+            return True
+        test_rule = rule.Rule(test_rule, logs=['bar'])
+        result = test_rule.process(None)
+        assert_equal(result, True)
+
+    def test_rule_process_with_context(self):
+        """Rule - Process, With Context"""
+        def test_rule(_, rule_context): #pylint: disable=missing-docstring
+            rule_context['relevant'] = 'data'
+            return True
+        test_rule = rule.Rule(test_rule, logs=['bar'], context={'output': 'context'})
+        result = test_rule.process(None)
+        assert_equal(result, True)
+        assert_equal(test_rule.context['relevant'], 'data')
+
+    def test_get_rule(self):
+        """Rule - Get Rule"""
+        rule_name = 'test_rule'
+        self._create_rule_helper(rule_name)
+        result = rule.Rule.get_rule(rule_name)
+        assert_equal(result.rule_name, rule_name)
+
+    def test_rule_names(self):
+        """Rule - Get Rule Names"""
+        rule_names = ['test_rule_01', 'test_rule_02']
+        for name in rule_names:
+            self._create_rule_helper(name)
+        assert_equal(rule.Rule.rule_names(), rule_names)
+
+    def test_get_rules_with_datatypes(self):
+        """Rule - Get Rules, Rule With Datatypes"""
+        # Add a rule (this one will have no datatypes)
+        self._create_rule_helper('no_datatypes')
+
+        # Add another rule with datatypes
+        self._create_rule_helper('with_datatypes', {'datatypes': ['sourceAddress']})
+
+        result = rule.Rule.rules_with_datatypes()
+        # Make sure both rules are there
+        assert_equal(len(rule.Rule.rule_names()), 2)
+        # Check to see if the one with datatypes is returned
+        assert_equal(len(result), 1)
+        assert_equal(result[0].rule_name, 'with_datatypes')
+
+    def test_get_rules_for_log_type(self):
+        """Rule - Get Rules, For Log Type"""
+        self._create_rule_helper('rule_01')
+        self._create_rule_helper('rule_02', {'logs': ['log_type_02']})
+        self._create_rule_helper('rule_03', {'logs': ['log_type_01', 'log_type_02']})
+        self._create_rule_helper('rule_04', {'logs': ['log_type_03']})
+
+        # Check for 4 total rules
+        assert_equal(len(rule.Rule._rules), 4)
+
+        # Two rules should have log_type_01, and two should have log_type_02
+        assert_equal(len(rule.Rule.rules_for_log_type('log_type_01')), 2)
+        assert_equal(len(rule.Rule.rules_for_log_type('log_type_02')), 2)
+
+        # Check to make sure the fourth rule has log_type_03
+        result = rule.Rule.rules_for_log_type('log_type_03')
+        assert_equal(len(result), 1)
+        assert_equal(result[0].rule_name, 'rule_04')

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -15,10 +15,9 @@ limitations under the License.
 """
 # pylint: disable=no-self-use,protected-access
 from mock import patch
+from nose.tools import assert_equal, raises
 
 from stream_alert.shared import rule
-
-from nose.tools import assert_equal, raises
 
 
 class TestRule(object):
@@ -56,13 +55,13 @@ def {}(_):
         self._create_rule_helper('test_rule')
         assert_equal(rule.Rule._rules.keys(), ['test_rule'])
 
-    @raises(rule.RuleInvalid)
+    @raises(rule.RuleCreationError)
     def test_rule_invalid(self):
         """Rule - Create Rule, Missing Args"""
         # Rules must either have `logs` or `datatypes` defined
         self._create_rule_helper('test_rule', {'outputs': ['fake_output']})
 
-    @raises(rule.RuleInvalid)
+    @raises(rule.RuleCreationError)
     def test_rule_exists(self):
         """Rule - Create Rule, Rule Already Exists"""
         # Rules must either have `logs` or `datatypes` defined
@@ -199,7 +198,7 @@ def {}(_):
 
         exec custom_matcher_code #pylint: disable=exec-used
 
-    @raises(rule.MatcherInvalid)
+    @raises(rule.MatcherCreationError)
     def test_matcher_exists(self):
         """Matcher - Create Matcher, Matcher Already Exists"""
         self._create_matcher_helper('test_matcher')

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -77,6 +77,7 @@ def {}(_):
             pass
         test_rule = rule.Rule(test_rule, outputs=['foo'], logs=['bar'])
         assert_equal(str(test_rule), '<Rule: test_rule; outputs: [\'foo\']; disabled: False>')
+        assert_equal(repr(test_rule), '<Rule: test_rule; outputs: [\'foo\']; disabled: False>')
 
     @patch('logging.Logger.exception')
     def test_rule_process_exception(self, log_mock):

--- a/tests/unit/stream_alert_shared/test_stats.py
+++ b/tests/unit/stream_alert_shared/test_stats.py
@@ -15,11 +15,11 @@ limitations under the License.
 """
 # pylint: disable=no-self-use
 from collections import namedtuple
+
 from mock import Mock, patch
+from nose.tools import assert_equal
 
 from stream_alert.shared import stats
-
-from nose.tools import assert_equal
 
 
 class TestRuleStats(object):

--- a/tests/unit/stream_alert_shared/test_stats.py
+++ b/tests/unit/stream_alert_shared/test_stats.py
@@ -1,0 +1,94 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=no-self-use
+from collections import namedtuple
+from mock import Mock, patch
+
+from stream_alert.shared import stats
+
+from nose.tools import assert_equal
+
+
+class TestRuleStats(object):
+    """TestTimeRule class"""
+    def setup(self):
+        stats.RULE_STATS.clear()
+
+    def teardown(self):
+        stats.RULE_STATS.clear()
+
+    @staticmethod
+    def _timed_func_helper():
+        @stats.time_rule
+        def test_func(_):
+            pass
+
+        fake = namedtuple('Rule', ['rule_name'])('test_rule')
+
+        test_func(fake)
+
+    def test_time_rule(self):
+        """Stats - Time Rule, Decorator"""
+        self._timed_func_helper()
+        assert_equal(len(stats.RULE_STATS), 1)
+        assert_equal(stats.RULE_STATS['test_rule'].calls, 1)
+
+    def test_rule_stats_add(self):
+        """Stats - Rule Statistics, Add"""
+        stat = stats.RuleStatistic(10.0)
+        stat += stats.RuleStatistic(12.5)
+
+        assert_equal(stat.calls, 1)
+        assert_equal(stat.tracked_time, 22.5)
+
+    def test_rule_stats_compare(self):
+        """Stats - Rule Statistics, Compare"""
+        stat_01 = stats.RuleStatistic(10.0)
+        stat_02 = stats.RuleStatistic(12.0)
+
+        assert_equal(stat_01 < stat_02, True)
+        assert_equal(stat_01 > stat_02, False)
+
+
+    def test_rule_stats_string(self):
+        """Stats - Rule Statistics, To String"""
+        stat = stats.RuleStatistic(10.0)
+        stat.calls = 1
+
+        assert_equal(str(stat), '   10.00000000 ms       1 calls     10.00000000 avg')
+
+    @patch('logging.Logger.error')
+    def test_print_rule_stats_empty(self, log_mock):
+        """Stats - Print Rule Stats, None"""
+        stats.print_rule_stats()
+        log_mock.assert_called_with('No rule statistics to print')
+
+    @patch('time.time', Mock(side_effect=[0.01, 0.02]))
+    @patch('logging.Logger.info')
+    def test_print_rule_stats(self, log_mock):
+        """Stats - Print Rule Stats"""
+        self._timed_func_helper()
+        stats.print_rule_stats()
+        log_mock.assert_called_with(
+            'Rule statistics:\n%s',
+            'test_rule       10.00000000 ms       1 calls     10.00000000 avg'
+        )
+
+    def test_print_rule_stats_reset(self,):
+        """Stats - Print Rule Stats, Reset"""
+        self._timed_func_helper()
+        stats.print_rule_stats(True)
+        assert_equal(len(stats.RULE_STATS), 0)

--- a/tests/unit/threat_intel_downloader/test_helpers.py
+++ b/tests/unit/threat_intel_downloader/test_helpers.py
@@ -18,86 +18,6 @@ from mock import Mock
 from tests.unit.threat_intel_downloader import FUNCTION_NAME, REGION
 
 
-def get_mock_context():
-    """Helper function to create a fake context object using Mock"""
-    arn = 'arn:aws:lambda:{}:123456789012:function:{}:development'
-    context = Mock(invoked_function_arn=(arn.format(REGION, FUNCTION_NAME)),
-                   function_name=FUNCTION_NAME,
-                   get_remaining_time_in_millis=Mock(return_value=100))
-
-    return context
-
-class MockRequestsResponse(object): # pylint: disable=too-few-public-methods
-    """Mocking class to mock requests.get() call"""
-    def __init__(self, json_data, status_code):
-        self.json_data = json_data
-        self.status_code = status_code
-
-    def json(self):
-        """Return data in json format"""
-        return self.json_data
-
-def mock_requests_get(*args, **kwargs): # pylint: disable=unused-argument
-    """Method to mock requests.get() call"""
-    return MockRequestsResponse({
-        "key1": "value1",
-        "objects": [
-            {
-                'value': 'malicious_domain.com',
-                'itype': 'c2_domain',
-                'source': 'ioc_source',
-                'type': 'domain',
-                'expiration_ts': '2017-12-31T00:01:02.123Z',
-                'key1': 'value1',
-                'key2': 'value2'
-            },
-            {
-                'value': 'malicious_domain2.com',
-                'itype': 'c2_domain',
-                'source': 'test_source',
-                'type': 'domain',
-                'expiration_ts': '2017-11-30T00:01:02.123Z',
-                'key1': 'value1',
-                'key2': 'value2'
-            }
-        ],
-        "meta": {
-            "next": None,
-            "offset": 100
-            }
-        }, 200)
-
-def mock_ssm_response():
-    return {
-        'threat_intel_downloader_api_creds': '{"api_user": "test_user", "api_key": "test_key"}',
-        'ti_test_state': '{"next_url": "test_next_url", "continue_invoke": "False"}'
-    }
-
-def mock_invalid_ssm_response():
-    return {
-        'threat_intel_downloader_api_creds': 'invalid_value'
-    }
-
-def mock_config():
-    '''Helper function to create a fake config for Threat Intel Downloader'''
-    return {
-        'account_id': '123456789012',
-        'function_name': 'prefix_threat_intel_downloader',
-        'handler': 'stream_alert.threat_intel_downloader.main.handler',
-        'interval': 'rate(1 day)',
-        'ioc_filters': ['crowdstrike', '@airbnb.com'],
-        'ioc_keys': ['expiration_ts', 'itype', 'source', 'type', 'value'],
-        'ioc_types': ['domain', 'ip', 'md5'],
-        'excluded_sub_types': ['bot_ip', 'brute_ip', 'scan_ip', 'spam_ip', 'tor_ip'],
-        'log_level': 'info',
-        'memory': '128',
-        'qualifier': 'development',
-        'region': 'us-east-1',
-        'table_rcu': 10,
-        'table_wcu': 10,
-        'timeout': '180'
-    }
-
 LAMBDA_FILE = 'conf/lambda.json'
 
 LAMBDA_SETTINGS = {
@@ -129,3 +49,89 @@ LAMBDA_SETTINGS = {
         'third_party_libraries': []
     }
 }
+
+
+def get_mock_context():
+    """Helper function to create a fake context object using Mock"""
+    arn = 'arn:aws:lambda:{}:123456789012:function:{}:development'
+    context = Mock(invoked_function_arn=(arn.format(REGION, FUNCTION_NAME)),
+                   function_name=FUNCTION_NAME,
+                   get_remaining_time_in_millis=Mock(return_value=100))
+
+    return context
+
+
+class MockRequestsResponse(object): # pylint: disable=too-few-public-methods
+    """Mocking class to mock requests.get() call"""
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        """Return data in json format"""
+        return self.json_data
+
+
+def mock_requests_get(*args, **kwargs): # pylint: disable=unused-argument
+    """Method to mock requests.get() call"""
+    return MockRequestsResponse({
+        "key1": "value1",
+        "objects": [
+            {
+                'value': 'malicious_domain.com',
+                'itype': 'c2_domain',
+                'source': 'ioc_source',
+                'type': 'domain',
+                'expiration_ts': '2017-12-31T00:01:02.123Z',
+                'key1': 'value1',
+                'key2': 'value2'
+            },
+            {
+                'value': 'malicious_domain2.com',
+                'itype': 'c2_domain',
+                'source': 'test_source',
+                'type': 'domain',
+                'expiration_ts': '2017-11-30T00:01:02.123Z',
+                'key1': 'value1',
+                'key2': 'value2'
+            }
+        ],
+        "meta": {
+            "next": None,
+            "offset": 100
+            }
+        }, 200)
+
+
+def mock_ssm_response():
+    return {
+        'threat_intel_downloader_api_creds': '{"api_user": "test_user", "api_key": "test_key"}',
+        'ti_test_state': '{"next_url": "test_next_url", "continue_invoke": "False"}'
+    }
+
+
+def mock_invalid_ssm_response():
+    return {
+        'threat_intel_downloader_api_creds': 'invalid_value'
+    }
+
+
+def mock_config():
+    '''Helper function to create a fake config for Threat Intel Downloader'''
+    return {
+        'account_id': '123456789012',
+        'function_name': 'prefix_threat_intel_downloader',
+        'handler': 'stream_alert.threat_intel_downloader.main.handler',
+        'interval': 'rate(1 day)',
+        'ioc_filters': ['crowdstrike', '@airbnb.com'],
+        'ioc_keys': ['expiration_ts', 'itype', 'source', 'type', 'value'],
+        'ioc_types': ['domain', 'ip', 'md5'],
+        'excluded_sub_types': ['bot_ip', 'brute_ip', 'scan_ip', 'spam_ip', 'tor_ip'],
+        'log_level': 'info',
+        'memory': '128',
+        'qualifier': 'development',
+        'region': 'us-east-1',
+        'table_rcu': 10,
+        'table_wcu': 10,
+        'timeout': '180'
+    }

--- a/tests/unit/threat_intel_downloader/test_main.py
+++ b/tests/unit/threat_intel_downloader/test_main.py
@@ -29,19 +29,15 @@ from stream_alert.threat_intel_downloader.main import (
     load_config,
     parse_lambda_func_arn
 )
-
 from stream_alert.threat_intel_downloader.exceptions import (
     ThreatStreamLambdaInvokeError,
     ThreatStreamConfigError
 )
-
 from tests.unit.app_integrations.test_helpers import (
     MockLambdaClient,
     MockSSMClient
 )
-
 from tests.unit.helpers.base import mock_open
-
 from tests.unit.threat_intel_downloader.test_helpers import (
     get_mock_context,
     mock_config,

--- a/tests/unit/threat_intel_downloader/test_threat_stream.py
+++ b/tests/unit/threat_intel_downloader/test_threat_stream.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,no-self-use
+import boto3
+from botocore.exceptions import ClientError
 from mock import patch, call
 from nose.tools import (
     assert_equal,
@@ -23,14 +25,9 @@ from nose.tools import (
     raises
 )
 
-import boto3
-from botocore.exceptions import ClientError
-
 from stream_alert.threat_intel_downloader.exceptions import ThreatStreamCredsError
 from stream_alert.threat_intel_downloader.threat_stream import ThreatStream
-
 from tests.unit.app_integrations.test_helpers import MockSSMClient
-
 from tests.unit.threat_intel_downloader.test_helpers import (
     mock_requests_get,
     mock_config,


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: large

## Background

To enable more complex rule handling (staging, disabling, etc) it has become necessary to more uniformly encapsulate rule logic into a class (vs the previously used and relatively inflexible namedtuple).

## Changes

* This is the first round of changes to enable supporting complex rule operations.
* Decoupling the `matcher`, `disable`, and `rule` decorators from the `StreamRules` class and migrating to `stream_alert.shared.rule`
* Renaming the `StreamRules` class to `RulesEngine` to better reflect the purpose of the class.
* Creating a `Rule` and `Matcher` class that will be instantiated through the use of the `@rule` and `@matcher` decorators, respectively.
* This simplifies import of the decorators to be just:
  * `from stream_alert.shared.rule import matcher`
  * `from stream_alert.shared.rule import disable`
  * `from stream_alert.shared.rule import rule`
* Updating the `@disable` decorator logic so it does not explicitly _remove_ the rule from the cached rules, but instead marks the rule as disabled through the use of a instance property of `disabled`.

## Testing

* Adding tests for the new `Rule` and `Matcher` classes.
* Updating various old or outdated tests (some that were not testing anything effectively).
* Updating the CLI test framework to support using the `@disable` decorator on a rule without having to remove the rule from the `trigger_rules` list of the test event.
* Now, a test event that has a rule within that is disabled will result in output similar to (see `disabled=1` below):
```
...

gsuite_admin
       [Pass]  [log='gsuite:reports']        validation  (stream_alert_app): G Suite Admin Report Log exmaple (validation only)

guard_duty_all
       [Pass]  [trigger=0,disabled=1]        rule      (kinesis): GuardDuty
...
``` 