### PR TITLE
SQS output sends only record and looks up queue URL

### DIFF
--- a/stream_alert/alert_processor/outputs/aws.py
+++ b/stream_alert/alert_processor/outputs/aws.py
@@ -363,11 +363,9 @@ class SQSOutput(AWSOutput):
         Returns:
             bool: True if alert was sent successfully, False otherwise
         """
-        # SQS queues can only be accessed via their URL
         queue_name = self.config[self.__service__][descriptor]
-        queue_url = 'https://sqs.{}.amazonaws.com/{}/{}'.format(
-            self.region, self.account_id, queue_name)
-        queue = boto3.resource('sqs', region_name=self.region).Queue(queue_url)
+        sqs = boto3.resource('sqs', region_name=self.region)
+        queue = sqs.get_queue_by_name(QueueName=queue_name)
 
-        response = queue.send_message(MessageBody=json.dumps(alert.output_dict()))
+        response = queue.send_message(MessageBody=json.dumps(alert.record, separators=(',', ':')))
         return self._log_status(response, descriptor)

--- a/terraform/modules/tf_alert_processor_iam/main.tf
+++ b/terraform/modules/tf_alert_processor_iam/main.tf
@@ -174,8 +174,13 @@ data "aws_iam_policy_document" "send_to_sqs_queues" {
   count = "${length(var.output_sqs_queues)}"
 
   statement {
-    effect    = "Allow"
-    actions   = ["sqs:SendMessage*"]
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage*",
+    ]
+
     resources = ["${local.sqs_arn_prefix}:${element(local.sqs_outputs, count.index)}"]
   }
 }


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The SQS output sends the entire alert dictionary (including rule description, outputs, etc), but most downstream processing needs only the alert record. Indeed, the Lambda output sends only the alert record.

## Changes

* Send only the alert record to SQS outputs (the log which triggered an alert)
* Lookup the SQS queue by name instead of hardcoding the URL

## Testing

* Deploy to another account
