### PR TITLE
[lambda] support vpc attachment

### DIFF
--- a/stream_alert_cli/terraform/streamalert.py
+++ b/stream_alert_cli/terraform/streamalert.py
@@ -44,6 +44,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
     """
     account = config['global']['account']
     modules = config['clusters'][cluster_name]['modules']
+    vpc_subnets = config['clusters'][cluster_name].get("vpc_subnets", "")
+    vpc_security_groups = config['clusters'][cluster_name].get("vpc_security_groups", "")
 
     cluster_dict['module']['stream_alert_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert',
@@ -59,6 +61,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
         'rule_processor_memory': modules['stream_alert']['rule_processor']['memory'],
         'rule_processor_timeout': modules['stream_alert']['rule_processor']['timeout'],
         'rules_table_arn': '${module.globals.rules_table_arn}',
+        'vpc_subnets': vpc_subnets,
+        'vpc_security_groups': vpc_security_groups,
     }
 
     if (config['global'].get('threat_intel')

--- a/stream_alert_cli/terraform/streamalert.py
+++ b/stream_alert_cli/terraform/streamalert.py
@@ -44,8 +44,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
     """
     account = config['global']['account']
     modules = config['clusters'][cluster_name]['modules']
-    vpc_subnets = config['clusters'][cluster_name].get("vpc_subnets", "")
-    vpc_security_groups = config['clusters'][cluster_name].get("vpc_security_groups", "")
+    vpc_subnets = config['clusters'][cluster_name].get('vpc_subnets', '[]')
+    vpc_security_groups = config['clusters'][cluster_name].get('vpc_security_groups', '[]')
 
     cluster_dict['module']['stream_alert_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert',

--- a/stream_alert_cli/terraform/streamalert.py
+++ b/stream_alert_cli/terraform/streamalert.py
@@ -44,8 +44,8 @@ def generate_stream_alert(cluster_name, cluster_dict, config):
     """
     account = config['global']['account']
     modules = config['clusters'][cluster_name]['modules']
-    vpc_subnets = config['clusters'][cluster_name].get('vpc_subnets', '[]')
-    vpc_security_groups = config['clusters'][cluster_name].get('vpc_security_groups', '[]')
+    vpc_subnets = config['clusters'][cluster_name].get('vpc_subnets', [])
+    vpc_security_groups = config['clusters'][cluster_name].get('vpc_security_groups', [])
 
     cluster_dict['module']['stream_alert_{}'.format(cluster_name)] = {
         'source': 'modules/tf_stream_alert',

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -14,8 +14,8 @@ resource "aws_lambda_function" "streamalert_rule_processor" {
   publish          = true
 
   vpc_config {
-    subnet_ids      = ["${var.vpc_subnets}"]
-    security_groups = ["${var.vpc_security_groups}"]
+    subnet_ids      = "${var.vpc_subnets}"
+    security_groups = "${var.vpc_security_groups}"
   }
 
   environment {

--- a/terraform/modules/tf_stream_alert/main.tf
+++ b/terraform/modules/tf_stream_alert/main.tf
@@ -13,6 +13,11 @@ resource "aws_lambda_function" "streamalert_rule_processor" {
   source_code_hash = "${base64sha256(file(var.filename))}"
   publish          = true
 
+  vpc_config {
+    subnet_ids      = ["${var.vpc_subnets}"]
+    security_groups = ["${var.vpc_security_groups}"]
+  }
+
   environment {
     variables = {
       ALERTS_TABLE   = "${var.prefix}_streamalert_alerts"

--- a/terraform/modules/tf_stream_alert/variables.tf
+++ b/terraform/modules/tf_stream_alert/variables.tf
@@ -68,3 +68,11 @@ variable "threat_intel_enabled" {
 variable "dynamodb_ioc_table" {
   default = "streamalert_threat_intel_ioc_table"
 }
+
+variable "vpc_subnets" {
+  type = "list"
+}
+
+variable "vpc_security_groups" {
+  type = "list"
+}

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -283,8 +283,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_memory': 128,
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
-                    'vpc_subnets': "",
-                    'vpc_security_groups': "",
+                    'vpc_subnets': '[]',
+                    'vpc_security_groups': '[]',
                 }
             }
         }
@@ -317,8 +317,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
                     'input_sns_topics': ['my-sns-topic-name'],
-                    'vpc_subnets': "",
-                    'vpc_security_groups': "",
+                    'vpc_subnets': '[]',
+                    'vpc_security_groups': '[]',
                 }
             }
         }

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -283,6 +283,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_memory': 128,
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
+                    'vpc_subnets': "",
+                    'vpc_security_groups': "",
                 }
             }
         }
@@ -315,6 +317,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
                     'input_sns_topics': ['my-sns-topic-name'],
+                    'vpc_subnets': "",
+                    'vpc_security_groups': "",
                 }
             }
         }

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -283,8 +283,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_memory': 128,
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
-                    'vpc_subnets': '[]',
-                    'vpc_security_groups': '[]',
+                    'vpc_subnets': [],
+                    'vpc_security_groups': [],
                 }
             }
         }
@@ -317,8 +317,8 @@ class TestTerraformGenerate(object):
                     'rule_processor_timeout': 25,
                     'rules_table_arn': '${module.globals.rules_table_arn}',
                     'input_sns_topics': ['my-sns-topic-name'],
-                    'vpc_subnets': '[]',
-                    'vpc_security_groups': '[]',
+                    'vpc_subnets': [],
+                    'vpc_security_groups': [],
                 }
             }
         }


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
size: small


## Background
Typically network calls from SA lambdas egress over the internet. Sometimes we want them to egress from our VPC subnets.

## Changes

This change should allow users to attach their RuleProcessor lambda clusters to VPC subnets and security groups.

## Testing

I ran the unit tests
