### PR TITLE
[tf] send message to SNS topic when alarms recover

### DIFF
--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -13,7 +13,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_invocation_errors" {
   evaluation_periods  = "${var.lambda_invocation_error_evaluation_periods}"
   period              = "${var.lambda_invocation_error_period}"
   alarm_description   = "StreamAlert Lambda Invocation Errors: ${element(var.lambda_functions, count.index)}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     FunctionName = "${element(var.lambda_functions, count.index)}"
@@ -33,7 +35,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_throttles" {
   evaluation_periods  = "${var.lambda_throttle_error_evaluation_periods}"
   period              = "${var.lambda_throttle_error_period}"
   alarm_description   = "StreamAlert Lambda Throttles: ${element(var.lambda_functions, count.index)}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     FunctionName = "${element(var.lambda_functions, count.index)}"
@@ -53,7 +57,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_iterator_age" {
   evaluation_periods  = "${var.lambda_iterator_age_error_evaluation_periods}"
   period              = "${var.lambda_iterator_age_error_period}"
   alarm_description   = "StreamAlert Lambda High Iterator Age: ${element(var.lambda_functions, count.index)}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     FunctionName = "${element(var.lambda_functions, count.index)}"
@@ -73,7 +79,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_iterator_age" {
   evaluation_periods  = "${var.kinesis_iterator_age_error_evaluation_periods}"
   period              = "${var.kinesis_iterator_age_error_period}"
   alarm_description   = "StreamAlert Kinesis High Iterator Age: ${var.kinesis_stream}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     StreamName = "${var.kinesis_stream}"
@@ -92,7 +100,9 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_kinesis_write_exceeded" {
   evaluation_periods  = "${var.kinesis_write_throughput_exceeded_evaluation_periods}"
   period              = "${var.kinesis_write_throughput_exceeded_period}"
   alarm_description   = "StreamAlert Kinesis Write Throughput Exceeded: ${var.kinesis_stream}"
-  alarm_actions       = ["${var.sns_topic_arn}"]
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     StreamName = "${var.kinesis_stream}"


### PR DESCRIPTION
to: @austinbyers or @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The Terraform module for `monitoring` is used to create CloudWatch alarms when certain thresholds are passed.  When alarms are triggered, a message is sent to an SNS topic, which can be subscribed by PagerDuty.

While digging through [PagerDuty documentation](https://www.pagerduty.com/docs/guides/aws-cloudwatch-integration-guide/), I discovered that the alarm wasn't configured to report back to SNS when alarms recover, which can auto resolve PagerDuty incidents.

## Changes

* Send messages to the cloudwatch monitoring SNS topic when the triggered alarm recovers

## Testing

Deployed in a test account
