### PR TITLE
[apps] fixing terraform bug where app iam would not be targeted during deploy

### DIFF
--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -107,7 +107,8 @@ def _create_and_upload(function_name, config, cluster=None):
         ),
         'apps': PackageMap(
             stream_alert_packages.AppIntegrationPackage,
-            {'module.app_{}_{}_lambda'.format(app_info['app_name'], cluster)
+            {'module.app_{}_{}_{}'.format(app_info['app_name'], cluster, suffix)
+             for suffix in {'lambda', 'iam'}
              for cluster, info in config['clusters'].iteritems()
              for app_info in info['modules'].get('stream_alert_apps', {}).values()
              if 'app_name' in app_info},


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

There is a bug where the IAM resources for apps are not added to the terraform targets during a deploy of the apps functions.

## Changes

* Fixing bug by adding the iam tf targets alongside the lambda tf targets during deploy of the apps functions.

## Testing

No unit tests but tested by doing a generate locally to make sure all the proper targets are included.
