### PR TITLE
small change to how lookup tables are accessed and quiet test logging

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -805,12 +805,21 @@ def _add_default_test_args(test_parser):
         default=DEFAULT_TEST_FILES_DIRECTORY
     )
 
-    # add the optional ability to change the test files directory
-    test_parser.add_argument(
+    # Add the optional ability to log verbosely or use quite logging for tests
+    verbose_group = test_parser.add_mutually_exclusive_group(required=False)
+
+    verbose_group.add_argument(
         '-v',
         '--verbose',
         action='store_true',
         help='Output additional information during testing'
+    )
+
+    verbose_group.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help='Suppress output for passing tests, only logging if there is a failure'
     )
 
 

--- a/stream_alert/rules_engine/rules_engine.py
+++ b/stream_alert/rules_engine/rules_engine.py
@@ -86,7 +86,7 @@ class RulesEngine(object):
         Returns:
             dict: A dictionary contains lookup table information.
         """
-        return cls._lookup_tables.tables().get(table_name) if cls._lookup_tables else None
+        return cls._lookup_tables.table(table_name) if cls._lookup_tables else dict()
 
     @classmethod
     def _load_rule_table(cls, config):

--- a/stream_alert/shared/lookup_tables.py
+++ b/stream_alert/shared/lookup_tables.py
@@ -39,8 +39,8 @@ class LookupTables(object):
     _tables = {}
 
     @classmethod
-    def tables(cls):
-        return LookupTables._tables
+    def table(cls, name):
+        return LookupTables._tables.get(name, {})
 
     @classmethod
     def _download_s3_objects(cls, buckets_info):

--- a/stream_alert_cli/test/handler.py
+++ b/stream_alert_cli/test/handler.py
@@ -70,6 +70,7 @@ class TestRunner(object):
         self._rules = options.rules
         self._files_dir = os.path.join(options.files_dir, '')  # ensure theres a trailing slash
         self._verbose = options.verbose
+        self._quiet = options.quiet
         self._s3_mocker = patch('stream_alert.classifier.payload.s3.boto3.resource').start()
         self._errors = defaultdict(list)  # cache errors to be logged at the endpoint
         self._tested_rules = set()
@@ -216,8 +217,10 @@ class TestRunner(object):
             self._passed += test_event.passed
             self._failed += test_event.failed
 
-            # It is possible for a test_event to have no results, so only print it if it does
-            if test_event:
+            # It is possible for a test_event to have no results,
+            # so only print it if it does and if quiet mode is no being used
+            # Quite mode is overridden if not all of the events passed
+            if test_event and not (self._quiet and test_event.all_passed):
                 print(test_event)
 
         self._finalize()

--- a/stream_alert_cli/test/results.py
+++ b/stream_alert_cli/test/results.py
@@ -34,6 +34,10 @@ class TestEventFile(object):
     __bool__ = __nonzero__
 
     @property
+    def all_passed(self):
+        return self.passed == len(self._results)
+
+    @property
     def passed(self):
         return sum(1 for result in self._results if result.passed)
 

--- a/tests/unit/stream_alert_shared/test_lookup_tables.py
+++ b/tests/unit/stream_alert_shared/test_lookup_tables.py
@@ -61,12 +61,11 @@ class TestLookupTables(object):
     def test_download_s3_object(self):
         """LookupTables - Download S3 Object"""
         LookupTables._download_s3_objects(self.buckets_info)
-        result = LookupTables.tables()
         expected_result = {
             'foo': {'bucket_name_key': 'foo_value'},
             'bar': {'bucket_name_key': 'bar_value'}
         }
-        assert_equal(result, expected_result)
+        assert_equal(LookupTables._tables, expected_result)
 
     @patch('logging.Logger.debug')
     def test_download_s3_object_compressed(self, mock_logger):
@@ -83,9 +82,8 @@ class TestLookupTables(object):
         }
 
         LookupTables._download_s3_objects(self.buckets_info)
-        result = LookupTables.tables()
 
-        assert_equal(result, expected_result)
+        assert_equal(LookupTables._tables, expected_result)
         mock_logger.assert_any_call('Data in \'%s\' is not compressed', 'foo.json')
 
     @patch('logging.Logger.error')
@@ -108,8 +106,7 @@ class TestLookupTables(object):
         )
         self.buckets_info['bucket_name'].pop()
         LookupTables._download_s3_objects(self.buckets_info)
-        result = LookupTables.tables()
-        assert_equal(result, {})
+        assert_equal(LookupTables._tables, {})
         mock_logger.assert_called_with('Reading %s from S3 is timed out.', 'foo.json')
 
     def test_load_lookup_tables_missing_config(self):


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Changes

* Slight change to the interface used to access lookup tables.
* Adding support for `--quiet` flag during running of tests.
  * Using this flag will log tests that fail, but will suppress logging of tests that pass

## Quiet output
```
$ python manage.py test rules --quiet
[INFO 2018-11-07 18:03:00,659 (stream_alert_cli.runner:58)]: Issues? Report here: https://github.com/airbnb/streamalert/issues

Running tests for files found in: tests/integration/rules/

Summary:

Total Tests: 77
Pass: 77
Fail: 0

[INFO 2018-11-07 18:03:01,106 (stream_alert_cli.runner:85)]: Completed

```

## Testing

Updating unit tests
