### PR TITLE
adding missing reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ netaddr==0.7.19
 nose==1.3.7
 nose-timer==0.7.1
 pathlib2==2.3.2
-pyfakefs==3.4.3
 pylint==1.7.4
 python-dateutil==2.6.1
 requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,3 +110,4 @@ wrapt==1.10.11
 xmltodict==0.11.0
 pathlib2==2.3.2
 pyfakefs==3.5
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,3 +108,5 @@ websocket-client==0.48.0
 Werkzeug==0.14.1
 wrapt==1.10.11
 xmltodict==0.11.0
+pathlib2==2.3.2
+pyfakefs==3.5


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: <optional-cc-to-specific-users>
size: small
resolves #<related-issue-goes-here>

## Background
Currently requirements.txt is missing two dependencies, 
```
pyfakefs
pathlib2
```


## Changes

Added both and pinned working version
## Testing

unit tests fail with missing libraries.  (they actually still fail after adding them, but they fail LESS and fail for non-library-missing based reasons)
