### PR TITLE
adding better support for description replacement within rule

### DIFF
--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -106,6 +106,7 @@ class Rule(object):
         self.initial_context = kwargs.get('context')
         self.context = None
         self.disabled = False
+        self._description = func.__doc__
         self._checksum = None
 
         if not (self.logs or self.datatypes):
@@ -212,7 +213,11 @@ class Rule(object):
 
     @property
     def description(self):
-        return self.func.__doc__ or self.DEFAULT_RULE_DESCRIPTION
+        return self._description or self.DEFAULT_RULE_DESCRIPTION
+
+    @description.setter
+    def description(self, description):
+        self._description = str(description)
 
     @property
     def outputs_set(self):

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -219,6 +219,17 @@ def {}(_):
         assert_equal(len(result), 1)
         assert_equal(result[0].name, 'with_datatypes')
 
+    def test_set_description(self):
+        """Rule - Set Description"""
+        def test_rule(_):
+            pass
+        test_rule = rule.Rule(test_rule, outputs=['foo'], logs=['bar'])
+
+        description = 'foobar description'
+        test_rule.description = description
+
+        assert_equal(test_rule.description, description)
+
     def test_get_rules_for_log_type(self):
         """Rule - Get Rules, For Log Type"""
         self._create_rule_helper('rule_01')


### PR DESCRIPTION
to: @chunyong-lin, @jbussing 
cc: @airbnb/streamalert-maintainers
size: small

## Background

The introduction of the `Rule` class broke the rule `__doc__` string replacement for description substitution.

## Changes

This change introduces a non-hacky way of replacing a rule's description with an alternate value.
* The default description will be the rule's current docstring, but can be overridden with `rule_name.description = ...` within the rule itself.

## Testing

Adding unit test to ensure the replacement happens as expected.
