### PR TITLE
[misc] Upgrades moto and botocore

### DIFF
--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -5,6 +5,7 @@ autopep8
 backoff
 bandit
 boto3
+botocore>=1.12.13
 boxsdk[jwt]==2.0.0a11
 cbapi
 coverage
@@ -13,7 +14,7 @@ cryptography
 google-api-python-client==1.6.4
 jsonpath_rw
 mock
-moto==1.3.3
+moto>=1.3.7
 netaddr
 nose
 nose-timer==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ autopep8==1.3.5
 backoff==1.6.0
 bandit==1.4.0
 boto3==1.7.66
+botocore==1.12.47
 boxsdk==2.0.0a11
 cbapi==1.3.6
 coverage==4.5.1
@@ -13,11 +14,12 @@ cryptography==2.3
 google-api-python-client==1.6.4
 jsonpath-rw==1.4.0
 mock==2.0.0
-moto==1.3.3
+moto==1.3.7
 netaddr==0.7.19
 nose==1.3.7
 nose-timer==0.7.1
 pathlib2==2.3.2
+pyfakefs==3.5
 pylint==1.7.4
 python-dateutil==2.6.1
 requests==2.19.1
@@ -37,7 +39,6 @@ backports.ssl-match-hostname==3.5.0.1
 backports.tempfile==1.0
 backports.weakref==1.0.post1
 boto==2.49.0
-botocore==1.10.66
 cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
@@ -50,8 +51,10 @@ docker==3.4.1
 docker-pycreds==0.3.0
 docopt==0.6.2
 docutils==0.14
+ecdsa==0.13
 enum34==1.1.6
 funcsigs==1.0.2
+future==0.17.1
 futures==3.2.0
 gitdb2==2.0.4
 GitPython==2.1.11
@@ -85,6 +88,7 @@ Pygments==2.2.0
 PyJWT==1.6.4
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
+python-jose==2.0.2
 pytz==2018.5
 PyYAML==3.13
 requests-toolbelt==0.8.0
@@ -107,6 +111,3 @@ websocket-client==0.48.0
 Werkzeug==0.14.1
 wrapt==1.10.11
 xmltodict==0.11.0
-pathlib2==2.3.2
-pyfakefs==3.5
-

--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -20,8 +20,7 @@ import re
 import backoff
 import boto3
 from botocore import client
-from botocore.exceptions import ClientError
-from botocore.vendored.requests.exceptions import ConnectionError, Timeout
+from botocore.exceptions import ClientError, ConnectionError, ReadTimeoutError, ConnectTimeoutError
 
 from stream_alert.rule_processor import FUNCTION_NAME
 from stream_alert.shared.logger import get_logger
@@ -174,7 +173,8 @@ class FirehoseClient(object):
             stream_name (str): The name of the Delivery Stream to send to
             record_batch (list): The records to send
         """
-        exceptions_to_backoff = (ClientError, ConnectionError, Timeout)
+        exceptions_to_backoff = (ClientError, ConnectionError,
+                                 ReadTimeoutError, ConnectTimeoutError)
 
         @backoff.on_predicate(backoff.fibo,
                               lambda resp: resp['FailedPutCount'] > 0,

--- a/stream_alert/rule_processor/firehose.py
+++ b/stream_alert/rule_processor/firehose.py
@@ -356,7 +356,3 @@ class FirehoseClient(object):
                 self._limit_record_size(record_batch)
                 for sized_batch in self._segment_records_by_size(record_batch):
                     self._firehose_request_helper(stream_name, sized_batch)
-
-        # explicitly close firehose client to resolve connection reset issue, suggested
-        # by AWS support team.
-        self._client._endpoint.http_session.close() #pylint: disable=protected-access

--- a/stream_alert/shared/lookup_tables.py
+++ b/stream_alert/shared/lookup_tables.py
@@ -21,9 +21,7 @@ import zlib
 
 import boto3
 from botocore import client
-from botocore.exceptions import ClientError
-from botocore.vendored.requests.exceptions import Timeout
-from botocore.vendored.requests.packages.urllib3.exceptions import TimeoutError
+from botocore.exceptions import ClientError, ReadTimeoutError, ConnectTimeoutError
 
 from stream_alert.shared.logger import get_logger
 
@@ -73,9 +71,7 @@ class LookupTables(object):
                     LOGGER.error('Encounterred error while downloading %s from %s, %s',
                                  json_file, bucket, err.response['Error']['Message'])
                     return _lookup_tables
-                except(Timeout, TimeoutError):
-                    # Catching TimeoutError will catch both `ReadTimeoutError` and
-                    # `ConnectionTimeoutError`.
+                except(ReadTimeoutError, ConnectTimeoutError):
                     LOGGER.error('Reading %s from S3 is timed out.', json_file)
                     return _lookup_tables
 

--- a/tests/scripts/rule_test.sh
+++ b/tests/scripts/rule_test.sh
@@ -1,2 +1,4 @@
 #! /bin/bash
+AWS_ACCESS_KEY_ID=test_key \
+AWS_SECRET_ACCESS_KEY=test_secret \
 ./manage.py lambda test --processor rule

--- a/tests/scripts/unit_tests.sh
+++ b/tests/scripts/unit_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+AWS_ACCESS_KEY_ID=test_key \
+AWS_SECRET_ACCESS_KEY=test_secret \
 nosetests tests/unit \
 --with-coverage \
 --cover-package=stream_alert \

--- a/tests/unit/stream_alert_shared/test_lookup_tables.py
+++ b/tests/unit/stream_alert_shared/test_lookup_tables.py
@@ -18,7 +18,7 @@ import json
 import os
 import zlib
 
-from botocore.vendored.requests.packages.urllib3.exceptions import ReadTimeoutError
+from botocore.exceptions import ReadTimeoutError
 
 from mock import patch
 from moto import mock_s3
@@ -84,9 +84,7 @@ class TestLookupTables(object):
     @patch('logging.Logger.error')
     def test_download_s3_object_bucket_timeout(self, mock_logger, mock_s3_conn): # pylint: disable=no-self-use
         """LookupTables - Read file from S3 timeout"""
-        mock_s3_conn.side_effect = ReadTimeoutError(
-            'TestPool', 'Test url', 'Test Read timed out.'
-        )
+        mock_s3_conn.side_effect = ReadTimeoutError(endpoint_url='Test Url')
         result = self.lookup_tables.download_s3_objects()
         assert_equal(result, {})
         mock_logger.assert_called_with(


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @chunyong-lin 
size: medium
resolves #????

## Background

[CSIRT-369](https://jira.airbnb.biz/browse/CSIRT-369)

I ran the unit tests and, much to my surprise, they attempted to connect to the production AWS Environment. I discovered that there was a compatibility bug between *botocore>=1.11.x* and *moto<=1.3.5*.

## Changes

* I upgraded *botocore* and *moto* to 1.12.x and 1.3.7, respectively, which have solutions to the incompatibility bug. Running the unit tests will now require the `AWS_PROFILE` environment variable to be set (I'm not sure if this was always the case or not)
  * **This might be changed**
* I removed a specific [connection-closing call](https://github.com/airbnb/streamalert/pull/842/files#diff-c4b7d9b58fa0fa355f600ae64c494b4aL362). This code was originally added in response to [a connection reset bug](https://github.com/airbnb/streamalert/issues/478), but it does not look like the fix actually addressed the issue. I do not know if there exists a way to explicitly close connections in botocore 1.12.*.

## Testing

```
Ran 803 tests in 16.286s
(venv) ~/extrepos/streamalert (derek--freeze-versions)$ tests/scripts/unit_tests.sh
```

```
[INFO 2018-11-19 17:29:29,561 (StreamAlertCLI:473)]: (77/77) Successful Tests
(venv) ~/extrepos/streamalert (derek--freeze-versions)$ tests/scripts/rule_test.sh 
```
