### PR TITLE
Better JSON and top-level error handling

### DIFF
--- a/stream_alert/rule_processor/main.py
+++ b/stream_alert/rule_processor/main.py
@@ -14,10 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from __future__ import absolute_import  # Suppresses RuntimeWarning import error in Lambda
+import json
 
+from stream_alert.rule_processor import LOGGER
 from stream_alert.rule_processor.handler import StreamAlert
 
 
 def handler(event, context):
     """Main Lambda handler function"""
-    StreamAlert(context).run(event)
+    try:
+        StreamAlert(context).run(event)
+    except Exception:
+        LOGGER.error('Invocation event: %s', json.dumps(event))
+        raise

--- a/stream_alert/rule_processor/parsers.py
+++ b/stream_alert/rule_processor/parsers.py
@@ -324,9 +324,14 @@ class JSONParser(ParserBase):
             for record in extracted_records:
                 try:
                     record = json.loads(record)
-                except ValueError:
+                except (ValueError, TypeError):
                     LOGGER.debug('Embedded json is invalid')
                     continue
+
+                if not isinstance(record, dict):
+                    LOGGER.warning('Record is not a dict: %s', record)
+                    continue
+
                 json_records.append(record)
             return json_records
 
@@ -368,7 +373,7 @@ class JSONParser(ParserBase):
         if isinstance(data, (unicode, str)):
             try:
                 loaded_data = json.loads(data)
-            except ValueError as err:
+            except (ValueError, TypeError) as err:
                 LOGGER.debug('JSON parse failed: %s', str(err))
                 LOGGER.debug('JSON parse could not load data: %s', str(data))
                 return False


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers 
size: small

## Background

We were seeing some errors of the form `'int' has no attribute 'update'` because:

```python
json.loads("0") == 0  # Returns an integer!
```

## Changes

* Add a top-level `try: except` around the rule processor to log the invocation event if an exception is raised for easier troubleshooting
* Check if nested records are dictionaries before continuing to process them

## Testing

* Changes have already been deployed in our account