### PR TITLE
[tf][athena] removing cloudwatch event rule and target

### DIFF
--- a/stream_alert_cli/terraform/athena.py
+++ b/stream_alert_cli/terraform/athena.py
@@ -57,7 +57,6 @@ def generate_athena(config):
         'lambda_timeout': athena_config.get('timeout', '60'),
         'lambda_log_level': athena_config.get('log_level', 'info'),
         'athena_data_buckets': data_buckets,
-        'schedule_expression': athena_config.get('schedule_expression', 'rate(10 minutes)'),
         'enable_metrics': athena_config.get('enable_metrics', False),
         'concurrency_limit': athena_config.get('concurrency_limit', 10),
         'account_id': config['global']['account']['aws_account_id'],

--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -102,23 +102,6 @@ resource "aws_lambda_event_source_mapping" "streamalert_athena_sqs_event_source"
   function_name    = "${aws_lambda_function.athena_partition_refresh.arn}"
 }
 
-// Cloudwatch Event Rule: Invoke the Athena function refresh every minute
-resource "aws_cloudwatch_event_rule" "invoke_athena_refresh" {
-  name        = "${var.prefix}_streamalert_invoke_athena_refresh"
-  description = "Invoke the Athena Refresh Lambda function every minute"
-
-  # https://amzn.to/2u5t0hS
-  schedule_expression = "${var.schedule_expression}"
-}
-
-// Cloudwatch Event Target: Point the Athena refresh rule to the Lambda function
-resource "aws_cloudwatch_event_target" "athena_lambda_function" {
-  rule = "${aws_cloudwatch_event_rule.invoke_athena_refresh.name}"
-  arn  = "${aws_lambda_function.athena_partition_refresh.arn}:production"
-
-  depends_on = ["aws_lambda_alias.athena_partition_refresh_production"]
-}
-
 // S3 Bucekt Notificaiton: Configure S3 to notify Lambda
 resource "aws_s3_bucket_notification" "bucket_notification" {
   count  = "${length(var.athena_data_buckets)}"

--- a/terraform/modules/tf_stream_alert_athena/variables.tf
+++ b/terraform/modules/tf_stream_alert_athena/variables.tf
@@ -56,11 +56,6 @@ variable "queue_name" {
   type = "string"
 }
 
-variable "schedule_expression" {
-  type    = "string"
-  default = "rate(10 minutes)"
-}
-
 variable "enable_metrics" {
   default = false
 }

--- a/tests/unit/stream_alert_cli/terraform/test_athena.py
+++ b/tests/unit/stream_alert_cli/terraform/test_athena.py
@@ -55,7 +55,6 @@ def test_generate_athena():
                 ],
                 'prefix': 'unit-testing',
                 'account_id': '12345678910',
-                'schedule_expression': 'rate(10 minutes)',
                 'concurrency_limit': 10
             },
             'athena_monitoring': {


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

I missed a few extra resources in https://github.com/airbnb/streamalert/pull/806.

## Changes

* Removing `aws_cloudwatch_event_rule` and `aws_cloudwatch_event_target`

## Testing

Updating unit tests.
