### PR TITLE
fixing bug where slack messages would split on each character if no newline existed

### DIFF
--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -155,7 +155,7 @@ class SlackOutput(OutputDispatcher):
                     ...
         """
         header_text = '*StreamAlert Rule Triggered: {}*'.format(rule_name)
-        attachments = [attachment for attachment in cls._format_attachments(alert, header_text)]
+        attachments = list(cls._format_attachments(alert, header_text))
         full_message = {
             'text': header_text,
             'mrkdwn': True,

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -175,6 +175,32 @@ class TestSlackOutput(object):
         assert_equal(len(result), 2)
         assert_equal(result[1], '*test_key_02:* test_value_02')
 
+    def test_split_attachment_text_newline(self):
+        """SlackOutput - Split Attachment, On Newline"""
+        message = {'messages': 'test\n' * 800}
+        result = list(SlackOutput._split_attachment_text(message))
+        assert_equal(len(result[0]), 3996)
+
+    def test_split_attachment_text_on_space(self):
+        """SlackOutput - Split Attachment, On Space"""
+        message = {'messages': 'test ' * 800}
+        result = list(SlackOutput._split_attachment_text(message))
+        assert_equal(len(result[0]), 3996)
+
+    def test_split_attachment_text_no_delimiter(self):
+        """SlackOutput - Split Attachment, No Delimiter"""
+        message = {'messages': 'test' * 2000}
+        result = list(SlackOutput._split_attachment_text(message))
+        assert_equal(len(result[1]), 4000)
+
+    @patch('logging.Logger.warning')
+    def test_max_attachments(self, log_mock):
+        """SlackOutput - Max Attachment Reached"""
+        alert = get_alert()
+        alert.record = {'info': 'test' * 20000}
+        list(SlackOutput._format_attachments(alert, 'foo'))
+        log_mock.assert_called_with('%s: %d-part message truncated to %d parts', alert, 21, 20)
+
     @patch('logging.Logger.info')
     @patch('requests.post')
     def test_dispatch_success(self, url_mock, log_mock):


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

We observed issues with the `SlackOutput` where many thousands of attachments could be included with a message.

## Changes

* Fixing an issue with message splitting that was a result of the message not containing any new line characters (or no new line characters within the max message size limit).
* If new lines do not exist in the range, we will fall back on splitting on the last _space_ in the chunk of text.
* If neither space nor new lines exists in the chunk of text, we will split on the max message size, ignoring delimiters altogether.
* Simplifying the attachment generation code significantly.

## Testing

* Adding tests for the various characters (or lack there of) we can split one (new line, space, none).
* Adding test for the max attachment logging as well.
