### PR TITLE
rule processor - adding check for staged rules

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -30,7 +30,7 @@
     },
     "rules_table": {
       "enabled": false,
-      "refresh_minutes": 10,
+      "cache_refresh_minutes": 10,
       "read_capacity": 20,
       "write_capacity": 5
     }

--- a/conf/global.json
+++ b/conf/global.json
@@ -30,6 +30,7 @@
     },
     "rules_table": {
       "enabled": false,
+      "refresh_minutes": 10,
       "read_capacity": 20,
       "write_capacity": 5
     }

--- a/manage.py
+++ b/manage.py
@@ -42,6 +42,9 @@ CLUSTERS = [
     for cluster in files
 ]
 
+# TODO (ryandeivert): remove when rule staging lambda is complete
+ENABLE_RULE_STAGING = False
+
 
 class UniqueSetAction(Action):
     """Subclass of argparse.Action to avoid multiple of the same choice from a list"""
@@ -795,12 +798,23 @@ Examples:
 
     lambda_deploy_parser = _generate_subparser(subparsers, 'deploy', usage, description, True)
 
-    # flag to manually bypass rule staging for new rules upon deploy
-    lambda_deploy_parser.add_argument(
-        '--skip-rule-staging',
-        action='store_true',
-        help=ARGPARSE_SUPPRESS
-    )
+    # TODO (ryandeivert): the below change is temporary and allows
+    # for using rule staging prior to having a promotion lambda in place
+    # Remove this block when this feature is complete
+    if not ENABLE_RULE_STAGING:
+        lambda_deploy_parser.add_argument(
+            '--stage-new-rules',
+            action='store_false',
+            dest='skip_rule_staging',
+            help=ARGPARSE_SUPPRESS
+        )
+    else:
+        # flag to manually bypass rule staging for new rules upon deploy
+        lambda_deploy_parser.add_argument(
+            '--skip-rule-staging',
+            action='store_true',
+            help=ARGPARSE_SUPPRESS
+        )
 
     # flag to manually bypass rule staging for specific rules during deploy
     lambda_deploy_parser.add_argument(

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -88,7 +88,7 @@ class StreamAlert(object):
 
         firehose_config = self.config['global'].get('infrastructure', {}).get('firehose', {})
         if firehose_config.get('enabled'):
-            self._firehose_client = StreamAlertFirehose(self.env['lambda_region'],
+            self._firehose_client = StreamAlertFirehose(self.env['region'],
                                                         firehose_config,
                                                         self.config['logs'])
 

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -170,7 +170,7 @@ class RulesEngine(object):
             if not record.get(key):
                 LOGGER.debug(
                     'The required subkey %s is not found when trying to process %s: \n%s',
-                    key, rule.rule_name, record)
+                    key, rule.name, record)
                 return False
             if not all(record[key].get(x) for x in nested_keys):
                 return False
@@ -350,7 +350,7 @@ class RulesEngine(object):
         # Combine the required alert outputs with the ones for this rule
         all_outputs = self._required_outputs_set.union(rule.outputs_set)
         alert = Alert(
-            rule.rule_name, record, all_outputs,
+            rule.name, record, all_outputs,
             cluster=os.environ['CLUSTER'],
             context=rule.context,
             log_source=str(payload.log_source),
@@ -363,7 +363,7 @@ class RulesEngine(object):
         )
 
         LOGGER.info('Rule [%s] triggered alert [%s] on log type [%s] from entity \'%s\' '
-                    'in service \'%s\'', rule.rule_name, alert.alert_id, payload.log_source,
+                    'in service \'%s\'', rule.name, alert.alert_id, payload.log_source,
                     payload.entity, payload.service())
 
         alerts.append(alert)
@@ -406,4 +406,4 @@ class RulesEngine(object):
         """
         return any(self._is_equal(alert.record, record)
                    for alert in alerts
-                   if rule.rule_name == alert.rule_name)
+                   if rule.name == alert.rule_name)

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -30,7 +30,7 @@ _IGNORE_KEYS = {StreamThreatIntel.IOC_KEY, NORMALIZATION_KEY}
 
 class RulesEngine(object):
     """Class to act as a rules engine that processes rules"""
-    _RULE_TABLE_LAST_REFRESH = None
+    _RULE_TABLE_LAST_REFRESH = datetime(year=1970, month=1, day=1)
     _RULE_TABLE = None
 
     def __init__(self, config, *rule_paths):
@@ -56,12 +56,10 @@ class RulesEngine(object):
             return
 
         now = datetime.utcnow()
-        refresh_delta = timedelta(minutes=rt_config.get('refresh_minutes', 10))
+        refresh_delta = timedelta(minutes=rt_config.get('cache_refresh_minutes', 10))
 
-        # The rule table will need 'refreshed' if 1) the table or last refresh time
-        # do not exist, or 2) if the refresh interval has been surpassed
-        needs_refresh = (not (cls._RULE_TABLE and cls._RULE_TABLE_LAST_REFRESH) or
-                         cls._RULE_TABLE_LAST_REFRESH + refresh_delta < now)
+        # The rule table will need 'refreshed' if the refresh interval has been surpassed
+        needs_refresh = cls._RULE_TABLE_LAST_REFRESH + refresh_delta < now
 
         if not needs_refresh:
             LOGGER.debug('Rule table does not need refreshed (last refresh time: %s; '

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -387,8 +387,12 @@ class RulesEngine(object):
         if self._threat_intel and self.check_alerts_duplication(record, rule, alerts):
             return
 
-        # Combine the required alert outputs with the ones for this rule
-        all_outputs = self._required_outputs_set.union(rule.outputs_set)
+        # Check if the rule is staged and, if so, only use the required alert outputs
+        if rule.is_staged(self._RULE_TABLE):
+            all_outputs = self._required_outputs_set
+        else: # Otherwise, combine the required alert outputs with the ones for this rule
+            all_outputs = self._required_outputs_set.union(rule.outputs_set)
+
         alert = Alert(
             rule.name, record, all_outputs,
             cluster=os.environ['CLUSTER'],

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -82,7 +82,7 @@ def rule(**opts):
 
 def disable(rule_instance):
     """Decorator to be used for disabling a rule"""
-    Rule.disable(rule_instance.rule_name)
+    Rule.disable(rule_instance.name)
     return rule_instance
 
 
@@ -95,7 +95,7 @@ class Rule(object):
 
     def __init__(self, func, **kwargs):
         self.func = func
-        self.rule_name = func.__name__
+        self.name = func.__name__
         self.datatypes = kwargs.get('datatypes')
         self.logs = kwargs.get('logs')
         self.matchers = kwargs.get('matchers')
@@ -111,17 +111,17 @@ class Rule(object):
         if not (self.logs or self.datatypes):
             raise RuleCreationError(
                 "Invalid rule [{}] - rule must have either 'logs' "
-                "or 'datatypes' declared'".format(self.rule_name)
+                "or 'datatypes' declared'".format(self.name)
             )
 
-        if self.rule_name in Rule._rules:
-            raise RuleCreationError('Rule [{}] already defined'.format(self.rule_name))
+        if self.name in Rule._rules:
+            raise RuleCreationError('Rule [{}] already defined'.format(self.name))
 
-        Rule._rules[self.rule_name] = self
+        Rule._rules[self.name] = self
 
     def __str__(self):
         return '<Rule: {}; outputs: {}; disabled: {}>'.format(
-            self.rule_name,
+            self.name,
             self.outputs,
             self.disabled
         )
@@ -163,7 +163,7 @@ class Rule(object):
 
             return self.func(record)
         except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Encountered error with rule: %s', self.rule_name)
+            LOGGER.exception('Encountered error with rule: %s', self.name)
 
         return False
 

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -143,6 +143,21 @@ class Rule(object):
 
         return all(Matcher.process(matcher_name, record) for matcher_name in self.matchers)
 
+    def is_staged(self, rule_table):
+        """Run any rule matchers against the record
+
+        Args:
+            rule_table (RuleTable): Front end for DynamoDB rule table to do rule info lookups
+
+        Returns:
+            bools: True if this rule is staged, False otherwise
+        """
+        if not rule_table:
+            return False
+
+        rule_info = rule_table.rule_info(self.name)
+        return rule_info.get('Staged', False)
+
     @time_rule
     def process(self, record):
         """Process will call this rule's function on the passed record

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -31,7 +31,9 @@ class RuleTable(object):
         """Load the given table to be used for rule information updates
 
         Args:
-            rule_import_paths (string): Variable number of paths to import rules
+            table_name (str): The name of the DynamoDB table from which to load
+                rule info
+            rule_import_paths (str): Variable number of paths to import rules
                 from. Useful for using this as a standalone class. Items for this
                 can be ommitted if instantiated from a caller that has already
                 loaded the rules files.

--- a/stream_alert/shared/rule_table.py
+++ b/stream_alert/shared/rule_table.py
@@ -165,6 +165,14 @@ class RuleTable(object):
             staged_until.strftime(RuleTable.DATETIME_FORMAT)
         )
 
+    def rule_info(self, rule_name):
+        """Get the rule info from the table information
+
+        Returns:
+            dict: Rule information for the specified rule from the DynamoDB rule table
+        """
+        return self.remote_rule_info.get(rule_name)
+
     def toggle_staged_state(self, rule_name, stage):
         """Mark the specified rule as staged=True or staged=False
 

--- a/stream_alert/shared/stats.py
+++ b/stream_alert/shared/stats.py
@@ -72,7 +72,7 @@ def time_rule(rule_func):
         result = rule_func(self, *args, **kwargs)
         time_end = time.time()
 
-        RULE_STATS[self.rule_name] += RuleStatistic((time_end - time_start) * 1000)
+        RULE_STATS[self.name] += RuleStatistic((time_end - time_start) * 1000)
 
         return result
 

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -863,7 +863,8 @@ class TestRulesEngine(object):
         self.config['global']['infrastructure']['rules_table']['enabled'] = False
         self.rules_engine._load_rule_table(self.config)
         assert_equal(self.rules_engine._RULE_TABLE, None)
-        assert_equal(self.rules_engine._RULE_TABLE_LAST_REFRESH, None)
+        assert_equal(self.rules_engine._RULE_TABLE_LAST_REFRESH,
+                     datetime(year=1970, month=1, day=1))
 
     @patch('stream_alert.shared.rule_table.RuleTable', Mock(return_value=True))
     @patch('logging.Logger.debug')
@@ -882,7 +883,7 @@ class TestRulesEngine(object):
     def test_load_rule_table_refresh(self, log_mock, date_mock):
         """Rules Engine - Load Rule Table, Refresh"""
         self.config['global']['infrastructure']['rules_table']['enabled'] = True
-        self.config['global']['infrastructure']['rules_table']['refresh_minutes'] = 5
+        self.config['global']['infrastructure']['rules_table']['cache_refresh_minutes'] = 5
 
         fake_date_now = datetime.utcnow()
         date_mock.utcnow.return_value = fake_date_now

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=no-self-use,protected-access,attribute-defined-outside-init
+from datetime import datetime, timedelta
 import json
 import os
 
-from mock import patch
+from mock import Mock, patch
 from nose.tools import (
     assert_equal,
     assert_false,
@@ -31,6 +32,7 @@ from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.config import load_config
 from stream_alert.shared.rule import disable, matcher, Matcher, rule, Rule
+from stream_alert.shared.rule_table import RuleTable
 
 from tests.unit.stream_alert_rule_processor.test_helpers import (
     load_and_classify_payload,
@@ -855,3 +857,78 @@ class TestRulesEngine(object):
         # alert tests
         assert_equal(alerts[0].context['assigned_user'], 'valid_user')
         assert_equal(alerts[0].context['assigned_policy_id'], 'valid_policy_id')
+
+    def test_load_rule_table_disabled(self):
+        """Rules Engine - Load Rule Table, Disabled"""
+        self.config['global']['infrastructure']['rules_table']['enabled'] = False
+        self.rules_engine._load_rule_table(self.config)
+        assert_equal(self.rules_engine._RULE_TABLE, None)
+        assert_equal(self.rules_engine._RULE_TABLE_LAST_REFRESH, None)
+
+    @patch('stream_alert.shared.rule_table.RuleTable', Mock(return_value=True))
+    @patch('logging.Logger.debug')
+    def test_load_rule_table_no_refresh(self, log_mock):
+        """Rules Engine - Load Rule Table, No Refresh"""
+        self.config['global']['infrastructure']['rules_table']['enabled'] = True
+        with patch.object(RulesEngine, '_RULE_TABLE', 'table'):
+            with patch.object(RulesEngine, '_RULE_TABLE_LAST_REFRESH', datetime.utcnow()):
+                self.rules_engine._load_rule_table(self.config)
+                assert_equal(self.rules_engine._RULE_TABLE, 'table')
+                log_mock.assert_called()
+
+    @patch('stream_alert.rule_processor.rules_engine.RuleTable', Mock(return_value=True))
+    @patch('stream_alert.rule_processor.rules_engine.datetime')
+    @patch('logging.Logger.info')
+    def test_load_rule_table_refresh(self, log_mock, date_mock):
+        """Rules Engine - Load Rule Table, Refresh"""
+        self.config['global']['infrastructure']['rules_table']['enabled'] = True
+        self.config['global']['infrastructure']['rules_table']['refresh_minutes'] = 5
+
+        fake_date_now = datetime.utcnow()
+        date_mock.utcnow.return_value = fake_date_now
+
+        refresh_date = datetime.utcnow() - timedelta(minutes=6)
+        with patch.object(RulesEngine, '_RULE_TABLE', 'table'):
+            with patch.object(RulesEngine, '_RULE_TABLE_LAST_REFRESH', refresh_date):
+                self.rules_engine._load_rule_table(self.config)
+                assert_equal(self.rules_engine._RULE_TABLE, True)
+                assert_equal(self.rules_engine._RULE_TABLE_LAST_REFRESH, fake_date_now)
+                log_mock.assert_called()
+
+    @patch.dict('os.environ', {'AWS_DEFAULT_REGION': 'us-east-1'})
+    def test_rule_staged_only(self):
+        """Rules Engine - Staged Rule"""
+        @rule(logs=['cloudwatch:test_match_types'],
+              outputs=['foobar'])
+        def rule_staged_only(_): # pylint: disable=unused-variable
+            """Modify context rule"""
+            return True
+
+        kinesis_data = json.dumps({
+            'account': 123456,
+            'region': '123456123456',
+            'source': '1.1.1.2',
+            'detail': {
+                'eventName': 'ConsoleLogin',
+                'sourceIPAddress': '1.1.1.2',
+                'recipientAccountId': '654321'
+            }
+        })
+        table = RuleTable('table')
+        table._remote_rule_info = {'rule_staged_only': {'Staged': True}}
+        self.config['global']['infrastructure']['rules_table']['enabled'] = True
+        with patch.object(RulesEngine, '_RULE_TABLE', table), \
+                patch.object(RulesEngine, '_RULE_TABLE_LAST_REFRESH', datetime.utcnow()):
+
+            self.rules_engine._load_rule_table(self.config)
+
+            # prepare the payloads
+            service, entity = 'kinesis', 'test_kinesis_stream'
+            raw_record = make_kinesis_raw_record(entity, kinesis_data)
+            payload = load_and_classify_payload(self.config, service, entity, raw_record)
+
+            # process payloads
+            alerts, _ = self.rules_engine.run(payload)
+
+            # alert tests
+            assert_equal(list(alerts[0].outputs)[0], 'aws-firehose:alerts')

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -141,7 +141,7 @@ def {}(_):
         rule_name = 'test_rule'
         self._create_rule_helper(rule_name)
         result = rule.Rule.get_rule(rule_name)
-        assert_equal(result.rule_name, rule_name)
+        assert_equal(result.name, rule_name)
 
     def test_rule_names(self):
         """Rule - Get Rule Names"""
@@ -191,7 +191,7 @@ def {}(_):
         assert_equal(len(rule.Rule.rule_names()), 2)
         # Check to see if the one with datatypes is returned
         assert_equal(len(result), 1)
-        assert_equal(result[0].rule_name, 'with_datatypes')
+        assert_equal(result[0].name, 'with_datatypes')
 
     def test_get_rules_for_log_type(self):
         """Rule - Get Rules, For Log Type"""
@@ -210,7 +210,7 @@ def {}(_):
         # Check to make sure the fourth rule has log_type_03
         result = rule.Rule.rules_for_log_type('log_type_03')
         assert_equal(len(result), 1)
-        assert_equal(result[0].rule_name, 'rule_04')
+        assert_equal(result[0].name, 'rule_04')
 
 
 class TestMatcher(object):

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -20,7 +20,7 @@ from mock import call, patch
 from nose.tools import assert_equal, assert_raises, raises
 from pyfakefs import fake_filesystem_unittest
 
-from stream_alert.shared import rule
+from stream_alert.shared import rule, rule_table
 
 
 # Rule to be used for checksum testing
@@ -177,6 +177,31 @@ def {}(_):
         assert_equal(rule.Rule._rules['test_rule'].checksum, rule.Rule.CHECKSUM_UNKNOWN)
         log_mock.assert_called_with('Could not checksum rule function')
 
+    def test_rule_is_staged_false(self):
+        """Rule - Is Staged = False"""
+        table = rule_table.RuleTable('table')
+        table._remote_rule_info = {'test_rule': {'Staged': False}}
+
+        def test_rule(_):
+            return True
+
+        # Test rule is not staged
+        unstaged_rule = test_rule = rule.Rule(test_rule, logs=['bar'])
+        assert_equal(unstaged_rule.is_staged(None), False)
+        assert_equal(unstaged_rule.is_staged(table), False)
+
+
+    def test_rule_is_staged(self):
+        """Rule - Is Staged = True"""
+        table = rule_table.RuleTable('table')
+        table._remote_rule_info = {'test_rule': {'Staged': True}}
+
+        def test_rule(_):
+            return True
+
+        # Test rule is not staged
+        staged_rule = test_rule = rule.Rule(test_rule, logs=['bar'])
+        assert_equal(staged_rule.is_staged(table), True)
 
     def test_get_rules_with_datatypes(self):
         """Rule - Get Rules, Rule With Datatypes"""

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -177,6 +177,7 @@ def {}(_):
         assert_equal(rule.Rule._rules['test_rule'].checksum, rule.Rule.CHECKSUM_UNKNOWN)
         log_mock.assert_called_with('Could not checksum rule function')
 
+    @patch.dict('os.environ', {'AWS_DEFAULT_REGION': 'us-east-1'})
     def test_rule_is_staged_false(self):
         """Rule - Is Staged = False"""
         table = rule_table.RuleTable('table')
@@ -190,7 +191,7 @@ def {}(_):
         assert_equal(unstaged_rule.is_staged(None), False)
         assert_equal(unstaged_rule.is_staged(table), False)
 
-
+    @patch.dict('os.environ', {'AWS_DEFAULT_REGION': 'us-east-1'})
     def test_rule_is_staged(self):
         """Rule - Is Staged = True"""
         table = rule_table.RuleTable('table')

--- a/tests/unit/stream_alert_shared/test_rule_table.py
+++ b/tests/unit/stream_alert_shared/test_rule_table.py
@@ -199,6 +199,14 @@ class TestRuleTable(object):
         record = self.rule_table._dynamo_record('foo_rule', False)
         assert_equal(record, expected_record)
 
+    def test_get_rule_info(self):
+        """Rule Table - Get Rule Info"""
+        rule_name = 'test_rule_01'
+        self._create_db_rule_with_name(rule_name, True)
+
+        expected_result = {'Staged': True}
+        assert_equal(self.rule_table.rule_info(rule_name), expected_result)
+
     @patch('stream_alert.shared.rule_table.datetime')
     def test_staged_window(self, date_mock):
         """Rule Table - Staged Window"""

--- a/tests/unit/stream_alert_shared/test_stats.py
+++ b/tests/unit/stream_alert_shared/test_stats.py
@@ -36,7 +36,7 @@ class TestRuleStats(object):
         def test_func(_):
             pass
 
-        fake = namedtuple('Rule', ['rule_name'])('test_rule')
+        fake = namedtuple('Rule', ['name'])('test_rule')
 
         test_func(fake)
 


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

Now that there is a rule table, the rule processor needs the ability to check the table for information on whether or not a rule is staged, etc.

## Changes

* Making a temporary update to the CLI so the default for deploy does NOT put new rules into staging.
  * Note: this will be reverted when the rule promotion lambda is in place & live.
* Fixing bug in firehose region lookup in the env.
* Adding a `_RULE_TABLE` class property to the `RulesEngine` that is cached throughout executions. It will be refreshed (aka recreated) if the configurable `refresh_minutes` have passed since the last refresh.
* Fixing stutter in `Rule.rule_name` attribute naming (renamed to `Rule.name`)
* Adding `is_staged` method to `Rule` class to allow rules to check if they are staged, given a `RuleTable` as a parameter.
* Updating the rules engine to only use required outputs if rule is staged.

## Testing

Adding unit tests for all new code and adjust old ones as necessary.
