### PR TITLE
[Data Normalization] Improve performance

### DIFF
--- a/stream_alert/shared/utils.py
+++ b/stream_alert/shared/utils.py
@@ -5,6 +5,8 @@ import logging
 from netaddr import IPAddress, IPNetwork
 from netaddr.core import AddrFormatError
 
+from stream_alert.shared import NORMALIZATION_KEY
+
 logging.basicConfig()
 LOGGER = logging.getLogger('StreamAlert')
 
@@ -125,7 +127,14 @@ def get_keys(data, search_key, max_matches=-1):
                     return results
 
             # Enqueue all nested dicts and lists for further searching
-            for val in obj.itervalues():
+            for key, val in obj.iteritems():
+                # The data may contain normalized keys if data normalization feature is in use.
+                # We need to exclude normalization information from the data, otherwise this
+                # helper may fetch info from normalization if there are keyname conflict.
+                # For example, Key name 'userName' is both existed as a normalized key defined
+                # in conf/types.json and cloudtrail record schemas.
+                if key == NORMALIZATION_KEY:
+                    continue
                 if val and isinstance(val, _CONTAINER_TYPES):
                     containers.append(val)
 

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -822,9 +822,8 @@ class TestRulesEngine(object):
         # generated before threat intel takes effect.
         assert_equal(len(alerts), 0)
 
-        # One record will be normalized twice by two different rules with different
-        # normalization keys. It should generate two alerts by two different rules
-        # from same record.
+        # One record will be normalized once by two different rules with different
+        # normalization keys.
         assert_equal(len(normalized_records), 1)
         assert_equal(normalized_records[0].pre_parsed_record['streamalert:normalization'].keys(),
                      ['fileHash', 'sourceDomain'])


### PR DESCRIPTION
to: @ryandeivert @austinbyers 
cc: @airbnb/streamalert-maintainers
size: median
resolves #717 

## Background
In current Data Normalization implementation, Data Normalization is applied to a record right before rule matching. So one record may be normalized multiple times when there are different rules using different `datatypes`. For example,
* Rule 1 
```
@rule(datatypes=['command'], ...)
def rule_get_commands(rec):
...
```
* Rule 2
```
@rule(datatypes=['sourceAddress'], ...)
def rule_get_ip_address(rec):
...
```
* Rule 3
```
@rule(datatypes=['command', `sourceAddress`], ...)
def rule_get_command_and_ip_address(rec):
...
```
In this case, one record will be normalized 3 times!!! The performance will become bottleneck when you will thousands records read from files from S3 bucket, and it will result lambda function to be timed out.

## Changes
* In rules engine, aggregate datatypes from all rules and normalize records only once before any rules matching.
* This change also update `get_keys` helper to skip normalization information.

## Testing
The testing environment has multiple rules using data normalization with different datatypes. And running time is based on `timeit`.
* 2761 carbonblack netconn records read from S3 file 
  * Before improvement, the running time is 24s
  * Apply improvement, the running time is 10s
  
* 7713 carbonblack event records read from S3 file
  * Before improvement, the running time is 37s
  * Apply improvement, the running time is 25s
  
* 1521 cloudtrail records read from S3 file
  * Before improvement, the running time is 584s
  * Apply improvement, the running time is 3s

Cloudtrail records seem to have significant benefit because they contains nested keys and ip addresses which will be normalized in my test environment.
