### PR TITLE
[firehose] backoff when firehose read timed out

### DIFF
--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -21,7 +21,7 @@ import backoff
 import boto3
 from botocore import client
 from botocore.exceptions import ClientError
-from botocore.vendored.requests.exceptions import ConnectionError
+from botocore.vendored.requests.exceptions import ConnectionError, Timeout
 
 from stream_alert.rule_processor import FUNCTION_NAME, LOGGER
 from stream_alert.shared.metrics import MetricLogger
@@ -177,7 +177,7 @@ class StreamAlertFirehose(object):
         """
         resp = {}
         record_batch_size = len(record_batch)
-        exceptions_to_backoff = (ClientError, ConnectionError)
+        exceptions_to_backoff = (ClientError, ConnectionError, Timeout)
 
         @backoff.on_predicate(backoff.fibo,
                               lambda resp: resp['FailedPutCount'] > 0,


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers

size: small
resolves NA

## Background
The PR #736 adding timeout when sending records to firehose, so we need to retry when firehose read timeout happened.

## Changes

* Handle firehose read timeout.

## Testing
* Rule testing
```
python manage.py lambda test --processor all
...
StreamAlertCLI [INFO]: (63/63) Successful Tests
StreamAlertCLI [INFO]: (34/34) Alert Tests Passed
```

* Unit testing
```
./tests/scripts/unit_tests.sh
...
Ran 736 tests in 12.525s

OK
```
