### PR TITLE
Terraform 0.11.X, Cloudwatch Log Output, Firehose Bug Fixes

### DIFF
--- a/stream_alert/alert_processor/outputs/aws.py
+++ b/stream_alert/alert_processor/outputs/aws.py
@@ -137,10 +137,8 @@ class KinesisFirehoseOutput(AWSOutput):
         LOGGER.info('Sending %s to aws-firehose:%s', alert, delivery_stream)
 
         resp = _firehose_request_wrapper(json_alert, delivery_stream)
-
-        if resp.get('RecordId'):
-            LOGGER.info('%s successfully sent to aws-firehose:%s with RecordId:%s',
-                        alert, delivery_stream, resp['RecordId'])
+        LOGGER.info('%s successfully sent to aws-firehose:%s',
+                    alert, delivery_stream)
 
         return self._log_status(resp, descriptor)
 
@@ -369,3 +367,30 @@ class SQSOutput(AWSOutput):
 
         response = queue.send_message(MessageBody=json.dumps(alert.record, separators=(',', ':')))
         return self._log_status(response, descriptor)
+
+
+@StreamAlertOutput
+class CloudwatchLogOutput(AWSOutput):
+    """Print alerts to the Cloudwatch Logger"""
+    __service__ = 'aws-cloudwatch-log'
+
+    @classmethod
+    def get_user_defined_properties(cls):
+        """Get properties that must be asssigned by the user when configuring a new Lambda
+        Returns:
+            OrderedDict: Contains various OutputProperty items
+        """
+        return OrderedDict([
+            ('descriptor',
+             OutputProperty(description='a short and unique descriptor for the cloudwatch log')),
+        ])
+
+    def dispatch(self, alert, descriptor):
+        """Send alert to Cloudwatch Logger for Lambda
+
+        Args:
+            alert (Alert): Alert instance which triggered a rule
+            descriptor (str): Output descriptor
+        """
+        LOGGER.info('New Alert:\n%s', json.dumps(alert.output_dict(), indent=4))
+        return self._log_status(True, descriptor)

--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -103,7 +103,8 @@ class StreamAlertFirehose(object):
         Args:
             batch (list): Record batch to iterate on
         """
-        for index, record in enumerate(batch):
+        for index in reversed(xrange(len(batch))):
+            record = batch[index]
             if len(json.dumps(record, separators=(",", ":"))) > cls.MAX_RECORD_SIZE:
                 # Show the first 1k bytes in order to not overload CloudWatch logs
                 LOGGER.error('The following record is too large'

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -45,7 +45,7 @@ from stream_alert_cli.terraform.s3_events import generate_s3_events
 from stream_alert_cli.terraform.threat_intel_downloader import generate_threat_intel_downloader
 
 RESTRICTED_CLUSTER_NAMES = ('main', 'athena')
-TERRAFORM_VERSIONS = {'application': '~> 0.10.6', 'provider': {'aws': '~> 1.11.0'}}
+TERRAFORM_VERSIONS = {'application': '~> 0.11.7', 'provider': {'aws': '~> 1.17.0'}}
 
 
 def generate_s3_bucket(bucket, logging, **kwargs):
@@ -411,7 +411,7 @@ def generate_global_lambda_settings(config, config_name, generate_func, tf_tmp_f
         message (str): Message will be logged by LOGGER.
     """
     if not config['lambda'].get(config_name):
-        LOGGER_CLI.info('Config for \'%s\' not in lambda.json', config_name)
+        LOGGER_CLI.warning('Config for \'%s\' not in lambda.json', config_name)
         remove_temp_terraform_file(tf_tmp_file, message)
         return
 

--- a/terraform/modules/tf_lambda/output.tf
+++ b/terraform/modules/tf_lambda/output.tf
@@ -1,17 +1,17 @@
 // Defined only if the Lambda is in a VPC
 output "function_vpc_arn" {
-  value = "${aws_lambda_function.function_vpc.arn}"
+  value = "${join(" ", aws_lambda_function.function_vpc.*.arn)}"
 }
 
 // Defined only if the Lambda is NOT in a VPC
 output "function_no_vpc_arn" {
-  value = "${aws_lambda_function.function_no_vpc.arn}"
+  value = "${join(" ", aws_lambda_function.function_no_vpc.*.arn)}"
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.role.arn}"
+  value = "${aws_iam_role.role.0.arn}"
 }
 
 output "role_id" {
-  value = "${aws_iam_role.role.id}"
+  value = "${aws_iam_role.role.0.id}"
 }

--- a/tests/unit/conf/outputs.json
+++ b/tests/unit/conf/outputs.json
@@ -1,4 +1,7 @@
 {
+  "aws-cloudwatch-log": [
+    "unit_test_default"
+  ],
   "aws-firehose": {
     "unit_test_delivery_stream": "unit_test_delivery_stream"
   },

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
@@ -31,7 +31,8 @@ from stream_alert.alert_processor.outputs.aws import (
     LambdaOutput,
     S3Output,
     SNSOutput,
-    SQSOutput
+    SQSOutput,
+    CloudwatchLogOutput
 )
 from stream_alert_cli.helpers import create_lambda_function
 from tests.unit.stream_alert_alert_processor import (
@@ -209,5 +210,25 @@ class TestSQSOutput(object):
         """SQSOutput - Dispatch Success"""
         assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
 
+        log_mock.assert_called_with('Successfully sent alert to %s:%s',
+                                    self.SERVICE, self.DESCRIPTOR)
+
+
+class TestCloudwatchLogOutput(object):
+    """Test class for CloudwatchLogOutput"""
+    DESCRIPTOR = 'unit_test_default'
+    SERVICE = 'aws-cloudwatch-log'
+
+    def setup(self):
+        """Create the Cloudwatch dispatcher"""
+        self._dispatcher = CloudwatchLogOutput(REGION, ACCOUNT_ID, FUNCTION_NAME, CONFIG)
+
+    @patch('logging.Logger.info')
+    def test_dispatch(self, log_mock):
+        """Cloudwatch - Dispatch"""
+        alert = get_alert()
+
+        assert_true(self._dispatcher.dispatch(alert, self.DESCRIPTOR))
+        assert_equal(log_mock.call_count, 2)
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -100,6 +100,7 @@ def test_output_loading():
         'aws-s3',
         'aws-sns',
         'aws-sqs',
+        'aws-cloudwatch-log',
         'carbonblack',
         'github',
         'jira',


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers 
size: medium
resolves #708 
resolves #609 

## Background

This PR is a combination of several small fixes, including Terraform 0.11.X support, various Firehose tweaks, and a new output for easily getting up and running with StreamAlert.  Having a Cloudwatch Log output allows users to quickly setup StreamAlert end-to-end without building additional infra or plugging in SaaS applications.

## Changes

* Support Terraform 0.11.X, and update the AWS provider.
* Add a new `CloudwatchLog` AWS output which simply logs alerts to the alert processor log stream.
* Reset the Firehose client if an error is raised - This was suggested by AWS as a potential fix to 
#478 

## Testing

Locally with unit tests, deployed in a side account to verify end-to-end flow on all features
