### PR TITLE
[athena] fixing logger format string and using lambda alias for invocation

### DIFF
--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -175,7 +175,7 @@ class AthenaRefresher(object):
             )
 
         for sqs_rec in event['Records']:
-            LOGGER.debug('Processing event with message ID \'%s\' and SentTimestamp %d',
+            LOGGER.debug('Processing event with message ID \'%s\' and SentTimestamp %s',
                          sqs_rec['messageId'],
                          sqs_rec['attributes']['SentTimestamp'])
 

--- a/terraform/modules/tf_stream_alert_athena/main.tf
+++ b/terraform/modules/tf_stream_alert_athena/main.tf
@@ -99,7 +99,7 @@ resource "aws_sqs_queue_policy" "streamalert_athena_data_bucket_notifications" {
 
 resource "aws_lambda_event_source_mapping" "streamalert_athena_sqs_event_source" {
   event_source_arn = "${aws_sqs_queue.streamalert_athena_data_bucket_notifications.arn}"
-  function_name    = "${aws_lambda_function.athena_partition_refresh.arn}"
+  function_name    = "${aws_lambda_function.athena_partition_refresh.arn}:${aws_lambda_alias.athena_partition_refresh_production.name}"
 }
 
 // S3 Bucekt Notificaiton: Configure S3 to notify Lambda


### PR DESCRIPTION
to: @austinbyers 
cc: @airbnb/streamalert-maintainers
size: small

## Background

@austinbyers observed the following stack trace:
```
%d format: a number is required, not unicode: TypeError
Traceback (most recent call last):
File "/var/task/stream_alert/athena_partition_refresh/main.py", line 212, in handler
AthenaRefresher().run(event)
File "/var/task/stream_alert/athena_partition_refresh/main.py", line 180, in run
sqs_rec['attributes']['SentTimestamp'])
File "/usr/lib64/python2.7/logging/__init__.py", line 1155, in debug
self._log(DEBUG, msg, args, **kwargs)
File "/usr/lib64/python2.7/logging/__init__.py", line 1286, in _log
self.handle(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 1296, in handle
self.callHandlers(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 1336, in callHandlers
hdlr.handle(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 759, in handle
self.emit(record)
File "/var/runtime/awslambda/bootstrap.py", line 446, in emit
msg = self.format(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 734, in format
return fmt.format(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 465, in format
record.message = record.getMessage()
File "/usr/lib64/python2.7/logging/__init__.py", line 329, in getMessage
msg = msg % self.args
TypeError: %d format: a number is required, not unicode
```

## Changes

* Fixing above error by using %s format string
* Updating event source mapping to invoke `production` alias instead of `$LATEST`

## Testing

Deployed in test account
