### PR TITLE
Make terraform state and s3 logging buckets configurable

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -35,9 +35,13 @@
       "write_capacity": 5
     }
   },
+  "s3_access_logging": {
+    "create_bucket": true,
+    "logging_bucket": "PREFIX_GOES_HERE.streamalert.s3-logging"
+  },
   "terraform": {
+    "create_bucket": true,
     "tfstate_bucket": "PREFIX_GOES_HERE.streamalert.terraform.state",
-    "tfstate_s3_key": "stream_alert_state/terraform.tfstate",
-    "tfvars": "terraform.tfvars"
+    "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   }
 }

--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -92,10 +92,19 @@ class CLIConfig(object):
             LOGGER_CLI.error('Prefix cannot contain underscores')
             return
 
-        tf_state_bucket = '{}.streamalert.terraform.state'.format(prefix)
         self.config['global']['account']['prefix'] = prefix
         self.config['global']['account']['kms_key_alias'] = '{}_streamalert_secrets'.format(prefix)
-        self.config['global']['terraform']['tfstate_bucket'] = tf_state_bucket
+
+        # Set logging bucket name only if we will be creating it
+        if self.config['global']['s3_access_logging'].get('create_bucket', True):
+            self.config['global']['s3_access_logging']['logging_bucket'] = (
+                '{}.streamalert.s3-logging'.format(prefix))
+
+        # Set Terraform state bucket name only if we will be creating it
+        if self.config['global']['terraform'].get('create_bucket', True):
+            self.config['global']['terraform']['tfstate_bucket'] = (
+                '{}.streamalert.terraform.state'.format(prefix))
+
         self.config['lambda']['athena_partition_refresh_config']['buckets'].clear()
         self.config['lambda']['athena_partition_refresh_config']['buckets'] \
             ['{}.streamalerts'.format(prefix)] = 'alerts'

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -32,8 +32,14 @@
       "write_capacity": 5
     }
   },
+  "s3_access_logging": {
+    "create_bucket": true,
+    "logging_bucket": "unit-testing.streamalert.s3-logging"
+  },
   "terraform": {
-    "tfstate_bucket": "unit-testing.terraform.tfstate"
+    "create_bucket": true,
+    "tfstate_bucket": "unit-testing.streamalert.terraform.state",
+    "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   },
   "threat_intel": {
     "dynamodb_table": "test_table_name",

--- a/tests/unit/helpers/base.py
+++ b/tests/unit/helpers/base.py
@@ -90,11 +90,6 @@ def basic_streamalert_config():
                 'prefix': 'unit-testing',
                 'region': 'us-west-2'
             },
-            'terraform': {
-                'tfstate_bucket': 'unit-testing.streamalert.terraform.state',
-                'tfstate_s3_key': 'stream_alert_state/terraform.tfstate',
-                'tfvars': 'terraform.tfvars'
-            },
             'infrastructure': {
                 'monitoring': {
                     'create_sns_topic': True,
@@ -112,7 +107,16 @@ def basic_streamalert_config():
                         }
                     }
                 }
-            }
+            },
+            's3_access_logging': {
+                'create_bucket': True,
+                'logging_bucket': 'unit-testing.streamalert.s3-logging'
+            },
+            'terraform': {
+                'create_bucket': True,
+                'tfstate_bucket': 'unit-testing.streamalert.terraform.state',
+                'tfstate_s3_key': 'stream_alert_state/terraform.tfstate'
+            },
         },
         'lambda': {
             'alert_merger_config': {

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -128,7 +128,7 @@ class TestTerraformGenerate(object):
                         }
                     },
                     'terraform_remote_state': {
-                        'bucket': 'unit-testing.terraform.tfstate',
+                        'bucket': 'unit-testing.streamalert.terraform.state',
                         'acl': 'private',
                         'force_destroy': True,
                         'versioning': {
@@ -136,7 +136,7 @@ class TestTerraformGenerate(object):
                         },
                         'logging': {
                             'target_bucket': 'unit-testing.streamalert.s3-logging',
-                            'target_prefix': 'unit-testing.terraform.tfstate/'
+                            'target_prefix': 'unit-testing.streamalert.terraform.state/'
                         }
                     },
                     'logging_bucket': {
@@ -154,7 +154,7 @@ class TestTerraformGenerate(object):
                             'prefix': '/',
                             'enabled': True,
                             'transition': {
-                                'days': 30,
+                                'days': 365,
                                 'storage_class': 'GLACIER'
                             }
                         }


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background
Having the terraform state bucket and S3 logging bucket configurable gives users flexibility in where they store these files.

## Changes

* Adds S3 access logging as a top-level config option.
* Fixes a bug where the existing terraform bucket and key in the config are ignored

For both of these, the bucket listed in the config is the one which is used, and it will be automatically created only if `create_bucket = True` (which it is by default, for backwards compatibility)

## Testing

* Deployed to a test account with the default option (create buckets automatically)
* Switch both terraform state and access logging to other, existing buckets:

```
Terraform will perform the following actions:

  - aws_s3_bucket.logging_bucket

  ~ aws_s3_bucket.stream_alert_secrets
      logging.2388277836.target_bucket: "" => "austin-s3-access-logs"
      logging.2388277836.target_prefix: "" => "austin-prefix.streamalert.secrets/"
      logging.862039767.target_bucket:  "austin-prefix.streamalert.s3-logging" => ""
      logging.862039767.target_prefix:  "austin-prefix.streamalert.secrets/" => ""

  ~ aws_s3_bucket.streamalerts
      logging.2190807831.target_bucket: "" => "austin-s3-access-logs"
      logging.2190807831.target_prefix: "" => "austin-prefix.streamalerts/"
      logging.3954707318.target_bucket: "austin-prefix.streamalert.s3-logging" => ""
      logging.3954707318.target_prefix: "austin-prefix.streamalerts/" => ""

  - aws_s3_bucket.terraform_remote_state

```