### PR TITLE
[tf] fixing bug with policy resource value

### DIFF
--- a/stream_alert_cli/terraform/cloudtrail.py
+++ b/stream_alert_cli/terraform/cloudtrail.py
@@ -97,9 +97,8 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
         if kinesis_enabled:
             module_info['event_pattern'] = json.dumps(event_pattern)
         else:
-            module_info['subscription_role_arn'] = ('${{module.cloudwatch_{}_{}.cloudwatch_'
-                                                    'subscription_role_arn}}'.format(cluster_name,
-                                                                                     region))
+            module_info['cw_destination_arn'] = ('${{module.cloudwatch_{}_{}.cloudwatch_'
+                                                 'destination_arn}}'.format(cluster_name, region))
 
     cluster_dict['module'][cloudtrail_module] = module_info
 

--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -124,8 +124,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudtrail_via_cloudwatch" {
   name            = "cloudtrail_delivery"
   log_group_name  = "${aws_cloudwatch_log_group.cloudtrail_logging.name}"
   filter_pattern  = "${var.exclude_home_region_events ? local.apply_filter_string : ""}"
-  role_arn        = "${var.subscription_role_arn}"
-  destination_arn = "${var.kinesis_arn}"
+  destination_arn = "${var.cw_destination_arn}"
   distribution    = "Random"
 }
 

--- a/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
@@ -40,7 +40,7 @@ variable "s3_logging_bucket" {
   type = "string"
 }
 
-variable "subscription_role_arn" {
+variable "cw_destination_arn" {
   default = ""
 }
 

--- a/terraform/modules/tf_stream_alert_cloudwatch/iam.tf
+++ b/terraform/modules/tf_stream_alert_cloudwatch/iam.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "cross_account_destination_policy" {
     ]
 
     resources = [
-      "${var.kinesis_stream_arn}",
+      "${aws_cloudwatch_log_destination.cloudwatch_kinesis.arn}",
     ]
   }
 }

--- a/terraform/modules/tf_stream_alert_cloudwatch/outputs.tf
+++ b/terraform/modules/tf_stream_alert_cloudwatch/outputs.tf
@@ -1,3 +1,7 @@
 output "cloudwatch_subscription_role_arn" {
   value = "${aws_iam_role.cloudwatch_subscription_role.arn}"
 }
+
+output "cloudwatch_destination_arn" {
+  value = "${aws_cloudwatch_log_destination.cloudwatch_kinesis.arn}"
+}


### PR DESCRIPTION
to: @jacknagz or @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

A bug was found with the policy doc that should allow `logs:PutSubscriptionFilter` for the cloudwatch destination.

## Changes

* Fixing bug by using the destination arn and not the kinesis stream arn the destination points to.
* Using the output of the destination arn as the destination in the subscription filter of the CloudTrail module.

## Testing

* Applied changes in test deploy with much success.