### PR TITLE
[tf] shortening resource name due to 64 char limit and adding role arn output

### DIFF
--- a/terraform/modules/tf_stream_alert_cloudwatch/iam.tf
+++ b/terraform/modules/tf_stream_alert_cloudwatch/iam.tf
@@ -1,7 +1,7 @@
 # IAM Role: Allows CloudWatch Logs to put data into
 # this cluster's default Kinesis stream
 resource "aws_iam_role" "cloudwatch_subscription_role" {
-  name = "stream_alert_${var.cluster}_cloudwatch_subscription_role_${var.region}"
+  name = "stream_alert_${var.cluster}_cw_sub_role_${var.region}"
 
   assume_role_policy = "${data.aws_iam_policy_document.cloudwatch_logs_assume_role_policy.json}"
 }

--- a/terraform/modules/tf_stream_alert_cloudwatch/outputs.tf
+++ b/terraform/modules/tf_stream_alert_cloudwatch/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudwatch_subscription_role_arn" {
+  value = "${aws_iam_role.cloudwatch_subscription_role.arn}"
+}


### PR DESCRIPTION
to: @austinbyers or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Most AWS resource names have a 64 character limit. This `cloudwatch_subscription_role` IAM role resource name easily exceeds that in most cases and needs to be shortened.

## Changes

* Shortening resource name so it shouldn't typically overflow the 64 character limit.

## Testing

Terraform plan successfully with this module enabled.
