### PR TITLE
adding rule staging toggling to the rule table

### DIFF
--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -102,7 +102,6 @@ class RuleTable(object):
                             {
                                 'Staged': True
                                 'StagedAt': '2018-04-19T02:23:13.332223Z',
-                                'NewlyStaged': True,
                                 'StagedUntil': '2018-04-21T02:23:13.332223Z'
                             }
                     }
@@ -144,8 +143,7 @@ class RuleTable(object):
         staged_at, staged_until = RuleTable._staged_window()
         item.update({
             'StagedAt': staged_at,
-            'StagedUntil': staged_until,
-            'NewlyStaged': True
+            'StagedUntil': staged_until
         })
 
         return item

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -66,9 +66,9 @@ class RuleTable(object):
                         left_pad=7,
                         property='{}:'.format(prop),
                         internal_pad=details_pad_size,
-                        value=value
+                        value=self.remote_rule_info[rule][prop]
                     )
-                    for prop, value in self.remote_rule_info[rule].iteritems()
+                    for prop in sorted(self.remote_rule_info[rule].keys())
                     if prop != 'Staged'
                 )
 

--- a/tests/unit/stream_alert_shared/test_rule_table.py
+++ b/tests/unit/stream_alert_shared/test_rule_table.py
@@ -56,9 +56,9 @@ class TestRuleTable(object):
         """Helper to create a fake local rule with specified name"""
         rule_module.Rule(Mock(__name__=name), logs=['fake_log_type'])
 
-    def _create_db_rule_with_name(self, name):
+    def _create_db_rule_with_name(self, name, stage=False):
         """Helper to create a fake database rule with specified name"""
-        self.rule_table._table.put_item(Item={'RuleName': name, 'Staged': False})
+        self.rule_table._table.put_item(Item={'RuleName': name, 'Staged': stage})
 
     def test_rule_table_name(self):
         """Rule Table - Table Name"""
@@ -165,7 +165,6 @@ class TestRuleTable(object):
             'fake_rule_00': {'Staged': False},
             'fake_rule_01': {'Staged': False},
             'now_staged_rule': {
-                'NewlyStaged': True,
                 'Staged': True,
                 'StagedAt': 'staged-at-date',
                 'StagedUntil': 'staged-until-date'
@@ -193,8 +192,7 @@ class TestRuleTable(object):
             'RuleName': 'foo_rule',
             'Staged': True,
             'StagedAt': 'staged-at-date',
-            'StagedUntil': 'staged-until-date',
-            'NewlyStaged': True
+            'StagedUntil': 'staged-until-date'
         }
 
         record = self.rule_table._dynamo_record('foo_rule', False)
@@ -233,8 +231,7 @@ class TestRuleTable(object):
             'RuleName': 'test_02',
             'Staged': True,
             'StagedAt': 'staged-at-date',
-            'StagedUntil': 'staged-at-date',
-            'NewlyStaged': True
+            'StagedUntil': 'staged-at-date'
         })
         with patch('sys.stdout', new=StringIO()) as stdout:
             print self.rule_table
@@ -263,8 +260,7 @@ Rule            Staged?
             'RuleName': 'test_02',
             'Staged': True,
             'StagedAt': 'staged-at-date',
-            'StagedUntil': 'staged-at-date',
-            'NewlyStaged': True
+            'StagedUntil': 'staged-until-date'
         })
         with patch('sys.stdout', new=StringIO()) as stdout:
             print self.rule_table.__str__(True)
@@ -273,8 +269,7 @@ Rule            Staged?
   1: test_01    False
   2: test_02    True
      - StagedAt:      staged-at-date
-     - NewlyStaged:   True
-     - StagedUntil:   staged-at-date
+     - StagedUntil:   staged-until-date
 """
 
             output = stdout.getvalue().strip()


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The `RuleTable` class needs the ability to toggle the staging state of a given rule.

## Changes

* Removing the `NewlyStaged` attribute from the default dynamo record, as I'm not sure it will actually be utilized and can be added back later if necessary.
* Adding a `toggle_staged_state` function to the RuleTable that will attempt to update the given rule's record with the new state. If moving to staging, this will also set the `staged_at` and `staged_until` attributes for the rule.

## Testing

Adding unit tests to cover new toggle functionality.
