### PR TITLE
[cli] fix error message and remove hard-coded services for outputs

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -30,6 +30,7 @@ import string
 
 
 from stream_alert import __version__ as version
+from stream_alert.alert_processor.outputs.output_base import StreamAlertOutput
 from stream_alert.shared import metrics
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.runner import cli_runner
@@ -121,11 +122,7 @@ The following outputs are supported:
     # Output service options
     output_parser.add_argument(
         '--service',
-        choices=[
-            'aws-firehose', 'aws-lambda', 'aws-s3', 'aws-sns', 'aws-sqs',
-            'github', 'jira', 'komand', 'pagerduty', 'pagerduty-incident', 'pagerduty-v2',
-            'phantom', 'slack',
-        ],
+        choices=sorted(StreamAlertOutput.get_all_outputs().keys()),
         required=True,
         help=ARGPARSE_SUPPRESS)
     output_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -575,7 +575,7 @@ class CLIConfig(object):
                     else:
                         self.config[key] = json.load(data)
             except ValueError:
-                raise CLIConfigError('[Config Error]: %s is not valid JSON', file_path)
+                raise CLIConfigError('[Config Error]: {} is not valid JSON'.format(file_path))
 
     @staticmethod
     def _config_writer(config, path, **kwargs):


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Someone in Slack sent a screenshot of a poorly formatted exception message. **This should be the last Exception in our _current_ code that handles formatting incorrectly.** Reviewers should look out for improper formatting in the future.

## Changes

* Using `str.format()` for custom exception message during instantiation instead of the invalid `('%s', arg)` syntax that should only be used for logging (not exceptions).
* Removing hard-coded alerting outputs from the CLI and loading them straight for the `StreamAlertOutput` class. Now when new outputs are implemented, they do not need to be updated here.


