### PR TITLE
support for adding rule information to dynamo table

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -29,6 +29,7 @@
       "create_sns_topic": true
     },
     "rules_table": {
+      "enabled": false,
       "read_capacity": 20,
       "write_capacity": 5
     }

--- a/manage.py
+++ b/manage.py
@@ -1625,6 +1625,63 @@ Examples:
         '--debug', action='store_true', help=ARGPARSE_SUPPRESS
     )
 
+def _add_rule_table_subparser(subparsers):
+    """Add the rule database helper subparser: manage.py rule-table [subcommand] [options]"""
+    rule_table_usage = 'manage.py rule-table [subcommand] [options]'
+    rule_table_description = ("""
+StreamAlertCLI v{}
+Print the status of or update remote StreamAlert rule information within the rule database
+
+Available Subcommands:
+
+    manage.py rule-table status          List the current staging status from the rules databse
+    manage.py rule-table update          Update the staging status of rules
+
+""".format(version))
+    rule_table_parser = subparsers.add_parser(
+        'rule-table',
+        usage=rule_table_usage,
+        description=rule_table_description,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS)
+
+    # Set the name of this parser to 'app'
+    rule_table_parser.set_defaults(command='rule-table')
+
+    rule_table_subparsers = rule_table_parser.add_subparsers()
+
+    _add_rule_table_status_subparser(rule_table_subparsers)
+
+def _add_rule_table_status_subparser(subparsers):
+    """Add the rule db status subparser: manage.py rule-table status"""
+    rule_table_list_usage = 'manage.py rule-table status'
+    rule_table_list_desc = ("""
+StreamAlertCLI v{}
+List all rules within the rule database and their staging status
+
+Command:
+
+    manage.py rule-table status       List rules in the rule database with their staging status
+
+Optional Arguments:
+
+    --verbose           Output additional information for rules in the database
+    --debug             Enable Debug logger output
+
+""".format(version))
+    rule_table_list_parser = subparsers.add_parser(
+        'status',
+        usage=rule_table_list_usage,
+        description=rule_table_list_desc,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS)
+
+    rule_table_list_parser.set_defaults(subcommand='status')
+
+    # allow verbose output for the CLI with the --debug option
+    rule_table_list_parser.add_argument('--verbose', action='store_true', help=ARGPARSE_SUPPRESS)
+    rule_table_list_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
+
 
 def build_parser():
     """Build the argument parser."""
@@ -1643,6 +1700,7 @@ Available Commands:
     manage.py live-test                  Send alerts to configured outputs
     manage.py metrics                    Enable or disable metrics for all lambda functions
     manage.py output                     Configure new StreamAlert outputs
+    manage.py rule-table                 Get the status of or update rules in the rules database
     manage.py terraform                  Manage StreamAlert infrastructure
     manage.py threat_intel               Enable, configure StreamAlert Threat Intelligence feature.
     manage.py threat_intel_downloader    Lambda function to retrieve IOC(s).
@@ -1680,6 +1738,7 @@ For additional details on the available commands, try:
     _add_kinesis_subparser(subparsers)
     _add_threat_intel_subparser(subparsers)
     _add_threat_intel_downloader_subparser(subparsers)
+    _add_rule_table_subparser(subparsers)
 
     return parser
 

--- a/manage.py
+++ b/manage.py
@@ -1645,7 +1645,7 @@ Available Subcommands:
         formatter_class=RawTextHelpFormatter,
         help=ARGPARSE_SUPPRESS)
 
-    # Set the name of this parser to 'app'
+    # Set the name of this parser to 'rule-table'
     rule_table_parser.set_defaults(command='rule-table')
 
     rule_table_subparsers = rule_table_parser.add_subparsers()

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -39,6 +39,40 @@ class RuleTable(object):
         import_folders(*rule_import_paths)
         self._remote_rule_info = None
 
+    def __str__(self, verbose=False):
+        """Return a human-readable respresentation of the table's data"""
+        if not self.remote_rule_names:
+            return 'Rule table is empty'
+
+        pad_size = max([len(rule) for rule in self.remote_rule_info.keys()]) + 4
+        output = ['{rule:<{pad}}Staged?'.format(rule='Rule', pad=pad_size+5)]
+        for index, rule in enumerate(sorted(self.remote_rule_info.keys()), start=1):
+            output.append(
+                '{index:>3d}: {rule: <{pad}}{staged}'.format(
+                    index=index,
+                    rule=rule,
+                    pad=pad_size,
+                    staged=self.remote_rule_info[rule]['Staged']
+                )
+            )
+            # Append additional information if verbose is enabled
+            if verbose:
+                details_pad_size = max([len(prop)
+                                        for prop in self.remote_rule_info[rule].keys()]) + 4
+                output.extend(
+                    '{prefix:>{left_pad}}{property: <{internal_pad}}{value}'.format(
+                        prefix='- ',
+                        left_pad=7,
+                        property='{}:'.format(prop),
+                        internal_pad=details_pad_size,
+                        value=value
+                    )
+                    for prop, value in self.remote_rule_info[rule].iteritems()
+                    if prop != 'Staged'
+                )
+
+        return '\n'.join(output)
+
     def _add_new_rules(self):
         """Add any new local rules (renamed rules included) to the remote database"""
         # If the table is empty, no rules have been added yet

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -1,0 +1,144 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from datetime import datetime, timedelta
+
+import boto3
+
+from stream_alert.shared import LOGGER
+from stream_alert.shared.rule import import_folders, Rule
+
+
+class RuleTable(object):
+    """Provides convenience methods for accessing and modifying the rules table."""
+    DEFAULT_STAGING_HOURS = 48
+    DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+    def __init__(self, table_name, *rule_import_paths):
+        """Load the given table to be used for rule information updates
+
+        Args:
+            rule_import_paths (string): Variable number of paths to import rules
+                from. Useful for using this as a standalone class. Items for this
+                can be ommitted if instantiated from a caller that has already
+                loaded the rules files.
+        """
+        self._table = boto3.resource('dynamodb').Table(table_name)
+        import_folders(*rule_import_paths)
+        self._remote_rule_info = None
+
+    def _add_new_rules(self):
+        """Add any new local rules (renamed rules included) to the remote database"""
+        # If the table is empty, no rules have been added yet
+        # Add them all as unstaged to avoid demoting rules from production status
+        init = (len(self.remote_rule_names) == 0)
+        with self._table.batch_writer() as batch:
+            for rule_name in self.local_not_remote:
+                LOGGER.debug('Adding rule \'%s\' (init=%s)', rule_name, init)
+                batch.put_item(self._dynamo_record(rule_name, init))
+
+    def _del_old_rules(self):
+        """Delete any rules that exist in the rule database but not locally"""
+        with self._table.batch_writer() as batch:
+            for rule_name in self.remote_not_local:
+                LOGGER.debug('Deleting rule \'%s\'', rule_name)
+                batch.delete_item(Key={'RuleName': rule_name})
+
+    def _get_remote_state(self):
+        """Return the current staging state for all rules stored in the database
+
+        Returns:
+            dict: key = rule name, value = True|False for staged
+        """
+        paginator = self._table.meta.client.get_paginator('scan')
+        page_iterator = paginator.paginate(TableName=self.name)
+        return {item['RuleName']: item['Staged']
+                for page in page_iterator
+                for item in page['Items']}
+
+    @staticmethod
+    def _dynamo_record(rule_name, init=False):
+        """Generate a DynamoDB record with this rule information
+
+        Args:
+            rule_name (string): Name of rule for this record
+            init (bool): [optional] argument that dictates if this is an initial
+                deploy of rule info to the rules table. Initial deployment of rule
+                info will skip the staging state as to avoid taking rules out of
+                production unexpectedly.
+        """
+        item = {
+            'RuleName': rule_name,
+            'Staged': not init
+        }
+
+        # If the database is empty (ie: newly created), do not stage existing rules
+        if init:
+            return item
+
+        staged_at, staged_until = RuleTable._staged_window()
+        item.update({
+            'StagedAt': staged_at,
+            'StagedUntil': staged_until,
+            'NewlyStaged': True
+        })
+
+        return item
+
+    @staticmethod
+    def _staged_window():
+        """Get staging window to be used for this rule
+
+        Returns:
+            tuple: staging start datetime, staging end datetime
+        """
+        staged_at = datetime.utcnow()
+        staged_until = staged_at + timedelta(hours=RuleTable.DEFAULT_STAGING_HOURS)
+        return (
+            staged_at.strftime(RuleTable.DATETIME_FORMAT),
+            staged_until.strftime(RuleTable.DATETIME_FORMAT)
+        )
+
+    def update(self):
+        """Update the database with new local rules and remove deleted ones from remote"""
+        self._add_new_rules()
+        self._del_old_rules()
+
+    @property
+    def local_not_remote(self):
+        """Rules that exist locally but not within the remote database"""
+        return self.local_rule_names.difference(set(self.remote_rule_names))
+
+    @property
+    def local_rule_names(self):
+        """Names of locally loaded rules"""
+        return set(Rule.rule_names())
+
+    @property
+    def name(self):
+        """Name of the DynamoDB table used to store alerts."""
+        return self._table.table_name
+
+    @property
+    def remote_rule_names(self):
+        """Rule names from the remote database. Returns cache if it exists"""
+        if not self._remote_rule_info:
+            self._remote_rule_info = self._get_remote_state()
+        return set(self._remote_rule_info)
+
+    @property
+    def remote_not_local(self):
+        """Rules that exist in the remote database but not locally"""
+        return set(self.remote_rule_names).difference(self.local_rule_names)

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -556,6 +556,29 @@ def setup_mock_alerts_table(table_name):
     )
 
 
+def setup_mock_rules_table(table_name):
+    """Create a mock DynamoDB rules table used by the CLI, rule processor, and rule promoter"""
+    boto3.client('dynamodb').create_table(
+        AttributeDefinitions=[
+            {
+                'AttributeName': 'RuleName',
+                'AttributeType': 'S'
+            }
+        ],
+        KeySchema=[
+            {
+                'AttributeName': 'RuleName',
+                'KeyType': 'HASH'
+            }
+        ],
+        ProvisionedThroughput={
+            'ReadCapacityUnits': 5,
+            'WriteCapacityUnits': 5
+        },
+        TableName=table_name
+    )
+
+
 def put_mock_s3_object(bucket, key, data, region):
     """Create a mock AWS S3 object for testing
 

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -16,6 +16,7 @@ limitations under the License.
 from collections import namedtuple
 import sys
 
+from stream_alert.shared import rule_table
 from stream_alert_cli import helpers
 from stream_alert_cli.manage_lambda import package as stream_alert_packages
 from stream_alert_cli.manage_lambda.version import LambdaVersion
@@ -52,6 +53,19 @@ def _publish_version(packages, config, clusters):
             return False
 
     return True
+
+def _update_rule_table(config):
+    """Update the rule table with any staging information
+
+    Args:
+        config (CLIConfig): The loaded StreamAlert config
+    """
+    # Get the rule import paths to load
+    rule_import_paths = config['global']['general']['rule_locations']
+
+    table_name = '{}_streamalert_rules'.format(config['global']['account']['prefix'])
+    table = rule_table.RuleTable(table_name, *rule_import_paths)
+    table.update()
 
 
 def _create_and_upload(function_name, config, cluster=None):
@@ -154,6 +168,9 @@ def deploy(options, config):
     # Run Terraform: Update the Lambda source code in $LATEST
     if not helpers.tf_runner(targets=deploy_targets):
         sys.exit(1)
+
+    # Update the rule table
+    _update_rule_table(config)
 
     # Publish a new production Lambda version
     if not _publish_version(packages, config, options.clusters):

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -60,6 +60,11 @@ def _update_rule_table(config):
     Args:
         config (CLIConfig): The loaded StreamAlert config
     """
+    # TODO: consider removing this once rule staging is feature complete
+    # Temporarily having a config setting that will disable updating the table for now
+    if not config['global']['infrastructure']['rules_table'].get('enabled', False):
+        return
+
     # Get the rule import paths to load
     rule_import_paths = config['global']['general']['rule_locations']
 

--- a/stream_alert_cli/rule_table.py
+++ b/stream_alert_cli/rule_table.py
@@ -1,0 +1,29 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from stream_alert.shared.rule_table import RuleTable
+
+
+def rule_table_handler(options, config):
+    """Handle operations related to the rule table (listing, updating, etc)
+
+    Args:
+        options (argparser.Namespace): Various options needed to by subcommand
+            handlers
+        config (CLIConfig): Loaded configuration from 'conf/' directory
+    """
+    table_name = '{}_streamalert_rules'.format(config['global']['account']['prefix'])
+    if options.subcommand == 'status':
+        print RuleTable(table_name).__str__(options.verbose)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -22,6 +22,7 @@ from stream_alert_cli.helpers import user_input
 from stream_alert_cli.kinesis.handler import kinesis_handler
 from stream_alert_cli.logger import LOGGER_CLI
 from stream_alert_cli.manage_lambda.handler import lambda_handler
+from stream_alert_cli.rule_table import rule_table_handler
 from stream_alert_cli.terraform.handler import terraform_handler
 from stream_alert_cli.test import stream_alert_test
 from stream_alert_cli.threat_intel_downloader.handler import (
@@ -86,6 +87,9 @@ def cli_runner(options):
 
     elif options.command == 'threat_intel_downloader':
         threat_intel_downloader_handler(options, CONFIG)
+
+    elif options.command == 'rule-table':
+        rule_table_handler(options, CONFIG)
 
 
 def configure_handler(options):

--- a/tests/unit/stream_alert_shared/test_rule_table.py
+++ b/tests/unit/stream_alert_shared/test_rule_table.py
@@ -51,8 +51,8 @@ class TestRuleTable(object):
         for i in range(count):
             cls._create_local_rule_with_name('fake_rule_{:02d}'.format(i))
 
-    @classmethod
-    def _create_local_rule_with_name(cls, name):
+    @staticmethod
+    def _create_local_rule_with_name(name):
         """Helper to create a fake local rule with specified name"""
         rule_module.Rule(Mock(__name__=name), logs=['fake_log_type'])
 

--- a/tests/unit/stream_alert_shared/test_rule_table.py
+++ b/tests/unit/stream_alert_shared/test_rule_table.py
@@ -1,0 +1,207 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from datetime import datetime
+import os
+
+from mock import Mock, patch
+from moto import mock_dynamodb2
+from nose.tools import assert_equal
+
+from stream_alert.shared import rule as rule_module, rule_table
+from stream_alert_cli.helpers import setup_mock_rules_table
+
+_RULES_TABLE = 'PREFIX_streamalert_rules'
+
+
+class TestRuleTable(object):
+    """Tests for shared/rule_table.py"""
+    # pylint: disable=protected-access
+
+    @patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'us-east-1'})
+    def setup(self):
+        """Rule Table - Create mock table and rules"""
+        # pylint: disable=attribute-defined-outside-init
+        self.dynamo_mock = mock_dynamodb2()
+        self.dynamo_mock.start()
+        setup_mock_rules_table(_RULES_TABLE)
+        self.rule_table = rule_table.RuleTable(_RULES_TABLE)
+
+    def teardown(self):
+        """Rule Table - Destroy previously created rules"""
+        rule_module.Rule._rules.clear()
+        self.dynamo_mock.stop()
+
+    @classmethod
+    def _create_local_rules(cls, count=5):
+        """Helper to create N fake local rules"""
+        for i in range(count):
+            cls._create_local_rule_with_name('fake_rule_{:02d}'.format(i))
+
+    @classmethod
+    def _create_local_rule_with_name(cls, name):
+        """Helper to create a fake local rule with specified name"""
+        rule_module.Rule(Mock(__name__=name), logs=['fake_log_type'])
+
+    def _create_db_rule_with_name(self, name):
+        """Helper to create a fake database rule with specified name"""
+        self.rule_table._table.put_item(Item={'RuleName': name, 'Staged': False})
+
+    def test_rule_table_name(self):
+        """Rule Table - Table Name"""
+        assert_equal(self.rule_table.name, _RULES_TABLE)
+
+    def test_local_rule_names(self):
+        """Rule Table - Local Rule Names"""
+        expected_result = {'test_rule_01', 'test_rule_02', 'test_rule_03'}
+        for rule_name in expected_result:
+            self._create_local_rule_with_name(rule_name)
+
+        assert_equal(self.rule_table.local_rule_names, expected_result)
+
+    def test_remote_rule_names(self):
+        """Rule Table - Remote Rules Names"""
+        expected_result = {'remote_rule_01', 'remote_rule_02', 'remote_rule_03'}
+        for rule_name in expected_result:
+            self._create_db_rule_with_name(rule_name)
+
+        assert_equal(self.rule_table.remote_rule_names, expected_result)
+
+    def test_local_not_remote_names(self):
+        """Rule Table - Local and Not Remote Rule Names"""
+        for rule_name in {'remote_rule_01', 'remote_rule_02'}:
+            self._create_db_rule_with_name(rule_name)
+
+        expected_result = {'test_rule_01', 'test_rule_02'}
+        for rule_name in expected_result:
+            self._create_local_rule_with_name(rule_name)
+
+        assert_equal(self.rule_table.local_not_remote, expected_result)
+
+    def test_remote_not_local_names(self):
+        """Rule Table - Remote and Not Local Rule Names"""
+        for rule_name in {'test_rule_01', 'test_rule_02'}:
+            self._create_local_rule_with_name(rule_name)
+
+        expected_result = {'remote_rule_01', 'remote_rule_02'}
+        for rule_name in expected_result:
+            self._create_db_rule_with_name(rule_name)
+
+        assert_equal(self.rule_table.remote_not_local, expected_result)
+
+    def test_add_new_rules(self):
+        """Rule Table - Add New Rules"""
+        self._create_local_rules(2)
+        self.rule_table._add_new_rules()
+        assert_equal(self.rule_table._table.item_count, 2)
+
+    def test_delete_old_rules(self):
+        """Rule Table - Delete New Rules"""
+        # Create 2 local rules and add them to the table
+        original_count = 2
+        self._create_local_rules(original_count)
+        self.rule_table._add_new_rules()
+
+        # Delete a local rule from the tracking dictionary
+        del rule_module.Rule._rules['fake_rule_01']
+
+        # Ensure the remote state is updated for the deletion of a rule
+        self.rule_table._del_old_rules()
+        assert_equal(len(self.rule_table._get_remote_state()), original_count-1)
+
+    def test_get_remote_state_init(self):
+        """Rule Table - Get Remote State of Rules, New Database"""
+        # Create 2 local rules and add them to the table
+        self._create_local_rules(2)
+        self.rule_table._add_new_rules()
+
+        expected_state = {
+            'fake_rule_00': False,
+            'fake_rule_01': False
+        }
+
+        state = self.rule_table._get_remote_state()
+        assert_equal(state, expected_state)
+
+    def test_get_remote_state(self):
+        """Rule Table - Get Remote State of Rules, Existing Database"""
+        # Create 2 local rules and add them to the currently empty
+        self._create_local_rules(2)
+        self.rule_table._add_new_rules()
+
+        # window_mock.return_value = ('start-staged-date', 'end-staged-date')
+        # Create 2 local rules and add them to the currently empty
+        self._create_local_rule_with_name('now_staged_rule')
+        self.rule_table._add_new_rules()
+
+        expected_state = {
+            'fake_rule_00': False,
+            'fake_rule_01': False,
+            'now_staged_rule': True,
+        }
+
+        state = self.rule_table._get_remote_state()
+        assert_equal(state, expected_state)
+
+    def test_dynamo_record_init(self):
+        """Rule Table - DynamoDB Record, New Database"""
+        expected_record = {
+            'RuleName': 'foo_rule',
+            'Staged': False
+        }
+
+        record = self.rule_table._dynamo_record('foo_rule', True)
+        assert_equal(record, expected_record)
+
+    @patch('stream_alert.shared.rule_table.RuleTable._staged_window')
+    def test_dynamo_record(self, window_mock):
+        """Rule Table - DynamoDB Record, Existing Database"""
+        window_mock.return_value = ('staged-at-date', 'staged-until-date')
+        expected_record = {
+            'RuleName': 'foo_rule',
+            'Staged': True,
+            'StagedAt': 'staged-at-date',
+            'StagedUntil': 'staged-until-date',
+            'NewlyStaged': True
+        }
+
+        record = self.rule_table._dynamo_record('foo_rule', False)
+        assert_equal(record, expected_record)
+
+    @patch('stream_alert.shared.rule_table.datetime')
+    def test_staged_window(self, date_mock):
+        """Rule Table - Staged Window"""
+        date_mock.utcnow.return_value = datetime(
+            year=2001, month=1, day=1, hour=12, minute=0, second=10, microsecond=123456)
+
+        staged_at, staged_until = self.rule_table._staged_window()
+        assert_equal(staged_at, '2001-01-01T12:00:10.123456Z')
+        assert_equal(staged_until, '2001-01-03T12:00:10.123456Z')
+
+    def test_update(self):
+        """Rule Table - Update"""
+        rule_name = 'init_rule'
+        self._create_db_rule_with_name(rule_name)
+        assert_equal(self.rule_table._table.item_count, 1)
+        self._create_local_rule_with_name('test_rule_01')
+        self._create_local_rule_with_name('test_rule_02')
+
+        # Run the update to ensure the old rule was deleted and the new rules are added
+        self.rule_table.update()
+        assert_equal(len(self.rule_table._get_remote_state()), 2)
+        item = self.rule_table._table.get_item(Key={'RuleName': rule_name})
+        assert_equal(item.get('Item'), None)
+        item = self.rule_table._table.get_item(Key={'RuleName': 'test_rule_02'})
+        assert_equal(item['Item']['RuleName'], 'test_rule_02')


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: large

## Background

In order to support rule staging, we need to implement a 'front end' for the rules DynamoDB table. This is the first iteration on a RuleTable performing that interaction.

## Changes

### RuleTable
Adding initial `RuleTable` that currently handles operations such as:
* Loading the state of all rules currently in the table
* Diff'ing the existing remote rules against the local rule set.
* Updating an empty table with rules (presumably adding rules for the first time). This operation will have rules bypass the 'staging' state and go straight to 'production'
* Updating a table that has previously existing entries with new rules. This operation will have rules go into the staging state for a default window of 48 hours (for now).
* Printing a human-readable format of the remote rule state. Optional `verbose` flag can be passed to print both staging status and all staging information.


### CLI
The cli now supports loading the `RuleTable` and printing the status of all rules within it.
* Future support will come for dynamic toggling of staging status in the RuleTable from the CLI

Example (non-verbose):
```
Rule                                                        Staged?
  1: binaryalert_yara_match                                 False
  2: bogus_new_rule                                         True
  3: cloudtrail_critical_api_calls                          False
  4: cloudtrail_mfa_policy_abuse_attempt                    False
  5: cloudtrail_network_acl_ingress_anywhere                False
```

Example (verbose):
```
Rule                                                        Staged?
  1: binaryalert_yara_match                                 False
  2: bogus_new_rule                                         True
     - StagedAt:      2018-04-19T02:23:13.332223Z
     - NewlyStaged:   True
     - StagedUntil:   2018-04-21T02:23:13.332223Z
  3: cloudtrail_critical_api_calls                          False
  4: cloudtrail_mfa_policy_abuse_attempt                    False
  5: cloudtrail_network_acl_ingress_anywhere                False
```


### Other Notes
Upon deploy, these changes will not have an effect as far as the rule processor is concerned.
A config flag is currently set that disables updating the RuleTable with rule information. This will likely be removed once this is feature complete.

## Testing

Adding 100% test coverage for the `RuleTable`. Tested locally with a local DynamoDB instance.
Will also test with an actual test account deploy before merging.
