### PR TITLE
Adding Helper Function To Support Wildcards With Specific Path Matching

### DIFF
--- a/helpers/base.py
+++ b/helpers/base.py
@@ -17,6 +17,7 @@ from fnmatch import fnmatch
 import logging
 import json
 import time
+import pathlib2
 
 from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.utils import (  # pylint: disable=unused-import
@@ -30,6 +31,24 @@ from stream_alert.shared.utils import (  # pylint: disable=unused-import
 logging.basicConfig()
 LOGGER = logging.getLogger('StreamAlert')
 
+def path_matches_any(text, patterns):
+    """Check if the text matches any of the given wildcard patterns
+    NOTE: Intended for specific use with filepaths with the need to be wildcard and fnmatch is too
+    greedy. Especially, useful in cases where a username in a filepath may need to be wildcarded.
+
+    For example;
+    path_matches_any('/Users/foobar/path/to/file', {'/Users/*/path/*/file'}) == True
+
+    Args:
+        text (str): Text to examine
+        patterns (iterable): Collection of string patterns, compatible with fnmatch (* wildcards)
+
+    Returns:
+        bool: True if the text matches at least one of the patterns, False otherwise.
+    """
+    if not isinstance(text, basestring):
+        return False
+    return any(pathlib2.PurePath(text).match(pattern) for pattern in patterns)
 
 def starts_with_any(text, prefixes):
     """Check if the text starts with any of the given prefixes.

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -16,6 +16,7 @@ moto==1.1.10
 netaddr
 nose
 nose-timer==0.7.1
+pathlib2
 pyfakefs
 pylint==1.7.4
 requests

--- a/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
+++ b/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
@@ -20,6 +20,14 @@ from nose.tools import assert_equal, assert_false, assert_true
 
 from helpers import base
 
+def test_path_matches_any():
+    """Helpers - Path Matches Any"""
+    patterns = {'/users/*/foobar', '/users/*/path/*/file'}
+    assert_true(base.path_matches_any('/users/user/foobar', patterns))
+    assert_false(base.path_matches_any('/users/user/baz/foobar', patterns))
+    assert_true(base.path_matches_any('/users/user/path/to/file', patterns))
+    assert_false(base.path_matches_any('/users/user/foobar/path/to/baz/file', patterns))
+
 
 def test_starts_with_any():
     """Helpers - Starts With Any"""


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @ryandeivert 
size: small

## Background

Needed to support the use of path specific wild carding. See difference between fnmatch() and PurePath().match() below.

![e0fe4dd6-5d0f-11e8-9246-ba2026260cfe](https://user-images.githubusercontent.com/25304987/40440497-1d432154-5e73-11e8-92ae-f479fee95d87.png)

## Changes

* Added path_matches_any() to helpers/base.py
* Added unit testing for path_matches_any()

## Testing

Local Unit Testing
```
$ nosetests -s -v ~/repos/streamalert/tests/unit/stream_alert_rule_processor/test_rule_helpers.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
Helpers - Path Matches Any ... ok
Helpers - Starts With Any ... ok
Helpers - Starts With Any ... ok
Helpers - Contains Any ... ok
Helpers - Matches Any ... ok
Helpers - Last Hour ... ok
Helpers - Fetch values from a record by normalized type ... ok
Helpers - Loading valid JSON ... ok
Helpers - Loading invalid JSON ... ok

----------------------------------------------------------------------
Ran 9 tests in 0.002s

OK
```