### PR TITLE
no longer double-encoding event pattern json for cloudtrail config

### DIFF
--- a/stream_alert_cli/terraform/cloudtrail.py
+++ b/stream_alert_cli/terraform/cloudtrail.py
@@ -57,13 +57,8 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     is_global_trail = modules['cloudtrail'].get('is_global_trail', True)
     region = config['global']['account']['region']
 
-    event_pattern_default = json.dumps({'account': [config['global']['account']['aws_account_id']]})
-    try:
-        event_pattern = json.loads(modules['cloudtrail'].get('event_pattern',
-                                                             event_pattern_default))
-    except ValueError:
-        LOGGER_CLI.error('Event Pattern is not valid JSON')
-        return False
+    event_pattern_default = {'account': [config['global']['account']['aws_account_id']]}
+    event_pattern = modules['cloudtrail'].get('event_pattern', event_pattern_default)
 
     # From here: http://amzn.to/2zF7CS0
     valid_event_pattern_keys = {

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import json
-
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.terraform import (
     common,
@@ -327,13 +325,13 @@ class TestTerraformGenerate(object):
             'enable_kinesis': True,
             'existing_trail': False,
             'is_global_trail': False,
-            'event_pattern': json.dumps({
+            'event_pattern': {
                 'source': ['aws.ec2'],
                 'account': '12345678910',
                 'detail': {
                     'state': ['running']
                 }
-            })
+            }
         }
         cloudtrail.generate_cloudtrail(
             cluster_name,
@@ -369,9 +367,9 @@ class TestTerraformGenerate(object):
             'enable_kinesis': True,
             'existing_trail': False,
             'is_global_trail': False,
-            'event_pattern': json.dumps({
+            'event_pattern': {
                 'invalid': ['aws.ec2']
-            })
+            }
         }
         result = cloudtrail.generate_cloudtrail(cluster_name, self.cluster_dict, self.config)
         assert_false(result)


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Since the `event_pattern` is a json object, and our configs are json, we do not need to double encode it within our configs.

## Changes

* Removing the requirement that the event pattern be embedded json within the cluster config for the cloudtrail module.

## Testing

Updating tests for change.
