### PR TITLE
adding precompiled libs for aliyun streamalert app

### DIFF
--- a/app_integrations/apps/README.rst
+++ b/app_integrations/apps/README.rst
@@ -23,8 +23,8 @@ Step by step:
    5. The bearer token is the string labeled with ``OAuth Access Token`` and beginning with ``xoxp-``. It's what's needed to authorize the Slack StreamAlert app.
 
 
-How to update boxsdk dependencies
-#################################
+How to update necessary dependencies
+####################################
 
 
 Create an EC2 Instance
@@ -63,8 +63,11 @@ on ec2 instance
   $ mkdir $HOME/build_temp $HOME/pip_temp
 
   # Install all of the dependencies to this directory
+  $ pip install boxsdk[jwt]==2.0.0a11 --build $HOME/build_temp/ --target $HOME/pip_temp
+
   # Replace the `boxsdk[jwt]==2.0.0a11` below with the desired package & version
-  $ python -c "import pip; pip.main(['install', 'boxsdk[jwt]==2.0.0a11', '--build', '$HOME/build_temp/',  '--target', '$HOME/pip_temp'])"
+  # For example, the following would update the aliyun dependencies:
+  # pip install aliyun-python-sdk-actiontrail==2.0.0 --build $HOME/build_temp/ --target $HOME/pip_temp
 
   # Change into the install directory
   $ cd $HOME/pip_temp

--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -202,9 +202,8 @@ class AppPackage(LambdaPackage):
     lambda_handler = 'app_integrations.main.handler'
     package_files = {'app_integrations'}
     package_name = 'stream_alert_app'
-    precompiled_libs = {'boxsdk[jwt]==2.0.0a11'}
+    precompiled_libs = {'boxsdk[jwt]==2.0.0a11', 'aliyun-python-sdk-actiontrail==2.0.0'}
     third_party_libs = {
-        'aliyun-python-sdk-core==2.8.5',
         'aliyun-python-sdk-actiontrail==2.0.0',
         'backoff',
         'boxsdk[jwt]==2.0.0a11',


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Observed the following error with the latest streamalert apps deploy:
```
module initialization error
Cannot load native module 'Crypto.Hash._SHA256': Trying '_SHA256.so': cannot load library /var/task/Crypto/Util/../Hash/_SHA256.so: /var/task/Crypto/Util/../Hash/_SHA256.so: invalid ELF header. Additionally, ctypes.util.find_library() did not manage to locate a library called '/var/task/Crypto/Util/../Hash/_SHA256.so', Trying '_SHA256module.so': cannot load library /var/task/Crypto/Util/../Hash/_SHA256module.so: /var/task/Crypto/Util/../Hash/_SHA256module.so: cannot open shared object file: No such file or directory. Additionally, ctypes.util.find_library() did not manage to locate a library called '/var/task/Crypto/Util/../Hash/_SHA256module.so'
```

## Changes

* Precompiling `aliyun-python-sdk-actiontrail==2.0.0` package and zipping for deployment package.
* Updating app `README.rst` with note about aliyun dependencies.

## Testing

Did a test deploy to ensure all is working.