### PR TITLE
[cli] deploy flags to support --stage-rules and --stage-rules during deploy

### DIFF
--- a/stream_alert_cli/rule_table.py
+++ b/stream_alert_cli/rule_table.py
@@ -20,7 +20,7 @@ def rule_table_handler(options, config):
     """Handle operations related to the rule table (listing, updating, etc)
 
     Args:
-        options (argparser.Namespace): Various options needed to by subcommand
+        options (argparser.Namespace): Various options needed by subcommand
             handlers
         config (CLIConfig): Loaded configuration from 'conf/' directory
     """


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The deploy process needs to be able to explicitly stage or unstage a given list of rules.

## Changes

* Adding `--stage-rules` and `--unstage-rules` arguments to the lambda deploy process.
* Creating a new subclass of the `argparse.Action` class that is used for handling errors with the user providing the same rules for both the `--stage-rules` and `--unstage-rules` arguments.

