### PR TITLE
small fixes for s3 events tf module and specifying region in AthenaClient

### DIFF
--- a/stream_alert/shared/athena.py
+++ b/stream_alert/shared/athena.py
@@ -24,6 +24,7 @@ from stream_alert.shared.backoff_handlers import (
     backoff_handler,
     success_handler
 )
+import stream_alert.shared.helpers.boto as boto_helpers
 from stream_alert.shared.logger import get_logger
 
 
@@ -41,7 +42,7 @@ class AthenaClient(object):
         database: Athena database name where tables will be queried
     """
 
-    def __init__(self, database_name, results_bucket, results_prefix):
+    def __init__(self, database_name, results_bucket, results_prefix, region=None):
         """Initialize the Boto3 Athena Client, and S3 results bucket/key
 
         Args:
@@ -49,7 +50,7 @@ class AthenaClient(object):
             results_bucket (str): S3 bucket in which to store Athena results
             results_prefix (str): S3 key prefix to prepend too results in the bucket
         """
-        self._client = boto3.client('athena')
+        self._client = boto3.client('athena', config=boto_helpers.default_config(region=region))
         self.database = database_name.strip()
 
         results_bucket = results_bucket.strip()

--- a/stream_alert/shared/helpers/boto.py
+++ b/stream_alert/shared/helpers/boto.py
@@ -29,5 +29,5 @@ def default_config(timeout=BOTO_TIMEOUT, region=REGION):
     return client.Config(
         connect_timeout=timeout,
         read_timeout=timeout,
-        region_name=region
+        region_name=region if region else REGION  # Ensure region is never empty
     )

--- a/stream_alert_cli/athena/handler.py
+++ b/stream_alert_cli/athena/handler.py
@@ -82,7 +82,12 @@ def get_athena_client(config):
         's3://{}.streamalert.athena-results'.format(prefix)
     )
 
-    return AthenaClient(db_name, results_bucket, 'stream_alert_cli')
+    return AthenaClient(
+        db_name,
+        results_bucket,
+        'stream_alert_cli',
+        region=config['global']['account']['region']
+    )
 
 
 def rebuild_partitions(table, bucket, config):

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -41,11 +41,11 @@ def run_command(runner_args, **kwargs):
 
     Args:
         runner_args (list): Commands to run via subprocess
-        kwargs:
-            cwd (str): A path to execute commands from
-            error_message (str): Message to show if command fails
-            quiet (bool): Whether to show command output or hide it
 
+    Keyword Args:
+        cwd (str): A path from which to execute commands
+        error_message (str): Message to output if command fails
+        quiet (bool): Set to True to suppress command output
     """
     default_error_message = "An error occurred while running: {}".format(' '.join(runner_args))
     error_message = kwargs.get('error_message', default_error_message)

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -68,7 +68,7 @@ def cli_runner(args):
         'custom-metrics': lambda opts: _custom_metrics_handler(opts, config),
         'deploy': lambda opts: deploy_handler(opts, config),
         'destroy': lambda opts: terraform_destroy_handler(opts, config),
-        'generate': lambda opts: terraform_generate_handler(config),
+        'generate': lambda opts: terraform_generate_handler(config, check_creds=False),
         'init': lambda opts: terraform_init(opts, config),
         'kinesis': lambda opts: kinesis_handler(opts, config),
         'list-targets': lambda opts: terraform_list_targets(config),

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -117,7 +117,10 @@ def generate_main(config, init=False):
     main_dict = infinitedict()
 
     # Configure provider along with the minimum version
-    main_dict['provider']['aws'] = {'version': TERRAFORM_VERSIONS['provider']['aws']}
+    main_dict['provider']['aws'] = {
+        'version': TERRAFORM_VERSIONS['provider']['aws'],
+        'region': config['global']['account']['region']
+    }
 
     # Configure Terraform version requirement
     main_dict['terraform']['required_version'] = TERRAFORM_VERSIONS['application']

--- a/stream_alert_cli/terraform/s3_events.py
+++ b/stream_alert_cli/terraform/s3_events.py
@@ -50,8 +50,14 @@ def generate_s3_events(cluster_name, cluster_dict, config):
         cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, index)] = {
             'source': 'modules/tf_stream_alert_s3_events',
             'lambda_role_id': '${{module.classifier_{}_lambda.role_id}}'.format(cluster_name),
+            'lambda_function_alias': (
+                '${{module.classifier_{}_lambda.function_alias}}'.format(cluster_name)
+            ),
             'lambda_function_alias_arn': (
                 '${{module.classifier_{}_lambda.function_alias_arn}}'.format(cluster_name)
+            ),
+            'lambda_function_name': (
+                '${{module.classifier_{}_lambda.function_name}}'.format(cluster_name)
             ),
             'bucket_id': bucket_info['bucket_id'],
             'notification_id': '{}_{}'.format(cluster_name, index),

--- a/terraform/modules/tf_lambda/output.tf
+++ b/terraform/modules/tf_lambda/output.tf
@@ -16,6 +16,11 @@ output "role_id" {
   value = "${aws_iam_role.role.0.id}"
 }
 
+// Combine the two mutually exclusive lists and export the first element as the function alias
+output "function_alias" {
+  value = "${element(concat(aws_lambda_alias.alias_vpc.*.name, aws_lambda_alias.alias_no_vpc.*.name), 0)}"
+}
+
 // Combine the two mutually exclusive lists and export the first element as the function name
 output "function_name" {
   value = "${element(concat(aws_lambda_function.function_vpc.*.function_name, aws_lambda_function.function_no_vpc.*.function_name), 0)}"

--- a/terraform/modules/tf_stream_alert_s3_events/main.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/main.tf
@@ -2,7 +2,7 @@
 resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "InvokeFromS3Bucket_${var.notification_id}"
   action        = "lambda:InvokeFunction"
-  function_name = "${var.lambda_function_alias_arn}"
+  function_name = "${var.lambda_function_name}"
   principal     = "s3.amazonaws.com"
   source_arn    = "arn:aws:s3:::${var.bucket_id}"
   qualifier     = "${var.lambda_function_alias}"

--- a/terraform/modules/tf_stream_alert_s3_events/variables.tf
+++ b/terraform/modules/tf_stream_alert_s3_events/variables.tf
@@ -14,6 +14,12 @@ variable "filter_suffix" {
 
 variable "lambda_function_alias_arn" {}
 
+variable "lambda_function_name" {}
+
+variable "lambda_function_alias" {
+  default = "production"
+}
+
 variable "lambda_role_id" {}
 
 variable "notification_id" {}

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -83,7 +83,8 @@ class TestTerraformGenerate(object):
         tf_main_expected = {
             'provider': {
                 'aws': {
-                    'version': generate.TERRAFORM_VERSIONS['provider']['aws']
+                    'version': generate.TERRAFORM_VERSIONS['provider']['aws'],
+                    'region': 'us-west-1'
                 }
             },
             'terraform': {

--- a/tests/unit/stream_alert_cli/terraform/test_s3_events.py
+++ b/tests/unit/stream_alert_cli/terraform/test_s3_events.py
@@ -46,8 +46,14 @@ def test_generate_s3_events():
         'module': {
             's3_events_unit-testing_advanced_0': {
                 'source': 'modules/tf_stream_alert_s3_events',
+                'lambda_function_alias': (
+                    '${module.classifier_advanced_lambda.function_alias}'
+                ),
                 'lambda_function_alias_arn': (
                     '${module.classifier_advanced_lambda.function_alias_arn}'
+                ),
+                'lambda_function_name': (
+                    '${module.classifier_advanced_lambda.function_name}'
                 ),
                 'bucket_id': 'unit-test-bucket.data',
                 'notification_id': 'advanced_0',
@@ -58,8 +64,14 @@ def test_generate_s3_events():
             },
             's3_events_unit-testing_advanced_1': {
                 'source': 'modules/tf_stream_alert_s3_events',
+                'lambda_function_alias': (
+                    '${module.classifier_advanced_lambda.function_alias}'
+                ),
                 'lambda_function_alias_arn': (
                     '${module.classifier_advanced_lambda.function_alias_arn}'
+                ),
+                'lambda_function_name': (
+                    '${module.classifier_advanced_lambda.function_name}'
                 ),
                 'bucket_id': 'unit-test.cloudtrail.data',
                 'enable_events': False,

--- a/tests/unit/stream_alert_rule_promotion/test_promoter.py
+++ b/tests/unit/stream_alert_rule_promotion/test_promoter.py
@@ -29,12 +29,12 @@ from tests.unit.helpers.aws_mocks import MockAthenaClient, setup_mock_rules_tabl
 _RULES_TABLE = 'unit-testing_streamalert_rules'
 
 
-def _mock_boto(name):
+def _mock_boto(name, **kwargs):
     """Hack to allow mocking boto3.client with moto and our own class"""
     if name == 'athena':
         return MockAthenaClient()
 
-    return client(name)
+    return client(name, **kwargs)
 
 
 class TestRulePromoter(object):

--- a/tests/unit/stream_alert_shared/test_athena.py
+++ b/tests/unit/stream_alert_shared/test_athena.py
@@ -37,7 +37,7 @@ class TestAthenaClient(object):
     """Test class for AthenaClient"""
 
     @patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'us-west-1'})
-    @patch('boto3.client', Mock(side_effect=lambda c: MockAthenaClient()))
+    @patch('boto3.client', Mock(side_effect=lambda c, config=None: MockAthenaClient()))
     def setup(self):
         """Setup the AthenaClient tests"""
 


### PR DESCRIPTION
to: @chunyong-lin / @Ryxias 
cc: @airbnb/streamalert-maintainers
resolves #834 

## Changes

* Fixing a bug in the `s3_events` terraform module that was introduced related to a missing variable.
* Fixing a bug where the `python manage.py generate` command would unnecessarily look for valid AWS creds before generating any tf.json files.
* Adding a `region` value to the terraform aws provider block due to this error in CI:
  * `Error: provider.aws: "region": required field is not set`
  * It seems the above can occur if the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables are not set (setting one of them caused the above error to go away). However, the error is also resolved by use adding the `region` field to the provider directly.
* Resolving #834 by supplying the region from the config as a keyword argument. This is _only_ supplied when the CLI creates and `AthenaClient` object, and will otherwise depend on the Lambda environment variables or the region.


## Testing

Updates to unit tests and deployed in testing account. I also tested creating an Athena table with the change to the Athena client with success.
