### PR TITLE
[rules] cloudtrail_mfa_policy_abuse_attempt rule logic improved

### DIFF
--- a/rules/community/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.py
+++ b/rules/community/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.py
@@ -66,7 +66,7 @@ def cloudtrail_mfa_policy_abuse_attempt(rec):
     # - 'AccessDenied'
     # - 'EntityAlreadyExists': Can't create another MFA device with the same name.
     # - 'LimitExceeded': Can't enable a second MFA device for the same user.
-    if 'errorCode' in rec and rec['eventName'] in _EVENT_NAMES:
+    if rec['errorCode'] and rec['eventName'] in _EVENT_NAMES:
         return True
 
     return False

--- a/tests/integration/rules/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_mfa_policy_abuse_attempt.json
@@ -133,5 +133,51 @@
     "trigger_rules":[
       "cloudtrail_mfa_policy_abuse_attempt"
     ]
+  },
+  {
+    "data":{
+      "Records":[
+        {
+          "awsRegion":"us-west-2",
+          "eventID":"123aaac1-123d-456a-1k29a4dd2kea",
+          "eventName":"CreateVirtualMFADevice",
+          "eventSource":"iam.amazonaws.com",
+          "eventTime":"2017-01-01T00:20:50Z",
+          "eventType":"AwsApiCall",
+          "eventVersion":"1.05",
+          "recipientAccountId":"123456789123",
+          "requestID":"...",
+          "requestParameters": {
+            "virtualMFADeviceName": "...",
+            "path": "..."
+          },
+          "responseElements": {
+            "virtualMFADevice": {
+              "serialNumber": "..."
+            }
+          },
+          "sourceIPAddress":"...",
+          "userAgent":"...",
+          "userIdentity":{
+            "accessKeyId":"...",
+            "accountId":"12345",
+            "arn":"...",
+            "principalId":"12345",
+            "sessionContext":{
+              "attributes":{
+                "creationDate":"...",
+                "mfaAuthenticated":"false"
+              }
+            },
+            "type":"..."
+          }
+        }
+      ]
+    },
+    "description":"Successfully creating an MFA device, while the user is not MFA'd should not create an alert.",
+    "log":"cloudtrail:events",
+    "service":"s3",
+    "source":"prefix.cluster.sample.bucket",
+    "trigger_rules":[]
   }
 ]


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @strcrzy 
size: small
resolves #803 

## Background

Because `errorCode` is an optional parameter set in `optional_top_level_keys`. If the record does not contain it, it gets set to the default value for it's type. In this case `str()`.

So checking that the key exists is not enough to indicate an error, instead check the value evaluates to True.

## Changes

* Only alert if the contents of `errorCode` is not False.
* Added integration test.

## Testing

* Added new integration test: `Successfully creating an MFA device, while the user is not MFA'd should not create an alert.`