### PR TITLE
[apps] Set last_timestamp to lambda starting time in salesforce

### DIFF
--- a/app_integrations/apps/salesforce.py
+++ b/app_integrations/apps/salesforce.py
@@ -13,7 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import calendar
+from datetime import datetime
 import re
+import time
 
 import backoff
 import requests
@@ -71,6 +74,7 @@ class SalesforceApp(AppIntegration):
         self._auth_headers = None
         self._instance_url = None
         self._latest_api_version = 0
+        self._current_time = int(calendar.timegm(time.gmtime()))
 
     @classmethod
     def _type(cls):
@@ -389,6 +393,10 @@ class SalesforceApp(AppIntegration):
             response = self._fetch_event_logs(log_file_path)
             logs.extend(response)
 
+        # Update last_timestamp to lambda function starting time
+        self._last_timestamp = datetime.utcfromtimestamp(
+            self._current_time
+        ).strftime(self.date_formatter())
         return logs
 
 @StreamAlertApp


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
We need to update `_last_timestamp` to lambda function starting time on salesforce app when it done with log gathering.

The reason to set it to lambda function starting time is because different log files may have different generating time from single query. 

## Changes

* Add the `_current_time` attribute in the class init and update it to `_last_timestamp` when the log gathering is done.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 659 tests in 12.964s

OK
```
