### PR TITLE
[apps] De-duplicate GSuite Events

### DIFF
--- a/stream_alert/apps/_apps/gsuite.py
+++ b/stream_alert/apps/_apps/gsuite.py
@@ -151,7 +151,13 @@ class GSuiteReportsApp(AppIntegration):
         # once during the first poll
         if not self._next_page_token:
             self._last_timestamp = activities[0]['id']['time']
+            self._context = [
+                activity['id']['uniqueQualifier']
+                for activity in activities
+                if activity['id']['time'] == self._last_timestamp
+            ]
             LOGGER.debug('Caching last timestamp: %s', self._last_timestamp)
+            LOGGER.debug('Caching last event ids: %s', self._context)
 
         self._next_page_token = results.get('nextPageToken')
         self._more_to_poll = bool(self._next_page_token)

--- a/stream_alert/apps/_apps/gsuite.py
+++ b/stream_alert/apps/_apps/gsuite.py
@@ -35,6 +35,11 @@ class GSuiteReportsApp(AppIntegration):
     _GOOGLE_API_EXCEPTIONS = (apiclient.errors.Error, client.Error, socket.timeout,
                               ssl.SSLError)
 
+    # The maximum number of unique event ids to store that occur on the most
+    # recent timestamp. These are used to de-duplicate events in the next poll.
+    # This is limited by AWS SSM parameter store maximum of 4096 characters.
+    _MAX_EVENT_IDS = 50
+
     def __init__(self, event, context):
         super(GSuiteReportsApp, self).__init__(event, context)
         self._activities_service = None
@@ -52,7 +57,7 @@ class GSuiteReportsApp(AppIntegration):
     @classmethod
     def date_formatter(cls):
         """Return a format string for a date, ie: 2010-10-28T10:26:35.000Z"""
-        return '%Y-%m-%dT%H:%M:%SZ'
+        return '%Y-%m-%dT%H:%M:%S.%fZ'
 
     @classmethod
     def _load_credentials(cls, keydata):
@@ -141,7 +146,12 @@ class GSuiteReportsApp(AppIntegration):
             LOGGER.error('[%s] No results received from the G Suite API request', self)
             return False
 
-        activities = results.get('items', [])
+        # Remove duplicate events present in the last time period.
+        last_event_ids = set(self._context.get("last_event_ids", []))
+        activities = [
+            activity for activity in results.get('items', [])
+            if activity['id']['uniqueQualifier'] not in last_event_ids
+        ]
         if not activities:
             LOGGER.info('[%s] No logs in response from G Suite API request', self)
             return False
@@ -151,16 +161,23 @@ class GSuiteReportsApp(AppIntegration):
         # once during the first poll
         if not self._next_page_token:
             self._last_timestamp = activities[0]['id']['time']
-            self._context = [
+            LOGGER.debug('[%s] Caching last timestamp: %s', self, self._last_timestamp)
+            # Store the event ids with the most recent timestamp to de-duplicate them next time
+            next_event_ids = [
                 activity['id']['uniqueQualifier']
                 for activity in activities
                 if activity['id']['time'] == self._last_timestamp
             ]
-            LOGGER.debug('Caching last timestamp: %s', self._last_timestamp)
-            LOGGER.debug('Caching last event ids: %s', self._context)
+            self._context['next_event_ids'] = next_event_ids[:self._MAX_EVENT_IDS]
+            if len(next_event_ids) > self._MAX_EVENT_IDS:
+                LOGGER.warning('[%s] More than %d next_event_ids. Unable to de-duplicate: %s',
+                               self, self._MAX_EVENT_IDS, next_event_ids[self._MAX_EVENT_IDS:])
 
         self._next_page_token = results.get('nextPageToken')
         self._more_to_poll = bool(self._next_page_token)
+
+        if not self._more_to_poll:
+            self._context['last_event_ids'] = self._context.get('next_event_ids', [])
 
         return activities
 

--- a/stream_alert/apps/app_base.py
+++ b/stream_alert/apps/app_base.py
@@ -81,6 +81,7 @@ class AppIntegration(object):
         self._more_to_poll = False
         self._poll_count = 0
         self._last_timestamp = 0
+        self._context = None
 
     def __str__(self):
         return self.type()
@@ -216,6 +217,7 @@ class AppIntegration(object):
         self._config.set_starting_timestamp(self.date_formatter())
 
         self._last_timestamp = self._config.last_timestamp
+        self._context = self._config.context
 
         # Mark this app as running, which updates the parameter store
         self._config.mark_running()
@@ -240,6 +242,7 @@ class AppIntegration(object):
                     self, self._gathered_log_count, self._poll_count)
 
         self._config.last_timestamp = self._last_timestamp
+        self._config.context = self._context
 
         # If there are more logs to poll, invoke this app function again and mark
         # the config as 'partial'. Marking the state as 'partial' prevents

--- a/stream_alert/apps/app_base.py
+++ b/stream_alert/apps/app_base.py
@@ -81,7 +81,7 @@ class AppIntegration(object):
         self._more_to_poll = False
         self._poll_count = 0
         self._last_timestamp = 0
-        self._context = None
+        self._context = {}
 
     def __str__(self):
         return self.type()

--- a/stream_alert/apps/config.py
+++ b/stream_alert/apps/config.py
@@ -62,7 +62,7 @@ class AppConfig(object):
         self._auth_config = auth_config
         self._current_state = state_config.get(self._STATE_KEY)
         self._last_timestamp = state_config.get(self._TIME_KEY)
-        self._context = state_config.get(self._CONTEXT_KEY)
+        self._context = state_config.get(self._CONTEXT_KEY, {})
         self._event = event
         self.function_name = func_name
         self.function_version = func_version
@@ -399,16 +399,19 @@ class AppConfig(object):
 
     @property
     def context(self):
-        """Get an additional context specific to each app"""
+        """Get an additional context dictionary specific to each app"""
         LOGGER.debug('Getting context: %s', self._context)
         return self._context
 
     @context.setter
     def context(self, context):
-        """Set an additional context specific to each app"""
+        """Set an additional context dictionary specific to each app"""
         if self._context == context:
             LOGGER.debug('App context is unchanged and will not be saved: %s', context)
             return
+
+        if not isinstance(context, dict):
+            raise AppStateError('Unable to set context: %s. Must be a dictionary', context)
 
         LOGGER.debug('Setting context to: %s', context)
 

--- a/stream_alert/apps/config.py
+++ b/stream_alert/apps/config.py
@@ -43,6 +43,7 @@ class AppConfig(object):
 
     _STATE_KEY = 'current_state'
     _TIME_KEY = 'last_timestamp'
+    _CONTEXT_KEY = 'context'
     _STATE_DESCRIPTION = 'State information for the \'{}\' app for use in the \'{}\' function'
 
     class States(object):
@@ -61,6 +62,7 @@ class AppConfig(object):
         self._auth_config = auth_config
         self._current_state = state_config.get(self._STATE_KEY)
         self._last_timestamp = state_config.get(self._TIME_KEY)
+        self._context = state_config.get(self._CONTEXT_KEY)
         self._event = event
         self.function_name = func_name
         self.function_version = func_version
@@ -273,9 +275,20 @@ class AppConfig(object):
         return self.last_timestamp
 
     def _save_state(self):
-        param_value = json.dumps(
-            {self._TIME_KEY: self.last_timestamp, self._STATE_KEY: self.current_state}
-        )
+        """Save the current state in the aws ssm paramater store
+
+        Raises:
+            AppStateError: If the parameter is unabled to be saved
+        """
+        try:
+            param_value = json.dumps({
+                self._TIME_KEY: self.last_timestamp,
+                self._STATE_KEY: self.current_state,
+                self._CONTEXT_KEY: self.context,
+            })
+        except TypeError as err:
+            raise AppStateError('Could not serialise state for name \'{}\'. Error: '
+                                '{}'.format(self._state_name, err.message))
         @backoff.on_exception(backoff.expo,
                               ClientError,
                               max_tries=self.MAX_STATE_SAVE_TRIES,
@@ -382,6 +395,24 @@ class AppConfig(object):
         LOGGER.debug('Setting last timestamp to: %s', timestamp)
 
         self._last_timestamp = timestamp
+        self._save_state()
+
+    @property
+    def context(self):
+        """Get an additional context specific to each app"""
+        LOGGER.debug('Getting context: %s', self._context)
+        return self._context
+
+    @context.setter
+    def context(self, context):
+        """Set an additional context specific to each app"""
+        if self._context == context:
+            LOGGER.debug('App context is unchanged and will not be saved: %s', context)
+            return
+
+        LOGGER.debug('Setting context to: %s', context)
+
+        self._context = context
         self._save_state()
 
     @property

--- a/tests/unit/stream_alert_apps/test_config.py
+++ b/tests/unit/stream_alert_apps/test_config.py
@@ -31,7 +31,7 @@ from tests.unit.stream_alert_apps.test_helpers import get_event, get_mock_contex
 @patch.object(AppConfig, 'MAX_STATE_SAVE_TRIES', 1)
 class TestAppConfig(object):
     """Test class for AppConfig"""
-    # pylint: disable=protected-access,no-self-use
+    # pylint: disable=protected-access,no-self-use,too-many-public-methods
 
     @patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'us-east-1'})
     def setup(self):
@@ -204,13 +204,18 @@ class TestAppConfig(object):
     @patch('stream_alert.apps.config.AppConfig._save_state')
     def test_set_context_same(self, save_mock):
         """AppConfig - Set Context, Same Value"""
-        self._config.context = None
+        self._config.context = {}
         save_mock.assert_not_called()
 
     @raises(AppStateError)
+    def test_set_context_not_a_dictionary(self):
+        """AppConfig - Context not a Dictionary"""
+        self._config.context = [1, 2, 3]
+
+    @raises(AppStateError)
     def test_set_context_not_serializable(self):
-        """AppConfig - Set Context, Not Serializable Value"""
-        self._config.context = { "Hello": set([1,2,3]) }
+        """AppConfig - Context not Serializable"""
+        self._config.context = {"key": object()}
 
     def test_is_failing(self):
         """AppConfig - Check If Failing"""

--- a/tests/unit/stream_alert_apps/test_config.py
+++ b/tests/unit/stream_alert_apps/test_config.py
@@ -195,6 +195,23 @@ class TestAppConfig(object):
         self._config.last_timestamp = 1234567890
         save_mock.assert_not_called()
 
+    @patch('stream_alert.apps.config.AppConfig._save_state')
+    def test_set_context_new(self, save_mock):
+        """AppConfig - Set Context, New Value"""
+        self._config.context = {"key": "value"}
+        save_mock.assert_called_once()
+
+    @patch('stream_alert.apps.config.AppConfig._save_state')
+    def test_set_context_same(self, save_mock):
+        """AppConfig - Set Context, Same Value"""
+        self._config.context = None
+        save_mock.assert_not_called()
+
+    @raises(AppStateError)
+    def test_set_context_not_serializable(self):
+        """AppConfig - Set Context, Not Serializable Value"""
+        self._config.context = { "Hello": set([1,2,3]) }
+
     def test_is_failing(self):
         """AppConfig - Check If Failing"""
         assert_false(self._config.is_failing)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @ryandeivert 
size: medium
resolves #800

## Background

The startTime passed to the Google Reports API includes the last event already processed in the previous lambda execution. So duplicate events are observed in subsequent API polls.

## Changes

    * Created new key "context" stored in the state parameter in ssm
    * Save at most 50 event ids from the most recent timestamp in the context. Limit of 4096 characters in ssm.
    * Correctly format dates with a fractional second component.
    * De-duplicate events based on last seen event ids.
    * Update unit tests to output unique timestamps per generated log.
    * Added unit tests

## Testing

Added new unit tests:
* test_gather_logs_duplicate_events_more_to_poll
* test_gather_logs_duplicate_events_next_poll
* test_set_context_new
* test_set_context_same
* test_set_context_not_a_dictionary
* test_set_context_not_serializable