### PR TITLE
[payload] shred the tmp directoy before downloading s3 objects

### DIFF
--- a/stream_alert_cli/test.py
+++ b/stream_alert_cli/test.py
@@ -89,6 +89,9 @@ class RuleProcessorTester(object):
         # Create a cache map of parsers to parser classes
         self.parsers = {}
 
+        # Patch the tmp shredding as to not slow down testing
+        patch('stream_alert.rule_processor.payload.S3Payload._shred_temp_directory').start()
+
     def test_processor(self, rules_filter, files_filter, validate_only):
         """Perform integration tests for the 'rule' Lambda function
 


### PR DESCRIPTION
to: @austinbyers or @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

To ensure Lambda's disk space is cleared on each invocation, let's shred the temp directory.

## Changes

* Shred temp
* Update tests
* Round for file sizes

## Testing

Local, CI, and deployed in a side account
