### PR TITLE
[parsers] better key-value parser support

### DIFF
--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -100,7 +100,7 @@ class TestKVParser(TestParser):
         return 'kv'
 
     def test_kv_parsing(self):
-        """KV Parser - Basic key value pairs"""
+        """KV Parser - Comma delimited, colon separated"""
         # setup
         schema = {
             'name': 'string',
@@ -117,6 +117,50 @@ class TestKVParser(TestParser):
 
         assert_equal(len(parsed_data), 1)
         assert_equal(parsed_data[0]['name'], 'joe bob')
+
+    def test_kv_parsing_2(self):
+        """KV Parser - Space delimited, equal sign separated"""
+        # setup
+        schema = {
+            'name': 'string',
+            'result': 'string',
+            'time': 'string',
+            'count': 'integer'
+        }
+        options = {
+            'separator': '=',
+            'delimiter': ' ',
+        }
+        data = 'name=test result=OK time=2:15PM count=5'
+
+        # get parsed data
+        parsed_data = self.parser_helper(data=data, schema=schema, options=options)
+
+        assert_equal(len(parsed_data), 1)
+        assert_equal(parsed_data[0]['name'], 'test')
+        assert_equal(parsed_data[0]['count'], '5')
+
+    def test_kv_parsing_3(self):
+        """KV Parser - Space delimited, equal sign separated with spaces in values"""
+        # setup
+        schema = {
+            'name': 'string',
+            'result': 'string',
+            'date': 'string',
+            'count': 'integer'
+        }
+        options = {
+            'separator': '=',
+            'delimiter': ' ',
+        }
+        data = 'name=test result=OK date="Friday, January 01, 2018" count=5'
+
+        # get parsed data
+        parsed_data = self.parser_helper(data=data, schema=schema, options=options)
+
+        assert_equal(len(parsed_data), 1)
+        assert_equal(parsed_data[0]['result'], 'OK')
+        assert_equal(parsed_data[0]['date'], 'Friday, January 01, 2018')
 
 
 class TestJSONParser(TestParser):

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -360,7 +360,7 @@ class TestRulesEngine(object):
         def auditd_bin_cat(rec):  # pylint: disable=unused-variable
             return (
                 rec['type'] == 'SYSCALL' and
-                rec['exe'] == '"/bin/cat"'
+                rec['exe'] == '/bin/cat'
             )
 
         @rule(logs=['test_log_type_kv_auditd'],


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The KV parser is fairly basic, and can't support parsing logs that have quoted fields, or spaces within values. Log types like `auditd`, `nginx`, and others use the style described in the unit test:

`key="value with spaces" another_key=2`

To support these logs, additional parser logic is now added. 

## Changes

* Support spaces in KV values, and strip quotes in data so rule writing is more intuitive
* Add unit test coverage

## Testing

Steps for how this change was tested and verified
