### PR TITLE
[core] allow req_subkeys with none and false values

### DIFF
--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -235,6 +235,11 @@ class RulesEngine(object):
                     'The required subkey %s is not found when trying to process %s: \n%s',
                     key, rule.name, record)
                 return False
+            if not isinstance(record.get(key), dict):
+                LOGGER.debug(
+                    'The required subkey %s is not a dictionary when trying to process %s: \n%s',
+                    key, rule.name, record)
+                return False
             if any(x not in record[key] for x in nested_keys):
                 return False
 

--- a/stream_alert/rule_processor/rules_engine.py
+++ b/stream_alert/rule_processor/rules_engine.py
@@ -235,7 +235,7 @@ class RulesEngine(object):
                     'The required subkey %s is not found when trying to process %s: \n%s',
                     key, rule.name, record)
                 return False
-            if not all(record[key].get(x) for x in nested_keys):
+            if any(x not in record[key] for x in nested_keys):
                 return False
 
         return True

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -281,6 +281,57 @@ class TestRulesEngine(object):
         assert_equal(alerts[0].rule_name, 'web_server')
         assert_equal(alerts[1].rule_name, 'data_location')
 
+    def test_process_subkeys_false_none_value(self):
+        """Rules Engine - Req Subkeys with False and None values"""
+        @rule(logs=['test_log_type_json_nested'],
+              outputs=['s3:sample_bucket'],
+              req_subkeys={'data': ['value']})
+        def value_false(rec):  # pylint: disable=unused-variable
+            return rec['data']['value'] == False
+
+        @rule(logs=['test_log_type_json_nested'],
+              outputs=['s3:sample_bucket'],
+              req_subkeys={'data': ['value']})
+        def value_none(rec):  # pylint: disable=unused-variable
+            return rec['data']['value'] is None
+
+        kinesis_data_items = [
+            {
+                'date': 'Dec 01 2016',
+                'unixtime': '1483139547',
+                'host': 'host1.web.prod.net',
+                'data': {
+                    'value': False
+                }
+            },
+            {
+                'date': 'Dec 01 2016',
+                'unixtime': '1483139547',
+                'host': 'host1.web.prod.net',
+                'data': {
+                    'value': None
+                }
+            }
+        ]
+
+        # prepare payloads
+        alerts = []
+        for data in kinesis_data_items:
+            kinesis_data = json.dumps(data)
+            # prepare the payloads
+            service, entity = 'kinesis', 'test_kinesis_stream'
+            raw_record = make_kinesis_raw_record(entity, kinesis_data)
+            payload = load_and_classify_payload(self.config, service, entity, raw_record)
+
+            alerts.extend(self.rules_engine.run(payload)[0])
+
+        # check alert output
+        assert_equal(len(alerts), 2)
+
+        # alert tests
+        assert_equal(alerts[0].rule_name, 'value_false')
+        assert_equal(alerts[1].rule_name, 'value_none')
+
     def test_syslog_rule(self):
         """Rules Engine - Syslog Rule"""
         @rule(logs=['test_log_type_syslog'],

--- a/tests/unit/stream_alert_rule_processor/test_rules_engine.py
+++ b/tests/unit/stream_alert_rule_processor/test_rules_engine.py
@@ -287,7 +287,7 @@ class TestRulesEngine(object):
               outputs=['s3:sample_bucket'],
               req_subkeys={'data': ['value']})
         def value_false(rec):  # pylint: disable=unused-variable
-            return rec['data']['value'] == False
+            return rec['data']['value'] is False
 
         @rule(logs=['test_log_type_json_nested'],
               outputs=['s3:sample_bucket'],


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small
resolves #787 Required subkey check fails when the subkey exists, but the value is false

## Background

Subkeys with False or None values should still cause the rule to be run

## Changes

* Required subkeys with none or false values should still cause the rule to be run.
* Using `any()` instead of `all()` should be faster, as `any()` can exit early if a subkey is missing.
* Check the type of the subkey item to make sure it is a dictionary
* Added `test_process_subkeys_false_none_value` to test `None` and `False` values for subkeys.
* Added `test_process_subkeys_non_dict` to make sure non dictionary subkey objects are handled.

## Testing

1. Created a new unit tests `test_process_subkeys_false_none_value` and `test_process_subkeys_non_dict`
2. Tests fail
3. Implemented fix in `rules_engine`
4. Tests pass