### PR TITLE
ensuring rule table is updated if any of the deployed functions is the rule processor

### DIFF
--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -158,7 +158,7 @@ def deploy(options, config):
         deploy_targets.update(targets)
 
     # Update the rule table now if the rule processor is being deployed
-    if 'rule' in options.processor:
+    if 'rule' in processors:
         _update_rule_table(options, config)
 
     # Terraform applies the new package and publishes a new version

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -54,6 +54,7 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
       "athena:GetQueryExecution",
       "athena:GetQueryResults",
       "athena:StartQueryExecution",
+      "glue:GetPartition",
       "glue:GetPartitions",
       "glue:GetTable",
     ]


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

There is a bug that will not update the rule table if the following command is used:

`python manage.py lambda deploy --processor all`

## Changes

* Fixing bug to update the rule table if any of the deployed functions is the rule processor.
* Adding permission for `glue:GetPartition` to rule promotion function iam.

## Testing

Tested in deploy.
