### PR TITLE
[threat intel] handle more exceptions when processing IP IOCs

### DIFF
--- a/stream_alert/shared/helpers.py
+++ b/stream_alert/shared/helpers.py
@@ -18,9 +18,13 @@ def valid_ip(ip_address):
     Returns:
         True if the ip_address is valid, otherwise False
     """
+    # Early return if ip address is '::1'
+    if ip_address == '::1':
+        return False
+
     try:
         IPAddress(ip_address)
-    except AddrFormatError:
+    except: # pylint: disable=bare-except
         return False
     return True
 

--- a/tests/unit/stream_alert_rule_processor/test_threat_intel.py
+++ b/tests/unit/stream_alert_rule_processor/test_threat_intel.py
@@ -301,6 +301,35 @@ class TestStreamThreatIntel(object):
             result = self.threat_intel._extract_ioc_from_record(record)
             assert_equal(len(result), 0)
 
+    def test_extract_ioc_from_record_corner_cases(self):
+        """
+        Threat Intel - Test extracting values with corner cases
+        """
+        records = [
+            {
+                'account': 54321,
+                'region': '654321654321',
+                'detail': {
+                    'eventName': 'ConsoleLogin',
+                    'userIdentity': {
+                        'userName': 'bob',
+                        'accountId': '54321'
+                    },
+                    'sourceIPAddress': '::1',
+                    'recipientAccountId': '54321'
+                },
+                'source': '1.1.1.2/24',
+                'streamalert:normalization': {
+                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
+                    'usernNme': [['detail', 'userIdentity', 'userName']]
+                }
+            }
+        ]
+        records = mock_normalized_records(records)
+        for record in records:
+            result = self.threat_intel._extract_ioc_from_record(record)
+            assert_equal(len(result), 0)
+
     def test_extract_ioc_from_record_without_excluded_ip(self):
         """
         Threat Intel - Test extracting values from records with excluded IPs


### PR DESCRIPTION
to: @ryandeivert or @strcrzy 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
Some ip address field actually contains a subnet. We need to handle `ValueError` when try to case a subnet to an `IPAddress` object. Also, we will return `Falso` early if the ip address is `::1`. 

## Changes
* Return earlier if address is `::1`. 
* Widen exception handling in helper `valid_ip`.
* Add unit test case responding to the fix.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 690 tests in 13.114s


OK
```
