### PR TITLE
adding support for bypassing staging for new rules during deploy

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -841,6 +841,8 @@ Required Arguments:
 
 Optional Arguments:
 
+    --skip-rule-staging                Skip staging of new rules so they go directly into
+                                         production.
     --debug                            Enable Debug logger output
 
 Examples:
@@ -856,6 +858,13 @@ Examples:
         help=ARGPARSE_SUPPRESS)
 
     lambda_deploy_parser.set_defaults(subcommand='deploy')
+
+    # flag to manually bypass rule staging for new rules upon deploy
+    lambda_deploy_parser.add_argument(
+        '--skip-rule-staging',
+        action='store_true',
+        help=ARGPARSE_SUPPRESS
+    )
 
     _add_default_lambda_args(lambda_deploy_parser)
 

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -73,15 +73,16 @@ class RuleTable(object):
 
         return '\n'.join(output)
 
-    def _add_new_rules(self):
+    def _add_new_rules(self, skip_staging=False):
         """Add any new local rules (renamed rules included) to the remote database"""
         # If the table is empty, no rules have been added yet
         # Add them all as unstaged to avoid demoting rules from production status
-        init = (len(self.remote_rule_names) == 0)
+        # Also, allow the user to bypass staging with the skip_staging flag
+        skip_staging = skip_staging or (len(self.remote_rule_names) == 0)
         with self._table.batch_writer() as batch:
             for rule_name in self.local_not_remote:
-                LOGGER.debug('Adding rule \'%s\' (init=%s)', rule_name, init)
-                batch.put_item(self._dynamo_record(rule_name, init))
+                LOGGER.debug('Adding rule \'%s\' (init=%s)', rule_name, skip_staging)
+                batch.put_item(self._dynamo_record(rule_name, skip_staging))
 
     def _del_old_rules(self):
         """Delete any rules that exist in the rule database but not locally"""
@@ -118,23 +119,26 @@ class RuleTable(object):
         }
 
     @staticmethod
-    def _dynamo_record(rule_name, init=False):
+    def _dynamo_record(rule_name, skip_staging=False):
         """Generate a DynamoDB record with this rule information
 
         Args:
             rule_name (string): Name of rule for this record
-            init (bool): [optional] argument that dictates if this is an initial
-                deploy of rule info to the rules table. Initial deployment of rule
-                info will skip the staging state as to avoid taking rules out of
-                production unexpectedly.
+            skip_staging (bool): [optional] Argument that dictates if this rule
+                should skip the staging phase.
+                An initial deployment of rule info will skip the staging state
+                as to avoid taking rules out of production unexpectedly. This
+                argument can also be used to during the deploy process to
+                immediately put new rules into production.
         """
         item = {
             'RuleName': rule_name,
-            'Staged': not init
+            'Staged': not skip_staging
         }
 
-        # If the database is empty (ie: newly created), do not stage existing rules
-        if init:
+        # We may want to skip staging if the database is empty (ie: newly created)
+        # or if the user is manually bypassing staging for this rule
+        if skip_staging:
             return item
 
         staged_at, staged_until = RuleTable._staged_window()
@@ -160,9 +164,9 @@ class RuleTable(object):
             staged_until.strftime(RuleTable.DATETIME_FORMAT)
         )
 
-    def update(self):
+    def update(self, skip_staging=False):
         """Update the database with new local rules and remove deleted ones from remote"""
-        self._add_new_rules()
+        self._add_new_rules(skip_staging)
         self._del_old_rules()
 
     @property

--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -54,7 +54,7 @@ def _publish_version(packages, config, clusters):
 
     return True
 
-def _update_rule_table(config):
+def _update_rule_table(config, skip_staging):
     """Update the rule table with any staging information
 
     Args:
@@ -70,7 +70,7 @@ def _update_rule_table(config):
 
     table_name = '{}_streamalert_rules'.format(config['global']['account']['prefix'])
     table = rule_table.RuleTable(table_name, *rule_import_paths)
-    table.update()
+    table.update(skip_staging)
 
 
 def _create_and_upload(function_name, config, cluster=None):
@@ -176,7 +176,7 @@ def deploy(options, config):
 
     # Update the rule table now if the rule processor is being deployed
     if 'rule' in options.processor:
-        _update_rule_table(config)
+        _update_rule_table(config, options.skip_rule_staging)
 
     # Publish a new production Lambda version
     if not _publish_version(packages, config, options.clusters):


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The deploy process needs the ability to have new rules bypass staging and go straight into production.

## Changes

* Adding support for promoting new rules immediately to productions (past the 'staging' phase) via a `--skip-rule-staging` arguments to the deploy command. For example: `manage.py lambda deploy --processor rule --skip-rule-staging`
