### PR TITLE
[apps] Fixed bug in GSuite event de-duplication

### DIFF
--- a/stream_alert/apps/_apps/gsuite.py
+++ b/stream_alert/apps/_apps/gsuite.py
@@ -49,7 +49,7 @@ class GSuiteReportsApp(AppIntegration):
         self._activities_service = None
         self._last_event_timestamp = None
         self._next_page_token = None
-        self._last_run_event_ids = set(self._context.get('last_event_ids', []))
+        self._last_run_event_ids = []
 
     @classmethod
     def _type(cls):
@@ -130,9 +130,11 @@ class GSuiteReportsApp(AppIntegration):
         # Cache the last event timestamp so it can be used for future requests
         if not self._next_page_token:
             self._last_event_timestamp = self._last_timestamp
+            self._last_run_event_ids = self._context.get('last_event_ids', [])
 
         LOGGER.debug('[%s] Querying activities since %s', self, self._last_event_timestamp)
         LOGGER.debug('[%s] Using next page token: %s', self, self._next_page_token)
+        LOGGER.debug('[%s] Last run event ids: %s', self, self._last_run_event_ids)
 
         activities_list = self._activities_service.list(
             userKey='all',
@@ -154,7 +156,7 @@ class GSuiteReportsApp(AppIntegration):
         # Remove duplicate events present in the last time period.
         activities = [
             activity for activity in results.get('items', [])
-            if activity['id']['uniqueQualifier'] not in self._last_run_event_ids
+            if activity['id']['uniqueQualifier'] not in set(self._last_run_event_ids)
         ]
         if not activities:
             LOGGER.info('[%s] No logs in response from G Suite API request', self)

--- a/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
@@ -253,10 +253,10 @@ class TestGSuiteReportsApp(object):
                 'items': self._get_sample_logs(10)
             }
             service_mock.list.return_value.execute.return_value = payload
-            self._app._last_run_event_ids = {
+            self._app._context['last_event_ids'] = [
                 -12345678901234567890 + 9,
                 -12345678901234567890 + 8
-            }
+            ]
 
             assert_equal(len(self._app._gather_logs()), 8)
             assert_equal(self._app._last_timestamp, '2011-06-17T15:39:18.460000Z')


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @ryandeivert 
size: small

## Background

The GSuite event de-duplication logic didn't de-duplicate events correctly because the app context was being read before it was correctly initialised.

## Changes

* Read _context during the first _gather_logs() run, not during __init__()
* Updated the unit test to set the context instead of last_run_event_ids directly

## Testing

1. Updated the unit test to set the _context instead of last_run_event_ids directly
2. Unit tests pass
3. Deployed to StreamAlert cluster
4. Verify contents of state in parameter store
5. Verify logs in CloudWatch logs
6. Events correctly de-duplicated