### PR TITLE
[classifier] Catch KeyError when parsing a record

### DIFF
--- a/stream_alert/rule_processor/classifier.py
+++ b/stream_alert/rule_processor/classifier.py
@@ -273,9 +273,13 @@ class StreamClassifier(object):
             # Convert data types per the schema
             # Use the root schema for the parser due to updates caused by
             # configuration settings such as envelope_keys and optional_keys
-            if not self._convert_type(
-                    parsed_data_value,
-                    schema_match.root_schema):
+            try:
+                if not self._convert_type(
+                        parsed_data_value,
+                        schema_match.root_schema):
+                    return False
+            except KeyError:
+                LOGGER.error('The payload is mis-classified. Payload [%s]', parsed_data_value)
                 return False
 
         normalized_types = StreamThreatIntel.normalized_type_mapping()


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
Catch `KeyError` during a record parsing in the classifier. It may result a `KeyError` exception when a record is mis-classified, although this situation is rare.

## Changes

* Catch `KeyError` and return `False`. It will result `Failed Parses` in Rule Processor if a record is mis-classified.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 736 tests in 10.559s

OK
```