### PR TITLE
using rules table arn from tf globals module

### DIFF
--- a/stream_alert_cli/terraform/streamalert.py
+++ b/stream_alert_cli/terraform/streamalert.py
@@ -58,7 +58,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
         'rule_processor_memory': modules['stream_alert']['rule_processor']['memory'],
         'rule_processor_timeout': modules['stream_alert']['rule_processor']['timeout'],
         'rule_processor_version': modules['stream_alert']['rule_processor']['current_version'],
-        'rule_processor_config': '${var.rule_processor_config}'
+        'rule_processor_config': '${var.rule_processor_config}',
+        'rules_table_arn': '${module.globals.rules_table_arn}',
     }
 
     if (config['global'].get('threat_intel')

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "read_rules_table" {
     ]
 
     resources = [
-      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.prefix}_streamalert_rules",
+      "${var.rules_table_arn}",
     ]
   }
 }

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -58,6 +58,8 @@ variable "rule_processor_metric_filters" {
   default = []
 }
 
+variable "rules_table_arn" {}
+
 variable "sns_topic_arn" {}
 
 variable "threat_intel_enabled" {

--- a/terraform/modules/tf_stream_alert_globals/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/output.tf
@@ -1,1 +1,3 @@
-
+output "rules_table_arn" {
+  value = "${aws_dynamodb_table.rules_table.arn}"
+}

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -254,6 +254,7 @@ class TestTerraformGenerate(object):
                     'rule_processor_timeout': 25,
                     'rule_processor_version': '$LATEST',
                     'rule_processor_config': '${var.rule_processor_config}',
+                    'rules_table_arn': '${module.globals.rules_table_arn}',
                 }
             }
         }
@@ -285,11 +286,11 @@ class TestTerraformGenerate(object):
                     'rule_processor_timeout': 25,
                     'rule_processor_version': '$LATEST',
                     'rule_processor_config': '${var.rule_processor_config}',
+                    'rules_table_arn': '${module.globals.rules_table_arn}',
                     'input_sns_topics': ['my-sns-topic-name'],
                 }
             }
         }
-
 
         assert_equal(self.cluster_dict['module']['stream_alert_advanced'],
                      expected_advanced_cluster['module']['stream_alert_advanced'])


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Changes

* Referencing the rules table ARN from the globals module instead of hard coding.
