### PR TITLE
[tf] remove alarm recover from lambda invocation errors

### DIFF
--- a/terraform/modules/tf_stream_alert_monitoring/main.tf
+++ b/terraform/modules/tf_stream_alert_monitoring/main.tf
@@ -15,7 +15,6 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_invocation_errors" {
   alarm_description   = "StreamAlert Lambda Invocation Errors: ${element(var.lambda_functions, count.index)}"
 
   alarm_actions = ["${var.sns_topic_arn}"]
-  ok_actions    = ["${var.sns_topic_arn}"]
 
   dimensions {
     FunctionName = "${element(var.lambda_functions, count.index)}"


### PR DESCRIPTION
to: @ryandeivert or @jacknagz 
cc: @airbnb/streamalert-maintainers
size: small
resolves N/A

## Background
The PR #734 enables CloudWatch alarm recovery and it helps resolving alarms more efficient. But lambda invocation errors are considered to be critical ones. We should have the awareness and know when and why there are lambda invocation errors. Remove alarm recovery from lambda invocation errors, so we will get paged event the errors are not consistent anymore.

## Changes

* Remove `ok_action` from lambda invocation error metric alarm.

## Testing
It is terraform code change, integration and unit tests won't be affected.
