### PR TITLE
function split part 2, adding classifier and normalizer 

### DIFF
--- a/conf/types_new.json
+++ b/conf/types_new.json
@@ -1,0 +1,392 @@
+{
+  "box": {
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "ip_address"
+      ]
+    }
+  }, 
+  "carbonblack": {
+    "command": {
+      "keys": [
+        "cmdline", 
+        "command_line"
+      ]
+    }, 
+    "destinationAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "remote_ip"
+      ]
+    }, 
+    "destinationDomain": {
+      "ioc_type": "domain", 
+      "keys": [
+        "domain"
+      ]
+    }, 
+    "destinationPort": {
+      "keys": [
+        "remote_port"
+      ]
+    }, 
+    "deviceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "interface_ip", 
+        "comms_ip"
+      ]
+    }, 
+    "fileHash": {
+      "ioc_type": "md5", 
+      "keys": [
+        "process_md5", 
+        "parent_md5", 
+        "expect_followon_w_md5", 
+        "md5"
+      ]
+    }, 
+    "fileName": {
+      "keys": [
+        "observed_filename", 
+        "file_path"
+      ]
+    }, 
+    "filePath": {
+      "keys": [
+        "path"
+      ]
+    }, 
+    "processName": {
+      "keys": [
+        "parent_name", 
+        "process_name"
+      ]
+    }, 
+    "processPath": {
+      "keys": [
+        "parent_path", 
+        "process_path", 
+        "path"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "ipv4", 
+        "local_ip"
+      ]
+    }, 
+    "sourcePort": {
+      "keys": [
+        "port", 
+        "local_port"
+      ]
+    }, 
+    "transportProtocol": {
+      "keys": [
+        "protocol"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "username"
+      ]
+    }
+  }, 
+  "cloudtrail": {
+    "destinationAccount": {
+      "keys": [
+        "recipientAccountId"
+      ]
+    }, 
+    "eventName": {
+      "keys": [
+        "eventName"
+      ]
+    }, 
+    "eventType": {
+      "keys": [
+        "eventType"
+      ]
+    }, 
+    "region": {
+      "keys": [
+        "region", 
+        "awsRegion"
+      ]
+    }, 
+    "sourceAccount": {
+      "keys": [
+        "account", 
+        "accountId"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "sourceIPAddress"
+      ]
+    }, 
+    "userAgent": {
+      "keys": [
+        "userAgent"
+      ]
+    }
+  }, 
+  "cloudwatch": {
+    "destinationAccount": {
+      "keys": [
+        "recipientAccountId"
+      ]
+    }, 
+    "destinationAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "destination"
+      ]
+    }, 
+    "destinationPort": {
+      "keys": [
+        "destport"
+      ]
+    }, 
+    "eventName": {
+      "keys": [
+        "eventName"
+      ]
+    }, 
+    "eventType": {
+      "keys": [
+        "eventType"
+      ]
+    }, 
+    "region": {
+      "keys": [
+        "region"
+      ]
+    }, 
+    "sourceAccount": {
+      "keys": [
+        "account"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "source", 
+        "sourceIPAddress"
+      ]
+    }, 
+    "sourcePort": {
+      "keys": [
+        "srcport"
+      ]
+    }, 
+    "transportProtocol": {
+      "keys": [
+        "protocol"
+      ]
+    }, 
+    "userAgent": {
+      "keys": [
+        "userAgent"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "userName", 
+        "owner", 
+        "invokedBy"
+      ]
+    }
+  }, 
+  "duo": {
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "ip"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "username"
+      ]
+    }
+  }, 
+  "ghe": {
+    "destinationAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "remote_address"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "actor_ip"
+      ]
+    }, 
+    "sourcePort": {
+      "keys": [
+        "port"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "actor", 
+        "current_user", 
+        "user"
+      ]
+    }
+  }, 
+  "gsuite": {
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "ipAddress"
+      ]
+    }
+  }, 
+  "onelogin": {
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "ipaddr", 
+        "proxy_ip"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "actor_user_name", 
+        "user_name"
+      ]
+    }
+  }, 
+  "osquery": {
+    "command": {
+      "keys": [
+        "cmdline", 
+        "command"
+      ]
+    }, 
+    "destinationAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "destination", 
+        "remote_address", 
+        "gateway"
+      ]
+    }, 
+    "destinationPort": {
+      "keys": [
+        "remote_port"
+      ]
+    }, 
+    "fileHash": {
+      "ioc_type": "md5", 
+      "keys": [
+        "md5", 
+        "sha1", 
+        "sha256"
+      ]
+    }, 
+    "filePath": {
+      "keys": [
+        "path", 
+        "directory"
+      ]
+    }, 
+    "fileSize": {
+      "keys": [
+        "size"
+      ]
+    }, 
+    "message": {
+      "keys": [
+        "message"
+      ]
+    }, 
+    "receiptTime": {
+      "keys": [
+        "unixTime"
+      ]
+    }, 
+    "severity": {
+      "keys": [
+        "severity"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "host", 
+        "source", 
+        "local_address", 
+        "address"
+      ]
+    }, 
+    "sourcePort": {
+      "keys": [
+        "local_port", 
+        "port"
+      ]
+    }, 
+    "sourceUserId": {
+      "keys": [
+        "uid"
+      ]
+    }, 
+    "transportProtocol": {
+      "keys": [
+        "protocol"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "username", 
+        "user"
+      ]
+    }
+  }, 
+  "pan": {
+    "destinationAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "dst", 
+        "natdst"
+      ]
+    }, 
+    "destinationPort": {
+      "keys": [
+        "dport", 
+        "natdport"
+      ]
+    }, 
+    "sourceAddress": {
+      "ioc_type": "ip", 
+      "keys": [
+        "src", 
+        "natsrc"
+      ]
+    }, 
+    "sourcePort": {
+      "keys": [
+        "sport", 
+        "natsport"
+      ]
+    }, 
+    "transportProtocol": {
+      "keys": [
+        "proto"
+      ]
+    }, 
+    "userName": {
+      "keys": [
+        "srcuser", 
+        "dstuser"
+      ]
+    }
+  }
+}

--- a/conf/types_new.json
+++ b/conf/types_new.json
@@ -1,390 +1,390 @@
 {
   "box": {
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "ip_address"
       ]
     }
-  }, 
+  },
   "carbonblack": {
     "command": {
       "keys": [
-        "cmdline", 
+        "cmdline",
         "command_line"
       ]
-    }, 
+    },
     "destinationAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "remote_ip"
       ]
-    }, 
+    },
     "destinationDomain": {
-      "ioc_type": "domain", 
+      "ioc_type": "domain",
       "keys": [
         "domain"
       ]
-    }, 
+    },
     "destinationPort": {
       "keys": [
         "remote_port"
       ]
-    }, 
+    },
     "deviceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "interface_ip", 
+        "interface_ip",
         "comms_ip"
       ]
-    }, 
+    },
     "fileHash": {
-      "ioc_type": "md5", 
+      "ioc_type": "md5",
       "keys": [
-        "process_md5", 
-        "parent_md5", 
-        "expect_followon_w_md5", 
+        "process_md5",
+        "parent_md5",
+        "expect_followon_w_md5",
         "md5"
       ]
-    }, 
+    },
     "fileName": {
       "keys": [
-        "observed_filename", 
+        "observed_filename",
         "file_path"
       ]
-    }, 
+    },
     "filePath": {
       "keys": [
         "path"
       ]
-    }, 
+    },
     "processName": {
       "keys": [
-        "parent_name", 
+        "parent_name",
         "process_name"
       ]
-    }, 
+    },
     "processPath": {
       "keys": [
-        "parent_path", 
-        "process_path", 
+        "parent_path",
+        "process_path",
         "path"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "ipv4", 
+        "ipv4",
         "local_ip"
       ]
-    }, 
+    },
     "sourcePort": {
       "keys": [
-        "port", 
+        "port",
         "local_port"
       ]
-    }, 
+    },
     "transportProtocol": {
       "keys": [
         "protocol"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
         "username"
       ]
     }
-  }, 
+  },
   "cloudtrail": {
     "destinationAccount": {
       "keys": [
         "recipientAccountId"
       ]
-    }, 
+    },
     "eventName": {
       "keys": [
         "eventName"
       ]
-    }, 
+    },
     "eventType": {
       "keys": [
         "eventType"
       ]
-    }, 
+    },
     "region": {
       "keys": [
-        "region", 
+        "region",
         "awsRegion"
       ]
-    }, 
+    },
     "sourceAccount": {
       "keys": [
-        "account", 
+        "account",
         "accountId"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "sourceIPAddress"
       ]
-    }, 
+    },
     "userAgent": {
       "keys": [
         "userAgent"
       ]
     }
-  }, 
+  },
   "cloudwatch": {
     "destinationAccount": {
       "keys": [
         "recipientAccountId"
       ]
-    }, 
+    },
     "destinationAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "destination"
       ]
-    }, 
+    },
     "destinationPort": {
       "keys": [
         "destport"
       ]
-    }, 
+    },
     "eventName": {
       "keys": [
         "eventName"
       ]
-    }, 
+    },
     "eventType": {
       "keys": [
         "eventType"
       ]
-    }, 
+    },
     "region": {
       "keys": [
         "region"
       ]
-    }, 
+    },
     "sourceAccount": {
       "keys": [
         "account"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "source", 
+        "source",
         "sourceIPAddress"
       ]
-    }, 
+    },
     "sourcePort": {
       "keys": [
         "srcport"
       ]
-    }, 
+    },
     "transportProtocol": {
       "keys": [
         "protocol"
       ]
-    }, 
+    },
     "userAgent": {
       "keys": [
         "userAgent"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
-        "userName", 
-        "owner", 
+        "userName",
+        "owner",
         "invokedBy"
       ]
     }
-  }, 
+  },
   "duo": {
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "ip"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
         "username"
       ]
     }
-  }, 
+  },
   "ghe": {
     "destinationAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "remote_address"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "actor_ip"
       ]
-    }, 
+    },
     "sourcePort": {
       "keys": [
         "port"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
-        "actor", 
-        "current_user", 
+        "actor",
+        "current_user",
         "user"
       ]
     }
-  }, 
+  },
   "gsuite": {
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
         "ipAddress"
       ]
     }
-  }, 
+  },
   "onelogin": {
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "ipaddr", 
+        "ipaddr",
         "proxy_ip"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
-        "actor_user_name", 
+        "actor_user_name",
         "user_name"
       ]
     }
-  }, 
+  },
   "osquery": {
     "command": {
       "keys": [
-        "cmdline", 
+        "cmdline",
         "command"
       ]
-    }, 
+    },
     "destinationAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "destination", 
-        "remote_address", 
+        "destination",
+        "remote_address",
         "gateway"
       ]
-    }, 
+    },
     "destinationPort": {
       "keys": [
         "remote_port"
       ]
-    }, 
+    },
     "fileHash": {
-      "ioc_type": "md5", 
+      "ioc_type": "md5",
       "keys": [
-        "md5", 
-        "sha1", 
+        "md5",
+        "sha1",
         "sha256"
       ]
-    }, 
+    },
     "filePath": {
       "keys": [
-        "path", 
+        "path",
         "directory"
       ]
-    }, 
+    },
     "fileSize": {
       "keys": [
         "size"
       ]
-    }, 
+    },
     "message": {
       "keys": [
         "message"
       ]
-    }, 
+    },
     "receiptTime": {
       "keys": [
         "unixTime"
       ]
-    }, 
+    },
     "severity": {
       "keys": [
         "severity"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "host", 
-        "source", 
-        "local_address", 
+        "host",
+        "source",
+        "local_address",
         "address"
       ]
-    }, 
+    },
     "sourcePort": {
       "keys": [
-        "local_port", 
+        "local_port",
         "port"
       ]
-    }, 
+    },
     "sourceUserId": {
       "keys": [
         "uid"
       ]
-    }, 
+    },
     "transportProtocol": {
       "keys": [
         "protocol"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
-        "username", 
+        "username",
         "user"
       ]
     }
-  }, 
+  },
   "pan": {
     "destinationAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "dst", 
+        "dst",
         "natdst"
       ]
-    }, 
+    },
     "destinationPort": {
       "keys": [
-        "dport", 
+        "dport",
         "natdport"
       ]
-    }, 
+    },
     "sourceAddress": {
-      "ioc_type": "ip", 
+      "ioc_type": "ip",
       "keys": [
-        "src", 
+        "src",
         "natsrc"
       ]
-    }, 
+    },
     "sourcePort": {
       "keys": [
-        "sport", 
+        "sport",
         "natsport"
       ]
-    }, 
+    },
     "transportProtocol": {
       "keys": [
         "proto"
       ]
-    }, 
+    },
     "userName": {
       "keys": [
-        "srcuser", 
+        "srcuser",
         "dstuser"
       ]
     }

--- a/stream_alert/classifier/classifier.py
+++ b/stream_alert/classifier/classifier.py
@@ -1,0 +1,210 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from collections import OrderedDict
+import logging
+from os import environ as env
+
+from stream_alert.classifier.normalize import Normalizer
+from stream_alert.classifier.parsers import get_parser
+from stream_alert.classifier.payload.payload_base import StreamPayload
+from stream_alert.shared import config, CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
+from stream_alert.shared.logger import get_logger
+from stream_alert.shared.metrics import MetricLogger
+from stream_alert.shared.stats import print_rule_stats
+
+
+LOGGER = get_logger(__name__)
+LOGGER_DEBUG_ENABLED = LOGGER.isEnabledFor(logging.DEBUG)
+
+
+class Classifier(object):
+    """Classify, map source, and parse a raw record into its declared type."""
+
+    _config = None
+
+    def __init__(self, verbose=False):
+        # Create some objects to be cached if they have not already been created
+        Classifier._config = Classifier._config or config.load_config(validate=True)
+
+        # Setup the normalization logic
+        Normalizer.load_from_config(self.config)
+
+        self._verbose = verbose
+        self._aws_region = env.get('AWS_REGION') or env.get('AWS_DEFAULT_REGION') or 'us-east-1'
+        self._payloads = []
+        self._failed_record_count = 0
+        self._processed_size = 0
+
+    @property
+    def config(self):
+        return Classifier._config
+
+    def _load_logs_for_resource(self, service, resource):
+        """Load the log types for this service type and resource value
+
+        Args:
+            service (str): Source service
+            resource (str): Resource within the service
+
+        Returns:
+            bool: True if the resource's log sources loaded properly
+        """
+        # Get all logs for the configured service/entity (s3, kinesis, or sns)
+        resources = self._config['sources'].get(service)
+        if not resources:
+            LOGGER.error('Service [%s] not declared in sources configuration', service)
+            return False
+
+        source_config = resources.get(resource)
+        if not source_config:
+            LOGGER.error(
+                'Resource [%s] not declared in sources configuration for service [%s]',
+                resource,
+                service)
+            return False
+
+        # Get the log schemas for source(s)
+        return OrderedDict(
+            (source, self.config['logs'][source])
+            for source in self.config['logs'].keys()
+            if source.split(':')[0] in source_config['logs']
+        )
+
+    @classmethod
+    def _process_log_schemas(cls, payload_record, logs_config):
+        """Get any log schemas that matched this log format
+
+        Args:
+            payload_record: A PayloadRecord object
+
+        Returns:
+            list: Contains any schemas that matched this log format
+                Each list entry contains the namedtuple of 'SchemaMatch' with
+                values of log_name, root_schema, parser, and parsed_data
+        """
+        # Loop over all logs schemas declared for this source
+        for log_type, options in logs_config.iteritems():
+            LOGGER.debug('Trying schema \'%s\' with options: %s', log_type, options)
+
+            # Get the parser type to use for this log and set up the parser
+            parser = get_parser(options['parser'])(options, log_type=log_type)
+
+            parsed = parser.parse(payload_record.data)
+            if not parsed:
+                LOGGER.debug('Failed to classify data with schema: %s', log_type)
+                continue
+
+            # Set the parser on successful parse
+            payload_record.parser = parser
+
+            return True
+
+        return False  #  unable to parse this record
+
+    def run(self, records):
+        """Run classificaiton of the records in the Lambda input
+
+        Args:
+            records (list): An list of records received by Lambda
+        """
+        LOGGER.debug('Number of incoming records: %d', len(records))
+        if not records:
+            return False
+
+        for input_record in records:
+            # Get the service and entity from the payload
+            payload = StreamPayload.load_from_raw_record(input_record)
+            if not payload:
+                continue
+
+            self._classify_payload(payload)
+
+        self._log_metrics()
+
+        # Only log rule info here if this is not running tests
+        # During testing, this gets logged at the end and printing here could be confusing
+        # since stress testing calls this method multiple times
+        if self._verbose:
+            print_rule_stats(True)
+
+    def _log_bad_records(self, payload_record, records):
+        for record in records:
+            LOGGER.error(
+                'Record does not match any defined schemas: %s\n%s', payload_record, record
+            )
+            self._failed_record_count += 1
+
+    def _classify_payload(self, payload):
+        """Run the record through the rules, saving any alerts and forwarding them to Dynamo.
+
+        Args:
+            payload (StreamPayload): StreamAlert payload object being processed
+        """
+        # Get logs defined for the service/entity in the config
+        logs_config = self._load_logs_for_resource(payload.service(), payload.resource)
+        if not logs_config:
+            LOGGER.error(
+                'No log types defined for resource [%s] in sources configuration for service [%s]',
+                payload.resource,
+                payload.service()
+            )
+            return
+
+        for record in payload.pre_parse():
+            # Increment the processed size using the length of this record
+            self._processed_size += len(record)
+
+            # Get the parser for this data
+            self._process_log_schemas(record, logs_config)
+
+            LOGGER.debug('Parsed and classified payload: %s', bool(record))
+
+            payload.fully_classified = payload.fully_classified and record
+            if not record:
+                self._log_bad_records(record, [record.data])
+                continue
+
+            LOGGER.debug(
+                'Classified %d record(s) with schema: %s',
+                len(record.parsed_records),
+                record.log_type
+            )
+
+            # Even if the parser was successful, there's a chance it
+            # could not parse all records, so log them here as invalid
+            self._log_bad_records(record, record.invalid_parses)
+
+            for parsed_rec in record.parsed_records:
+                Normalizer.normalize(parsed_rec, record.log_type)
+
+            self._payloads.append(record)
+
+    def _log_metrics(self):
+        """Perform some metric logging before exiting"""
+        MetricLogger.log_metric(
+            FUNCTION_NAME,
+            MetricLogger.TOTAL_RECORDS,
+            sum(len(payload.parsed_records for payload in self._payloads))
+        )
+
+        MetricLogger.log_metric(
+            FUNCTION_NAME, MetricLogger.TOTAL_PROCESSED_SIZE, self._processed_size
+        )
+
+        LOGGER.debug('Invalid record count: %d', self._failed_record_count)
+        MetricLogger.log_metric(
+            FUNCTION_NAME, MetricLogger.FAILED_PARSES, self._failed_record_count
+        )

--- a/stream_alert/classifier/classifier.py
+++ b/stream_alert/classifier/classifier.py
@@ -87,15 +87,15 @@ class Classifier(object):
     def _process_log_schemas(cls, payload_record, logs_config):
         """Get any log schemas that matched this log format
 
+        If successful, this method sets the PayloadRecord.parser attribute to the parser
+        that was used to parse the data.
+
         Args:
             payload_record: A PayloadRecord object
             logs_config: Subset of entire logs.json schemas to use for processing
 
         Returns:
             bool: True if the payload's data was successfully parsed, False otherwise
-
-        Sets:
-            PayloadRecord.parser: Assigns a parser to the PayloadRecord for the data
         """
         # Loop over all logs schemas declared for this source
         for log_type, options in logs_config.iteritems():
@@ -117,7 +117,7 @@ class Classifier(object):
         return False  # unable to parse this record
 
     def _classify_payload(self, payload):
-        """Run the record through the rules, saving any alerts and forwarding them to Dynamo.
+        """Run the payload through the classification logic to determine the data type
 
         Args:
             payload (StreamPayload): StreamAlert payload object being processed
@@ -167,6 +167,7 @@ class Classifier(object):
         Args:
             payload_record (PayloadRecord): PayloadRecord instance that, when logged to output,
                 prints some information that will be helpful for debugging bad data
+            invalid_record_count (int): Number of invalid records to increment the count by
         """
         if not invalid_record_count:
             return  # don't log anything if the count of invalid records is not > 0

--- a/stream_alert/classifier/normalize.py
+++ b/stream_alert/classifier/normalize.py
@@ -1,0 +1,129 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+
+from stream_alert.shared import NORMALIZATION_KEY
+from stream_alert.shared.logger import get_logger
+
+
+LOGGER = get_logger(__name__)
+LOGGER_DEBUG_ENABLED = LOGGER.isEnabledFor(logging.DEBUG)
+
+
+class Normalizer(object):
+    """Normalizer class to handle log key normalization in payloads"""
+
+    # Store the normalized CEF types mapping to original keys from the records
+    _types_config = None
+
+    @classmethod
+    def match_types(cls, record, normalized_types):
+        """Check for normalized types within record
+
+        Args:
+            record (dict): Parsed payload of log
+            normalized_types (dict): Normalized types mapping
+
+        Returns:
+            dict: A dict of normalized_types with original key names
+
+        Example:
+            record={
+                'region': 'region_name',
+                'detail': {
+                    'awsRegion': 'region_name'
+                }
+            }
+            normalized_types={
+                'region': ['region', 'awsRegion']
+            }
+
+            return={
+                'region': [['region'], ['detail', 'awsRegion']]
+            }
+        """
+        return {
+            key: list(cls._extract_paths(record, set(values)))
+            for key, values in normalized_types.iteritems()
+        }
+
+    @classmethod
+    def _extract_paths(cls, record, normalized_keys, path=None):
+        """Recursively extract lists of path parts from a dictionary
+
+        Args:
+            record (dict): Parsed payload of log
+            normalized_keys (set): Normalized keys for which to extract paths
+            path (list=None): Parts of current path for which keys are being extracted
+
+        Yields:
+            list: Parts of path in dictionary that contain normalized keys
+        """
+        path = path or []
+        for key, value in record.iteritems():
+            temp_path = [item for item in path]
+            temp_path.append(key)
+            if key in normalized_keys:
+                yield temp_path
+            if isinstance(value, dict):
+                for nested_path in cls._extract_paths(value, normalized_keys, temp_path):
+                    yield nested_path
+
+    @classmethod
+    def normalize(cls, record, log_type):
+        """Apply data normalization to a record
+
+        Args:
+            record (dict): The parsed log w/wo data normalization
+            log_type (str): Type of log for which to apply normalizaiton
+        """
+        log_normalized_types = cls._types_config.get(log_type)
+        if not log_normalized_types:
+            LOGGER.debug('No normalized types defined for log type: %s', log_type)
+            return
+
+        found_types = cls.match_types(record, log_normalized_types)
+        if not found_types:
+            LOGGER.error('No normalized values found in record: %s', log_normalized_types)
+            return
+
+        # Add normalized keys to the record
+        record.update({NORMALIZATION_KEY: found_types})
+
+    @classmethod
+    def load_from_config(cls, config):
+        """Extract and store the data types from the config in the proper format
+
+        Args:
+            config (dict): Config read from 'conf/' directory
+
+        Returns:
+            Normalizer: Class to be used for normalization logic
+        """
+        if cls._types_config:
+            return cls  # config is already populated
+
+        if 'types_new' not in config:  # TODO: change this and below to types
+            return cls  # nothing to do
+
+        cls._types_config = {
+            log_source: {
+                normalized_type: metadata['keys']
+                for normalized_type, metadata in key_mapping.iteritems()
+            } for log_source, key_mapping in config['types_new'].iteritems()
+        }
+
+        return cls  # there are no instance methods, so just return the class

--- a/stream_alert/classifier/normalize.py
+++ b/stream_alert/classifier/normalize.py
@@ -56,7 +56,7 @@ class Normalizer(object):
             }
         """
         return {
-            key: list(cls._extract_paths(record, set(values)))
+            key: list(cls._extract_paths(record, values))
             for key, values in normalized_types.iteritems()
         }
 
@@ -95,13 +95,8 @@ class Normalizer(object):
             LOGGER.debug('No normalized types defined for log type: %s', log_type)
             return
 
-        found_types = cls.match_types(record, log_normalized_types)
-        if not found_types:
-            LOGGER.error('No normalized values found in record: %s', log_normalized_types)
-            return
-
         # Add normalized keys to the record
-        record.update({NORMALIZATION_KEY: found_types})
+        record.update({NORMALIZATION_KEY: cls.match_types(record, log_normalized_types)})
 
     @classmethod
     def load_from_config(cls, config):
@@ -121,7 +116,7 @@ class Normalizer(object):
 
         cls._types_config = {
             log_source: {
-                normalized_type: metadata['keys']
+                normalized_type: set(metadata['keys'])
                 for normalized_type, metadata in key_mapping.iteritems()
             } for log_source, key_mapping in config['types_new'].iteritems()
         }

--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -90,40 +90,40 @@ class ParserBase:
         return cls._type
 
     @property
-    def log_schema_type(self):
-        return self._schema_type
-
-    @property
-    def schema(self):
+    def _schema(self):
         return self._options.get('schema', {})
 
     @property
-    def configuration(self):
+    def _configuration(self):
         return self._options.get('configuration', {})
 
     @property
-    def optional_top_level_keys(self):
-        return set(self.configuration.get('optional_top_level_keys', {}))
+    def _optional_top_level_keys(self):
+        return set(self._configuration.get('optional_top_level_keys', {}))
 
     @property
-    def log_patterns(self):
-        return self.configuration.get('log_patterns')
+    def _log_patterns(self):
+        return self._configuration.get('log_patterns')
 
     @property
-    def json_path(self):
-        return self.configuration.get('json_path')
+    def _json_path(self):
+        return self._configuration.get('json_path')
 
     @property
-    def envelope_schema(self):
-        return self.configuration.get('envelope_keys', {})
+    def _envelope_schema(self):
+        return self._configuration.get('envelope_keys', {})
 
     @property
-    def optional_envelope_keys(self):
-        return set(self.configuration.get('optional_envelope_keys', {}))
+    def _optional_envelope_keys(self):
+        return set(self._configuration.get('optional_envelope_keys', {}))
 
     @property
     def valid(self):
         return len(self._valid_parses) != 0
+
+    @property
+    def log_schema_type(self):
+        return self._schema_type
 
     @property
     def invalid_parses(self):
@@ -363,8 +363,8 @@ class ParserBase:
         # TODO (ryandeivert): check the value of types defined in the schema to ensure
         # they are valid before erroring out at the _convert_type stage
         values = [
-            (self.schema, self.optional_top_level_keys),
-            (self.envelope_schema, self.optional_envelope_keys)
+            (self._schema, self._optional_top_level_keys),
+            (self._envelope_schema, self._optional_envelope_keys)
         ]
 
         return all(optionals.issubset(schema) for schema, optionals in values)
@@ -382,7 +382,7 @@ class ParserBase:
             return
 
         self._apply_envelope(record, envelope)
-        self._add_optional_keys(record, self.schema, self.optional_top_level_keys)
+        self._add_optional_keys(record, self._schema, self._optional_top_level_keys)
 
         self._valid_parses.append(record)
 
@@ -395,13 +395,13 @@ class ParserBase:
         Returns:
             dict: Key/values extracted from the log to be used as the envelope
         """
-        if not self.envelope_schema:
+        if not self._envelope_schema:
             return
 
         LOGGER.debug('Extracting envelope keys')
         return {
             key: payload[key]
-            for key in self.envelope_schema
+            for key in self._envelope_schema
             if key in payload  # This is fine since some of these may be optional
         }
 
@@ -415,9 +415,9 @@ class ParserBase:
             list: A list of JSON records extracted via JSON path
         """
         # Handle jsonpath extraction of records
-        LOGGER.debug('Parsing records with JSONPath: %s', self.json_path)
+        LOGGER.debug('Parsing records with JSONPath: %s', self._json_path)
 
-        return jmespath.search(self.json_path, payload)
+        return jmespath.search(self._json_path, payload)
 
     def parse(self, data):
         """Main parser method to be handle parsing of the passed data
@@ -431,7 +431,7 @@ class ParserBase:
         # Ensure the schema is defined properly. Invalid schemas will not be used
         if not self._validate_schema():
             LOGGER.error(
-                'Schema definition is not valid (%s):\n%s', self._schema_type, self.schema)
+                'Schema definition is not valid (%s):\n%s', self._schema_type, self._schema)
             return False
 
         data_copy = None
@@ -450,21 +450,25 @@ class ParserBase:
                 data_copy = data
 
         # Check to make sure any non-optional envelope keys exist before proceeding
-        if not self._key_check(data_copy, self.envelope_schema, self.optional_envelope_keys, True):
+        if not self._key_check(
+                data_copy, self._envelope_schema, self._optional_envelope_keys, True
+            ):
             return False
 
         # Get the envelope and try to convert the value to the proper type(s)
         envelope = self._extract_envelope(data_copy)
-        if not self._convert_type(envelope, self.envelope_schema, self.optional_envelope_keys):
+        if not self._convert_type(envelope, self._envelope_schema, self._optional_envelope_keys):
             return False
 
         # Add the optional envelope keys to record once at the beginning
-        self._add_optional_keys(envelope, self.envelope_schema, self.optional_envelope_keys)
+        self._add_optional_keys(envelope, self._envelope_schema, self._optional_envelope_keys)
 
         for record, valid in self._parse(data_copy):
-            valid = valid and self._key_check(record, self.schema, self.optional_top_level_keys)
-            valid = valid and self._convert_type(record, self.schema, self.optional_top_level_keys)
-            valid = valid and self._matches_log_patterns(record, self.log_patterns)
+            valid = valid and self._key_check(record, self._schema, self._optional_top_level_keys)
+            valid = valid and self._convert_type(
+                record, self._schema, self._optional_top_level_keys
+            )
+            valid = valid and self._matches_log_patterns(record, self._log_patterns)
             self._add_parse_result(record, valid, envelope)
 
         return self.valid
@@ -490,11 +494,11 @@ class JSONParser(ParserBase):
 
     @property
     def embedded_json(self):
-        return self.configuration.get('embedded_json', False)
+        return self._configuration.get('embedded_json', False)
 
     @property
     def json_regex_key(self):
-        return self.configuration.get('json_regex_key')
+        return self._configuration.get('json_regex_key')
 
     def _extract_via_json_path(self, json_payload):
         """Extract records from the original json payload using the JSON configuration
@@ -579,11 +583,11 @@ class JSONParser(ParserBase):
                 Examples: [({'key': 'value'}, True)]
         """
         # TODO (ryandeivert): migrate all of this to the base class and do away with JSONParser
-        if not (self.json_path or self.json_regex_key):
+        if not (self._json_path or self.json_regex_key):
             return [(data, True)]  # Nothing special to be done
 
         records = []
-        if self.json_path:
+        if self._json_path:
             records = self._extract_via_json_path(data)
         elif self.json_regex_key:
             records = self._extract_via_json_regex_key(data)
@@ -599,19 +603,19 @@ class CSVParser(ParserBase):
     @property
     def delimiter(self):
         # default delimiter = ','
-        return str(self.configuration.get('delimiter', ','))
+        return str(self._configuration.get('delimiter', ','))
 
     @property
     def quotechar(self):
         # default quotechar = '"'
-        return str(self.configuration.get('quotechar', '"'))
+        return str(self._configuration.get('quotechar', '"'))
 
     @property
     def escapechar(self):
         # default escapechar = None
         # only cast to string if it exists since casting NoneType to string will result in 'None'
-        return (str(self.configuration['escapechar'])
-                if 'escapechar' in self.configuration else None)
+        return (str(self._configuration['escapechar'])
+                if 'escapechar' in self._configuration else None)
 
     def _get_reader(self, data):
         """Return the CSV reader for the data using the configured delimiter, etc
@@ -640,7 +644,7 @@ class CSVParser(ParserBase):
                 Examples: [({'key': 'value'}, True)]
         """
         extracted_data = []
-        if self.json_path:
+        if self._json_path:
             # Support extraction of csv data within json
             extracted_data = self._json_path_records(data)
             if not extracted_data:
@@ -649,7 +653,7 @@ class CSVParser(ParserBase):
         # Fall back on the data as default if extraction failed
         data = extracted_data or [data]
 
-        return self._extract_records(data, self.schema)
+        return self._extract_records(data, self._schema)
 
     def _extract_records(self, data, schema):
         """Extract record(s) from the csv data using the specified schema
@@ -720,12 +724,12 @@ class KVParser(ParserBase):
     @property
     def delimiter(self):
         # default delimiter = ' '
-        return str(self.configuration.get('delimiter', ' '))
+        return str(self._configuration.get('delimiter', ' '))
 
     @property
     def separator(self):
         # default separator = '='
-        return str(self.configuration.get('separator', '='))
+        return str(self._configuration.get('separator', '='))
 
     def _parse(self, data):
         """Parse a key/value string into a dictionary
@@ -754,7 +758,7 @@ class KVParser(ParserBase):
             # remove any blank strings that may exist in our list
             fields = [field for field in data.split(self.delimiter) if field]
             # first check the field length matches our # of keys
-            if len(fields) != len(self.schema):
+            if len(fields) != len(self._schema):
                 return False
 
             for index, field in enumerate(fields):
@@ -768,7 +772,7 @@ class KVParser(ParserBase):
                 # handle duplicate keys
                 if key in kv_payload:
                     # load key from our configuration
-                    kv_payload[self.schema.keys()[index]] = value
+                    kv_payload[self._schema.keys()[index]] = value
                 else:
                     # add the data value
                     kv_payload[key] = value

--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -81,6 +81,9 @@ class ParserBase:
         self._valid_parses = []
         self._invalid_parses = []
 
+    def __len__(self):
+        return len(self._valid_parses)
+
     @classmethod
     def type(cls):
         """Returns the type of parser"""
@@ -127,7 +130,7 @@ class ParserBase:
         return self._invalid_parses
 
     @property
-    def parses(self):
+    def parsed_records(self):
         return self._valid_parses
 
     @classmethod

--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -81,6 +81,12 @@ class ParserBase:
         self._valid_parses = []
         self._invalid_parses = []
 
+    def __nonzero__(self):
+        return self.valid
+
+    # For forward compatibility to Python3
+    __bool__ = __nonzero__
+
     def __len__(self):
         return len(self._valid_parses)
 

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -46,7 +46,7 @@ class PayloadRecord(object):
 
         ParserBase implements __nonzero__ as well, so return the result of it
         """
-        return bool(self._parser)
+        return self._parser is not None
 
     # For forward compatibility to Python3
     __bool__ = __nonzero__
@@ -59,19 +59,32 @@ class PayloadRecord(object):
         )
 
     def __repr__(self):
-        if self:
-            return '<{} valid:{}; log type:{}; parsed records:{}; invalid records:{};>'.format(
+        if not self:
+            return '<{} valid:{}; raw record:{};>'.format(
+                self.__class__.__name__,
+                bool(self),
+                self._record_data
+            )
+
+        if self.invalid_records:
+            return (
+                '<{} valid:{}; log type:{}; parsed records:{}; invalid records:{} ({}); '
+                'raw record:{};>'
+            ).format(
                 self.__class__.__name__,
                 bool(self),
                 self.log_schema_type,
                 len(self.parsed_records),
-                len(self.invalid_records)
+                len(self.invalid_records),
+                self.invalid_records,
+                self._record_data
             )
 
-        return '<{} valid:{}; raw record:{};>'.format(
+        return '<{} valid:{}; log type:{}; parsed records:{};>'.format(
             self.__class__.__name__,
             bool(self),
-            self._record_data
+            self.log_schema_type,
+            len(self.parsed_records)
         )
 
     @property
@@ -92,7 +105,7 @@ class PayloadRecord(object):
 
     @property
     def invalid_records(self):
-        return self.parser.invalid_records if self else []
+        return self.parser.invalid_parses if self else []
 
     @property
     def log_schema_type(self):

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -68,7 +68,7 @@ class PayloadRecord(object):
                 len(self.invalid_records)
             )
 
-        return '<{} valid:{} raw record:{}>'.format(
+        return '<{} valid:{}; raw record:{};>'.format(
             self.__class__.__name__,
             bool(self),
             self._record_data

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -66,6 +66,7 @@ class PayloadRecord(object):
                 self._record_data
             )
 
+        # If there are invalid records, log the count and the raw data to output
         if self.invalid_records:
             return (
                 '<{} valid:{}; log type:{}; parsed records:{}; invalid records:{} ({}); '

--- a/tests/unit/streamalert/classifier/payload/test_payload_base.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_base.py
@@ -79,36 +79,25 @@ class TestStreamPayload(object):
 
     def test_non_zero_false(self):
         """StreamPayload - Non Zero/Bool, False"""
+        self._payload.fully_classified = False
         assert_equal(bool(self._payload), False)
 
     def test_non_zero_true(self):
         """StreamPayload - Non Zero/Bool, True"""
-        self._payload.data_type = 'type'
-        self._payload.log_source = 'source'
-        self._payload.records = ['records']
         assert_equal(bool(self._payload), True)
 
     def test_repr(self):
         """StreamPayload - Repr"""
-        self._payload.data_type = 'type'
-        self._payload.log_source = 'source'
-        self._payload.records = ['records']
-        self._payload.fully_classified = False
-        expected_result = (
-            '<StreamPayload valid:False log_source:source resource:foobar '
-            'type:type record:[\'records\']>'
-        )
+        expected_result = '<StreamPayload valid:True; resource:foobar;>'
         assert_equal(repr(self._payload), expected_result)
 
-    def test_log_type_property(self):
-        """StreamPayload - Log Type"""
-        self._payload.log_source = 'source:log_type'
-        assert_equal(self._payload.log_type, 'source')
-
-    def test_log_sub_type_property(self):
-        """StreamPayload - Log Sub Type"""
-        self._payload.log_source = 'source:log_type'
-        assert_equal(self._payload.log_subtype, 'log_type')
+    def test_repr_invalid(self):
+        """StreamPayload - Repr, Invalid"""
+        self._payload.fully_classified = False
+        expected_result = (
+            '<StreamPayload valid:False; resource:foobar; raw record:{\'key\': \'value\'};>'
+        )
+        assert_equal(repr(self._payload), expected_result)
 
     def test_load_from_raw_record_kinesis(self):
         """StreamPayload - Load from Raw Record, Kinesis"""

--- a/tests/unit/streamalert/classifier/payload/test_payload_record.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_record.py
@@ -33,9 +33,9 @@ class TestPayloadRecord(object):
     def _mock_parser(cls, records=None, invalid_records=None):
         return Mock(
             parsed_records=records if records else [],
-            invalid_records=invalid_records if invalid_records else [],
+            invalid_parses=invalid_records if invalid_records else [],
             log_schema_type='foo:bar',
-            __nonzero__=Mock(return_value=records is not None)
+            __nonzero__=lambda: records is not None
         )
 
     def test_non_zero_false(self):
@@ -58,15 +58,27 @@ class TestPayloadRecord(object):
 
     def test_repr(self):
         """PayloadRecord - Repr"""
-        self._payload_record._parser = self._mock_parser(records=['foobarbaz'])
+        self._payload_record._parser = self._mock_parser(records=[self._record])
         expected_result = (
-            '<PayloadRecord valid:True; log type:foo:bar; parsed records:1; invalid records:0;>'
+            '<PayloadRecord valid:True; log type:foo:bar; parsed records:1;>'
         )
         assert_equal(repr(self._payload_record), expected_result)
 
     def test_repr_invalid(self):
         """PayloadRecord - Repr, Invalid"""
         expected_result = '<PayloadRecord valid:False; raw record:{\'key\': \'value\'};>'
+        assert_equal(repr(self._payload_record), expected_result)
+
+    def test_repr_invalid_records(self):
+        """PayloadRecord - Repr, Invalid Records"""
+        self._payload_record._parser = self._mock_parser(
+            records=[self._record],
+            invalid_records=[self._record]
+        )
+        expected_result = (
+            '<PayloadRecord valid:True; log type:foo:bar; parsed records:1; invalid records:1 '
+            '([{\'key\': \'value\'}]); raw record:{\'key\': \'value\'};>'
+        )
         assert_equal(repr(self._payload_record), expected_result)
 
     def test_data_property(self):

--- a/tests/unit/streamalert/classifier/payload/test_payload_record.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_record.py
@@ -1,0 +1,122 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from mock import Mock
+from nose.tools import assert_equal
+
+from stream_alert.classifier.payload.payload_base import PayloadRecord
+
+
+class TestPayloadRecord(object):
+    """PayloadRecord tests"""
+    # pylint: disable=no-self-use,protected-access
+
+    def setup(self):
+        """PayloadRecord - Setup"""
+        # pylint: disable=attribute-defined-outside-init
+        self._record = {'key': 'value'}
+        self._payload_record = PayloadRecord(self._record)
+
+    @classmethod
+    def _mock_parser(cls, records=None, invalid_records=None):
+        return Mock(
+            parsed_records=records if records else [],
+            invalid_records=invalid_records if invalid_records else [],
+            log_schema_type='foo:bar',
+            __nonzero__=Mock(return_value=records is not None)
+        )
+
+    def test_non_zero_false(self):
+        """PayloadRecord - Non Zero/Bool, False"""
+        assert_equal(bool(self._payload_record), False)
+
+    def test_non_zero_true(self):
+        """PayloadRecord - Non Zero/Bool, True"""
+        self._payload_record._parser = self._mock_parser(records=['foobarbaz'])
+        assert_equal(bool(self._payload_record), True)
+
+    def test_len_str(self):
+        """PayloadRecord - Length, Str Data"""
+        self._payload_record._record_data = 'foobar'
+        assert_equal(len(self._payload_record), 6)
+
+    def test_len_dict(self):
+        """PayloadRecord - Length, Dict Data"""
+        assert_equal(len(self._payload_record), 15)
+
+    def test_repr(self):
+        """PayloadRecord - Repr"""
+        self._payload_record._parser = self._mock_parser(records=['foobarbaz'])
+        expected_result = (
+            '<PayloadRecord valid:True; log type:foo:bar; parsed records:1; invalid records:0;>'
+        )
+        assert_equal(repr(self._payload_record), expected_result)
+
+    def test_repr_invalid(self):
+        """PayloadRecord - Repr, Invalid"""
+        expected_result = '<PayloadRecord valid:False; raw record:{\'key\': \'value\'};>'
+        assert_equal(repr(self._payload_record), expected_result)
+
+    def test_data_property(self):
+        """PayloadRecord - Data Property"""
+        assert_equal(self._payload_record.data, self._record)
+
+    def test_parser_property(self):
+        """PayloadRecord - Parser Property"""
+        parser = self._mock_parser()
+        self._payload_record._parser = parser
+        assert_equal(self._payload_record.parser, parser)
+
+    def test_parser_property_setter(self):
+        """PayloadRecord - Parser Property, Setter"""
+        parser = self._mock_parser()
+        self._payload_record.parser = parser
+        assert_equal(self._payload_record._parser, parser)
+
+    def test_parsed_records_property(self):
+        """PayloadRecord - Parsed Records Property"""
+        self._payload_record._parser = self._mock_parser(records=[self._record])
+        assert_equal(self._payload_record.parsed_records, [self._record])
+
+    def test_parsed_records_property_empty(self):
+        """PayloadRecord - Parsed Records Property, Empty"""
+        assert_equal(self._payload_record.parsed_records, [])
+
+    def test_invalid_records_property(self):
+        """PayloadRecord - Invalid Records Property"""
+        self._payload_record._parser = self._mock_parser(
+            records=[self._record],  # the parser must have records to be considered valid at all
+            invalid_records=[self._record]
+        )
+        assert_equal(self._payload_record.invalid_records, [self._record])
+
+    def test_invalid_records_property_empty(self):
+        """PayloadRecord - Invalid Records Property, Empty"""
+        assert_equal(self._payload_record.invalid_records, [])
+
+    def test_log_schema_type_property(self):
+        """PayloadRecord - Log Schema Type"""
+        self._payload_record._parser = self._mock_parser(records=[self._record])
+        assert_equal(self._payload_record.log_schema_type, 'foo:bar')
+
+    def test_log_type_property(self):
+        """PayloadRecord - Log Type"""
+        self._payload_record._parser = self._mock_parser(records=[self._record])
+        assert_equal(self._payload_record.log_type, 'foo')
+
+    def test_log_sub_type_property(self):
+        """PayloadRecord - Log Sub Type"""
+        self._payload_record._parser = self._mock_parser(records=[self._record])
+        assert_equal(self._payload_record.log_subtype, 'bar')

--- a/tests/unit/streamalert/classifier/test_classifier.py
+++ b/tests/unit/streamalert/classifier/test_classifier.py
@@ -1,0 +1,303 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from collections import OrderedDict
+
+from mock import Mock, patch
+from nose.tools import assert_equal
+
+import stream_alert.classifier.classifier as classifier_module
+from stream_alert.classifier.classifier import Classifier
+
+
+class TestClassifier(object):
+    """Classifier tests"""
+    # pylint: disable=protected-access,no-self-use,attribute-defined-outside-init
+
+    _service_name = 'service_name'
+    _resource_name = 'resource_name'
+
+    def teardown(self):
+        Classifier._config = None
+
+    @classmethod
+    def _mock_conf(cls):
+        return {
+            'logs': cls._mock_logs(),
+            'sources': cls._mock_sources()
+        }
+
+    @classmethod
+    def _mock_sources(cls):
+        return {
+            cls._service_name: {
+                cls._resource_name: {
+                    'logs': [
+                        'log_type_01'
+                    ]
+                }
+            }
+        }
+
+    @classmethod
+    def _mock_logs(cls):
+        return OrderedDict([
+            ('log_type_01:sub_type', OrderedDict([
+                ('parser', 'json'),
+                ('schema', OrderedDict([
+                    ('type_01_key_01', 'string'),
+                    ('type_01_key_02', 'integer'),
+                    ('type_01_key_03', 'boolean')
+                ]))
+            ])),
+            ('log_type_02:sub_type', OrderedDict([
+                ('parser', 'json'),
+                ('schema', OrderedDict([
+                    ('type_02_key_01', 'string'),
+                    ('type_02_key_02', 'integer'),
+                    ('type_02_key_03', 'boolean')
+                ]))
+            ]))
+        ])
+
+    @classmethod
+    def _mock_payload(cls, records):
+        return Mock(
+            service=lambda: cls._service_name,
+            resource=cls._resource_name,
+            pre_parse=lambda: records
+        )
+
+    @classmethod
+    def _mock_payload_record(cls):
+        return Mock(
+            data={'key': 'value'},
+            parsed_records=[{'key_{}'.format(i): 'value'} for i in range(2)],
+            invalid_records=[{'key_{}'.format(i): 'value'} for i in range(1)],
+            log_schema_type='foo:bar',
+            log_type='foo',
+            __nonzero__=lambda s: True,
+            __len__=lambda s: 10,
+            parser=None,
+        )
+
+    @classmethod
+    def _mock_parser(cls, parse_result):
+        return Mock(
+            return_value=Mock(
+                parse=Mock(side_effect=parse_result)
+            )
+        )
+
+    def setup(self):
+        """Classifier - Setup"""
+        with patch('stream_alert.classifier.classifier.config.load_config',
+                   Mock(return_value=self._mock_conf())):
+            with patch.object(classifier_module, 'Normalizer'):
+                self._classifier = Classifier()
+
+    def test_config_property(self):
+        """Classifier - Config Property"""
+        assert_equal(self._classifier._config, self._mock_conf())
+
+    def test_load_logs_for_resource(self):
+        """Classifier - Load Logs for Resource"""
+        expected_result = OrderedDict([
+            ('log_type_01:sub_type', OrderedDict([
+                ('parser', 'json'),
+                ('schema', OrderedDict([
+                    ('type_01_key_01', 'string'),
+                    ('type_01_key_02', 'integer'),
+                    ('type_01_key_03', 'boolean')
+                ]))
+            ]))
+        ])
+
+        result = self._classifier._load_logs_for_resource(self._service_name, self._resource_name)
+        assert_equal(result, expected_result)
+
+    @patch('logging.Logger.error')
+    def test_load_logs_for_resource_invalid_service(self, log_mock):
+        """Classifier - Load Logs for Resource, Invalid Service"""
+        service = 'invalid_service'
+        result = self._classifier._load_logs_for_resource(service, self._resource_name)
+        assert_equal(result, False)
+        log_mock.assert_called_with('Service [%s] not declared in sources configuration', service)
+
+    @patch('logging.Logger.error')
+    def test_load_logs_for_resource_invalid_resource(self, log_mock):
+        """Classifier - Load Logs for Resource, Invalid Resource"""
+        resource = 'invalid_resource'
+        result = self._classifier._load_logs_for_resource(self._service_name, resource)
+        assert_equal(result, False)
+        log_mock.assert_called_with(
+            'Resource [%s] not declared in sources configuration for service [%s]',
+            resource,
+            self._service_name
+        )
+
+    @patch.object(classifier_module, 'get_parser')
+    def test_process_log_schemas(self, parse_mock):
+        """Classifier - Process Log Schemas"""
+        logs_config = self._mock_logs()
+        payload_record = self._mock_payload_record()
+        mock_parser = self._mock_parser([True])
+        expected_log_type = 'log_type_01:sub_type'
+        parse_mock.return_value = mock_parser
+
+        result = Classifier._process_log_schemas(payload_record, logs_config)
+        assert_equal(result, True)
+        mock_parser.assert_called_with(
+            logs_config[expected_log_type], log_type=expected_log_type
+        )
+        assert_equal(payload_record.parser, mock_parser())
+
+    @patch('logging.Logger.debug')
+    @patch.object(classifier_module, 'get_parser')
+    def test_process_log_schemas_multiple(self, parse_mock, log_mock):
+        """Classifier - Process Log Schemas, Multiple Calls"""
+        logs_config = self._mock_logs()
+        payload_record = self._mock_payload_record()
+        mock_parser = self._mock_parser([False, True])
+        expected_log_type = 'log_type_02:sub_type'
+        parse_mock.return_value = mock_parser
+
+        result = Classifier._process_log_schemas(payload_record, logs_config)
+        assert_equal(result, True)
+        mock_parser.assert_called_with(
+            logs_config[expected_log_type], log_type=expected_log_type
+        )
+        assert_equal(payload_record.parser, mock_parser())
+        log_mock.assert_any_call(
+            'Failed to classify data with schema: %s', 'log_type_01:sub_type'
+        )
+
+    @patch('logging.Logger.debug')
+    @patch.object(classifier_module, 'get_parser')
+    def test_process_log_schemas_failure(self, parse_mock, log_mock):
+        """Classifier - Process Log Schemas, Failure"""
+        logs_config = self._mock_logs()
+        payload_record = self._mock_payload_record()
+        mock_parser = self._mock_parser([False, False])
+        parse_mock.return_value = mock_parser
+
+        result = Classifier._process_log_schemas(payload_record, logs_config)
+        assert_equal(result, False)
+        assert_equal(payload_record.parser, None)
+        log_mock.assert_any_call(
+            'Failed to classify data with schema: %s', 'log_type_01:sub_type'
+        )
+        log_mock.assert_any_call(
+            'Failed to classify data with schema: %s', 'log_type_02:sub_type'
+        )
+
+    @patch.object(Classifier, '_process_log_schemas')
+    def test_classify_payload(self, process_mock):
+        """Classifier - Classify Payload"""
+        with patch.object(classifier_module, 'Normalizer') as normalizer_mock:
+            with patch.object(Classifier, '_log_bad_records') as log_mock:
+                payload_record = self._mock_payload_record()
+                self._classifier._classify_payload(self._mock_payload([payload_record]))
+                process_mock.assert_called_with(
+                    payload_record,
+                    OrderedDict([
+                        ('log_type_01:sub_type', self._mock_logs()['log_type_01:sub_type'])
+                    ])
+                )
+                normalizer_mock.normalize.assert_called_with(
+                    payload_record.parsed_records[-1], 'foo'
+                )
+                assert_equal(self._classifier._payloads, [payload_record])
+                log_mock.assert_called_with(payload_record, 1)
+
+    @patch('logging.Logger.error')
+    def test_classify_payload_no_logs(self, log_mock):
+        """Classifier - Classify Payload, Log Logs Config"""
+        with patch.object(Classifier, '_load_logs_for_resource') as log_resource_mock:
+            log_resource_mock.return_value = {}
+            self._classifier._classify_payload(self._mock_payload([self._mock_payload_record()]))
+
+            log_resource_mock.assert_called_with(self._service_name, self._resource_name)
+            log_mock.assert_called_with(
+                'No log types defined for resource [%s] in sources configuration for service [%s]',
+                self._resource_name,
+                self._service_name
+            )
+
+    def test_classify_payload_bad_record(self):
+        """Classifier - Classify Payload, Bad Record"""
+        with patch.object(Classifier, '_process_log_schemas'):
+            with patch.object(Classifier, '_log_bad_records') as log_mock:
+                payload_record = self._mock_payload_record()
+                payload_record.__nonzero__ = lambda s: False
+                self._classifier._classify_payload(self._mock_payload([payload_record]))
+                log_mock.assert_called_with(payload_record, 1)
+
+    def test_log_bad_records(self):
+        """Classifier - Log Bad Records"""
+        self._classifier._log_bad_records(None, 2)
+        assert_equal(self._classifier._failed_record_count, 2)
+
+    def test_log_bad_records_zero(self):
+        """Classifier - Log Bad Records, None"""
+        self._classifier._log_bad_records(None, 0)
+        assert_equal(self._classifier._failed_record_count, 0)
+
+    @patch.object(classifier_module.MetricLogger, 'log_metric')
+    def test_log_metrics(self, metric_mock):
+        """Classifier - Log Metrics"""
+        payload_record = self._mock_payload_record()
+        self._classifier._payloads = [
+            payload_record
+        ]
+        self._classifier._processed_size = 10
+        self._classifier._failed_record_count = 10
+        self._classifier._log_metrics()
+
+        metric_mock.assert_any_call('classifier', 'TotalRecords', 2)
+        metric_mock.assert_any_call('classifier', 'TotalProcessedSize', 10)
+        metric_mock.assert_any_call('classifier', 'FailedParses', 10)
+
+    @patch.object(Classifier, '_classify_payload')
+    def test_run(self, classifiy_mock):
+        """Classifier - Run"""
+        with patch.object(classifier_module.StreamPayload, 'load_from_raw_record') as load_mock:
+            payload = self._mock_payload([self._mock_payload_record()])
+            load_mock.return_value = payload
+            self._classifier.run([Mock()])
+            classifiy_mock.assert_called_with(payload)
+
+    @patch('logging.Logger.debug')
+    def test_run_no_records(self, log_mock):
+        """Classifier - Run, No Records"""
+        self._classifier.run([])
+        log_mock.assert_called_with('Number of incoming records: %d', 0)
+
+    @patch.object(Classifier, '_classify_payload')
+    def test_run_no_payloads(self, classifiy_mock):
+        """Classifier - Run, No Payloads"""
+        with patch.object(classifier_module.StreamPayload, 'load_from_raw_record') as load_mock:
+            load_mock.return_value = False
+            self._classifier.run([Mock()])
+            classifiy_mock.assert_not_called()
+
+    @patch.object(classifier_module, 'print_rule_stats')
+    def test_run_log_stats(self, stats_mock):
+        """Classifier - Run, Log Stats"""
+        self._classifier._verbose = True
+        with patch.object(classifier_module.StreamPayload, 'load_from_raw_record') as load_mock:
+            load_mock.return_value = False
+            self._classifier.run([Mock()])
+            stats_mock.assert_called_with(True)

--- a/tests/unit/streamalert/classifier/test_normalizer.py
+++ b/tests/unit/streamalert/classifier/test_normalizer.py
@@ -1,0 +1,201 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from mock import patch
+from nose.tools import assert_equal
+
+from stream_alert.classifier.normalize import Normalizer
+
+
+class TestNormalizer(object):
+    """Normalizer tests"""
+    # pylint: disable=protected-access,no-self-use,attribute-defined-outside-init
+
+    def teardown(self):
+        Normalizer._types_config = None
+
+    @classmethod
+    def _test_record(cls):
+        return {
+            'account': 123456,
+            'region': 'region_name',
+            'detail': {
+                'awsRegion': 'region_name',
+                'source': '1.1.1.2',
+                'userIdentity': {
+                    "userName": "Alice",
+                    "invokedBy": "signin.amazonaws.com"
+                }
+            },
+            'sourceIPAddress': '1.1.1.2'
+        }
+
+    def test_match_types(self):
+        """Normalizer - Match Types"""
+        normalized_types = {
+            'region': ['region', 'awsRegion'],
+            'sourceAccount': ['account', 'accountId'],
+            'ipv4': ['destination', 'source', 'sourceIPAddress']
+        }
+        expected_results = {
+            'sourceAccount': [['account']],
+            'ipv4': [['sourceIPAddress'], ['detail', 'source']],
+            'region': [['region'], ['detail', 'awsRegion']]
+        }
+
+        results = Normalizer.match_types(self._test_record(), normalized_types)
+        assert_equal(results, expected_results)
+
+    def test_match_types_multiple(self):
+        """Normalizer - Match Types, Mutiple Sub-keys"""
+        normalized_types = {
+            'account': ['account'],
+            'region': ['region', 'awsRegion'],
+            'ipv4': ['destination', 'source', 'sourceIPAddress'],
+            'userName': ['userName', 'owner', 'invokedBy']
+        }
+        expected_results = {
+            'account': [['account']],
+            'ipv4': [['sourceIPAddress'], ['detail', 'source']],
+            'region': [['region'], ['detail', 'awsRegion']],
+            'userName': [
+                ['detail', 'userIdentity', 'userName'],
+                ['detail', 'userIdentity', 'invokedBy']
+            ]
+        }
+
+        results = Normalizer.match_types(self._test_record(), normalized_types)
+        assert_equal(results, expected_results)
+
+    def test_normalize(self):
+        """Normalizer - Normalize"""
+        log_type = 'cloudtrail'
+        Normalizer._types_config = {
+            log_type: {
+                'region': {
+                    'region',
+                    'awsRegion'
+                },
+                'sourceAccount': {
+                    'account',
+                    'accountId'
+                }
+            }
+        }
+        record = self._test_record()
+        Normalizer.normalize(record, log_type)
+
+        expected_record = {
+            'account': 123456,
+            'region': 'region_name',
+            'detail': {
+                'awsRegion': 'region_name',
+                'source': '1.1.1.2',
+                'userIdentity': {
+                    "userName": "Alice",
+                    "invokedBy": "signin.amazonaws.com"
+                }
+            },
+            'sourceIPAddress': '1.1.1.2',
+            'streamalert:normalization': {
+                'region': [['region'], ['detail', 'awsRegion']],
+                'sourceAccount': [['account']]
+            }
+        }
+
+        assert_equal(record, expected_record)
+
+    @patch('logging.Logger.debug')
+    def test_normalize_none_defined(self, log_mock):
+        """Normalizer - Normalize, No Types Defined"""
+        log_type = 'cloudtrail'
+        Normalizer._types_config = {}
+        Normalizer.normalize(self._test_record(), log_type)
+        log_mock.assert_called_with('No normalized types defined for log type: %s', log_type)
+
+    def test_normalize_bad_normalized_key(self):
+        """Normalizer - Normalize, Bad Key(s)"""
+        log_type = 'cloudtrail'
+        bad_types = {
+            'bad_key_01',
+            'bad_key_02'
+        }
+        Normalizer._types_config = {
+            log_type: {
+                'bad_type': bad_types
+            }
+        }
+        expected_record = {
+            'account': 123456,
+            'region': 'region_name',
+            'detail': {
+                'awsRegion': 'region_name',
+                'source': '1.1.1.2',
+                'userIdentity': {
+                    "userName": "Alice",
+                    "invokedBy": "signin.amazonaws.com"
+                }
+            },
+            'sourceIPAddress': '1.1.1.2',
+            'streamalert:normalization': {
+                'bad_type': [],
+            }
+        }
+
+        record = self._test_record()
+        Normalizer.normalize(record, log_type)
+        assert_equal(record, expected_record)
+
+    def test_load_from_config(self):
+        """Normalizer - Load From Config"""
+        config = {
+            'types_new': {
+                'cloudtrail': {
+                    'region': {
+                        'keys': [
+                            'region',
+                            'awsRegion'
+                        ]
+                    },
+                    'sourceAccount': {
+                        'keys': [
+                            'account',
+                            'accountId'
+                        ]
+                    }
+                }
+            }
+        }
+        normalizer = Normalizer.load_from_config(config)
+        expected_config = {
+            'cloudtrail': {
+                'region': {
+                    'region',
+                    'awsRegion'
+                },
+                'sourceAccount': {
+                    'account',
+                    'accountId'
+                }
+            }
+        }
+        assert_equal(normalizer, Normalizer)
+        assert_equal(normalizer._types_config, expected_config)
+
+    def test_load_from_config_empty(self):
+        """Normalizer - Load From Config, Empty"""
+        normalizer = Normalizer.load_from_config({})
+        assert_equal(normalizer, Normalizer)
+        assert_equal(normalizer._types_config, None)

--- a/tests/unit/streamalert/classifier/test_parsers_base.py
+++ b/tests/unit/streamalert/classifier/test_parsers_base.py
@@ -61,12 +61,12 @@ class TestParserBaseConfiguration(object):
             'timestamp': 'string',
             'host': 'string'
         }
-        assert_equal(self._parser.schema, expected_result)
+        assert_equal(self._parser._schema, expected_result)
 
     def test_optional_top_level_keys_property(self):
         """ParserBase - Optional Top Level Keys Property"""
         expected_result = {'host'}
-        assert_equal(self._parser.optional_top_level_keys, expected_result)
+        assert_equal(self._parser._optional_top_level_keys, expected_result)
 
     def test_log_patterns_property(self):
         """ParserBase - Log Patterns Property"""
@@ -75,23 +75,23 @@ class TestParserBaseConfiguration(object):
                 'foo*'
             ]
         }
-        assert_equal(self._parser.log_patterns, expected_result)
+        assert_equal(self._parser._log_patterns, expected_result)
 
     def test_json_path_property(self):
         """ParserBase - JSON Path Property"""
-        assert_equal(self._parser.json_path, 'logEvents[].message')
+        assert_equal(self._parser._json_path, 'logEvents[].message')
 
     def test_envelope_schema_property(self):
         """ParserBase - Envelope Schema Property"""
         expected_result = {
             'env_key_01': 'string'
         }
-        assert_equal(self._parser.envelope_schema, expected_result)
+        assert_equal(self._parser._envelope_schema, expected_result)
 
     def test_optional_envelope_keys_property(self):
         """ParserBase - Optional Envelope Keys Property"""
         expected_result = {'env_key_01'}
-        assert_equal(self._parser.optional_envelope_keys, expected_result)
+        assert_equal(self._parser._optional_envelope_keys, expected_result)
 
 
 class TestParserBaseClassMethods(object):

--- a/tests/unit/streamalert/classifier/test_parsers_base.py
+++ b/tests/unit/streamalert/classifier/test_parsers_base.py
@@ -516,7 +516,7 @@ class TestParserBaseMethods(object):
         item = 'foobar'
         parser = ParserBase(None)
         parser._valid_parses.append(item)
-        assert_equal(parser.parses, [item])
+        assert_equal(parser.parsed_records, [item])
 
     def test_invalid_parses_property(self):
         """ParserBase - Invalid Parses Property"""

--- a/tests/unit/streamalert/classifier/test_parsers_csv.py
+++ b/tests/unit/streamalert/classifier/test_parsers_csv.py
@@ -23,7 +23,7 @@ from stream_alert.classifier.parsers import CSVParser
 
 class TestCSVParser(object):
     """Test class for CSVParser"""
-    # pylint: disable=attribute-defined-outside-init,no-self-use,protected-access
+    # pylint: disable=no-self-use,protected-access
 
     @classmethod
     def _default_schema(cls):

--- a/tests/unit/streamalert/classifier/test_parsers_csv.py
+++ b/tests/unit/streamalert/classifier/test_parsers_csv.py
@@ -51,7 +51,7 @@ class TestCSVParser(object):
                 'message': 'test message!!!!'
             }
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_csv_parsing_space_delimited(self):
         """CSVParser - Space separated data"""
@@ -75,7 +75,7 @@ class TestCSVParser(object):
                 'message': 'test message!!!!'
             }
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_csv_parsing_alt_quoted(self):
         """CSVParser - Single Quoted Field"""
@@ -101,7 +101,7 @@ class TestCSVParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_csv_parsing_from_json(self):
         """CSVParser - CSV within JSON"""
@@ -157,7 +157,7 @@ class TestCSVParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_nested_csv(self):
         """CSVParser - Nested CSV"""
@@ -200,7 +200,7 @@ class TestCSVParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_nested_csv_invalid(self):
         """CSVParser - Nested CSV, Invalid"""

--- a/tests/unit/streamalert/classifier/test_parsers_json.py
+++ b/tests/unit/streamalert/classifier/test_parsers_json.py
@@ -85,7 +85,7 @@ class TestJSONParser(object):
         expected_result = [
             record_data
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_invalid_json_path(self):
         """JSONParser - Invalid JSON Path"""
@@ -159,7 +159,7 @@ class TestJSONParser(object):
                 }
             }
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_regex_key_invalid_json(self):
         """JSONParser - Regex Key with Invalid JSON Object"""
@@ -305,7 +305,7 @@ class TestJSONParser(object):
         expected_result = [
             expected_record
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_json_regex_key_with_envelope(self):
         """JSONParser - Regex key with envelope"""
@@ -336,7 +336,7 @@ class TestJSONParser(object):
                 }
             }
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_json_regex_key(self):
         """JSONParser - Regex key"""
@@ -370,7 +370,7 @@ class TestJSONParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_embedded_json(self):
         """JSONParser - Embedded JSON"""
@@ -418,7 +418,7 @@ class TestJSONParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_embedded_json_invalid(self):
         """JSONParser - Embedded JSON, Invalid"""
@@ -484,7 +484,7 @@ class TestJSONParser(object):
             data
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_optional_keys_json(self):
         """JSONParser - Optional top level keys"""
@@ -535,7 +535,7 @@ class TestJSONParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_nested_records_with_missing_keys(self):
         """JSONParser - Nested records with missing keys"""
@@ -587,7 +587,7 @@ class TestJSONParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_valid_result)
+        assert_equal(parser.parsed_records, expected_valid_result)
         assert_equal(parser.invalid_parses, expected_invalid_result)
 
     def test_optional_keys_with_json_path(self):
@@ -648,7 +648,7 @@ class TestJSONParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_cloudtrail(self):
         """JSONParser - Cloudtrail JSON"""
@@ -738,7 +738,7 @@ class TestJSONParser(object):
         expected_result = [
             rec for rec in data['Records']
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_cloudwatch(self):
         """JSONParser - CloudWatch JSON with envelope keys"""
@@ -873,7 +873,7 @@ class TestJSONParser(object):
                 }
             }
         ]
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_inspec(self):
         """JSONParser - Inspec JSON"""
@@ -972,7 +972,7 @@ class TestJSONParser(object):
             control for prof in data['profiles'] for control in prof['controls']
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_parse_record_copy(self):
         """JSONParser - Parse, Ensure Copy"""
@@ -987,7 +987,7 @@ class TestJSONParser(object):
 
         parser = JSONParser(options)
         assert_equal(parser.parse(record_data), True)
-        assert_equal(id(parser.parses[0]) == id(record_data), False)
+        assert_equal(id(parser.parsed_records[0]) == id(record_data), False)
 
     @patch('logging.Logger.error')
     def test_extract_via_json_path_bad_json(self, log_mock):

--- a/tests/unit/streamalert/classifier/test_parsers_kv.py
+++ b/tests/unit/streamalert/classifier/test_parsers_kv.py
@@ -50,7 +50,7 @@ class TestKVParser(object):
             }
         ]
 
-        assert_equal(parser.parses, expected_result)
+        assert_equal(parser.parsed_records, expected_result)
 
     def test_extract_record_invalid_field_count(self):
         """KV Parser - Extract Record, Invalid Field Count"""


### PR DESCRIPTION
to: @strcrzy , @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Note(s) to reviewers

Again, sorry this is fairly large. This largely builds upon in-flight changes in #821, and you'll notice this branch is being PR'd against that branch. This is getting meta, but once that branch merges into the main `ryandeivert-function-split` feature branch, I will switch this PR to the main feature branch.

## Background

Follow up to #821 

This adds two more of the core components of the `classifier` function, namely the actual `Classifier` and a `Normalizer` class.

## Changes

* Some updates to code that is in Part 1 (#821), such as:
  * Updating `ParserBase` properties to be more clear, wherein some (most) properties are now protected instead of public. This is mostly so it's obvious what properties should be used be callers.
* Adding a `Normalizer` class to encapsulate all of the normalization logic needed in the classification function. This class basically take the previously implemented normalization logic from the `RulesEngine` class and moves it together in one place.
  * This new class also decouples the `ThreatIntel` logic entirely.
  * Making a change to the format of the `conf/types.json` file to be more expressive and allow for easier/cleaner declaration of normalization keys AND ioc types (if applicable).

Now instead of this:
```
{
  "box": {
    "sourceAddress:ioc_ip": [
      "ip_address"
    ]
}
```

The format is:
```
{
  "box": {
    "sourceAddress": {
      "ioc_type": "ip", 
      "keys": [
        "ip_address"
      ]
    }
  }
}
```
* Fleshing out the `PayloadRecord` class and beefing up the functionality of it. This class will now cache the actual `ParserBase` class that was used to parse the record's data, including any parsed records, the log type, etc.
* Other general maintenance and updates to code committed in Pt 1.

## Testing

Adding all new unit test coverage and updates to any migrated ones that were used.
