### PR TITLE
[rule-staging] only creating rules table if rule staging is enabled

### DIFF
--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -177,7 +177,7 @@ def generate_main(config, init=False):
     generate_firehose(config, main_dict, logging_bucket)
 
     # Configure global resources like Firehose alert delivery and alerts table
-    main_dict['module']['globals'] = {
+    global_module = {
         'source': 'modules/tf_stream_alert_globals',
         'account_id': config['global']['account']['aws_account_id'],
         'region': config['global']['account']['region'],
@@ -186,12 +186,17 @@ def generate_main(config, init=False):
         'alerts_table_read_capacity': (
             config['global']['infrastructure']['alerts_table']['read_capacity']),
         'alerts_table_write_capacity': (
-            config['global']['infrastructure']['alerts_table']['write_capacity']),
-        'rules_table_read_capacity': (
-            config['global']['infrastructure']['rule_staging']['table']['read_capacity']),
-        'rules_table_write_capacity': (
-            config['global']['infrastructure']['rule_staging']['table']['write_capacity'])
+            config['global']['infrastructure']['alerts_table']['write_capacity'])
     }
+
+    if config['global']['infrastructure']['rule_staging'].get('enabled'):
+        global_module['enable_rule_staging'] = True
+        global_module['rules_table_read_capacity'] = (
+            config['global']['infrastructure']['rule_staging']['table']['read_capacity'])
+        global_module['rules_table_write_capacity'] = (
+            config['global']['infrastructure']['rule_staging']['table']['write_capacity'])
+
+    main_dict['module']['globals'] = global_module
 
     # KMS Key and Alias creation
     main_dict['resource']['aws_kms_key']['server_side_encryption'] = {

--- a/stream_alert_cli/terraform/rule_promotion.py
+++ b/stream_alert_cli/terraform/rule_promotion.py
@@ -29,6 +29,11 @@ def generate_rule_promotion(config):
     Returns:
         dict: Rule Promotion dict to be marshaled to JSON
     """
+    # The Rule Promotion Lambda function is dependent on the rule staging feature being,
+    # enabled, so do not generate the code for this Lambda function if it not enabled
+    if not config['global']['infrastructure']['rule_staging'].get('enabled', False):
+        return False
+
     result = infinitedict()
 
     athena_config = config['lambda']['athena_partition_refresh_config']

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -1,16 +1,19 @@
 // SNS topic to send
 resource "aws_sns_topic" "digest_sns_topic" {
-  name = "${var.digest_sns_topic}"
+  count = "${var.rules_table_arn == "" ? 0 : 1}"
+  name  = "${var.digest_sns_topic}"
 }
 
 // CloudWatch event to trigger Lambda and send digest on a schedule
 resource "aws_cloudwatch_event_rule" "send_digest_invocation_schedule" {
+  count               = "${var.rules_table_arn == "" ? 0 : 1}"
   name                = "${var.function_name}_digest_schedule"
   description         = "Invokes ${var.function_name} at ${var.send_digest_schedule_expression}"
   schedule_expression = "${var.send_digest_schedule_expression}"
 }
 
 resource "aws_cloudwatch_event_target" "send_digest_invocation" {
+  count = "${var.rules_table_arn == "" ? 0 : 1}"
   rule  = "${aws_cloudwatch_event_rule.send_digest_invocation_schedule.name}"
   arn   = "${var.function_alias_arn}"
   input = "{\"send_digest\": true}"
@@ -18,6 +21,7 @@ resource "aws_cloudwatch_event_target" "send_digest_invocation" {
 
 // Allow Lambda function to be invoked via a CloudWatch event rule
 resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
+  count         = "${var.rules_table_arn == "" ? 0 : 1}"
   statement_id  = "AllowExecutionFromCloudWatch_${var.function_name}_digest_schedule"
   action        = "lambda:InvokeFunction"
   function_name = "${var.function_name}"
@@ -28,12 +32,15 @@ resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
 
 // Allow the Rule Promotion function to perform necessary actions
 resource "aws_iam_role_policy" "rule_promotion_actions" {
+  count  = "${var.rules_table_arn == "" ? 0 : 1}"
   name   = "RulePromotionActions"
   role   = "${var.role_id}"
   policy = "${data.aws_iam_policy_document.rule_promotion_actions.json}"
 }
 
 data "aws_iam_policy_document" "rule_promotion_actions" {
+  count = "${var.rules_table_arn == "" ? 0 : 1}"
+
   statement {
     sid    = "PublishDigestToSNS"
     effect = "Allow"

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -1,19 +1,16 @@
 // SNS topic to send
 resource "aws_sns_topic" "digest_sns_topic" {
-  count = "${var.rules_table_arn == "" ? 0 : 1}"
-  name  = "${var.digest_sns_topic}"
+  name = "${var.digest_sns_topic}"
 }
 
 // CloudWatch event to trigger Lambda and send digest on a schedule
 resource "aws_cloudwatch_event_rule" "send_digest_invocation_schedule" {
-  count               = "${var.rules_table_arn == "" ? 0 : 1}"
   name                = "${var.function_name}_digest_schedule"
   description         = "Invokes ${var.function_name} at ${var.send_digest_schedule_expression}"
   schedule_expression = "${var.send_digest_schedule_expression}"
 }
 
 resource "aws_cloudwatch_event_target" "send_digest_invocation" {
-  count = "${var.rules_table_arn == "" ? 0 : 1}"
   rule  = "${aws_cloudwatch_event_rule.send_digest_invocation_schedule.name}"
   arn   = "${var.function_alias_arn}"
   input = "{\"send_digest\": true}"
@@ -21,7 +18,6 @@ resource "aws_cloudwatch_event_target" "send_digest_invocation" {
 
 // Allow Lambda function to be invoked via a CloudWatch event rule
 resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
-  count         = "${var.rules_table_arn == "" ? 0 : 1}"
   statement_id  = "AllowExecutionFromCloudWatch_${var.function_name}_digest_schedule"
   action        = "lambda:InvokeFunction"
   function_name = "${var.function_name}"
@@ -32,15 +28,12 @@ resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
 
 // Allow the Rule Promotion function to perform necessary actions
 resource "aws_iam_role_policy" "rule_promotion_actions" {
-  count  = "${var.rules_table_arn == "" ? 0 : 1}"
   name   = "RulePromotionActions"
   role   = "${var.role_id}"
   policy = "${data.aws_iam_policy_document.rule_promotion_actions.json}"
 }
 
 data "aws_iam_policy_document" "rule_promotion_actions" {
-  count = "${var.rules_table_arn == "" ? 0 : 1}"
-
   statement {
     sid    = "PublishDigestToSNS"
     effect = "Allow"

--- a/terraform/modules/tf_stream_alert/iam.tf
+++ b/terraform/modules/tf_stream_alert/iam.tf
@@ -89,12 +89,15 @@ data "aws_iam_policy_document" "streamalert_rule_processor_read_dynamodb" {
 
 // Allow the Rule Processor to read the rules table
 resource "aws_iam_role_policy" "read_rules_table" {
+  count  = "${var.rules_table_arn == "" ? 0 : 1}"
   name   = "ReadRulesTable"
   role   = "${aws_iam_role.streamalert_rule_processor_role.id}"
   policy = "${data.aws_iam_policy_document.read_rules_table.json}"
 }
 
 data "aws_iam_policy_document" "read_rules_table" {
+  count = "${var.rules_table_arn == "" ? 0 : 1}"
+
   statement {
     effect = "Allow"
 

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -34,6 +34,7 @@ resource "aws_dynamodb_table" "alerts_table" {
 
 // DynamoDB table to store some rule information
 resource "aws_dynamodb_table" "rules_table" {
+  count          = "${var.enable_rule_staging ? 1 : 0}"
   name           = "${var.prefix}_streamalert_rules"
   read_capacity  = "${var.rules_table_read_capacity}"
   write_capacity = "${var.rules_table_write_capacity}"

--- a/terraform/modules/tf_stream_alert_globals/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/output.tf
@@ -1,3 +1,3 @@
 output "rules_table_arn" {
-  value = "${aws_dynamodb_table.rules_table.arn}"
+  value = "${element(concat(aws_dynamodb_table.rules_table.*.arn, list("")), 0)}"
 }

--- a/terraform/modules/tf_stream_alert_globals/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/variables.tf
@@ -10,6 +10,10 @@ variable "alerts_table_read_capacity" {}
 
 variable "alerts_table_write_capacity" {}
 
+variable "enable_rule_staging" {
+  default = false
+}
+
 variable "rules_table_read_capacity" {
   default = 5
 }

--- a/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
@@ -29,7 +29,8 @@ class TestRulePromotion(object):
         self.rule_promo_config = self.config['lambda']['rule_promotion_config']
 
     def test_generate(self):
-        """CLI - Terraform Generate Rule Promotion"""
+        """CLI - Terraform Generate Rule Promotion, Staging Enabled"""
+        self.config['global']['infrastructure']['rule_staging']['enabled'] = True
         result = rule_promotion.generate_rule_promotion(config=self.config)
         expected = {
             'module': {
@@ -75,4 +76,9 @@ class TestRulePromotion(object):
             }
         }
 
-        assert_equal(expected, result)
+        assert_equal(result, expected)
+
+    def test_generate_disabled(self):
+        """CLI - Terraform Generate Rule Promotion, Staging Disabled"""
+        result = rule_promotion.generate_rule_promotion(config=self.config)
+        assert_equal(result, False)


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

If the rule staging feature is not enabled, the rules dynamo table does not need to be created.

## Changes

* Adding a conditional to only create rules table if staging is enabled.
* Updating other dependent resources.
* Adding check to only allow the rule promotion lambda to be created if the rule_staging feature is enabled

## Testing

* Performed a `python manage.py terraform build` with setting enabled and disabled, and ensured the right resources would be created.
* Added unit test to ensure rule promo lambda module is not created.