### PR TITLE
fixing bug where apps could time out between gather calls

### DIFF
--- a/stream_alert/apps/app_base.py
+++ b/stream_alert/apps/app_base.py
@@ -376,7 +376,8 @@ class AppIntegration(object):
         try:
             # Add a 50% buffer to the time it took to account for some unforeseen delay and to give
             # this function enough time to spawn a new invocation if there are more logs to poll
-            while (self._gather() * self._POLL_BUFFER_MULTIPLIER) < self._remaining_seconds:
+            while (((self._gather() * self._POLL_BUFFER_MULTIPLIER) + self._sleep_seconds()) <
+                   self._remaining_seconds):
                 LOGGER.debug('[%s] More logs to poll: %s', self, self._more_to_poll)
                 self._config.report_remaining_seconds()
                 if not self._more_to_poll:


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
size: small

## Background

Identified bug from recent refactor that allowed for looping of gather calls to not take into account the time apps may have to 'sleep' between new api requests.

## Changes

* Adding the sleep seconds returned by the app to the calculated time that would be needed for another request to be successfully made.

