### PR TITLE
fix to only update rule table if rule proc is deployed

### DIFF
--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -174,8 +174,9 @@ def deploy(options, config):
     if not helpers.tf_runner(targets=deploy_targets):
         sys.exit(1)
 
-    # Update the rule table
-    _update_rule_table(config)
+    # Update the rule table now if the rule processor is being deployed
+    if 'rule' in options.processor:
+        _update_rule_table(config)
 
     # Publish a new production Lambda version
     if not _publish_version(packages, config, options.clusters):


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The rule table should only really be updated if the rule processor is being deployed (not, say, if only the alert processor is deployed).

## Changes

* Ensuring rule processor is being deployed before updating rules tables.

