### PR TITLE
updating rule promo perms to allow reading athena data from s3

### DIFF
--- a/stream_alert_cli/terraform/rule_promotion.py
+++ b/stream_alert_cli/terraform/rule_promotion.py
@@ -33,6 +33,9 @@ def generate_rule_promotion(config):
     """
     result = infinitedict()
 
+    athena_config = config['lambda']['athena_partition_refresh_config']
+    data_buckets = athena_config['buckets'].keys()
+
     state_param = json.dumps({
         'send_digest_hour_utc':
             int(config['lambda']['rule_promotion_config']['send_digest_hour_utc']),
@@ -47,7 +50,8 @@ def generate_rule_promotion(config):
         'digest_sns_topic': StatsPublisher.formatted_sns_topic_arn(config).split(':')[-1],
         'role_id': '${module.rule_promotion_lambda.role_id}',
         'rules_table_arn': '${module.globals.rules_table_arn}',
-        'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}'
+        'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}',
+        'athena_data_buckets': data_buckets
     }
 
     # Set variables for the Lambda module

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -20,10 +20,16 @@ resource "aws_iam_role_policy" "rule_promotion_actions" {
 
 data "aws_iam_policy_document" "rule_promotion_actions" {
   statement {
-    sid       = "PublishDigestToSNS"
-    effect    = "Allow"
-    actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.digest_sns_topic.arn}"]
+    sid    = "PublishDigestToSNS"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      "${aws_sns_topic.digest_sns_topic.arn}",
+    ]
   }
 
   statement {
@@ -35,11 +41,13 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
       "dynamodb:UpdateItem",
     ]
 
-    resources = ["${var.rules_table_arn}"]
+    resources = [
+      "${var.rules_table_arn}",
+    ]
   }
 
   statement {
-    sid    = "QueryAthenaAlerts"
+    sid    = "AthenaQueryAlerts"
     effect = "Allow"
 
     actions = [
@@ -56,7 +64,7 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
   }
 
   statement {
-    sid    = "AthenaQueryResults"
+    sid    = "AthenaResultsAccess"
     effect = "Allow"
 
     actions = [
@@ -76,7 +84,7 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
   }
 
   statement {
-    sid    = "GetSSMParameter"
+    sid    = "SSMParameterAccess"
     effect = "Allow"
 
     actions = [
@@ -86,6 +94,20 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
 
     resources = [
       "${aws_ssm_parameter.stats_publisher_state.arn}",
+    ]
+  }
+
+  statement {
+    sid    = "AthenaDataAccess"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${formatlist("arn:aws:s3:::%s*", var.athena_data_buckets)}",
     ]
   }
 }

--- a/terraform/modules/tf_rule_promotion_iam/variables.tf
+++ b/terraform/modules/tf_rule_promotion_iam/variables.tf
@@ -21,3 +21,8 @@ variable "role_id" {
 variable "athena_results_bucket_arn" {
   description = "S3 bucket arn to use for Athena search results"
 }
+
+variable "athena_data_buckets" {
+  description = "List of S3 buckets where Athena data is stored"
+  type        = "list"
+}

--- a/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
@@ -41,7 +41,11 @@ class TestRulePromotion(object):
                     'stats_publisher_state_name': 'staging_stats_publisher_state',
                     'stats_publisher_state_value': state,
                     'digest_sns_topic': 'staging_stats',
-                    'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}'
+                    'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}',
+                    'athena_data_buckets': [
+                        'unit-testing.streamalert.data',
+                        'unit-testing.streamalerts'
+                    ]
                 },
                 'rule_promotion_lambda': {
                     'alarm_actions': ['arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring'],


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The Rule Promotion lambda logged an error of:
`Query 61aa0909-9608-427a-9df3-c7def32f516f FAILED with reason Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 12345), exiting!`

## Changes

* Fixing s3 permission for reading athena data

## Testing

Updating unit test and deployed.
