### PR TITLE
[cli] adding stage subcommand to rule-table command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1660,6 +1660,7 @@ Available Subcommands:
     rule_table_subparsers = rule_table_parser.add_subparsers()
 
     _add_rule_table_status_subparser(rule_table_subparsers)
+    _add_rule_table_stage_subparser(rule_table_subparsers)
 
 def _add_rule_table_status_subparser(subparsers):
     """Add the rule db status subparser: manage.py rule-table status"""
@@ -1690,6 +1691,51 @@ Optional Arguments:
     # allow verbose output for the CLI with the --debug option
     rule_table_list_parser.add_argument('--verbose', action='store_true', help=ARGPARSE_SUPPRESS)
     rule_table_list_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
+
+
+def _add_rule_table_stage_subparser(subparsers):
+    """Add the rule db stage subparser: manage.py rule-table stage"""
+    rule_table_stage_usage = 'manage.py rule-table stage'
+    rule_table_stage_desc = ("""
+StreamAlertCLI v{}
+Stage or unstage rules given their name as a space-separated list
+
+Command:
+
+    manage.py rule-table stage    Stage the rules provided in a space-separated list
+
+Optional Arguments:
+
+    --unstage                     Inverts the default action and unstages the rules provided
+    --debug                       Enable Debug logger output
+
+""".format(version))
+    rule_table_stage_parser = subparsers.add_parser(
+        'stage',
+        usage=rule_table_stage_usage,
+        description=rule_table_stage_desc,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS)
+
+    rule_table_stage_parser.set_defaults(subcommand='stage')
+
+    rule_table_stage_parser.add_argument(
+        'rules',
+        action=UniqueSetAction,
+        default=set(),
+        help=ARGPARSE_SUPPRESS,
+        nargs='+'
+    )
+
+    rule_table_stage_parser.add_argument(
+        '-u', '--unstage',
+        action='store_false',
+        dest='stage',
+        help=ARGPARSE_SUPPRESS
+    )
+
+    # allow debug output for the CLI with the --debug option
+    rule_table_stage_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
 
 
 def build_parser():

--- a/manage.py
+++ b/manage.py
@@ -1660,7 +1660,7 @@ Available Subcommands:
     rule_table_subparsers = rule_table_parser.add_subparsers()
 
     _add_rule_table_status_subparser(rule_table_subparsers)
-    _add_rule_table_stage_subparser(rule_table_subparsers)
+    _add_rule_table_staging_subparsers(rule_table_subparsers)
 
 def _add_rule_table_status_subparser(subparsers):
     """Add the rule db status subparser: manage.py rule-table status"""
@@ -1693,21 +1693,20 @@ Optional Arguments:
     rule_table_list_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
 
 
-def _add_rule_table_stage_subparser(subparsers):
+def _add_rule_table_staging_subparsers(subparsers):
     """Add the rule db stage subparser: manage.py rule-table stage"""
     rule_table_stage_usage = 'manage.py rule-table stage'
     rule_table_stage_desc = ("""
 StreamAlertCLI v{}
-Stage or unstage rules given their name as a space-separated list
+Stage rules given their name as a space-separated list
 
 Command:
 
-    manage.py rule-table stage    Stage the rules provided in a space-separated list
+    manage.py rule-table stage         Stage the rules provided in a space-separated list
 
 Optional Arguments:
 
-    --unstage                     Inverts the default action and unstages the rules provided
-    --debug                       Enable Debug logger output
+    --debug                            Enable Debug logger output
 
 """.format(version))
     rule_table_stage_parser = subparsers.add_parser(
@@ -1718,8 +1717,35 @@ Optional Arguments:
         help=ARGPARSE_SUPPRESS)
 
     rule_table_stage_parser.set_defaults(subcommand='stage')
+    _add_default_rule_table_staging_args(rule_table_stage_parser)
 
-    rule_table_stage_parser.add_argument(
+    rule_table_unstage_usage = 'manage.py rule-table unstage'
+    rule_table_unstage_desc = ("""
+StreamAlertCLI v{}
+Unstage rules given their name as a space-separated list
+
+Command:
+
+    manage.py rule-table unstage       Unstage the rules provided in a space-separated list
+
+Optional Arguments:
+
+    --debug                            Enable Debug logger output
+
+""".format(version))
+    rule_table_unstage_parser = subparsers.add_parser(
+        'unstage',
+        usage=rule_table_unstage_usage,
+        description=rule_table_unstage_desc,
+        formatter_class=RawTextHelpFormatter,
+        help=ARGPARSE_SUPPRESS)
+
+    rule_table_unstage_parser.set_defaults(subcommand='unstage')
+    _add_default_rule_table_staging_args(rule_table_unstage_parser)
+
+def _add_default_rule_table_staging_args(subparser):
+    """Add the default arguments to the rule table staging parsers"""
+    subparser.add_argument(
         'rules',
         action=UniqueSetAction,
         default=set(),
@@ -1727,15 +1753,8 @@ Optional Arguments:
         nargs='+'
     )
 
-    rule_table_stage_parser.add_argument(
-        '-u', '--unstage',
-        action='store_false',
-        dest='stage',
-        help=ARGPARSE_SUPPRESS
-    )
-
     # allow debug output for the CLI with the --debug option
-    rule_table_stage_parser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
+    subparser.add_argument('--debug', action='store_true', help=ARGPARSE_SUPPRESS)
 
 
 def build_parser():

--- a/stream_alert_cli/logger.py
+++ b/stream_alert_cli/logger.py
@@ -60,11 +60,24 @@ logging.basicConfig(format='%(name)s [%(levelname)s]: %(message)s')
 LOGGER_CLI = logging.getLogger('StreamAlertCLI')
 LOGGER_CLI.setLevel(logging.INFO)
 
+ALL_LOGGERS = {LOGGER_SA, LOGGER_SO, LOGGER_SH, LOGGER_CLI}
+
+
 # silence imported loggers
 for logger in logging.Logger.manager.loggerDict:
     if logger.startswith('StreamAlert'):
         continue
     logging.getLogger(logger).setLevel(logging.CRITICAL)
+
+
+def set_logger_levels(level):
+    """Set all of the loggers that could be used to the provided logger level
+
+    Args:
+        level (str): The level at which the log verbosity should be set
+    """
+    for sa_logger in ALL_LOGGERS:
+        sa_logger.setLevel(level)
 
 
 def get_log_memory_handler():

--- a/stream_alert_cli/rule_table.py
+++ b/stream_alert_cli/rule_table.py
@@ -28,7 +28,8 @@ def rule_table_handler(options, config):
     if options.subcommand == 'status':
         print RuleTable(table_name).__str__(options.verbose)
 
-    if options.subcommand == 'stage':
+    if options.subcommand in {'stage', 'unstage'}:
+        stage = (options.subcommand == 'stage')
         table = RuleTable(table_name)
         for rule in options.rules:
-            table.toggle_staged_state(rule, options.stage)
+            table.toggle_staged_state(rule, stage)

--- a/stream_alert_cli/rule_table.py
+++ b/stream_alert_cli/rule_table.py
@@ -27,3 +27,8 @@ def rule_table_handler(options, config):
     table_name = '{}_streamalert_rules'.format(config['global']['account']['prefix'])
     if options.subcommand == 'status':
         print RuleTable(table_name).__str__(options.verbose)
+
+    if options.subcommand == 'stage':
+        table = RuleTable(table_name)
+        for rule in options.rules:
+            table.toggle_staged_state(rule, options.stage)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -20,7 +20,7 @@ from stream_alert_cli.athena.handler import athena_handler
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.helpers import user_input
 from stream_alert_cli.kinesis.handler import kinesis_handler
-from stream_alert_cli.logger import LOGGER_CLI
+from stream_alert_cli.logger import LOGGER_CLI, set_logger_levels
 from stream_alert_cli.manage_lambda.handler import lambda_handler
 from stream_alert_cli.rule_table import rule_table_handler
 from stream_alert_cli.terraform.handler import terraform_handler
@@ -47,7 +47,7 @@ def cli_runner(options):
     LOGGER_CLI.info(cli_load_message)
 
     if options.debug:
-        LOGGER_CLI.setLevel('DEBUG')
+        set_logger_levels('DEBUG')
 
     if options.command == 'output':
         configure_output(options)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Users need the ability to run a command to stage or unstage a current rule in the rules db.

## Changes

* Adding a subcommand to support staging or unstaging of rules.
* Staging will work like so:
`$ python manage.py rule-table stage foo_rule bar_rule`
* Un-staging will work like so:
`$ python manage.py rule-table unstage foo_rule bar_rule`
