### PR TITLE
better alert processor output success/failure logging

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -82,13 +82,13 @@ Adding support for a new service involves five steps:
                                     '(ie: name of integration/channel/service/etc)'))
     ])
 
-  def dispatch(self, **kwargs):
+  def _dispatch(self, **kwargs):
     """Handles the actual sending of alerts to the configured service.
     Any external API calls for this service should be added here.
-    This method should call the `_log_status()` base class method upon completion.
+    This method should return a boolean where True means the alert was successfully sent.
     """
     ...
-    self._log_status(boolean)
+    return True
 
 **Note**: The ``OutputProperty`` object used in ``get_user_defined_properties`` is a namedtuple consisting of a few properties:
 
@@ -121,7 +121,7 @@ Adding support for a new service involves five steps:
 
    - The ``output_parser`` contains a ``choices`` list for ``--service`` that must include this new service.
 
-6. Extend the ``AlertProcessorTester.setup_outputs`` method in ``stream_alert_cli/test.py`` module to provide mock credentials for your new output. 
+6. Extend the ``AlertProcessorTester.setup_outputs`` method in ``stream_alert_cli/test.py`` module to provide mock credentials for your new output.
 
 .. note:: New AWS Service outputs should subclass ``AWSOutput`` instead of ``StreamOutputBase``
 

--- a/stream_alert/alert_processor/outputs/aws.py
+++ b/stream_alert/alert_processor/outputs/aws.py
@@ -363,8 +363,7 @@ class SQSOutput(AWSOutput):
         sqs = boto3.resource('sqs', region_name=self.region)
         queue = sqs.get_queue_by_name(QueueName=queue_name)
 
-        response = queue.send_message(MessageBody=json.dumps(alert.record, separators=(',', ':')))
-        return self._log_status(response, descriptor)
+        return queue.send_message(MessageBody=json.dumps(alert.record, separators=(',', ':')))
 
 
 @StreamAlertOutput
@@ -383,7 +382,7 @@ class CloudwatchLogOutput(AWSOutput):
              OutputProperty(description='a short and unique descriptor for the cloudwatch log')),
         ])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Cloudwatch Logger for Lambda
 
         Args:
@@ -391,4 +390,4 @@ class CloudwatchLogOutput(AWSOutput):
             descriptor (str): Output descriptor
         """
         LOGGER.info('New Alert:\n%s', json.dumps(alert.output_dict(), indent=4))
-        return self._log_status(True, descriptor)
+        return True

--- a/stream_alert/alert_processor/outputs/carbonblack.py
+++ b/stream_alert/alert_processor/outputs/carbonblack.py
@@ -54,7 +54,7 @@ class CarbonBlackOutput(OutputDispatcher):
                             cred_requirement=True)),
         ])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send ban hash command to CarbonBlack
 
         Args:
@@ -66,11 +66,11 @@ class CarbonBlackOutput(OutputDispatcher):
         """
         if not alert.context:
             LOGGER.error('[%s] Alert must contain context to run actions', self.__service__)
-            return self._log_status(False, descriptor)
+            return False
 
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         client = CbResponseAPI(**creds)
 
@@ -98,7 +98,7 @@ class CarbonBlackOutput(OutputDispatcher):
                 banned_hash.enabled = True
                 banned_hash.save()
 
-            return self._log_status(banned_hash.enabled is True, descriptor)
+            return banned_hash.enabled is True
         else:
             LOGGER.error('[%s] Action not supported: %s', self.__service__, action)
-            return self._log_status(False, descriptor)
+            return False

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -69,7 +69,7 @@ class GithubOutput(OutputDispatcher):
         """
         return {'api': 'https://api.github.com'}
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Github
 
         Args:
@@ -81,7 +81,7 @@ class GithubOutput(OutputDispatcher):
         """
         credentials = self._load_creds(descriptor)
         if not credentials:
-            return self._log_status(False, descriptor)
+            return False
 
         username_password = "{}:{}".format(credentials['username'],
                                            credentials['access_token'])
@@ -99,8 +99,6 @@ class GithubOutput(OutputDispatcher):
         LOGGER.debug('sending alert to Github repository %s', credentials['repository'])
 
         try:
-            success = self._post_request_retry(url, issue, headers)
+            return self._post_request_retry(url, issue, headers)
         except OutputRequestFailure:
-            success = False
-
-        return self._log_status(success, descriptor)
+            return False

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -99,6 +99,8 @@ class GithubOutput(OutputDispatcher):
         LOGGER.debug('sending alert to Github repository %s', credentials['repository'])
 
         try:
-            return self._post_request_retry(url, issue, headers)
+            self._post_request_retry(url, issue, headers)
         except OutputRequestFailure:
             return False
+
+        return True

--- a/stream_alert/alert_processor/outputs/jira.py
+++ b/stream_alert/alert_processor/outputs/jira.py
@@ -272,7 +272,7 @@ class JiraOutput(OutputDispatcher):
         return '{}={}'.format(resp_dict['session']['name'],
                               resp_dict['session']['value'])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Jira
 
         Args:
@@ -284,7 +284,7 @@ class JiraOutput(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         issue_id = None
         comment_id = None
@@ -296,7 +296,7 @@ class JiraOutput(OutputDispatcher):
 
         # Validate successful authentication
         if not self._auth_cookie:
-            return self._log_status(False, descriptor)
+            return False
 
         # If aggregation is enabled, attempt to add alert to an existing issue. If a
         # failure occurs in this block, creation of a new Jira issue will be attempted.
@@ -308,7 +308,7 @@ class JiraOutput(OutputDispatcher):
                     LOGGER.debug('Sending alert to an existing Jira issue %s with comment %s',
                                  issue_id,
                                  comment_id)
-                    return self._log_status(True, descriptor)
+                    return True
                 else:
                     LOGGER.error('Encountered an error when adding alert to existing '
                                  'Jira issue %s. Attempting to create new Jira issue.',
@@ -322,4 +322,4 @@ class JiraOutput(OutputDispatcher):
         if issue_id:
             LOGGER.debug('Sending alert to a new Jira issue %s', issue_id)
 
-        return self._log_status(issue_id or comment_id, descriptor)
+        return bool(issue_id or comment_id)

--- a/stream_alert/alert_processor/outputs/komand.py
+++ b/stream_alert/alert_processor/outputs/komand.py
@@ -56,7 +56,7 @@ class KomandOutput(OutputDispatcher):
                             cred_requirement=True))
         ])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Komand
 
         Args:
@@ -68,12 +68,11 @@ class KomandOutput(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         headers = {'Authorization': creds['komand_auth_token']}
 
         LOGGER.debug('sending alert to Komand')
 
         resp = self._post_request(creds['url'], {'data': alert.output_dict()}, headers, False)
-        success = self._check_http_response(resp)
-        return self._log_status(success, descriptor)
+        return self._check_http_response(resp)

--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -513,7 +513,7 @@ class OutputDispatcher(object):
         LOGGER.info('Sending %s to %s', alert, output)
         descriptor = output.split(':')[1]
         try:
-            sent = self._dispatch(alert, descriptor)
+            sent = bool(self._dispatch(alert, descriptor))
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception('Exception when sending %s to %s. Alert:\n%s',
                              alert, output, repr(alert))

--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -260,8 +260,6 @@ class OutputDispatcher(object):
         else:
             LOGGER.error('Failed to send alert to %s:%s', cls.__service__, descriptor)
 
-        return bool(success)
-
     @classmethod
     def _catch_exceptions(cls):
         """Classmethod that returns a tuple of the exceptions to catch"""
@@ -489,7 +487,7 @@ class OutputDispatcher(object):
         """
 
     @abstractmethod
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alerts to the given service.
 
         Args:
@@ -499,3 +497,28 @@ class OutputDispatcher(object):
         Returns:
             bool: True if alert was sent successfully, False otherwise
         """
+
+    def dispatch(self, alert, output):
+        """Send alerts to the given service.
+
+        This wraps the protected subclass method of _dispatch to aid in usability
+
+        Args:
+            alert (Alert): Alert instance which triggered a rule
+            descriptor (str): Output descriptor (e.g. slack channel, pd integration)
+
+        Returns:
+            bool: True if alert was sent successfully, False otherwise
+        """
+        LOGGER.info('Sending %s to %s', alert, output)
+        descriptor = output.split(':')[1]
+        try:
+            sent = self._dispatch(alert, descriptor)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception('Exception when sending %s to %s. Alert:\n%s',
+                             alert, output, repr(alert))
+            sent = False
+
+        self._log_status(sent, descriptor)
+
+        return sent

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -128,9 +128,11 @@ class PagerDutyOutput(OutputDispatcher):
         }
 
         try:
-            return self._post_request_retry(creds['url'], data, None, True)
+            self._post_request_retry(creds['url'], data, None, True)
         except OutputRequestFailure:
             return False
+
+        return True
 
 
 @StreamAlertOutput
@@ -190,9 +192,11 @@ class PagerDutyOutputV2(OutputDispatcher):
         data = events_v2_data(alert, creds['routing_key'])
 
         try:
-            return self._post_request_retry(creds['url'], data, None, True)
+            self._post_request_retry(creds['url'], data, None, True)
         except OutputRequestFailure:
             return False
+
+        return True
 
 
 class PagerdutySearchDelay(Exception):
@@ -694,4 +698,4 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             note = rule_context.get('note', 'Creating SOX Incident')
             self._add_incident_note(merged_id, note)
 
-        return incident_id
+        return True

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -100,7 +100,7 @@ class PagerDutyOutput(OutputDispatcher):
                             cred_requirement=True))
         ])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Pagerduty
 
         Args:
@@ -112,7 +112,7 @@ class PagerDutyOutput(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         message = 'StreamAlert Rule Triggered - {}'.format(alert.rule_name)
         details = {
@@ -128,11 +128,9 @@ class PagerDutyOutput(OutputDispatcher):
         }
 
         try:
-            success = self._post_request_retry(creds['url'], data, None, True)
+            return self._post_request_retry(creds['url'], data, None, True)
         except OutputRequestFailure:
-            success = False
-
-        return self._log_status(success, descriptor)
+            return False
 
 
 @StreamAlertOutput
@@ -175,7 +173,7 @@ class PagerDutyOutputV2(OutputDispatcher):
                             cred_requirement=True))
         ])
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert to Pagerduty
 
         Args:
@@ -187,16 +185,14 @@ class PagerDutyOutputV2(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         data = events_v2_data(alert, creds['routing_key'])
 
         try:
-            success = self._post_request_retry(creds['url'], data, None, True)
+            return self._post_request_retry(creds['url'], data, None, True)
         except OutputRequestFailure:
-            success = False
-
-        return self._log_status(success, descriptor)
+            return False
 
 
 class PagerdutySearchDelay(Exception):
@@ -582,7 +578,7 @@ class PagerDutyIncidentOutput(OutputDispatcher):
 
         return note_rec.get('id', False)
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send incident to Pagerduty Incidents API v2
 
         Args:
@@ -594,7 +590,7 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         # Cache base_url
         self._base_url = creds['api']
@@ -610,7 +606,7 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         user_email = creds['email_from']
         if not self._user_verify(user_email, False):
             LOGGER.error('Could not verify header From: %s, %s', user_email, self.__service__)
-            return self._log_status(False, descriptor)
+            return False
 
         # Add From to the headers after verifying
         self._headers['From'] = user_email
@@ -657,12 +653,12 @@ class PagerDutyIncidentOutput(OutputDispatcher):
 
         if not incident:
             LOGGER.error('Could not create main incident, %s', self.__service__)
-            return self._log_status(False, descriptor)
+            return False
 
         # Extract the json blob from the response, returned by self._post_request_retry
         incident_json = incident.json()
         if not incident_json:
-            return self._log_status(False, descriptor)
+            return False
 
         # Extract the incident id from the incident that was just created
         incident_id = incident_json.get('incident', {}).get('id')
@@ -673,14 +669,14 @@ class PagerDutyIncidentOutput(OutputDispatcher):
         event = self._create_event(event_data)
         if not event:
             LOGGER.error('Could not create incident event, %s', self.__service__)
-            return self._log_status(False, descriptor)
+            return False
 
         # Lookup the incident_key returned as dedup_key to get the incident id
         incident_key = event.get('dedup_key')
 
         if not incident_key:
             LOGGER.error('Could not get incident key, %s', self.__service__)
-            return self._log_status(False, descriptor)
+            return False
 
         # Keep that id to be merged later with the created incident
         event_incident_id = self._get_event_incident_id(incident_key)
@@ -698,4 +694,4 @@ class PagerDutyIncidentOutput(OutputDispatcher):
             note = rule_context.get('note', 'Creating SOX Incident')
             self._add_incident_note(merged_id, note)
 
-        return self._log_status(incident_id, descriptor)
+        return incident_id

--- a/stream_alert/alert_processor/outputs/phantom.py
+++ b/stream_alert/alert_processor/outputs/phantom.py
@@ -159,6 +159,8 @@ class PhantomOutput(OutputDispatcher):
                     'label': 'Alert'}
         artifact_url = os.path.join(creds['url'], self.ARTIFACT_ENDPOINT)
         try:
-            return self._post_request_retry(artifact_url, artifact, headers, False)
+            self._post_request_retry(artifact_url, artifact, headers, False)
         except OutputRequestFailure:
             return False
+
+        return True

--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -216,7 +216,7 @@ class SlackOutput(OutputDispatcher):
 
         return all_lines
 
-    def dispatch(self, alert, descriptor):
+    def _dispatch(self, alert, descriptor):
         """Send alert text to Slack
 
         Args:
@@ -228,13 +228,11 @@ class SlackOutput(OutputDispatcher):
         """
         creds = self._load_creds(descriptor)
         if not creds:
-            return self._log_status(False, descriptor)
+            return False
 
         slack_message = self._format_message(alert.rule_name, alert)
 
         try:
-            success = self._post_request_retry(creds['url'], slack_message)
+            return self._post_request_retry(creds['url'], slack_message)
         except OutputRequestFailure:
-            success = False
-
-        return self._log_status(success, descriptor)
+            return False

--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -233,6 +233,8 @@ class SlackOutput(OutputDispatcher):
         slack_message = self._format_message(alert.rule_name, alert)
 
         try:
-            return self._post_request_retry(creds['url'], slack_message)
+            self._post_request_retry(creds['url'], slack_message)
         except OutputRequestFailure:
             return False
+
+        return True

--- a/tests/unit/stream_alert_alert_processor/test_main.py
+++ b/tests/unit/stream_alert_alert_processor/test_main.py
@@ -15,13 +15,11 @@ limitations under the License.
 """
 import os
 
-from mock import ANY, call, MagicMock, Mock, patch
+from mock import ANY, MagicMock, Mock, patch
 from nose.tools import (
     assert_equal,
-    assert_false,
     assert_is_instance,
-    assert_is_none,
-    assert_true
+    assert_is_none
 )
 
 from stream_alert.alert_processor.main import AlertProcessor, handler

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
@@ -224,6 +224,7 @@ class TestCloudwatchLogOutput(object):
     """Test class for CloudwatchLogOutput"""
     DESCRIPTOR = 'unit_test_default'
     SERVICE = 'aws-cloudwatch-log'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Create the Cloudwatch dispatcher"""
@@ -234,7 +235,7 @@ class TestCloudwatchLogOutput(object):
         """Cloudwatch - Dispatch"""
         alert = get_alert()
 
-        assert_true(self._dispatcher.dispatch(alert, self.DESCRIPTOR))
-        assert_equal(log_mock.call_count, 2)
+        assert_true(self._dispatcher.dispatch(alert, self.OUTPUT))
+        assert_equal(log_mock.call_count, 3)
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_aws.py
@@ -71,6 +71,7 @@ class TestFirehoseOutput(object):
     """Test class for AWS Kinesis Firehose"""
     DESCRIPTOR = 'unit_test_delivery_stream'
     SERVICE = 'aws-firehose'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Setup before each method"""
@@ -98,7 +99,7 @@ class TestFirehoseOutput(object):
     @patch('logging.Logger.info')
     def test_dispatch(self, log_mock):
         """Kinesis Firehose - Output Dispatch Success"""
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -107,7 +108,7 @@ class TestFirehoseOutput(object):
         """Output Dispatch - Kinesis Firehose with Large Payload"""
         alert = get_alert()
         alert.record = 'test' * 1000 * 1000
-        assert_false(self._dispatcher.dispatch(alert, self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(alert, self.OUTPUT))
 
 
 @mock_lambda
@@ -115,6 +116,7 @@ class TestLambdaOutput(object):
     """Test class for LambdaOutput"""
     DESCRIPTOR = 'unit_test_lambda'
     SERVICE = 'aws-lambda'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Setup before each method"""
@@ -129,7 +131,7 @@ class TestLambdaOutput(object):
     @patch('logging.Logger.info')
     def test_dispatch(self, log_mock):
         """LambdaOutput dispatch"""
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -140,7 +142,8 @@ class TestLambdaOutput(object):
         alt_descriptor = '{}_qual'.format(self.DESCRIPTOR)
         create_lambda_function(CONFIG[self.SERVICE][alt_descriptor], REGION)
 
-        assert_true(self._dispatcher.dispatch(get_alert(), alt_descriptor))
+        assert_true(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, alt_descriptor])))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, alt_descriptor)
@@ -151,6 +154,7 @@ class TestS3Output(object):
     """Test class for S3Output"""
     DESCRIPTOR = 'unit_test_bucket'
     SERVICE = 'aws-s3'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Setup before each method"""
@@ -166,7 +170,7 @@ class TestS3Output(object):
     @patch('logging.Logger.info')
     def test_dispatch(self, log_mock):
         """S3Output - Dispatch Success"""
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -177,6 +181,7 @@ class TestSNSOutput(object):
     """Test class for SNSOutput"""
     DESCRIPTOR = 'unit_test_topic'
     SERVICE = 'aws-sns'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Create the dispatcher and the mock SNS topic."""
@@ -187,7 +192,7 @@ class TestSNSOutput(object):
     @patch('logging.Logger.info')
     def test_dispatch(self, log_mock):
         """SNSOutput - Dispatch Success"""
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -198,6 +203,7 @@ class TestSQSOutput(object):
     """Test class for SQSOutput"""
     DESCRIPTOR = 'unit_test_queue'
     SERVICE = 'aws-sqs'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
 
     def setup(self):
         """Create the dispatcher and the mock SQS queue."""
@@ -208,7 +214,7 @@ class TestSQSOutput(object):
     @patch('logging.Logger.info')
     def test_dispatch(self, log_mock):
         """SQSOutput - Dispatch Success"""
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_carbonblack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_carbonblack.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-# pylint: disable=no-self-use,unused-argument,attribute-defined-outside-init
+# pylint: disable=no-self-use,unused-argument,attribute-defined-outside-init,protected-access
 from collections import OrderedDict
 
 from mock import call, patch
@@ -43,6 +43,7 @@ class TestCarbonBlackOutput(object):
     """Test class for CarbonBlackOutput"""
     DESCRIPTOR = 'unit_test_carbonblack'
     SERVICE = 'carbonblack'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'carbon.foo.bar',
              'ssl_verify': 'Y',
              'token': '1234567890127a3d7f37f4153270bff41b105899'}
@@ -61,7 +62,7 @@ class TestCarbonBlackOutput(object):
     @patch('logging.Logger.error')
     def test_dispatch_no_context(self, mock_logger):
         """CarbonBlackOutput - Dispatch No Context"""
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
         mock_logger.assert_has_calls([
             call('[%s] Alert must contain context to run actions', 'carbonblack'),
             call('Failed to send alert to %s:%s', 'carbonblack', 'unit_test_carbonblack')
@@ -76,7 +77,7 @@ class TestCarbonBlackOutput(object):
                 'value': 'BANNED_ENABLED_HASH'
             }
         }
-        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.OUTPUT))
 
     @patch.object(carbonblack, 'CbResponseAPI', side_effect=MockCBAPI)
     def test_dispatch_banned_disabled(self, mock_cb):
@@ -87,7 +88,7 @@ class TestCarbonBlackOutput(object):
                 'value': 'BANNED_DISABLED_HASH'
             }
         }
-        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.OUTPUT))
 
     @patch.object(carbonblack, 'CbResponseAPI', side_effect=MockCBAPI)
     def test_dispatch_not_banned(self, mock_cb):
@@ -98,7 +99,7 @@ class TestCarbonBlackOutput(object):
                 'value': 'NOT_BANNED_HASH'
             }
         }
-        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=alert_context), self.OUTPUT))
 
     @patch('logging.Logger.error')
     @patch.object(carbonblack, 'CbResponseAPI', side_effect=MockCBAPI)
@@ -109,7 +110,8 @@ class TestCarbonBlackOutput(object):
                 'action': 'rickroll',
             }
         }
-        assert_false(self._dispatcher.dispatch(get_alert(context=alert_context), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(context=alert_context), self.OUTPUT))
+
         mock_logger.assert_has_calls([
             call('[%s] Action not supported: %s', 'carbonblack', 'rickroll'),
             call('Failed to send alert to %s:%s', 'carbonblack', 'unit_test_carbonblack')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_github.py
@@ -41,6 +41,7 @@ class TestGithubOutput(object):
     """Test class for GithubOutput"""
     DESCRIPTOR = 'unit_test_repo'
     SERVICE = 'github'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'username': 'unit_test_user', 'access_token':
              'unit_test_access_token', 'repository': 'unit_test_org/unit_test_repo',
              'labels': 'label1,label2'}
@@ -59,7 +60,7 @@ class TestGithubOutput(object):
         url_mock.return_value.status_code = 200
         url_mock.return_value.json.return_value = dict()
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         assert_equal(url_mock.call_args[0][0],
                      'https://api.github.com/repos/unit_test_org/unit_test_repo/issues')
@@ -80,7 +81,7 @@ class TestGithubOutput(object):
         url_mock.return_value.status_code = 200
         url_mock.return_value.json.return_value = dict()
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         assert_equal(url_mock.call_args[1]['json']['labels'], ['label1', 'label2'])
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
@@ -94,12 +95,14 @@ class TestGithubOutput(object):
         url_mock.return_value.json.return_value = json_error
         url_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
+
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_mock):
         """GithubOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, 'bad_descriptor')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_jira.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_jira.py
@@ -36,6 +36,7 @@ class TestJiraOutput(object):
     """Test class for JiraOutput"""
     DESCRIPTOR = 'unit_test_jira'
     SERVICE = 'jira'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'username': 'jira@foo.bar',
              'password': 'jirafoobar',
              'url': 'jira.foo.bar',
@@ -64,7 +65,7 @@ class TestJiraOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.side_effect = [auth_resp, {'id': 5000}]
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -83,7 +84,7 @@ class TestJiraOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.side_effect = [auth_resp, {'id': 5000}]
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -102,7 +103,7 @@ class TestJiraOutput(object):
         type(post_mock.return_value).status_code = PropertyMock(side_effect=[200, 200, 200])
         post_mock.return_value.json.side_effect = [auth_resp, {}, {'id': 5000}]
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -155,7 +156,7 @@ class TestJiraOutput(object):
         post_mock.return_value.content = 'content'
         post_mock.return_value.json.return_value = dict()
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -167,7 +168,7 @@ class TestJiraOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.return_value = {}
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -185,7 +186,7 @@ class TestJiraOutput(object):
         post_mock.return_value.content = 'some bad content'
         post_mock.return_value.json.side_effect = [auth_resp, dict()]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -203,7 +204,7 @@ class TestJiraOutput(object):
         post_mock.return_value.content = 'some bad content'
         post_mock.return_value.json.side_effect = [auth_resp, dict()]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -220,7 +221,7 @@ class TestJiraOutput(object):
         auth_resp = {'session': {'name': 'cookie_name', 'value': 'cookie_value'}}
         post_mock.return_value.json.side_effect = [auth_resp, {}]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -238,7 +239,7 @@ class TestJiraOutput(object):
         auth_resp = {'session': {'name': 'cookie_name', 'value': 'cookie_value'}}
         post_mock.return_value.json.side_effect = [auth_resp, {'id': 6000}]
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Encountered an error when adding alert to existing Jira '
                                     'issue %s. Attempting to create new Jira issue.', 5000)
@@ -247,7 +248,8 @@ class TestJiraOutput(object):
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_error_mock):
         """JiraOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_error_mock.assert_called_with('Failed to send alert to %s:%s',
                                           self.SERVICE, 'bad_descriptor')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_komand.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_komand.py
@@ -36,6 +36,7 @@ class TestKomandutput(object):
     """Test class for KomandOutput"""
     DESCRIPTOR = 'unit_test_komand'
     SERVICE = 'komand'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'http://komand.foo.bar',
              'komand_auth_token': 'mocked_auth_token'}
 
@@ -52,7 +53,7 @@ class TestKomandutput(object):
         """KomandOutput - Dispatch Success"""
         post_mock.return_value.status_code = 200
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -65,14 +66,15 @@ class TestKomandutput(object):
         json_error = {'message': 'error message', 'errors': ['error1']}
         post_mock.return_value.json.return_value = json_error
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_error_mock):
         """KomandOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_error_mock.assert_called_with('Failed to send alert to %s:%s',
                                           self.SERVICE, 'bad_descriptor')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -41,6 +41,7 @@ class TestPagerDutyOutput(object):
     """Test class for PagerDutyOutput"""
     DESCRIPTOR = 'unit_test_pagerduty'
     SERVICE = 'pagerduty'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'http://pagerduty.foo.bar/create_event.json',
              'service_key': 'mocked_service_key'}
 
@@ -64,7 +65,7 @@ class TestPagerDutyOutput(object):
         """PagerDutyOutput - Dispatch Success"""
         post_mock.return_value.status_code = 200
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -75,14 +76,15 @@ class TestPagerDutyOutput(object):
         """PagerDutyOutput - Dispatch Failure, Bad Request"""
         post_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_mock):
         """PagerDutyOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, 'bad_descriptor')
 
@@ -93,6 +95,7 @@ class TestPagerDutyOutputV2(object):
     """Test class for PagerDutyOutputV2"""
     DESCRIPTOR = 'unit_test_pagerduty-v2'
     SERVICE = 'pagerduty-v2'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'http://pagerduty.foo.bar/create_event.json',
              'routing_key': 'mocked_routing_key'}
 
@@ -115,7 +118,7 @@ class TestPagerDutyOutputV2(object):
         """PagerDutyOutputV2 - Dispatch Success"""
         post_mock.return_value.status_code = 200
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -128,14 +131,15 @@ class TestPagerDutyOutputV2(object):
         post_mock.return_value.json.return_value = json_error
         post_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_mock):
         """PagerDutyOutputV2 - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, 'bad_descriptor')
 
@@ -150,6 +154,7 @@ class TestPagerDutyIncidentOutput(object):
     """Test class for PagerDutyIncidentOutput"""
     DESCRIPTOR = 'unit_test_pagerduty-incident'
     SERVICE = 'pagerduty-incident'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'api': 'https://api.pagerduty.com',
              'token': 'mocked_token',
              'service_name': 'mocked_service_name',
@@ -491,7 +496,7 @@ class TestPagerDutyIncidentOutput(object):
 
         ctx = {'pagerduty-incident': {'assigned_user': 'valid_user'}}
 
-        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -523,7 +528,7 @@ class TestPagerDutyIncidentOutput(object):
 
         ctx = {'pagerduty-incident': {'assigned_policy_id': 'valid_policy_id'}}
 
-        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -560,7 +565,7 @@ class TestPagerDutyIncidentOutput(object):
             }
         }
 
-        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -593,7 +598,7 @@ class TestPagerDutyIncidentOutput(object):
 
         ctx = {'pagerduty-incident': {'assigned_user': 'invalid_user'}}
 
-        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -623,7 +628,7 @@ class TestPagerDutyIncidentOutput(object):
         # PUT /incidents/indicent_id/merge
         put_mock.return_value.status_code = 200
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -643,7 +648,7 @@ class TestPagerDutyIncidentOutput(object):
         # POST /incidents
         post_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -671,7 +676,7 @@ class TestPagerDutyIncidentOutput(object):
 
         ctx = {'pagerduty-incident': {'assigned_policy_id': 'valid_policy_id'}}
 
-        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(context=ctx), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -690,7 +695,7 @@ class TestPagerDutyIncidentOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.return_value = {}
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -710,7 +715,7 @@ class TestPagerDutyIncidentOutput(object):
         json_event = {}
         post_mock.return_value.json.side_effect = [json_incident, json_event]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -730,7 +735,7 @@ class TestPagerDutyIncidentOutput(object):
         json_event = {'not_dedup_key': 'returned_dedup_key'}
         post_mock.return_value.json.side_effect = [json_incident, json_event]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -747,7 +752,7 @@ class TestPagerDutyIncidentOutput(object):
         # /incidents
         post_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -761,13 +766,14 @@ class TestPagerDutyIncidentOutput(object):
         json_user = {'not_users': [{'id': 'no_user_id'}]}
         get_mock.return_value.json.return_value = json_user
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_mock):
         """PagerDutyIncidentOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, 'bad_descriptor')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_phantom.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_phantom.py
@@ -37,6 +37,7 @@ class TestPhantomOutput(object):
     """Test class for PhantomOutput"""
     DESCRIPTOR = 'unit_test_phantom'
     SERVICE = 'phantom'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'http://phantom.foo.bar',
              'ph_auth_token': 'mocked_auth_token'}
 
@@ -58,7 +59,7 @@ class TestPhantomOutput(object):
         # dispatch
         post_mock.return_value.status_code = 200
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -75,7 +76,7 @@ class TestPhantomOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.return_value = {'id': 1948}
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -93,7 +94,7 @@ class TestPhantomOutput(object):
         json_error = {'message': 'error message', 'errors': ['error1']}
         post_mock.return_value.json.return_value = json_error
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -110,7 +111,7 @@ class TestPhantomOutput(object):
         json_error = {'message': 'error message', 'errors': ['error1']}
         post_mock.return_value.json.return_value = json_error
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -126,7 +127,7 @@ class TestPhantomOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.return_value = {}
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -142,8 +143,7 @@ class TestPhantomOutput(object):
         post_mock.return_value.status_code = 200
         post_mock.return_value.json.return_value = dict()
 
-
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
@@ -160,14 +160,15 @@ class TestPhantomOutput(object):
         json_error = {'message': 'error message', 'errors': ['error1']}
         post_mock.return_value.json.return_value.side_effect = [{'id': 1948}, json_error]
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_error_mock):
         """PhantomOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_error_mock.assert_called_with('Failed to send alert to %s:%s',
                                           self.SERVICE, 'bad_descriptor')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -42,6 +42,7 @@ class TestSlackOutput(object):
     """Test class for SlackOutput"""
     DESCRIPTOR = 'unit_test_channel'
     SERVICE = 'slack'
+    OUTPUT = ':'.join([SERVICE, DESCRIPTOR])
     CREDS = {'url': 'https://api.slack.com/web-hook-key'}
 
     def setup(self):
@@ -181,7 +182,7 @@ class TestSlackOutput(object):
         url_mock.return_value.status_code = 200
         url_mock.return_value.json.return_value = dict()
 
-        assert_true(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Successfully sent alert to %s:%s',
                                     self.SERVICE, self.DESCRIPTOR)
@@ -194,13 +195,14 @@ class TestSlackOutput(object):
         url_mock.return_value.json.return_value = json_error
         url_mock.return_value.status_code = 400
 
-        assert_false(self._dispatcher.dispatch(get_alert(), self.DESCRIPTOR))
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, self.DESCRIPTOR)
 
     @patch('logging.Logger.error')
     def test_dispatch_bad_descriptor(self, log_mock):
         """SlackOutput - Dispatch Failure, Bad Descriptor"""
-        assert_false(self._dispatcher.dispatch(get_alert(), 'bad_descriptor'))
+        assert_false(
+            self._dispatcher.dispatch(get_alert(), ':'.join([self.SERVICE, 'bad_descriptor'])))
 
         log_mock.assert_called_with('Failed to send alert to %s:%s', self.SERVICE, 'bad_descriptor')


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: medium

## Background

I noticed that the way logging 'success' or 'failures' during alert dispatching was sort of janky. This updates the way logging occurs to make it much easier for someone to implement an alert output and not reason about logging statuses.

## Changes

* The alert output's `_dispatch` method now just returns True or False, depending on success or failure.
* Updating the output base class's `dispatch` method to call the subclass `_dispatch` method and handle the status logging of the result.
* Updating the alert processor to remove a now unnecessary method (`_send_alert`).
* Updates to documentation to explain the new interface for this.

## Testing

* Updating all unit tests for the changes made.
