### PR TITLE
assortment of small fixes to rule staging

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -788,6 +788,8 @@ Optional Arguments:
 
     --skip-rule-staging                Skip staging of new rules so they go directly into
                                          production.
+    --stage-rules                      Stage the rules provided in a space-separated list
+    --unstage-rules                    Unstage the rules provided in a space-separated list
     --debug                            Enable debug logger output
 
 Examples:
@@ -816,18 +818,18 @@ Examples:
             help=ARGPARSE_SUPPRESS
         )
 
-    # flag to manually bypass rule staging for specific rules during deploy
+    # flag to manually demote specific rules to staging during deploy
     lambda_deploy_parser.add_argument(
-        '--unstage-rules',
+        '--stage-rules',
         action=MutuallyExclusiveStagingAction,
         default=set(),
         help=ARGPARSE_SUPPRESS,
         nargs='+'
     )
 
-    # flag to manually demote specific rules to staging during deploy
+    # flag to manually bypass rule staging for specific rules during deploy
     lambda_deploy_parser.add_argument(
-        '--stage-rules',
+        '--unstage-rules',
         action=MutuallyExclusiveStagingAction,
         default=set(),
         help=ARGPARSE_SUPPRESS,
@@ -1504,7 +1506,8 @@ Print the status of or update remote StreamAlert rule information within the rul
 Available Subcommands:
 
     manage.py rule-table status          List the current staging status from the rules databse
-    manage.py rule-table stage           Update the staging status of rules
+    manage.py rule-table stage           Stage the rules provided in a space-separated list
+    manage.py rule-table unstage         Unstage the rules provided in a space-separated list
 
 """.format(version)
 

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -156,6 +156,9 @@ class Rule(object):
             return False
 
         rule_info = rule_table.rule_info(self.name)
+        if not rule_info:
+            return False
+
         return rule_info.get('Staged', False)
 
     @time_rule

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -86,3 +86,24 @@ data "aws_iam_policy_document" "streamalert_rule_processor_read_dynamodb" {
     ]
   }
 }
+
+// Allow the Rule Processor to read the rules table
+resource "aws_iam_role_policy" "read_rules_table" {
+  name   = "ReadRulesTable"
+  role   = "${aws_iam_role.streamalert_rule_processor_role.id}"
+  policy = "${data.aws_iam_policy_document.read_rules_table.json}"
+}
+
+data "aws_iam_policy_document" "read_rules_table" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:Scan",
+    ]
+
+    resources = [
+      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.prefix}_streamalert_rules",
+    ]
+  }
+}


### PR DESCRIPTION
to: @chunyong-lin or @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Discovered some small bugs related to rule staging that needed addressed.

## Changes

* Adding IAM perms so the rule processor can read rule table (`dynamodb:Scan`)
* Fixing CLI help message in `manage.py`
* Ensuring rule info is returned before looking up staged status

## Testing

Deployed to test
