### PR TITLE
[tf][firehose] support per firehose metric alarms for IncomingRecords

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -23,7 +23,7 @@
       "buffer_size": 128,
       "compression_format": "GZIP",
       "enabled": false,
-      "enabled_logs": []
+      "enabled_logs": {}
     },
     "monitoring": {
       "create_sns_topic": true

--- a/docs/source/firehose.rst
+++ b/docs/source/firehose.rst
@@ -94,11 +94,18 @@ The following Firehose configuration settings are defined in ``global.json``:
     "infrastructure": {
       "firehose": {
         "enabled": true,
-        "enabled_logs": [
-          "osquery",
-          "cloudwatch",
-          "ghe"
-        ],
+        "enabled_logs": {
+          "osquery": {
+            "enable_alarm": true
+          },
+          "cloudwatch": {},
+          "ghe": {
+            "enable_alarm": true,
+            "evaluation_periods": 10,
+            "period_seconds": 3600,
+            "log_min_count_threshold": 100000
+          }
+        },
         "s3_bucket_suffix": "streamalert.data",
         "buffer_size": 64,
         "buffer_interval": 300,
@@ -120,6 +127,27 @@ Key                      Required  Default               Description
 ``buffer_interval``      ``No``    ``300 (seconds)``     The frequency of data delivery to Amazon S3
 ``compression_format``   ``No``    ``GZIP``              The compression algorithm to use on data stored in S3
 ======================   ========  ====================  ===========
+
+Throughput Alarms
+-----------------
+
+Additionlly, each Firehose that is created can be configured with an alarm that fires when
+incoming logs drops below a specified threshold. This is disabled by default, and enabled by
+setting ``enable_alarm`` to ``true`` within the configuration for the log ype. See the config
+example above for how this should be performed.
+
+Alarms Options
+~~~~~~~~~~~~~~
+
+============================  =======================================  ===========
+Key                           Default                                  Description
+----------------------------  ---------------------------------------  -----------
+``enable_alarm``              ``false``                                If set to ``true``, a CloudWatch Metric Alarm will be created for this log type
+``evaluation_periods``        ``1``                                    Consecutive periods the records count threshold must be breached before triggering an alarm
+``period_seconds``            ``86400``                                Period over which to count the IncomingRecords (default: 86400 seconds [1 day])
+``log_min_count_threshold``   ``1000``                                 Alarm if IncomingRecords count drops below this value in the specified period(s)
+``alarm_actions``             ``stream_alert_monitoring SNS topic``    Optional list of CloudWatch alarm actions (e.g. SNS topic ARNs)
+============================  =======================================  ===========
 
 Deploying
 ---------

--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -284,9 +284,11 @@ class FirehoseClient(object):
         Args:
             firehose_config (dict): Loaded Firehose config from global.json
             log_sources (dict): Loaded logs.json file
+            force_load (bool=False): Set to True if the log sources should be reloaded
+                even if there is cached values
 
         Returns:
-            set: Enabled logs
+            dict: Enabled logs, key: sanitized table name, value: log type value
         """
         # Do not reload the logs if they are already cached
         if cls._ENABLED_LOGS and not force_load:

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -19,7 +19,7 @@ import json
 from stream_alert.rule_processor import FUNCTION_NAME, LOGGER
 from stream_alert.rule_processor.alert_forward import AlertForwarder
 from stream_alert.rule_processor.classifier import StreamClassifier
-from stream_alert.rule_processor.firehose import StreamAlertFirehose
+from stream_alert.rule_processor.firehose import FirehoseClient
 from stream_alert.rule_processor.payload import load_stream_payload
 from stream_alert.rule_processor.rules_engine import RulesEngine
 from stream_alert.shared import config, stats
@@ -88,9 +88,11 @@ class StreamAlert(object):
 
         firehose_config = self.config['global'].get('infrastructure', {}).get('firehose', {})
         if firehose_config.get('enabled'):
-            self._firehose_client = StreamAlertFirehose(self.env['region'],
-                                                        firehose_config,
-                                                        self.config['logs'])
+            self._firehose_client = FirehoseClient(
+                self.env['region'],
+                firehose_config=firehose_config,
+                log_sources=self.config['logs']
+            )
 
         payload_with_normalized_records = []
         for raw_record in records:

--- a/stream_alert/rule_processor/handler.py
+++ b/stream_alert/rule_processor/handler.py
@@ -211,10 +211,7 @@ class StreamAlert(object):
 
             # Add all parsed records to the categorized payload dict only if Firehose is enabled
             if self._firehose_client:
-                # Only send payloads with enabled log sources
-                if self._firehose_client.enabled_log_source(payload.log_source):
-                    self._firehose_client.categorized_payloads[payload.log_source].extend(
-                        payload.records)
+                self._firehose_client.add_payload_records(payload.log_source, payload.records)
 
             if not record_alerts:
                 continue

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -32,7 +32,7 @@ from moto import (mock_cloudwatch, mock_dynamodb2, mock_kinesis, mock_kms, mock_
                   mock_sns, mock_sqs)
 
 from stream_alert_cli.logger import LOGGER_CLI
-from stream_alert.rule_processor.firehose import StreamAlertFirehose
+from stream_alert.rule_processor.firehose import FirehoseClient
 
 
 SCHEMA_TYPE_LOOKUP = {
@@ -496,13 +496,12 @@ def setup_mock_firehose_delivery_streams(config):
     if not firehose_config:
         return
 
-    region = config['global']['account']['region']
-    sa_firehose = StreamAlertFirehose(region, firehose_config, config['logs'])
+    enabled_logs = FirehoseClient.load_enabled_log_sources(firehose_config, config['logs'])
 
-    for log_type in sa_firehose.enabled_logs:
+    for log_type in enabled_logs:
         stream_name = 'streamalert_data_{}'.format(log_type)
         prefix = '{}/'.format(log_type)
-        create_delivery_stream(region, stream_name, prefix)
+        create_delivery_stream(config['global']['account']['region'], stream_name, prefix)
 
 
 def setup_mock_dynamodb_rules_table(config):

--- a/stream_alert_cli/terraform/firehose.py
+++ b/stream_alert_cli/terraform/firehose.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from stream_alert.rule_processor.firehose import FirehoseClient
+from stream_alert_cli.terraform.common import monitoring_topic_arn
 
-def generate_firehose(config, main_dict, logging_bucket):
+def generate_firehose(logging_bucket, main_dict, config):
     """Generate the Firehose Terraform modules
 
     Args:
@@ -48,18 +49,50 @@ def generate_firehose(config, main_dict, logging_bucket):
         force_load=True
     )
 
+    log_alarms_config = config['global']['infrastructure']['firehose'].get('enabled_logs', {})
+
     # Add the Delivery Streams individually
-    for enabled_log in sa_firehose.enabled_logs:
-        main_dict['module']['kinesis_firehose_{}'.format(enabled_log)] = {
+    for log_stream_name, log_type_name in enabled_logs.iteritems():
+        module_dict = {
             'source': 'modules/tf_stream_alert_kinesis_firehose_delivery_stream',
             'buffer_size': config['global']['infrastructure']
                            ['firehose'].get('buffer_size', 64),
             'buffer_interval': config['global']['infrastructure']
-                               ['firehose'].get('buffer_interval', 300),\
+                               ['firehose'].get('buffer_interval', 300),
             'compression_format': config['global']['infrastructure']
                                   ['firehose'].get('compression_format', 'GZIP'),
-            'log_name': enabled_log,
+            'log_name': log_stream_name,
             'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
             's3_bucket_name': firehose_s3_bucket_name,
             'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
         }
+
+        # Try to get alarm info for this specific log type
+        alarm_info = log_alarms_config.get(log_type_name)
+        if not alarm_info and ':' in log_type_name:
+            # Fallback on looking for alarm info for the parent log type
+            alarm_info = log_alarms_config.get(log_type_name.split(':')[0])
+
+        if alarm_info and alarm_info.get('enable_alarm'):
+            module_dict['enable_alarm'] = True
+
+            # There are defaults of these defined in the terraform module, so do
+            # not set the variable values unless explicitly specified
+            if alarm_info.get('log_min_count_threshold'):
+                module_dict['alarm_threshold'] = alarm_info.get('log_min_count_threshold')
+
+            if alarm_info.get('evaluation_periods'):
+                module_dict['evaluation_periods'] = alarm_info.get('evaluation_periods')
+
+            if alarm_info.get('period_seconds'):
+                module_dict['period_seconds'] = alarm_info.get('period_seconds')
+
+            if alarm_info.get('alarm_actions'):
+                if not isinstance(alarm_info.get('alarm_actions'), list):
+                    module_dict['alarm_actions'] = [alarm_info.get('alarm_actions')]
+                else:
+                    module_dict['alarm_actions'] = alarm_info.get('alarm_actions')
+            else:
+                module_dict['alarm_actions'] = [monitoring_topic_arn(config)]
+
+        main_dict['module']['kinesis_firehose_{}'.format(log_stream_name)] = module_dict

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -174,7 +174,7 @@ def generate_main(config, init=False):
         )
 
     # Setup Firehose Delivery Streams
-    generate_firehose(config, main_dict, logging_bucket)
+    generate_firehose(logging_bucket, main_dict, config)
 
     # Configure global resources like Firehose alert delivery and alerts table
     global_module = {

--- a/terraform/modules/tf_stream_alert_kinesis_firehose_delivery_stream/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_firehose_delivery_stream/main.tf
@@ -18,3 +18,22 @@ resource "aws_kinesis_firehose_delivery_stream" "stream_alert_data" {
     kms_key_arn        = "${var.kms_key_arn}"
   }
 }
+
+// AWS CloudWatch Metric Alarm for this Firehose
+resource "aws_cloudwatch_metric_alarm" "firehose_records_alarm" {
+  count               = "${var.enable_alarm ? 1 : 0}"
+  alarm_name          = "streamalert_data_${var.log_name}_record_count"
+  namespace           = "AWS/Firehose"
+  metric_name         = "IncomingRecords"
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  threshold           = "${var.alarm_threshold}"
+  evaluation_periods  = "${var.evaluation_periods}"
+  period              = "${var.period_seconds}"
+  alarm_description   = "StreamAlert Firehose record count less than expected threshold: ${var.log_name}"
+  alarm_actions       = "${var.alarm_actions}"
+
+  dimensions {
+    DeliveryStreamName = "${aws_kinesis_firehose_delivery_stream.stream_alert_data.name}"
+  }
+}

--- a/terraform/modules/tf_stream_alert_kinesis_firehose_delivery_stream/variables.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_firehose_delivery_stream/variables.tf
@@ -26,3 +26,29 @@ variable "s3_bucket_name" {
 variable "kms_key_arn" {
   type = "string"
 }
+
+variable "enable_alarm" {
+  default     = false
+  description = "Enable CloudWatch metric alarm for Firehose IncomingRecords count"
+}
+
+variable "alarm_threshold" {
+  default     = 1000
+  description = "Alarm if IncomingRecords count drops below this value in the specified period(s)"
+}
+
+variable "evaluation_periods" {
+  default     = 1
+  description = "Consecutive periods the records count threshold must be breached before triggering an alarm"
+}
+
+variable "period_seconds" {
+  default     = 86400
+  description = "Period over which to count the IncomingRecords (default: 86400 seconds [1 day])"
+}
+
+variable "alarm_actions" {
+  type        = "list"
+  default     = []
+  description = "Optional list of CloudWatch alarm actions (e.g. SNS topic ARNs)"
+}

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -14,6 +14,13 @@
       "read_capacity": 5,
       "write_capacity": 5
     },
+    "firehose": {
+      "buffer_interval": 900,
+      "buffer_size": 128,
+      "compression_format": "GZIP",
+      "enabled": true,
+      "enabled_logs": {}
+    },
     "lookup_tables": {
       "buckets": {
         "bucket_name": [

--- a/tests/unit/stream_alert_cli/terraform/test_firehose.py
+++ b/tests/unit/stream_alert_cli/terraform/test_firehose.py
@@ -1,0 +1,187 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from nose.tools import assert_equal
+
+from stream_alert_cli.config import CLIConfig
+from stream_alert_cli.terraform import common, firehose
+
+class TestFirehoseGenerate(object):
+    """Class for testing firehose generation code"""
+    #pylint: disable=attribute-defined-outside-init
+
+    def setup(self):
+        """Setup before each method"""
+        self._logging_bucket_name = 'logging-bucket-name'
+        self.config = CLIConfig(config_path='tests/unit/conf')
+
+    def _default_firehose_config(self):
+        return {
+            'source': 'modules/tf_stream_alert_kinesis_firehose_setup',
+            'account_id': "12345678910",
+            'prefix': 'unit-testing',
+            'region': 'us-west-1',
+            's3_logging_bucket': self._logging_bucket_name,
+            's3_bucket_name': 'unit-testing.streamalert.data',
+            'kms_key_id': '${aws_kms_key.server_side_encryption.key_id}'
+        }
+
+    def test_firehose_defaults(self):
+        """CLI - Terraform Generate Kinesis Firehose, Defaults"""
+        cluster_dict = common.infinitedict()
+        firehose.generate_firehose(self._logging_bucket_name, cluster_dict, self.config)
+
+        expected_result = {
+            'module': {
+                'kinesis_firehose_setup': self._default_firehose_config(),
+            }
+        }
+
+        assert_equal(cluster_dict, expected_result)
+
+    def test_firehose_enabled_log(self):
+        """CLI - Terraform Generate Kinesis Firehose, Enabled Log"""
+        cluster_dict = common.infinitedict()
+
+        # Add an enabled log, with no alarm configuration (aka: alarms disabled)
+        self.config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'json:embedded': {}
+        }
+
+        firehose.generate_firehose(self._logging_bucket_name, cluster_dict, self.config)
+
+        expected_result = {
+            'module': {
+                'kinesis_firehose_setup': self._default_firehose_config(),
+                'kinesis_firehose_json_embedded': {
+                    'source': 'modules/tf_stream_alert_kinesis_firehose_delivery_stream',
+                    'buffer_size': 128,
+                    'buffer_interval': 900,
+                    'compression_format': 'GZIP',
+                    'log_name': 'json_embedded',
+                    'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
+                    's3_bucket_name': 'unit-testing.streamalert.data',
+                    'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
+                }
+            }
+        }
+
+        assert_equal(cluster_dict, expected_result)
+
+    def test_firehose_enabled_log_alarm_defaults(self):
+        """CLI - Terraform Generate Kinesis Firehose, Enabled Alarm - Default Settings"""
+        cluster_dict = common.infinitedict()
+
+        # Add an enabled log, with alarms on (will use terraform default settings)
+        self.config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'json:embedded': {
+                'enable_alarm': True
+            }
+        }
+
+        firehose.generate_firehose(self._logging_bucket_name, cluster_dict, self.config)
+
+        expected_result = {
+            'module': {
+                'kinesis_firehose_setup': self._default_firehose_config(),
+                'kinesis_firehose_json_embedded': {
+                    'source': 'modules/tf_stream_alert_kinesis_firehose_delivery_stream',
+                    'buffer_size': 128,
+                    'buffer_interval': 900,
+                    'compression_format': 'GZIP',
+                    'log_name': 'json_embedded',
+                    'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
+                    's3_bucket_name': 'unit-testing.streamalert.data',
+                    'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+                    'enable_alarm': True,
+                    'alarm_actions': ['arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring']
+                }
+            }
+        }
+
+        assert_equal(cluster_dict, expected_result)
+
+    def test_firehose_enabled_log_alarm_custom(self):
+        """CLI - Terraform Generate Kinesis Firehose, Enabled Alarm - Custom Settings"""
+        cluster_dict = common.infinitedict()
+
+        # Add an enabled log, with alarms on with custom settings
+        self.config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'json:embedded': {
+                'enable_alarm': True,
+                'evaluation_periods': 10,
+                'period_seconds': 3600,
+                'log_min_count_threshold': 100000
+            }
+        }
+
+        firehose.generate_firehose(self._logging_bucket_name, cluster_dict, self.config)
+
+        expected_result = {
+            'module': {
+                'kinesis_firehose_setup': self._default_firehose_config(),
+                'kinesis_firehose_json_embedded': {
+                    'source': 'modules/tf_stream_alert_kinesis_firehose_delivery_stream',
+                    'buffer_size': 128,
+                    'buffer_interval': 900,
+                    'compression_format': 'GZIP',
+                    'log_name': 'json_embedded',
+                    'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
+                    's3_bucket_name': 'unit-testing.streamalert.data',
+                    'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+                    'enable_alarm': True,
+                    'evaluation_periods': 10,
+                    'period_seconds': 3600,
+                    'alarm_threshold': 100000,
+                    'alarm_actions': ['arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring']
+                }
+            }
+        }
+
+        assert_equal(cluster_dict, expected_result)
+
+    def test_firehose_enabled_log_alarm_custom_sns(self):
+        """CLI - Terraform Generate Kinesis Firehose, Enabled Alarm - Custom SNS"""
+        cluster_dict = common.infinitedict()
+
+        # Add an enabled log, with alarms on with custom alarm actions
+        self.config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'json:embedded': {
+                'enable_alarm': True,
+                'alarm_actions': 'do something crazy'
+            }
+        }
+
+        firehose.generate_firehose(self._logging_bucket_name, cluster_dict, self.config)
+
+        expected_result = {
+            'module': {
+                'kinesis_firehose_setup': self._default_firehose_config(),
+                'kinesis_firehose_json_embedded': {
+                    'source': 'modules/tf_stream_alert_kinesis_firehose_delivery_stream',
+                    'buffer_size': 128,
+                    'buffer_interval': 900,
+                    'compression_format': 'GZIP',
+                    'log_name': 'json_embedded',
+                    'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
+                    's3_bucket_name': 'unit-testing.streamalert.data',
+                    'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+                    'enable_alarm': True,
+                    'alarm_actions': ['do something crazy']
+                }
+            }
+        }
+
+        assert_equal(cluster_dict, expected_result)

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -233,9 +233,11 @@ class TestTerraformGenerate(object):
             's3_bucket_suffix': 'my-data',
             'buffer_size': 10,
             'buffer_interval': 650,
-            'enabled_logs': [
-                'cloudwatch'
-            ]
+            'enabled_logs': {
+                'cloudwatch': {
+                    'enable_alarm': False
+                }
+            }
         }
         tf_main = generate.generate_main(config=self.config, init=False)
 


### PR DESCRIPTION
to: @austinbyers or @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: large

## Background

Currently, StreamAlert uses individual AWS Firehose delivery streams for each log type ingested and parsed. This enables a somewhat simple and reliable way to determine if processing of a specific log type has dropped off.

## Changes

* Slight refactor to StreamAlertFirehose client to make performing some actions easier.
  * The prior class required instantiation for performing operations such as determining enabled log types, etc, which was overkill.
  * Migrating a few methods to be class methods, since instantiation will create a boto client which is not needed for CLI operations.
  * Also renaming from `StreamAlertFirehose` to just `FirehoseClient` since it's less wordy.
  * Updating all areas that used this class.
* Migrating payload categorization logic to `FirehoseClient` class instead of handling in the main `StreamAlert`.
* Adding terraform code for minimum log count alarm support in Firehose DeliveryStreams
* Updating terraform generation code for firehose log count alarms configuration

## Testing

* Updating/renaming old `StreamAlertFirehose` unit tests.
* Adding unit tests for firehose terraform generation code (no tests previously existed).
