### PR TITLE
Fix threat intel downloader permission

### DIFF
--- a/terraform/modules/tf_threat_intel_downloader/iam.tf
+++ b/terraform/modules/tf_threat_intel_downloader/iam.tf
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "get_api_creds_from_ssm" {
     effect = "Allow"
 
     actions = [
-      "ssm:GetParameters",
+      "ssm:Get*",
     ]
 
     resources = [


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
In PR #728 we changed to use [get_parameter](https://github.com/airbnb/streamalert/blob/master/stream_alert/threat_intel_downloader/main.py#L87) rather than use `get_parameters`. So we need `ssm:Get*` permission.

## Changes

* Use `ssm:Get*` for threat intel downloader role.

## Testing
This is terraform change. Run `terraform plan` internally, and plan will only change threat intel download ssm permission.
