### PR TITLE
[parsers] add cloudtrail via cloudwatch logs support

### DIFF
--- a/conf/logs.json
+++ b/conf/logs.json
@@ -1080,6 +1080,58 @@
     },
     "parser": "json"
   },
+  "cloudwatch:cloudtrail": {
+    "schema": {
+      "additionalEventData": {},
+      "apiVersion": "string",
+      "awsRegion": "string",
+      "errorCode": "string",
+      "errorMessage": "string",
+      "eventID": "string",
+      "eventName": "string",
+      "eventSource": "string",
+      "eventTime": "string",
+      "eventType": "string",
+      "eventVersion": "string",
+      "managementEvent": "boolean",
+      "readOnly": "boolean",
+      "recipientAccountId": "string",
+      "requestID": "string",
+      "requestParameters": {},
+      "resources": [],
+      "responseElements": {},
+      "serviceEventDetails": {},
+      "sharedEventID": "string",
+      "sourceIPAddress": "string",
+      "userAgent": "string",
+      "userIdentity": {},
+      "vpcEndpointId": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "embedded_json": true,
+      "envelope_keys": {
+        "logGroup": "string",
+        "logStream": "string",
+        "messageType": "string",
+        "owner": "string",
+        "subscriptionFilters": []
+      },
+      "json_path": "logEvents[*].message",
+      "optional_top_level_keys": [
+        "additionalEventData",
+        "apiVersion",
+        "errorCode",
+        "errorMessage",
+        "managementEvent",
+        "readOnly",
+        "resources",
+        "serviceEventDetails",
+        "sharedEventID",
+        "vpcEndpointId"
+      ]
+    }
+  },
   "cloudtrail:events": {
     "schema": {
       "additionalEventData": {},

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -280,7 +280,7 @@ class JSONParser(ParserBase):
                     try:
                         record = json.loads(match.value)
                     except ValueError:
-                        LOGGER.debug('Embedded json is invalid')
+                        LOGGER.warning('Embedded json is invalid')
                         continue
                 if envelope:
                     record.update({ENVELOPE_KEY: envelope})

--- a/tests/integration/rules/cloudwatch/cloudtrail_via_cloudwatch.json
+++ b/tests/integration/rules/cloudwatch/cloudtrail_via_cloudwatch.json
@@ -1,0 +1,26 @@
+[
+  {
+    "data": {
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789012",
+    "logGroup": "CloudTrail/DefaultLogGroup",
+    "logStream": "123456789012_CloudTrail_us-east-1",
+    "subscriptionFilters": [
+        "FooBarSubscription"
+    ],
+    "logEvents": [
+        {
+            "id": "44056647182143267075860006634052172261824828947338793472",
+            "timestamp": 1526951139360,
+            "message": "{\"eventVersion\": \"foo\", \"eventID\": \"bar\", \"eventTime\": \"foo\", \"sharedEventID\": \"bar\", \"additionalEventData\": {}, \"requestParameters\": {}, \"eventType\": \"foo\", \"responseElements\": {}, \"awsRegion\": \"foo\", \"eventName\": \"bar\", \"readOnly\": true, \"userIdentity\": {}, \"eventSource\": \"foo\", \"requestID\": \"bar\", \"userAgent\": \"foo\", \"sourceIPAddress\": \"bar\", \"resources\": \"foo\", \"recipientAccountId\": \"bar\"}"
+        }
+      ]
+    },
+    "description": "CloudTrail logs via CloudWatch logs DATA_MESSAGE (validation only)",
+    "log": "cloudwatch:cloudtrail",
+    "service": "kinesis",
+    "source": "prefix_cluster1_stream_alert_kinesis",
+    "trigger_rules": [],
+    "validate_schema_only": true
+  }
+]

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -307,6 +307,21 @@
     },
     "parser": "json"
   },
+  "json:embedded": {
+    "schema": {
+      "nested_key_01": "string",
+      "nested_key_02": "string"
+    },
+    "parser": "json",
+    "configuration": {
+      "embedded_json": true,
+      "envelope_keys": {
+        "env_key_01": "string",
+        "env_key_02": "string"
+      },
+      "json_path": "test_list[*].message"
+    }
+  },
   "json:regex_key_with_envelope": {
     "schema": {
       "nested_key_1": "string",

--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -441,7 +441,7 @@ class TestJSONParser(TestParser):
         assert_items_equal(parsed_result[0].keys(), expected_keys)
         assert_items_equal(parsed_result[0]['streamalert:envelope_keys'], expected_env_keys)
 
-    @patch('logging.Logger.debug')
+    @patch('logging.Logger.warning')
     def test_embedded_json_invalid(self, log_mock):
         """JSON Parser - Embedded JSON, Invalid"""
         schema = self.config['logs']['json:embedded']['schema']

--- a/tests/unit/stream_alert_rule_processor/test_parsers.py
+++ b/tests/unit/stream_alert_rule_processor/test_parsers.py
@@ -16,7 +16,7 @@ limitations under the License.
 from collections import OrderedDict
 import json
 
-from mock import patch
+from mock import call, patch
 from nose.tools import (
     assert_equal,
     assert_false,
@@ -411,14 +411,56 @@ class TestJSONParser(TestParser):
                        '"nested_key_2": "more_nested_info",'
                        '"nested_key_3": "even_more"}'
         })
-        parsed_result = self.parser_helper(data=data,
-                                           schema=schema,
-                                           options=options)
+        parsed_result = self.parser_helper(data=data, schema=schema, options=options)
 
         assert_items_equal(parsed_result[0].keys(),
                            ['nested_key_1',
                             'nested_key_2',
                             'nested_key_3'])
+
+    def test_embedded_json(self):
+        """JSON Parser - Embedded JSON"""
+        schema = self.config['logs']['json:embedded']['schema']
+        options = self.config['logs']['json:embedded']['configuration']
+
+        data = json.dumps({
+            'env_key_01': 'data',
+            'env_key_02': 'time',
+            'test_list': [
+                {
+                    'id': 'foo',
+                    'message': ('{\"nested_key_01\":\"bar\",'
+                                '\"nested_key_02\":\"baz\"}')
+                }
+            ]
+        })
+
+        parsed_result = self.parser_helper(data=data, schema=schema, options=options)
+        expected_keys = {'nested_key_01', 'nested_key_02', 'streamalert:envelope_keys'}
+        expected_env_keys = {'env_key_01', 'env_key_02'}
+        assert_items_equal(parsed_result[0].keys(), expected_keys)
+        assert_items_equal(parsed_result[0]['streamalert:envelope_keys'], expected_env_keys)
+
+    @patch('logging.Logger.debug')
+    def test_embedded_json_invalid(self, log_mock):
+        """JSON Parser - Embedded JSON, Invalid"""
+        schema = self.config['logs']['json:embedded']['schema']
+        options = self.config['logs']['json:embedded']['configuration']
+
+        data = json.dumps({
+            'env_key_01': 'data',
+            'env_key_02': 'time',
+            'test_list': [
+                {
+                    'id': 'foo',
+                    'message': '{\"invalid_json\"}'
+                }
+            ]
+        })
+
+        result = self.parser_helper(data=data, schema=schema, options=options)
+        assert_equal(result, False)
+        log_mock.assert_has_calls([call('Embedded json is invalid')])
 
     def test_basic_json(self):
         """JSON Parser - Non-nested JSON objects"""


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Logs that are ingested via CloudWatch logs subscription filter have a unique format. The format is described [here in step 8 under Example # 1](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html). The `message` objects within the list of `logEvents` are stored as embedded json objects. However, currently, there is no easy way to use a json path in combination with loading an embedded json object. This adds support for loading of embedded json objects for json records extracted via a json path.

## Changes

* Adding new `logs.json` config option of `embedded_json` that is a boolean indicating if the extracted json object is an embedded object (encoded json within json).
* Adding json loading logic for embedded json objects via new method of `_extract_records`. This new method also handles the json regex extraction & loading.
* Adding CloudTrail log via CloudWatch logs schema support. See [here](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html) for more info on the contents of the log.


## Testing

* Adding unit tests for the extraction of the embedded json object.
