### PR TITLE
additional doc change and adding ability to CLI to list terraform targets

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -68,7 +68,7 @@ Deploying an App only takes 3 steps:
 
 1. Configure the App through the CLI (via ``python manage.py app new``).
 2. Enter the required authentication information.
-3. Deploy the new App and the Rule Processor.
+3. Deploy the new App and the Classifier.
 
 To get help configuring a new App, use:
 
@@ -133,14 +133,14 @@ Once the above is completed, a logger statement similar to the following will co
 
 Your configuration files (``conf/clusters/<cluster>.json`` and ``conf/sources.json``) have now been updated and are ready to be deployed.
 
-3. Deploy the new App and the Rule Processor
+3. Deploy the new App and the Classifier
 ````````````````````````````````````````````
 
-The recommended process is to deploy both the `apps` function and the `rule` processor function with:
+The recommended process is to deploy both the `apps` function and the `classifier` processor function with:
 
 .. code-block:: bash
 
-  $ python manage.py deploy --function rule apps
+  $ python manage.py deploy --function classifier apps
 
 Authorizing the Slack App
 -------------------------

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -15,23 +15,31 @@ Data Lifecycle
 This includes Kinesis, S3, SNS, or using a `StreamAlert App <app-configuration.html>`_ to periodically
 poll data from a third-party API.
 
-2. Inbound logs are directed to the "rule processor" Lambda function in one of your `clusters <clusters.html>`_.
-The rule processor is the first and most substantial component of StreamAlert, responsible for parsing,
-classifying, and normalizing logs, running each record through the rules engine, and saving any alerts
-to a DynamoDB table. The rule processor(s) also optionally forward raw log records to Firehose so
-they can be queried with `Athena <athena-overview.html>`_.
+2. Inbound logs are first ingested via the "classifier" Lambda function in one of your
+`clusters <clusters.html>`_. The classifier is the first and most substantial component of
+StreamAlert, responsible for parsing, classifying, and performing normalization on logs.
+The classifier(s) can also optionally forward the resulting logs from classification to Firehose
+for historical retention and searching via `Athena <athena-overview.html>`_. The same results
+also get sent to an SQS Queue for further downstream analysis.
 
-3. The "alert merger" Lambda function regularly scans the alerts DynamoDB table. When new alerts arrive,
-they are either forwarded immediately (by default) or, if merge options are specified, they are
-bundled together with similar alerts before proceeding to the next stage.
+3. The SQS Queue that the classifier function(s) send data to is then utilized by a "rules engine"
+Lambda function. Note that this function is **not** "clustered" like the classifier(s) and is global
+to the StreamAlert deployment. The data read from the queue will be ran through the defined rules,
+and any alerts that are triggered will be sent to a DynamoDB table. Optionally, the rules engine
+function can read Threat Intelligence information from DynamoDB, or perform other lookup-style
+operations using data stored in S3.
 
-4. The "alert processor" Lambda function is responsible for actually delivering the alert to its
+4. The "alert merger" Lambda function regularly scans the alerts DynamoDB table. When new alerts
+arrive, they are either forwarded immediately (by default) or, if merge options are specified, they
+are bundled together with similar alerts before proceeding to the next stage.
+
+5. The "alert processor" Lambda function is responsible for actually delivering the alert to its
 configured `outputs <outputs.html>`_. All alerts implicitly include a Firehose output, which feeds
-an S3 bucket that can be queried with Athena. Alerts will be retried indefinitely until they are successfully
-delivered, at which point they will be removed from the DynamoDB table.
+an S3 bucket that can be queried with Athena. Alerts will be retried indefinitely until they are
+successfully delivered, at which point they will be removed from the DynamoDB table.
 
-5. An "athena partition refresh" Lambda function runs periodically to onboard new StreamAlert data
+6. An "athena partition refresh" Lambda function runs periodically to onboard new StreamAlert data
 and alerts into their respective Athena databases for historical search.
 
-Other StreamAlert components include DynamoDB tables and Lambda functions for optional rule promotion
-and threat intelligence integration.
+Other StreamAlert components include DynamoDB tables and Lambda functions for optional rule
+promotion and regularly updating threat intelligence information.

--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -1,8 +1,8 @@
 Clusters
 ========
 
-Inbound data is directed to one of your StreamAlert *clusters*, each with its own data sources
-and rule processor. For many applications, one cluster may be enough. However, adding
+Inbound data is directed to one of StreamAlert's *clusters*, each with its own data sources
+and classifier function. For many applications, one cluster may be enough. However, adding
 additional clusters can potentially improve performance and provide isolated analysis pipelines. For
 example, you could have:
 
@@ -16,25 +16,23 @@ example, you could have:
 Each cluster is defined by its own JSON file in the
 `conf/clusters <https://github.com/airbnb/streamalert/tree/stable/conf/clusters>`_ directory.
 To add a new cluster, simply create a new JSON file with the cluster name and fill in your desired
-configuration (described below).
+configuration, described below.
 
 Changes to cluster configuration can be applied with one of the following:
 
 .. code-block:: bash
 
   ./manage.py build  # Apply all changes
-  ./manage.py build --target cloudtrail  # Apply changes to CloudTrail module only
+  ./manage.py build --target cloudwatch_monitoring_*  # Only apply changes to CloudWatch module for all clusters
 
 Configuration options are divided into different modules, each of which is discussed below.
 
 
 .. _main_cluster_module:
 
-Rule Processor
---------------
-``stream_alert`` is the only required module because it configures the cluster's rule processor.
-
-This module is implemented by `terraform/modules/tf_stream_alert <https://github.com/airbnb/streamalert/tree/stable/terraform/modules/tf_stream_alert>`_.
+Classifier Function
+-------------------
+``stream_alert`` is the only required module because it configures the cluster's classifier.
 
 Example: Minimal Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,17 +43,20 @@ Example: Minimal Cluster
     "id": "minimal-cluster",
     "modules": {
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
+          "enable_custom_metrics": true,
+          "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
     "region": "us-east-1"
   }
 
-Example: Rule Processor with SNS Inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Example: Classifier with SNS Inputs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
 
@@ -63,7 +64,7 @@ Example: Rule Processor with SNS Inputs
     "id": "sns-inputs",
     "modules": {
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
           "enable_custom_metrics": true,
           "inputs": {
             "aws-sns": [
@@ -71,22 +72,23 @@ Example: Rule Processor with SNS Inputs
             ]
           },
           "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
     "region": "us-east-1"
   }
 
-Configuration Options
-~~~~~~~~~~~~~~~~~~~~~
+Classifier Configuration Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ==========================  ===========  ===============
 **Key**                     **Default**  **Description**
 --------------------------  -----------  ---------------
 ``enable_custom_metrics``   ``true``     Enable :ref:`custom metrics <custom_metrics>` for the cluster
 ``enable_threat_intel``     ``false``    Toggle threat intel integration (beta)
-``inputs``                  ``{}``       SNS topics which can invoke the rule processor (see example)
+``inputs``                  ``{}``       SNS topics which can invoke the classifier function (see example)
 ``log_level``               ``"info"``   Lambda CloudWatch logging level
 ``memory``                  ---          Lambda function memory (MB)
 ``timeout``                 ---          Lambda function timeout (seconds)
@@ -118,9 +120,12 @@ Example: CloudTrail via S3 Events
         }
       ],
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
+          "enable_custom_metrics": true,
+          "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
@@ -128,7 +133,7 @@ Example: CloudTrail via S3 Events
   }
 
 This creates a new CloudTrail and an S3 bucket for the resulting logs. Each new object in the bucket
-invokes the StreamAlert rule processor via :ref:`S3 events <s3_events>`. For this data, rules should
+invokes the StreamAlert classifier function via :ref:`S3 events <s3_events>`. For this data, rules should
 be written against the ``cloudtrail:events`` log type.
 
 Example: CloudTrail via CloudWatch Logs
@@ -157,9 +162,12 @@ Example: CloudTrail via CloudWatch Logs
           "enabled": true
         },
         "stream_alert": {
-          "rule_processor": {
+          "classifier_config": {
+            "enable_custom_metrics": true,
+            "log_level": "info",
+            "log_retention_days": 14,
             "memory": 128,
-            "timeout": 10
+            "timeout": 60
           }
         }
       },
@@ -167,7 +175,7 @@ Example: CloudTrail via CloudWatch Logs
     }
 
 This also creates the CloudTrail and S3 bucket, but now the CloudTrail logs are also delivered to
-CloudWatch Logs and then to a Kinesis subscription which feeds the rule processor. This can scale to
+CloudWatch Logs and then to a Kinesis subscription which feeds the classifier function. This can scale to
 higher throughput, since StreamAlert does not have to download potentially very large files from
 S3. In this case, rules should be written against the ``cloudwatch:events`` log type.
 
@@ -232,9 +240,12 @@ Example: CloudWatch Logs Cluster
         "enabled": true
       },
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
+          "enable_custom_metrics": true,
+          "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
@@ -268,7 +279,7 @@ CloudWatch Monitoring
 ---------------------
 To ensure data collection is running smoothly, we recommend enabling
 `CloudWatch metric alarms <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#CloudWatchAlarms>`_
-to monitor the health of your rule processor Lambda function and (if applicable) your Kinesis stream.
+to monitor the health the classifier Lambda function(s) and, if applicable, the respective Kinesis stream.
 
 This module is implemented by `terraform/modules/tf_stream_alert_monitoring <https://github.com/airbnb/streamalert/tree/stable/terraform/modules/tf_stream_alert_monitoring>`_.
 
@@ -292,9 +303,12 @@ Example: Enable CloudWatch Monitoring
         }
       },
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
+          "enable_custom_metrics": true,
+          "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
@@ -304,9 +318,9 @@ Example: Enable CloudWatch Monitoring
 This enables both the Kinesis and Lambda alarms and illustrates how the alarm thresholds can be tuned.
 A total of 5 alarms will be created:
 
-* Rule processor Lambda invocation errors
-* Rule processor Lambda throttles
-* Rule processor Lambda iterator age (applicable only for Kinesis invocations)
+* Classifier Lambda function invocation errors
+* Classifier Lambda function throttles
+* Classifier Lambda function iterator age, applicable only for Kinesis invocations
 * Kinesis iterator age
 * Kinesis write exceeded
 
@@ -364,7 +378,7 @@ as follows:
       "...": "...",
 
       "monitoring": {
-        "sns_topic_name": "your-existing-topic-name"
+        "sns_topic_name": "existing-topic-name"
       },
 
       "...": "..."
@@ -380,12 +394,12 @@ Kinesis Data Streams
 
 This module creates a
 `Kinesis Data Stream <https://docs.aws.amazon.com/streams/latest/dev/key-concepts.html>`_
-in your cluster, which is the most common approach for StreamAlert data ingestion.
+in the cluster, which is the most common approach for StreamAlert data ingestion.
 In fact, the :ref:`CloudTrail <cloudtrail>`, :ref:`CloudWatch Logs <cloudwatch_logs>`,
 and :ref:`VPC Flow Logs<flow_logs>` cluster modules all rely on Kinesis streams for data delivery.
 
 Each Kinesis stream is a set of *shards*, which in aggregate determine the total data capacity of
-your stream. Indeed, this is the primary motivation for StreamAlert's cluster design - each cluster
+the stream. Indeed, this is the primary motivation for StreamAlert's cluster design - each cluster
 can have its own data stream whose shard counts can be configured individually.
 
 This module is implemented by `terraform/modules/tf_stream_alert_kinesis_streams <https://github.com/airbnb/streamalert/tree/stable/terraform/modules/tf_stream_alert_kinesis_streams>`_.
@@ -417,9 +431,12 @@ Example: Kinesis Cluster
         "enabled": true
       },
       "stream_alert": {
-        "rule_processor": {
+        "classifier_config": {
+          "enable_custom_metrics": true,
+          "log_level": "info",
+          "log_retention_days": 14,
           "memory": 128,
-          "timeout": 10
+          "timeout": 60
         }
       }
     },
@@ -434,7 +451,7 @@ Example: Kinesis Cluster
   }
 
 This creates a Kinesis stream and an associated IAM user and hooks up stream events to the
-StreamAlert rule processor in this cluster. The ``outputs`` instruct Terraform to print the IAM
+StreamAlert classifier function in this cluster. The ``outputs`` instruct Terraform to print the IAM
 username and access keypair for the newly created user.
 
 Configuration Options
@@ -487,7 +504,7 @@ Finally, apply the Terraform changes to ensure a consistent state.
 Kinesis Events
 --------------
 
-The Kinesis Events module connects a Kinesis Stream to the rule processor Lambda function.
+The Kinesis Events module connects a Kinesis Stream to the classifier Lambda function.
 
 .. note:: The :ref:`Kinesis module <kinesis_module>` must also be enabled.
 
@@ -499,7 +516,7 @@ Configuration Options
 ===============  ============  ===============
 **Key**          **Default**   **Description**
 ---------------  ------------  ---------------
-``batch_size``   ``100``       Max records the rule processor can receive per invocation
+``batch_size``   ``100``       Max records the classifier function can receive per invocation
 ``enabled``      ``false``     Toggle the kinesis events on and off
 ===============  ============  ===============
 
@@ -510,7 +527,7 @@ VPC Flow Logs
 -------------
 
 `VPC Flow Logs <https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html>`_
-capture information about the IP traffic going to and from your AWS VPC.
+capture information about the IP traffic going to and from an AWS VPC.
 
 When writing rules for this data, use the ``cloudwatch:flow_logs`` log source.
 
@@ -551,9 +568,12 @@ Example: Flow Logs Cluster
           "enabled": true
         },
         "stream_alert": {
-          "rule_processor": {
+          "classifier_config": {
+            "enable_custom_metrics": true,
+            "log_level": "info",
+            "log_retention_days": 14,
             "memory": 128,
-            "timeout": 10
+            "timeout": 60
           }
         }
       },
@@ -585,9 +605,9 @@ S3 Events
 ---------
 
 You can enable `S3 event notifications <https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html>`_
-on any of your S3 buckets to invoke the StreamAlert rule processor. When the StreamAlert rule
-processor receives this notification, it downloads the object from S3 and runs each record
-through the rules engine.
+on any of your S3 buckets to invoke the StreamAlert classifier function. When the StreamAlert classifier
+function receives this notification, it downloads the object from S3 and runs each record
+through the classification logic.
 
 This module is implemented by `terraform/modules/tf_stream_alert_s3_events <https://github.com/airbnb/streamalert/tree/stable/terraform/modules/tf_stream_alert_s3_events>`_.
 
@@ -601,26 +621,29 @@ Example: S3 Events Cluster
       "modules": {
         "s3_events": [
           {
-            "bucket_id": "your-bucket-1",
+            "bucket_id": "bucket-1",
             "enable_events": true
           },
           {
-            "bucket_id": "your-bucket-2",
+            "bucket_id": "bucket-2",
             "enable_events": true
           }
         ],
         "stream_alert": {
-          "rule_processor": {
+          "classifier_config": {
+            "enable_custom_metrics": true,
+            "log_level": "info",
+            "log_retention_days": 14,
             "memory": 128,
-            "timeout": 10
+            "timeout": 60
           }
         }
       },
       "region": "us-east-1"
     }
 
-This configures 2 buckets to notify the rule processor in this cluster, and authorizes StreamAlert
-to download objects from either bucket.
+This configures the two buckets to notify the classifier function in this cluster when new objects
+arrive in the bucket, and authorizes the classifier to download objects from either bucket.
 
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/firehose.rst
+++ b/docs/source/firehose.rst
@@ -121,7 +121,7 @@ Options
 Key                      Required  Default               Description
 ----------------------   --------  --------------------  -----------
 ``enabled``              ``Yes``   ``None``              If set to ``false``, will not create a Kinesis Firehose
-``enabled_logs``         ``Yes``   ``[]``                The set of classified logs to send to Kinesis Firehose from the Rule Processor
+``enabled_logs``         ``Yes``   ``[]``                The set of classified logs to send to Kinesis Firehose from the Classifier function
 ``s3_bucket_suffix``     ``No``    ``streamalert.data``  The suffix of the S3 bucket used for Kinesis Firehose data. The naming scheme is: ``prefix.suffix``
 ``buffer_size``          ``No``    ``64 (MB)``           The amount of buffered incoming data before delivering it to Amazon S3
 ``buffer_interval``      ``No``    ``300 (seconds)``     The frequency of data delivery to Amazon S3

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -150,7 +150,7 @@ Open ``conf/clusters/prod.json`` and change the ``stream_alert`` module to look 
 
   {
     "stream_alert": {
-      "rule_processor": {
+      "classifier_config": {
         "enable_custom_metrics": true,
         "inputs": {
           "aws-sns": [
@@ -158,8 +158,9 @@ Open ``conf/clusters/prod.json`` and change the ``stream_alert`` module to look 
           ]
         },
         "log_level": "info",
+        "log_retention_days": 14,
         "memory": 128,
-        "timeout": 10
+        "timeout": 60
       }
     }
   }
@@ -208,7 +209,7 @@ alerts on any usage of the root AWS account. Change the rule decorator to:
 
 .. code-block:: bash
 
-  # Hook the streamalert-test-data SNS topic up to the StreamAlert rule processor
+  # Hook the streamalert-test-data SNS topic up to the StreamAlert Classifier function
   ./manage.py build
 
   # Deploy a new version of all of the Lambda functions with the updated rule and config files

--- a/docs/source/rule-staging.rst
+++ b/docs/source/rule-staging.rst
@@ -10,7 +10,7 @@ rules can be staged. After the initial staging period, wherein a noisy rule is t
 extra noise or false positives, staged rules can be promoted.
 
 When Rule Staging is enabled, new rules will, by default, be *staged* upon a deploy of the
-Rule Processor Lambda function.
+Rules Engine Lambda function.
 See the `Skip Staging During Deploy`_ section
 for more information.
 
@@ -49,7 +49,7 @@ A few configuration options are available to customize the feature to your needs
 ===========================  =======  ===========
 Key                          Default  Description
 ---------------------------  -------  -----------
-``cache_refresh_minutes``    ``10``   Maximum amount of time (in minutes) the Rule Processor
+``cache_refresh_minutes``    ``10``   Maximum amount of time (in minutes) the Rules Engine function
                                       should wait to force refresh the rule staging information.
 ``table.read_capacity``      ``20``   DynamoDB read capacity to allocate to the table that stores staging
                                       information. The default setting should be sufficient in most use cases.
@@ -101,9 +101,9 @@ with the following command:
 Skip Staging During Deploy
 ++++++++++++++++++++++++++
 
-As noted above, all new rules will be *staged* by default during a Rule Processor deploy when the
+As noted above, all new rules will be *staged* by default during a Rules Engine deploy when the
 Rule Staging feature is enabled. There may, however, be occasions when all new rules should not be
-staged during a deploy. To allow for this, the Rule Processor can be deployed with the following command:
+staged during a deploy. To allow for this, the Rules Engine can be deployed with the following command:
 
 .. code-block:: bash
 

--- a/manage.py
+++ b/manage.py
@@ -43,11 +43,6 @@ CLUSTERS = [
     for cluster in files
 ]
 
-TF_MODULE_TARGETS = sorted([
-    'athena', 'cloudwatch_monitoring', 'cloudtrail', 'flow_logs', 'kinesis',
-    'kinesis_events', 'stream_alert', 's3_events', 'threat_intel_downloader'
-])
-
 
 class UniqueSetAction(Action):
     """Subclass of argparse.Action to avoid multiple of the same choice from a list"""
@@ -863,10 +858,12 @@ def _add_default_tf_args(tf_parser):
         '-t',
         '--target',
         metavar='TARGET',
-        choices=TF_MODULE_TARGETS,
         help=(
-            'One or more of the following terraform module names to target: {}'
-        ).format(', '.join(TF_MODULE_TARGETS)),
+            'One or more Terraform module name to target. Use `list-targets` for a list '
+            'of available targets'
+        ),
+        action=UniqueSetAction,
+        default=set(),
         nargs='+'
     )
 
@@ -882,7 +879,7 @@ def _setup_build_subparser(subparser):
             '''\
             Example:
 
-                manage.py build --target kinesis_events
+                manage.py build --target alert_processor_lambda
             '''
         )
     )
@@ -898,7 +895,7 @@ def _setup_destroy_subparser(subparser):
             '''\
             Example:
 
-                manage.py destroy --target s3_events
+                manage.py destroy --target aws_s3_bucket.streamalerts
             '''
         )
     )
@@ -1391,6 +1388,10 @@ def build_parser():
         'kinesis': (
             _setup_kinesis_subparser,
             'Update AWS Kinesis settings and run Terraform to apply changes'
+        ),
+        'list-targets': (
+            None,
+            'List available Terraform modules to be used for targeted builds'
         ),
         'output': (
             _setup_output_subparser,

--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -254,11 +254,13 @@ class ParserBase:
             return False
 
         if not is_envelope and keys != schema_keys:
-            LOGGER.debug(
-                'Missing required keys in record: %s vs %s',
-                schema_keys - keys,
-                keys - schema_keys,
-            )
+            expected = schema_keys - keys
+            if expected:
+                LOGGER.debug('Expected keys not found in record: %s', ', '.join(sorted(expected)))
+
+            found = keys - schema_keys
+            if found:
+                LOGGER.debug('Found keys not expected in record: %s', ', '.join(sorted(found)))
             return False
 
         # Nested key check

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -74,7 +74,7 @@ def run_command(runner_args, **kwargs):
     return True
 
 
-def continue_prompt(message=''):
+def continue_prompt(message=None):
     """Continue prompt to verify that a user wants to continue or not.
 
     This prompt's purpose is to prevent accidental changes

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -31,6 +31,7 @@ from stream_alert_cli.terraform.handlers import (
     terraform_clean_handler,
     terraform_destroy_handler,
     terraform_init,
+    terraform_list_targets
 )
 from stream_alert_cli.test.handler import test_handler
 from stream_alert_cli.threat_intel_downloader.handler import threat_intel_downloader_handler
@@ -70,6 +71,7 @@ def cli_runner(args):
         'generate': lambda opts: terraform_generate_handler(config),
         'init': lambda opts: terraform_init(opts, config),
         'kinesis': lambda opts: kinesis_handler(opts, config),
+        'list-targets': lambda opts: terraform_list_targets(config),
         'output': lambda opts: output_handler(opts, config),
         'rollback': lambda opts: rollback_handler(opts, config),
         'rule-staging': lambda opts: rule_staging_handler(opts, config),

--- a/stream_alert_cli/terraform/metrics.py
+++ b/stream_alert_cli/terraform/metrics.py
@@ -174,7 +174,7 @@ def generate_cluster_cloudwatch_metric_alarms(cluster_name, cluster_dict, config
 
     stream_alert_config = config['clusters'][cluster_name]['modules']['stream_alert']
 
-    # Add cluster metric alarms for the rule and alert processors
+    # Add cluster metric alarms for the clustered function(s). ie: classifier
     metric_alarms = [
         metric_alarm
         for func in CLUSTERED_FUNCTIONS

--- a/tests/unit/streamalert/classifier/test_parsers_base.py
+++ b/tests/unit/streamalert/classifier/test_parsers_base.py
@@ -266,8 +266,7 @@ class TestParserBaseClassMethods(object):
             'not_key': 'test'
         }
         assert_equal(ParserBase._key_check(record, schema), False)
-        log_mock.assert_called_with(
-            'Missing required keys in record: %s vs %s', {'key'}, {'not_key'})
+        log_mock.assert_called_with('Found keys not expected in record: %s', 'not_key')
 
     def test_key_check_nested(self):
         """ParserBase - Key Check, Nested"""
@@ -301,8 +300,7 @@ class TestParserBaseClassMethods(object):
             }
         }
         assert_equal(ParserBase._key_check(record, schema), False)
-        log_mock.assert_any_call(
-            'Missing required keys in record: %s vs %s', {'key_02'}, {'key_01'})
+        log_mock.assert_any_call('Expected keys not found in record: %s', 'key_02')
 
     def test_key_check_nested_loose(self):
         """ParserBase - Key Check, Loose Nested Schema"""


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Currently, the terraform 'targeting' is fairly simplistic and cannot be extended easily without managing a bunch of different 'targets' in multiple places. This change is to dynamically build a list of targets and allow the use to specify any of them with the `manage.py build` command or otherwise.

## Changes

* Adding a `list-targets` command to the CLI that outputs the various targets available for a deployment/configuration.
* Example:
```bash
$ python manage.py list-targets
Target                                                           Type
-------------------------------------------------------------------------
alert_merger_iam                                                 module
alert_merger_lambda                                              module
alert_processor_iam                                              module
alert_processor_lambda                                           module
athena_monitoring                                                module
classifier_prod_iam                                              module
classifier_prod_lambda                                           module
cloudwatch_monitoring_prod                                       module
globals                                                          module
metric_filters_AlertMerger_AlertAttempts_global                  module
metric_filters_Classifier_FailedParses                           module
metric_filters_Classifier_FailedParses_PROD                      module
...
aws_s3_bucket.stream_alert_secrets                               resource
aws_s3_bucket.streamalerts                                       resource
aws_s3_bucket.terraform_remote_state                             resource
aws_sns_topic.stream_alert_monitoring                            resource
```
* Updating the `--target` argument logic for commands like `manage.py build` to allow for wildcarding any of these listed targets.
* Example: `manage.py build --target classifier_prod_*` will now target both the `classifier_prod_iam` and `classifier_prod_lambda` modules.
* A bunch of documentation updates to change the now-deprecated `rule_processor` references.

## Testing

Updates to unit tests where necessary.
