### PR TITLE
Grant rule promotion Lambda kms:Decrypt permissions for Athena

### DIFF
--- a/stream_alert_cli/terraform/rule_promotion.py
+++ b/stream_alert_cli/terraform/rule_promotion.py
@@ -45,7 +45,8 @@ def generate_rule_promotion(config):
         'function_alias_arn': '${module.rule_promotion_lambda.function_alias_arn}',
         'function_name': '${module.rule_promotion_lambda.function_name}',
         'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}',
-        'athena_data_buckets': data_buckets
+        'athena_data_buckets': data_buckets,
+        's3_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
     }
 
     # Set variables for the Lambda module

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -80,6 +80,13 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
   }
 
   statement {
+    sid       = "AthenaDecryptKMS"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["${var.s3_kms_key_arn}"]
+  }
+
+  statement {
     sid    = "AthenaResultsAccess"
     effect = "Allow"
 

--- a/terraform/modules/tf_rule_promotion_iam/variables.tf
+++ b/terraform/modules/tf_rule_promotion_iam/variables.tf
@@ -30,3 +30,7 @@ variable "athena_data_buckets" {
   description = "List of S3 buckets where Athena data is stored"
   type        = "list"
 }
+
+variable "s3_kms_key_arn" {
+  description = "KMS key ARN used for server-side encryption"
+}

--- a/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
@@ -45,7 +45,8 @@ class TestRulePromotion(object):
                     'athena_data_buckets': [
                         'unit-testing.streamalert.data',
                         'unit-testing.streamalerts'
-                    ]
+                    ],
+                    's3_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
                 },
                 'rule_promotion_lambda': {
                     'alarm_actions': ['arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring'],


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The rule promotion Lambda function needs permission to use the KMS key for the Athena table

## Changes

* Grant `kms:Decrypt` for rule promotion Lambda

## Testing

* Test deploy
