### PR TITLE
[cli][tf] adding ability to send cloudtrail to another cluster's cloudwatch destination

### DIFF
--- a/terraform/modules/tf_stream_alert_cloudtrail/main.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/main.tf
@@ -124,7 +124,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudtrail_via_cloudwatch" {
   name            = "cloudtrail_delivery"
   log_group_name  = "${aws_cloudwatch_log_group.cloudtrail_logging.name}"
   filter_pattern  = "${var.exclude_home_region_events ? local.apply_filter_string : ""}"
-  destination_arn = "${var.cw_destination_arn}"
+  destination_arn = "${var.cloudwatch_destination_arn}"
   distribution    = "Random"
 }
 

--- a/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
+++ b/terraform/modules/tf_stream_alert_cloudtrail/variables.tf
@@ -40,7 +40,7 @@ variable "s3_logging_bucket" {
   type = "string"
 }
 
-variable "cw_destination_arn" {
+variable "cloudwatch_destination_arn" {
   default = ""
 }
 


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

It's possible to enable the `cloudtrail` module in a different cluster than the `cloudwatch` module, but the cloudtrail module needs access to a destination arn from the cloudwatch module in order to send events to it.

## Changes

* Adding support for a config option to supply a destination arn that is different than the current cluster's destination arn.

## Testing

Applied and deployed 👏 
