### PR TITLE
adding simple rule checksumming POC

### DIFF
--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -186,8 +186,8 @@ class Rule(object):
                         md5.update(ast.dump(expression))
 
                 self._checksum = md5.hexdigest()
-            except (TypeError, IndentationError, IndexError) as err:
-                LOGGER.error(err)
+            except (TypeError, IndentationError, IndexError):
+                LOGGER.exception('Could not checksum rule function')
                 self._checksum = self.CHECKSUM_UNKNOWN
 
         return self._checksum

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -13,8 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import ast
 from copy import deepcopy
+import hashlib
 import importlib
+import inspect
 import os
 
 from stream_alert.shared import LOGGER
@@ -86,6 +89,7 @@ def disable(rule_instance):
 class Rule(object):
     """Rule class to handle processing"""
     DEFAULT_RULE_DESCRIPTION = 'No rule description provided'
+    CHECKSUM_UNKNOWN = 'checksum unknown'
 
     _rules = {}
 
@@ -102,6 +106,7 @@ class Rule(object):
         self.initial_context = kwargs.get('context')
         self.context = None
         self.disabled = False
+        self._checksum = None
 
         if not (self.logs or self.datatypes):
             raise RuleCreationError(
@@ -161,6 +166,31 @@ class Rule(object):
             LOGGER.exception('Encountered error with rule: %s', self.rule_name)
 
         return False
+
+    @property
+    def checksum(self):
+        """Produce an md5 for the contents of this rule.
+
+        This logic applies to expressions within the function only. It does not take
+        into account: the function name, docstring, comments, or decorator arguments
+        """
+        if not self._checksum:
+            try:
+                code = inspect.getsource(self.func)
+                root = ast.parse(code)
+                md5 = hashlib.md5()  # nosec
+                for expression in root.body[0].body:
+                    # This check is necessary to ensure changes to the docstring
+                    # are allowed without altering the checksum
+                    if not isinstance(expression, ast.Expr):
+                        md5.update(ast.dump(expression))
+
+                self._checksum = md5.hexdigest()
+            except (TypeError, IndentationError, IndexError) as err:
+                LOGGER.error(err)
+                self._checksum = self.CHECKSUM_UNKNOWN
+
+        return self._checksum
 
     @property
     def description(self):


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

A stretch goal for rule staging would allow for identifying changes to the body of a rule (as opposed to just _new_ rules). The idea involves checksumming the contents of the rule.

## Changes

* This is a POC of how we can identify changes to the contents of a rule function, exclusive of the docstring, code comments, or changes to the decorator arguments.
* Adding a `checksum` property to the `Rule` class which generates an md5 as a checksum for the contents of the rule function, or returns the previously cached hash if this has already been computed.
* This gets the raw code for a rule function, using `inspect`, and walks the AST for the code. It then calculates a running hash for the expressions within the function, excluding the docstring value.
* Shoutout to @austinbyers for his help in dreaming up this concept.

## Testing

No additional testing added at the moment
