### PR TITLE
removal of code since loggers now have their levels set before testing happens

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -38,8 +38,6 @@ from stream_alert_cli.logger import (
     get_log_memory_handler,
     LOGGER_CLI,
     LOGGER_SA,
-    LOGGER_SH,
-    LOGGER_SO,
     SuppressNoise
 )
 
@@ -1000,20 +998,7 @@ def stream_alert_test(options, config):
         os.environ['AWS_DEFAULT_REGION'] = config['global']['account']['region']
         os.environ['CLUSTER'] = run_options.get('cluster') or ''
 
-        if options.debug:
-            # TODO(jack): Currently there is no (clean) way to set
-            #             the logger formatter to provide more verbose
-            #             output in debug mode.  Running basicConfig twice
-            #             does not actually change the formatter on the logger object.
-            #             This functionality can be added during the logging refactor
-            # Example Steps:
-            #   call .shutdown() on the existing logger
-            #   debug_formatter = logging.Formatter(
-            #       '%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s')
-            #   set the new logger to the formatter above
-            for streamalert_logger in (LOGGER_SA, LOGGER_SH, LOGGER_SO, LOGGER_CLI):
-                streamalert_logger.setLevel(logging.DEBUG)
-        else:
+        if not options.debug:
             # Add a filter to suppress a few noisy log messages
             LOGGER_SA.addFilter(SuppressNoise())
 


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

[This change](https://github.com/airbnb/streamalert/pull/703/commits/c3a292c2725dd768fea42b2aad022fa18e41a9ac) sets the logger levels before getting to the testing phase, so this code is no longer necessary.

## Changes

* Removing unnecessary code block that is no longer required due to aforementioned change.

