### PR TITLE
adding support for specifying rule import paths

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -5,6 +5,14 @@
     "prefix": "PREFIX_GOES_HERE",
     "region": "us-east-1"
   },
+  "general": {
+    "rule_locations": [
+      "rules"
+    ],
+    "matcher_locations": [
+      "matchers"
+    ]
+  },
   "infrastructure": {
     "alerts_table": {
       "read_capacity": 5,

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -57,9 +57,12 @@ class StreamAlert(object):
         self._processed_size = 0
         self._alerts = []
 
+        rule_import_paths = [item for location in {'rule_locations', 'matcher_locations'}
+                             for item in self.config['global']['general'][location]]
+
         # Create an instance of the StreamRules class that gets cached in the
         # StreamAlert class as an instance property
-        self._rules_engine = RulesEngine(self.config)
+        self._rules_engine = RulesEngine(self.config, *rule_import_paths)
 
         # Firehose client attribute
         self._firehose_client = None

--- a/stream_alert/rule_processor/main.py
+++ b/stream_alert/rule_processor/main.py
@@ -14,45 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from __future__ import absolute_import  # Suppresses RuntimeWarning import error in Lambda
-import importlib
-import os
 
 from stream_alert.rule_processor.handler import StreamAlert
-
-
-def _python_rule_paths():
-    """Yields all .py files in matchers/ and rules/."""
-    # 'matchers' and 'rules' are top-level folders, both in the repo (when testing)
-    # and in the generated Lambda packages.
-    for folder in ('matchers', 'rules'):
-        for root, _, files in os.walk(folder):
-            for file_name in files:
-                if file_name.endswith('.py') and not file_name.startswith('__'):
-                    yield os.path.join(root, file_name)
-
-
-def _path_to_module(path):
-    """Convert a Python rules file path to an importable module name.
-
-    For example, "rules/community/cloudtrail_critical_api_calls.py" becomes
-    "rules.community.cloudtrail_critical_api_calls"
-
-    Raises:
-        NameError if a '.' appears anywhere in the path except the file extension.
-    """
-    base_name = os.path.splitext(path)[0]
-    if '.' in base_name:
-        raise NameError('Python file {} cannot be imported because of "." in the name', path)
-    return os.path.splitext(path)[0].replace('/', '.')
-
-
-def _import_rules():
-    """Dynamically import all rules files."""
-    for path in _python_rule_paths():
-        importlib.import_module(_path_to_module(path))
-
-
-_import_rules()
 
 
 def handler(event, context):

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -21,7 +21,7 @@ from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.threat_intel import StreamThreatIntel
 from stream_alert.shared import NORMALIZATION_KEY, resources
 from stream_alert.shared.alert import Alert
-from stream_alert.shared.rule import Rule
+from stream_alert.shared.rule import import_folders, Rule
 
 
 _IGNORE_KEYS = {StreamThreatIntel.IOC_KEY, NORMALIZATION_KEY}
@@ -33,6 +33,8 @@ class RulesEngine(object):
         """Initialize a RulesEngine instance to cache a StreamThreatIntel instance."""
         self._threat_intel = StreamThreatIntel.load_from_config(config)
         self._required_outputs_set = resources.get_required_outputs()
+        import_folders(*[item for location in {'rule_locations', 'matcher_locations'}
+                         for item in config['global']['general'][location]])
 
     @staticmethod
     def match_types(record, normalized_types, datatypes):

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -203,12 +203,12 @@ class RulesEngine(object):
 
         for record in payload.records:
             for rule in rules:
-                # matcher check
-                if not rule.check_matchers(record):
-                    continue
-
                 # subkey check
                 if not self.process_subkeys(record, payload.type, rule):
+                    continue
+
+                # matcher check
+                if not rule.check_matchers(record):
                     continue
 
                 if rule.datatypes:

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -29,12 +29,11 @@ _IGNORE_KEYS = {StreamThreatIntel.IOC_KEY, NORMALIZATION_KEY}
 
 class RulesEngine(object):
     """Class to act as a rules engine that processes rules"""
-    def __init__(self, config):
+    def __init__(self, config, *rule_paths):
         """Initialize a RulesEngine instance to cache a StreamThreatIntel instance."""
         self._threat_intel = StreamThreatIntel.load_from_config(config)
         self._required_outputs_set = resources.get_required_outputs()
-        import_folders(*[item for location in {'rule_locations', 'matcher_locations'}
-                         for item in config['global']['general'][location]])
+        import_folders(*rule_paths)
 
     @staticmethod
     def match_types(record, normalized_types, datatypes):

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -14,9 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from copy import deepcopy
+import importlib
+import os
 
 from stream_alert.shared import LOGGER
 from stream_alert.shared.stats import time_rule
+
+
+def _python_file_paths(*paths):
+    """Yields all .py files in the passed paths
+
+    Args:
+        *paths (string): Variable length tuple of paths from within which any
+            .py files should be imported
+
+    Yields:
+        str: Relative path to .py file to me imported using importlib
+    """
+    for folder in paths:
+        for root, _, files in os.walk(folder):
+            for file_name in files:
+                if file_name.endswith('.py') and not file_name.startswith('__'):
+                    yield os.path.join(root, file_name)
+
+
+def _path_to_module(path):
+    """Convert a Python rules file path to an importable module name.
+
+    For example, "rules/community/cloudtrail_critical_api_calls.py" becomes
+    "rules.community.cloudtrail_critical_api_calls"
+
+    Raises:
+        NameError if a '.' appears anywhere in the path except the file extension.
+    """
+    base_name = os.path.splitext(path)[0]
+    if '.' in base_name:
+        raise NameError('Python file "{}" cannot be imported '
+                        'because of "." in the name'.format(path))
+    return base_name.replace('/', '.')
+
+
+def import_folders(*paths):
+    """Dynamically import all rules files.
+
+    Args:
+        *paths (string): Variable length tuple of paths from within which any
+            .py files should be imported
+    """
+    for path in _python_file_paths(*paths):
+        importlib.import_module(_path_to_module(path))
 
 
 class RuleCreationError(Exception):

--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -30,8 +30,6 @@ from mock import patch
 
 from stream_alert.alert_processor import main as StreamOutput
 from stream_alert.rule_processor.handler import StreamAlert
-# import all rules loaded from the main handler
-import stream_alert.rule_processor.main  # pylint: disable=unused-import
 from stream_alert.rule_processor.parsers import get_parser
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.shared import resources, stats, rule

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -5,6 +5,10 @@
     "prefix": "unit-testing",
     "region": "us-west-1"
   },
+  "general": {
+    "matcher_locations": [],
+    "rule_locations": []
+  },
   "infrastructure": {
     "alerts_table": {
       "read_capacity": 5,

--- a/tests/unit/stream_alert_rule_processor/test_handler.py
+++ b/tests/unit/stream_alert_rule_processor/test_handler.py
@@ -170,9 +170,9 @@ class TestStreamAlert(object):
         self.__sa_handler.run(event)
 
         assert_equal(
-            log_mock.call_args[0][0],
+            log_mock.call_args_list[0][0][0],
             'Record does not match any defined schemas: %s\n%s')
-        assert_equal(log_mock.call_args[0][2], '{"bad": "data"}')
+        assert_equal(log_mock.call_args_list[0][0][2], '{"bad": "data"}')
 
     @patch('stream_alert.rule_processor.alert_forward.AlertForwarder.send_alerts')
     @patch('stream_alert.rule_processor.handler.RulesEngine.run')

--- a/tests/unit/stream_alert_rule_processor/test_main.py
+++ b/tests/unit/stream_alert_rule_processor/test_main.py
@@ -14,73 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from mock import call, patch
-from nose.tools import assert_equal, assert_raises
-from pyfakefs import fake_filesystem_unittest
 
 from stream_alert.rule_processor import main
 
 
-class RuleImportTest(fake_filesystem_unittest.TestCase):
-    """Test rule import logic with a mocked filesystem."""
-    # pylint: disable=protected-access
-
-    def setUp(self):
-        self.setUpPyfakefs()
-
-        # Add rules files which should be imported.
-        self.fs.CreateFile('matchers/matchers.py')
-        self.fs.CreateFile('rules/example.py')
-        self.fs.CreateFile('rules/community/cloudtrail/critical_api.py')
-
-        # Add other files which should NOT be imported.
-        self.fs.CreateFile('matchers/README')
-        self.fs.CreateFile('rules/__init__.py')
-        self.fs.CreateFile('rules/example.pyc')
-        self.fs.CreateFile('rules/community/REVIEWERS')
-
-    def tearDown(self):
-        self.tearDownPyfakefs()
-
-    @staticmethod
-    def test_python_rule_paths():
-        """Rule Processor Main - Find rule paths"""
-        result = set(main._python_rule_paths())
-        expected = {
-            'matchers/matchers.py',
-            'rules/example.py',
-            'rules/community/cloudtrail/critical_api.py'
-        }
-        assert_equal(expected, result)
-
-    @staticmethod
-    def test_path_to_module():
-        """Rule Processor Main - Convert rule path to module name"""
-        assert_equal('name', main._path_to_module('name.py'))
-        assert_equal('a.b.c.name', main._path_to_module('a/b/c/name.py'))
-
-    @staticmethod
-    def test_path_to_module_invalid():
-        """Rule Processor Main - Raise NameError for invalid Python filename."""
-        assert_raises(NameError, main._path_to_module, 'a.b.py')
-        assert_raises(NameError, main._path_to_module, 'a/b/old.name.py')
-
-    @staticmethod
-    @patch.object(main, 'importlib')
-    def test_import_rules(mock_importlib):
-        """Rule Processor Main - Import all rule modules."""
-        main._import_rules()
-        mock_importlib.assert_has_calls([
-            call.import_module('matchers.matchers'),
-            call.import_module('rules.example'),
-            call.import_module('rules.community.cloudtrail.critical_api')
-        ], any_order=True)
-
-    @staticmethod
-    @patch.object(main, 'StreamAlert')
-    def test_handler(mock_stream_alert):
-        """Rule Processor Main - Handler is invoked"""
-        main.handler('event', 'context')
-        mock_stream_alert.assert_has_calls([
-            call('context'),
-            call().run('event')
-        ])
+@patch.object(main, 'StreamAlert')
+def test_handler(mock_stream_alert):
+    """Rule Processor Main - Handler is invoked"""
+    main.handler('event', 'context')
+    mock_stream_alert.assert_has_calls([
+        call('context'),
+        call().run('event')
+    ])

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use,protected-access,attribute-defined-outside-init
 import json
 import os
 
@@ -26,14 +26,13 @@ from nose.tools import (
     assert_true,
 )
 
-from stream_alert.rule_processor.config import load_config, load_env
+from stream_alert.rule_processor.config import load_config
 from stream_alert.rule_processor.parsers import get_parser
 from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.rule import disable, matcher, Matcher, rule, Rule
 
 from tests.unit.stream_alert_rule_processor.test_helpers import (
-    get_mock_context,
     load_and_classify_payload,
     make_kinesis_raw_record,
     MockDynamoDBClient,
@@ -45,18 +44,6 @@ from helpers.base import fetch_values_by_datatype
 @patch.dict(os.environ, {'CLUSTER': ''})
 class TestRulesEngine(object):
     """Test class for RulesEngine"""
-    @classmethod
-    def setup_class(cls):
-        """Setup the class before any methods"""
-        context = get_mock_context()
-        cls.env = load_env(context)
-
-    @classmethod
-    def teardown_class(cls):
-        """Teardown the class after all methods"""
-        cls.env = None
-        cls.config = None
-        cls.rules_engine = None
 
     def setup(self):
         """Setup before each method"""


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

Currently based largely on changes in #689, this enables specifying arbitrary paths from within which to import rule and matcher files.

## Changes

* Adding `rule_locations` and `matcher_locations` options to global config (see [Up for Disucssion](#up-for-discussion) below for more info).
* Moving rule import logic to the `stream_alert.shared.rule` module so it is decoupled from the lambda handler code.
* Calling the import code from within the new `RulesEngine` class, which will load the various paths in the config.
* Updating `stream_alert_cli/test.py` to remove the formerly required `import stream_alert.rule_processor.main` line to force rule loading out of band.
* Updating message in a `NameError` that was improperly formatting output.

## Up for Discussion

* Naming convention for the `rule_locations` - I've currently put this under a `general` category in the global.json config but I'm not 100% in love with that. Any ideas?
* We could now support 'global' rules as well as having rules specific to clusters (in the cluster's rule processor config). This could actually result in a slight optimization. There are surely clusters we have now that use 'matchers' to restrict on environment when we could just restrict what rules are loaded for a given environment.

## Testing

Migrating rule loading unit tests to the `stream_alert_shared/test_rule.py` tests file.
Removing parts of TestRulesEngine that were not actually doing anything.
