### PR TITLE
updates to raise appropriate errors from athena client, etc

### DIFF
--- a/stream_alert/rule_promotion/promoter.py
+++ b/stream_alert/rule_promotion/promoter.py
@@ -104,6 +104,8 @@ class RulePromoter(object):
                 row_values = [data.values()[0] for data in row['Data']]
                 rule_name, alert_count = row_values[0], int(row_values[1])
 
+                LOGGER.debug('Found %d alerts for rule \'%s\'', alert_count, rule_name)
+
                 self._staging_stats[rule_name].alert_count = alert_count
 
     def run(self):

--- a/stream_alert/rule_promotion/publisher.py
+++ b/stream_alert/rule_promotion/publisher.py
@@ -103,17 +103,10 @@ class StatsPublisher(object):
         Returns:
             str: Execution ID for running Athena query
         """
-        # If there are no alerts, do not run the comprehensive query
-        if not stat.alert_count:
-            return
-
         info_statement = stat.sql_info_statement
         LOGGER.debug('Querying alert info for rule \'%s\': %s', stat.rule_name, info_statement)
 
         response = self._athena_client.run_async_query(info_statement)
-        if not response:
-            LOGGER.error('Failed to query alert info for rule: \'%s\'', stat.rule_name)
-            return
 
         return response['QueryExecutionId']
 
@@ -156,6 +149,10 @@ class StatsPublisher(object):
         if self._should_send_digest:
 
             for stat in stats:
+                # If there are no alerts, do not run the comprehensive query
+                if not stat:
+                    continue
+
                 stat.execution_id = self._query_alerts(stat)
 
             self._publish_message(stats)

--- a/stream_alert/rule_promotion/statistic.py
+++ b/stream_alert/rule_promotion/statistic.py
@@ -18,6 +18,8 @@ limitations under the License.
 class StagingStatistic(object):
     """Store information on generated alerts."""
 
+    _ALERT_COUNT_UNKOWN = 'unknown'
+
     _COUNT_QUERY_TEMPLATE = ("SELECT '{rule_name}' AS rule_name, count(*) AS count "
                              "FROM alerts WHERE dt >= '{date}-{hour:02}' AND "
                              "rule_name = '{rule_name}'")
@@ -34,8 +36,14 @@ class StagingStatistic(object):
         self._current_time = current_time
         self._staged_at = staged_at
         self.staged_until = staged_until
-        self.alert_count = 'unknown'
+        self.alert_count = self._ALERT_COUNT_UNKOWN
         self.execution_id = None
+
+    def __nonzero__(self):
+        return self.alert_count not in {0, self._ALERT_COUNT_UNKOWN}
+
+    # For forward compatibility to Python3
+    __bool__ = __nonzero__
 
     def __lt__(self, other):
         """Statistic should be ordered by their alert count."""

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -69,7 +69,7 @@ def import_folders(*paths):
 
 
 class RuleCreationError(Exception):
-    """Exeception to raise for any errors with invalid rules"""
+    """Exception to raise for any errors with invalid rules"""
 
 
 def rule(**opts):
@@ -242,7 +242,7 @@ class Rule(object):
 
 
 class MatcherCreationError(Exception):
-    """Exeception to raise for any errors with invalid matchers"""
+    """Exception to raise for any errors with invalid matchers"""
 
 
 def matcher(matcher_func):

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -100,7 +100,7 @@ def {}(_):
 
     @patch('logging.Logger.exception')
     def test_rule_process_exception(self, log_mock):
-        """Rule - Process, Exeception"""
+        """Rule - Process, Exception"""
         # Create a rule function that will raise an exception
         def test_rule(_):
             raise ValueError('this is a bad rule')


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

When I observed the error noted in #778, I realized athena errors could be handled/propagated better. For instance, errors such as that one should have resulted in a AWS Lambda error, but instead was just logged as an error.

## Changes

* Introducing an `AthenaQueryExecutionError` exception class that should be used to raise any errors that occur during the execution process.
* Updating all applicable areas where errors/exceptions that were previously just logged should probably bubble up and either cause and exception or be handled by the caller.
* Updating calling code to be more concise and handle exceptions where necessary.
* Removing some now unnecessary return result checks, since exceptions will be raised when the return result would be bad.
* Updates to docstrings to include new exception that could be raised.
* Adding 'falsey' method to `StagingStatistic` class to simplify some checks.

## Testing

Updating all unit tests to ensure the proper exception(s) get raised.

