### PR TITLE
 properly exiting CLI on errors for all handlers

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -27,6 +27,7 @@ terraform <cmd>
 from argparse import Action, ArgumentParser, RawDescriptionHelpFormatter
 import os
 import string
+import sys
 import textwrap
 
 
@@ -1003,7 +1004,7 @@ def _setup_athena_create_table_subparser(subparsers):
         """Make sure the input is in the format column_name=type"""
         err = ('Invalid override expression [{}]. The proper format is '
                '"column_name=value_type"').format(val)
-        if not '=' in val:
+        if '=' not in val:
             raise athena_create_table_parser.error(err)
 
         if len(val.split('=')) != 2:
@@ -1493,7 +1494,7 @@ def main():
     """Entry point for the CLI."""
     parser = build_parser()
     options = parser.parse_args()
-    cli_runner(options)
+    sys.exit(not cli_runner(options))
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -1494,6 +1494,8 @@ def main():
     """Entry point for the CLI."""
     parser = build_parser()
     options = parser.parse_args()
+
+    # Exit with the result, which will be False if an error occurs, or True otherwise
     sys.exit(not cli_runner(options))
 
 

--- a/stream_alert_cli/manage_lambda/rollback.py
+++ b/stream_alert_cli/manage_lambda/rollback.py
@@ -30,7 +30,7 @@ def _rollback_production(lambda_client, function_name):
         function_name (str): Name of function to be rolled back
 
     Returns:
-        bool: True if no errors occurred, False otherwise
+        bool: False if errors occurred, True otherwise
     """
     version = lambda_client.get_alias(
         FunctionName=function_name, Name='production')['FunctionVersion']
@@ -66,7 +66,7 @@ def rollback_handler(options, config):
         config (dict): Parsed configuration from conf/
 
     Returns:
-        bool: True if no errors occurred, False otherwise
+        bool: False if errors occurred, True otherwise
     """
     # Make sure the Terraform code is up to date
     if not terraform_generate_handler(config=config):

--- a/stream_alert_cli/manage_lambda/rollback.py
+++ b/stream_alert_cli/manage_lambda/rollback.py
@@ -23,7 +23,15 @@ LOGGER = get_logger(__name__)
 
 
 def _rollback_production(lambda_client, function_name):
-    """Rollback the production alias for the given function name."""
+    """Rollback the production alias for the given function name.
+
+    Args:
+        lambda_client (boto3.client): boto3 client to use for rolling back the function
+        function_name (str): Name of function to be rolled back
+
+    Returns:
+        bool: True if no errors occurred, False otherwise
+    """
     version = lambda_client.get_alias(
         FunctionName=function_name, Name='production')['FunctionVersion']
 
@@ -31,12 +39,12 @@ def _rollback_production(lambda_client, function_name):
         # This won't happen with Terraform, but the alias could have been manually changed.
         LOGGER.error('%s:production is pointing to $LATEST instead of a published version',
                      function_name)
-        return
+        return False
 
     current_version = int(version)
     if current_version == 1:
         LOGGER.warn('%s:production is already at version 1', function_name)
-        return
+        return False
 
     LOGGER.info('Rolling back %s:production from version %d => %d',
                 function_name, current_version, current_version - 1)
@@ -45,6 +53,9 @@ def _rollback_production(lambda_client, function_name):
             FunctionName=function_name, Name='production', FunctionVersion=str(current_version - 1))
     except ClientError:
         LOGGER.exception('version not updated')
+        return False
+
+    return True
 
 
 def rollback_handler(options, config):
@@ -53,10 +64,13 @@ def rollback_handler(options, config):
     Args:
         options: Argparse parsed options
         config (dict): Parsed configuration from conf/
+
+    Returns:
+        bool: True if no errors occurred, False otherwise
     """
     # Make sure the Terraform code is up to date
     if not terraform_generate_handler(config=config):
-        return
+        return False
 
     LOGGER.info('Rolling back: %s', ' '.join(options.processor))
 
@@ -65,27 +79,48 @@ def rollback_handler(options, config):
     clusters = sorted(options.clusters or config.clusters())
     client = boto3.client('lambda')
 
+    # Track the success of rolling back the functions
+    success = True
     if rollback_all or 'alert' in options.processor:
-        _rollback_production(client, '{}_streamalert_alert_processor'.format(prefix))
+        success = success and _rollback_production(
+            client,
+            '{}_streamalert_alert_processor'.format(prefix)
+        )
 
     if rollback_all or 'alert_merger' in options.processor:
-        _rollback_production(client, '{}_streamalert_alert_merger'.format(prefix))
+        success = success and _rollback_production(
+            client,
+            '{}_streamalert_alert_merger'.format(prefix)
+        )
 
     if rollback_all or 'apps' in options.processor:
         for cluster in clusters:
             apps_config = config['clusters'][cluster]['modules'].get('stream_alert_apps', {})
             for lambda_name in sorted(apps_config):
-                _rollback_production(client, lambda_name)
+                success = success and _rollback_production(client, lambda_name)
 
     if rollback_all or 'athena' in options.processor:
-        _rollback_production(client, '{}_streamalert_athena_partition_refresh'.format(prefix))
+        success = success and _rollback_production(
+            client,
+            '{}_streamalert_athena_partition_refresh'.format(prefix)
+        )
 
     if rollback_all or 'classifier' in options.processor:
         for cluster in clusters:
-            _rollback_production(client, '{}_{}_streamalert_classifier'.format(prefix, cluster))
+            success = success and _rollback_production(
+                client,
+                '{}_{}_streamalert_classifier'.format(prefix, cluster)
+            )
 
     if rollback_all or 'rule' in options.processor:
-        _rollback_production(client, '{}_streamalert_rules_engine'.format(prefix))
+        success = success and _rollback_production(
+            client, '{}_streamalert_rules_engine'.format(prefix)
+        )
 
     if rollback_all or 'threat_intel_downloader' in options.processor:
-        _rollback_production(client, '{}_streamalert_threat_intel_downloader'.format(prefix))
+        success = success and _rollback_production(
+            client,
+            '{}_streamalert_threat_intel_downloader'.format(prefix)
+        )
+
+    return success

--- a/stream_alert_cli/rule_table.py
+++ b/stream_alert_cli/rule_table.py
@@ -23,6 +23,9 @@ def rule_staging_handler(options, config):
         options (argparse.Namespace): Various options needed by subcommand
             handlers
         config (CLIConfig): Loaded configuration from 'conf/' directory
+
+    Returns:
+        bool: False if errors occurred, True otherwise
     """
     if options.subcommand == 'enable':
         config.toggle_rule_staging(options.enable)
@@ -36,3 +39,5 @@ def rule_staging_handler(options, config):
         table = RuleTable(table_name)
         for rule in options.rules:
             table.toggle_staged_state(rule, stage)
+
+    return True

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -374,11 +374,11 @@ def terraform_generate_handler(config, init=False, check_tf=True, check_creds=Tr
     """
     # Check for valid credentials
     if check_creds and not check_credentials():
-        return
+        return False
 
     # Verify terraform is installed
     if check_tf and not terraform_check():
-        return
+        return False
 
     cleanup_old_tf_files(config)
 

--- a/stream_alert_cli/test/handler.py
+++ b/stream_alert_cli/test/handler.py
@@ -20,7 +20,6 @@ from collections import defaultdict
 import json
 import os
 import re
-import sys
 import time
 import zlib
 

--- a/stream_alert_cli/test/handler.py
+++ b/stream_alert_cli/test/handler.py
@@ -41,7 +41,17 @@ LOGGER = get_logger(__name__)
 
 
 def test_handler(options, config):
-    sys.exit(TestRunner(options, config).run())
+    """Handler for starting the test framework
+
+    Args:
+        options (argparse.Namespace): Parsed arguments
+        config (CLIConfig): Loaded StreamAlert config
+
+    Returns:
+        bool: False if errors occurred, True otherwise
+    """
+
+    return TestRunner(options, config).run()
 
 
 class TestRunner(object):
@@ -213,7 +223,7 @@ class TestRunner(object):
 
         self._finalize()
 
-        return self._failed != 0
+        return self._failed == 0
 
     def _get_test_files(self):
         """Helper to get rule files to be tested

--- a/stream_alert_cli/threat_intel_downloader/handler.py
+++ b/stream_alert_cli/threat_intel_downloader/handler.py
@@ -26,8 +26,11 @@ def threat_intel_downloader_handler(options, config):
     """Configure Threat Intel Downloader from command line
 
     Args:
-        options (namedtuple): The parsed args passed from the CLI
-        config (CLIConfig): Loaded StreamAlert CLI
+        options (argparse.Namespace): Parsed arguments
+        config (CLIConfig): Loaded StreamAlert config
+
+    Returns:
+        bool: False if errors occurred, True otherwise
     """
     def _validate_options(options):
         if not options.interval:
@@ -45,15 +48,15 @@ def threat_intel_downloader_handler(options, config):
         return True
 
     if not options:
-        return
+        return False
 
     if options.subcommand == 'enable':
         if not _validate_options(options):
-            return
+            return False
         if config.add_threat_intel_downloader(vars(options)):
-            save_api_creds_info(config['global']['account']['region'])
+            return save_api_creds_info(config['global']['account']['region'])
     elif options.subcommand == 'update-auth':
-        save_api_creds_info(config['global']['account']['region'], overwrite=True)
+        return save_api_creds_info(config['global']['account']['region'], overwrite=True)
 
 def save_api_creds_info(region, overwrite=False):
     """Function to add API creds information to parameter store

--- a/tests/unit/stream_alert_cli/manage_lambda/test_rollback.py
+++ b/tests/unit/stream_alert_cli/manage_lambda/test_rollback.py
@@ -4,6 +4,7 @@ import unittest
 
 from botocore.exceptions import ClientError
 import mock
+from nose.tools import assert_equal
 
 from stream_alert_cli.manage_lambda import rollback
 from tests.unit.helpers.config import basic_streamalert_config, MockCLIConfig
@@ -62,9 +63,13 @@ class RollbackTest(unittest.TestCase):
     @mock.patch.object(rollback, '_rollback_production')
     def test_rollback_all(self, mock_helper):
         """CLI - Lambda rollback all"""
-        rollback.rollback_handler(
-            MockOptions(None, ['all']),
-            MockCLIConfig(config=basic_streamalert_config())
+        mock_helper.return_value = True
+        assert_equal(
+            rollback.rollback_handler(
+                MockOptions(None, ['all']),
+                MockCLIConfig(config=basic_streamalert_config())
+            ),
+            True
         )
         mock_helper.assert_has_calls([
             mock.call(mock.ANY, 'unit-testing_streamalert_alert_processor'),
@@ -82,9 +87,13 @@ class RollbackTest(unittest.TestCase):
     @mock.patch.object(rollback, '_rollback_production')
     def test_rollback_subset(self, mock_helper):
         """CLI - Lambda rollback apps and rule"""
-        rollback.rollback_handler(
-            MockOptions(None, ['apps', 'rule']),
-            MockCLIConfig(config=basic_streamalert_config())
+        mock_helper.return_value = True
+        assert_equal(
+            rollback.rollback_handler(
+                MockOptions(None, ['apps', 'rule']),
+                MockCLIConfig(config=basic_streamalert_config())
+            ),
+            True
         )
         mock_helper.assert_has_calls([
             mock.call(mock.ANY, 'unit-testing_corp_box_admin_events_box_collector_app'),


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

The CLI has never properly exited with error codes for the various handlers. This PR is to add a uniform interface for returning on errors and exit properly.

## Changes

* Each CLI handler returns `False` if there is an error, or `True` otherwise.

## Testing

Ran tests and checked errors code to ensure this is working.