### PR TITLE
Enable server-side encryption for alerts/rules tables and SQS

### DIFF
--- a/stream_alert_cli/terraform/athena.py
+++ b/stream_alert_cli/terraform/athena.py
@@ -60,6 +60,7 @@ def generate_athena(config):
         'schedule_expression': athena_config.get('schedule_expression', 'rate(10 minutes)'),
         'current_version': athena_config['current_version'],
         'enable_metrics': athena_config.get('enable_metrics', False),
+        'account_id': config['global']['account']['aws_account_id'],
         'prefix': prefix
     }
 

--- a/terraform/modules/tf_stream_alert_athena/kms.tf
+++ b/terraform/modules/tf_stream_alert_athena/kms.tf
@@ -1,0 +1,16 @@
+// KMS key: Server-Side Encryption for SQS
+resource "aws_kms_key" "sse" {
+  description         = "Athena SQS server-side encryption"
+  enable_key_rotation = true
+
+  policy = "${data.aws_iam_policy_document.kms_sse_allow_s3.json}"
+
+  tags {
+    Name = "StreamAlert"
+  }
+}
+
+resource "aws_kms_alias" "sse" {
+  name          = "alias/${var.prefix}_streamalert_sqs_sse"
+  target_key_id = "${aws_kms_key.sse.key_id}"
+}

--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -69,6 +69,9 @@ resource "aws_sqs_queue" "streamalert_athena_data_bucket_notifications" {
   # Retain messages for one day
   message_retention_seconds = 86400
 
+  # Enable server-side encryption of messages in the queue
+  kms_master_key_id = "${aws_kms_key.sse.arn}"
+
   tags {
     Name = "StreamAlert"
   }

--- a/terraform/modules/tf_stream_alert_athena/variables.tf
+++ b/terraform/modules/tf_stream_alert_athena/variables.tf
@@ -47,6 +47,10 @@ variable "database_name" {
   default = "streamalert"
 }
 
+variable "account_id" {
+  type = "string"
+}
+
 variable "prefix" {
   type = "string"
 }

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -23,6 +23,9 @@ resource "aws_dynamodb_table" "alerts_table" {
     name = "AlertID"
     type = "S"
   }
+  server_side_encryption {
+    enabled = true
+  }
   tags {
     Name = "StreamAlert"
   }
@@ -38,6 +41,10 @@ resource "aws_dynamodb_table" "rules_table" {
   attribute {
     name = "RuleName"
     type = "S"
+  }
+
+  server_side_encryption {
+    enabled = true
   }
 
   tags {

--- a/tests/unit/stream_alert_cli/terraform/test_athena.py
+++ b/tests/unit/stream_alert_cli/terraform/test_athena.py
@@ -61,6 +61,7 @@ def test_generate_athena():
                     'unit-testing.streamalert.data'
                 ],
                 'prefix': 'unit-testing',
+                'account_id': '12345678910',
                 'schedule_expression': 'rate(10 minutes)'
             },
             'athena_monitoring': {


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small
contributes to: #758 

## Background

We will be encrypting all StreamAlert data at rest, and Dynamo and SQS are the easiest to start with.  For reference, https://github.com/airbnb/binaryalert/pull/121 is a similar PR which enabled server-side encryption for BinaryAlert

## Changes

* Enable server-side encryption for the alerts and rules DynamoDB tables
    * We'll do the optional threat intel table later
* Enable server-side encryption of the only SQS queue (athena_partition_refresh) using a newly created KMS key

**WARNING**: Applying this change will delete your existing alerts table. Make sure it is empty (with no pending alerts) before re-creating it

## Testing

* Deployed from scratch in a test account. Used the AWS console to verify the two tables and the queue are encrypted. Alerts landed in the table, sent to outputs, and the athena partition refresh function was able to pull the s3 events off of the SQS queue