### PR TITLE
using absolute import to get rid of aws lambda import warning

### DIFF
--- a/app_integrations/main.py
+++ b/app_integrations/main.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 from app_integrations.apps.app_base import StreamAlertApp
 from app_integrations.config import AppConfig
 


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

All (most?) of our other Lambda functions import `absolute_import`, which suppresses errors in AWS Lambda logs related to `unable to import...`.

## Changes

* Adding the absolute import line to the apps function as well.
