### PR TITLE
[firehose] only retry failed records when re-calling put_record_batch

### DIFF
--- a/tests/unit/stream_alert_rule_processor/test_firehose.py
+++ b/tests/unit/stream_alert_rule_processor/test_firehose.py
@@ -16,7 +16,7 @@ limitations under the License.
 # pylint: disable=protected-access,no-self-use
 from mock import patch
 from moto import mock_kinesis
-from nose.tools import (assert_equal, assert_false, assert_not_equal, assert_true)
+from nose.tools import assert_equal, assert_false, assert_true
 
 from stream_alert.rule_processor.firehose import StreamAlertFirehose
 from stream_alert.shared.config import load_config
@@ -239,24 +239,6 @@ class TestStreamAlertFirehose(object):
 
         assert_equal(len(sa_firehose._enabled_logs), 0)
         assert_true(mock_logging.error.called)
-
-    @patch('logging.Logger.info')
-    @mock_kinesis
-    def test_firehose_reset(self, mock_logging):
-        """StreamAlertFirehose - Test Reset Firehose Client"""
-        def test_func():
-            pass
-        sa_firehose = StreamAlertFirehose(region='us-east-1', firehose_config={}, log_sources={})
-
-        id_1 = id(sa_firehose._firehose_client)
-        sa_firehose._backoff_handler_firehose_reset({
-            'target': test_func,
-            'wait': 0.134315135,
-            'tries': 3})
-        id_2 = id(sa_firehose._firehose_client)
-
-        assert_true(mock_logging.called)
-        assert_not_equal(id_1, id_2)
 
     def test_strip_successful_records(self):
         """StreamAlertFirehose - Strip Successful Records"""

--- a/tests/unit/stream_alert_rule_processor/test_firehose.py
+++ b/tests/unit/stream_alert_rule_processor/test_firehose.py
@@ -240,7 +240,7 @@ class TestStreamAlertFirehose(object):
         assert_equal(len(sa_firehose._enabled_logs), 0)
         assert_true(mock_logging.error.called)
 
-    @patch('stream_alert.rule_processor.firehose.LOGGER')
+    @patch('logging.Logger.info')
     @mock_kinesis
     def test_firehose_reset(self, mock_logging):
         """StreamAlertFirehose - Test Reset Firehose Client"""
@@ -251,11 +251,11 @@ class TestStreamAlertFirehose(object):
         id_1 = id(sa_firehose._firehose_client)
         sa_firehose._backoff_handler_firehose_reset({
             'target': test_func,
-            'wait': '0.134315135',
+            'wait': 0.134315135,
             'tries': 3})
         id_2 = id(sa_firehose._firehose_client)
 
-        assert_true(mock_logging.info.called)
+        assert_true(mock_logging.called)
         assert_not_equal(id_1, id_2)
 
     def test_segment_records_by_size(self):

--- a/tests/unit/stream_alert_rule_processor/test_firehose.py
+++ b/tests/unit/stream_alert_rule_processor/test_firehose.py
@@ -258,6 +258,24 @@ class TestStreamAlertFirehose(object):
         assert_true(mock_logging.called)
         assert_not_equal(id_1, id_2)
 
+    def test_strip_successful_records(self):
+        """StreamAlertFirehose - Strip Successful Records"""
+        batch = [{'test': 'success'}, {'test': 'data'}, {'other': 'failure'}, {'other': 'info'}]
+        response = {
+            'FailedPutCount': 1,
+            'RequestResponses': [
+                {'RecordId': 'rec_id_00'},
+                {'RecordId': 'rec_id_01'},
+                {'ErrorCode': 10, 'ErrorMessage': 'foo'},
+                {'RecordId': 'rec_id_03'}
+            ]
+        }
+
+        expected_batch = [{'other': 'failure'}]
+        StreamAlertFirehose._strip_successful_records(batch, response)
+
+        assert_equal(batch, expected_batch)
+
     def test_segment_records_by_size(self):
         """StreamAlertFirehose - Segment Large Records"""
         sa_firehose = StreamAlertFirehose(region='us-east-1', firehose_config={}, log_sources={})


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

If firehose fails to send some records within a batch of records, the response will identify which ones failed to send. We can leverage this information to only retry items that failed, instead of retrying the entire batch.

## Changes

* Fixing issue with firehose client reset when a backoff exception occurs.  This resets the client with the proper config, which includes connect and read timeout information.
* Adding logic to only retry firehose records that have failed to send in the batch. This modifies the list of records by reference, and the backed-off function will see the new, modified list.

## Testing

Tested in a local script with backoff and adding unit tests for the function that performs the stripping of successful records from the batch.
