### PR TITLE
update normalization logic to store raw values instead of paths to values in json

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -161,21 +161,20 @@ datatypes
 .. code-block:: python
 
   """These rules apply to several different log types, defined in conf/normalized_types.json"""
-  from rules.helpers.base import fetch_values_by_datatype
   from stream_alert.shared.rule import rule
+  from stream_alert.shared.normalize import Normalizer
 
   @rule(datatypes=['sourceAddress'], outputs=['aws-sns:my-topic'])
   def ip_watchlist_hit(record):
       """Source IP address matches watchlist."""
-      return '127.0.0.1' in fetch_values_by_datatype(record, 'sourceAddress')
-
+      return '127.0.0.1' in Normalizer.get_values_for_normalized_type(record, 'sourceAddress')
 
   @rule(datatypes=['command'], outputs=['aws-sns:my-topic'])
   def command_etc_shadow(record):
       """Command line arguments include /etc/shadow"""
       return any(
           '/etc/shadow' in cmd.lower()
-          for cmd in fetch_values_by_datatype(record, 'command')
+          for cmd in Normalizer.get_values_for_normalized_type(record, 'command')
       )
 
 logs

--- a/rules/community/mitre_attack/defense_evasion/multi/obfuscated_files_or_information/right_to_left_character.py
+++ b/rules/community/mitre_attack/defense_evasion/multi/obfuscated_files_or_information/right_to_left_character.py
@@ -1,6 +1,6 @@
 """Detection of the right to left override unicode character U+202E in filename or process name."""
-from rules.helpers.base import fetch_values_by_datatype
 from stream_alert.shared.rule import rule
+from stream_alert.shared.normalize import Normalizer
 
 
 @rule(datatypes=['command', 'filePath', 'processPath', 'fileName'])
@@ -22,22 +22,22 @@ def right_to_left_character(rec):
     # Unicode character U+202E, right-to-left-override (RLO)
     rlo = u'\u202e'
 
-    commands = fetch_values_by_datatype(rec, 'command')
+    commands = Normalizer.get_values_for_normalized_type(rec, 'command')
     for command in commands:
         if isinstance(command, unicode) and rlo in command:
             return True
 
-    file_paths = fetch_values_by_datatype(rec, 'filePath')
+    file_paths = Normalizer.get_values_for_normalized_type(rec, 'filePath')
     for file_path in file_paths:
         if isinstance(file_path, unicode) and rlo in file_path:
             return True
 
-    process_paths = fetch_values_by_datatype(rec, 'processPath')
+    process_paths = Normalizer.get_values_for_normalized_type(rec, 'processPath')
     for process_path in process_paths:
         if isinstance(process_path, unicode) and rlo in process_path:
             return True
 
-    file_names = fetch_values_by_datatype(rec, 'fileName')
+    file_names = Normalizer.get_values_for_normalized_type(rec, 'fileName')
     for file_name in file_names:
         if isinstance(file_name, unicode) and rlo in file_name:
             return True

--- a/rules/helpers/base.py
+++ b/rules/helpers/base.py
@@ -20,7 +20,6 @@ import random
 import time
 import pathlib2
 
-from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.utils import (  # pylint: disable=unused-import
     # Import some utility functions which are useful for rules as well
     get_first_key,
@@ -140,33 +139,6 @@ def last_hour(unixtime, hours=1):
     seconds = hours * 3600
     # sometimes bash histories do not contain the `time` column
     return int(time.time()) - int(unixtime) <= seconds if unixtime else False
-
-
-def fetch_values_by_datatype(rec, datatype):
-    """Fetch values of normalized_type.
-
-    Args:
-        rec (dict): parsed payload of any log
-        datatype (str): normalized type user interested
-
-    Returns:
-        (list) The values of normalized types
-    """
-    results = []
-    if not rec.get(NORMALIZATION_KEY):
-        return results
-
-    if datatype not in rec[NORMALIZATION_KEY]:
-        return results
-
-    for original_keys in rec[NORMALIZATION_KEY][datatype]:
-        result = rec
-        if isinstance(original_keys, list):
-            for original_key in original_keys:
-                result = result[original_key]
-        results.append(result)
-
-    return results
 
 
 def data_has_value(data, search_value):

--- a/stream_alert/alert_processor/main.py
+++ b/stream_alert/alert_processor/main.py
@@ -20,11 +20,12 @@ import backoff
 from botocore.exceptions import ClientError
 
 from stream_alert.alert_processor.outputs.output_base import StreamAlertOutput
-from stream_alert.shared import backoff_handlers, NORMALIZATION_KEY, resources
+from stream_alert.shared import backoff_handlers, resources
 from stream_alert.shared.alert import Alert, AlertCreationError
 from stream_alert.shared.alert_table import AlertTable
 from stream_alert.shared.config import load_config
 from stream_alert.shared.logger import get_logger
+from stream_alert.shared.normalize import Normalizer
 
 LOGGER = get_logger(__name__)
 
@@ -143,8 +144,8 @@ class AlertProcessor(object):
 
         # Remove normalization key from the record.
         # TODO: Consider including this in at least some outputs, e.g. default Athena firehose
-        if NORMALIZATION_KEY in alert.record:
-            del alert.record[NORMALIZATION_KEY]
+        if Normalizer.NORMALIZATION_KEY in alert.record:
+            del alert.record[Normalizer.NORMALIZATION_KEY]
 
         result = self._send_to_outputs(alert)
         self._update_table(alert, result)

--- a/stream_alert/classifier/classifier.py
+++ b/stream_alert/classifier/classifier.py
@@ -17,12 +17,12 @@ from collections import OrderedDict
 import logging
 
 from stream_alert.classifier.clients import FirehoseClient, SQSClient
-from stream_alert.classifier.normalize import NORMALIZATION_KEY, Normalizer
 from stream_alert.classifier.parsers import get_parser
 from stream_alert.classifier.payload.payload_base import StreamPayload
 from stream_alert.shared import config, CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.metrics import MetricLogger
+from stream_alert.shared.normalize import Normalizer
 
 
 LOGGER = get_logger(__name__)
@@ -212,7 +212,7 @@ class Classifier(object):
             MetricLogger.NORMALIZED_RECORDS,
             sum(
                 1 for payload in self._payloads
-                for log in payload.parsed_records if log.get(NORMALIZATION_KEY)
+                for log in payload.parsed_records if log.get(Normalizer.NORMALIZATION_KEY)
             )
         )
         MetricLogger.log_metric(

--- a/stream_alert/shared/__init__.py
+++ b/stream_alert/shared/__init__.py
@@ -5,6 +5,5 @@ ATHENA_PARTITION_REFRESH_NAME = 'athena_partition_refresh'
 CLASSIFIER_FUNCTION_NAME = 'classifier'
 RULES_ENGINE_FUNCTION_NAME = 'rules_engine'
 RULE_PROMOTION_NAME = 'rule_promotion'
-NORMALIZATION_KEY = 'streamalert:normalization'
 
 CLUSTERED_FUNCTIONS = {CLASSIFIER_FUNCTION_NAME}

--- a/stream_alert/shared/utils.py
+++ b/stream_alert/shared/utils.py
@@ -4,8 +4,8 @@ from collections import deque
 from netaddr import IPAddress, IPNetwork
 from netaddr.core import AddrFormatError
 
-from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.logger import get_logger
+from stream_alert.shared.normalize import Normalizer
 
 
 LOGGER = get_logger(__name__)
@@ -133,7 +133,7 @@ def get_keys(data, search_key, max_matches=-1):
                 # helper may fetch info from normalization if there are keyname conflict.
                 # For example, Key name 'userName' is both existed as a normalized key defined
                 # in conf/normalized_types.json and cloudtrail record schemas.
-                if key == NORMALIZATION_KEY:
+                if key == Normalizer.NORMALIZATION_KEY:
                     continue
                 if val and isinstance(val, _CONTAINER_TYPES):
                     containers.append(val)

--- a/tests/unit/stream_alert_alert_processor/test_main.py
+++ b/tests/unit/stream_alert_alert_processor/test_main.py
@@ -24,9 +24,9 @@ from nose.tools import (
 
 from stream_alert.alert_processor.main import AlertProcessor, handler
 from stream_alert.alert_processor.outputs.output_base import OutputDispatcher
-from stream_alert.shared import NORMALIZATION_KEY
 from stream_alert.shared.alert import Alert
 from stream_alert.shared.config import load_config
+from stream_alert.shared.normalize import Normalizer
 from tests.unit.stream_alert_alert_processor import (
     ALERTS_TABLE,
     MOCK_ENV
@@ -52,7 +52,7 @@ class TestAlertProcessor(object):
         self.processor = AlertProcessor()
         self.alert = Alert(
             'hello_world',
-            {'abc': 123, NORMALIZATION_KEY: {}},
+            {'abc': 123, Normalizer.NORMALIZATION_KEY: {}},
             {'slack:unit-test-channel'}
         )
 

--- a/tests/unit/streamalert/rules_engine/test_threat_intel.py
+++ b/tests/unit/streamalert/rules_engine/test_threat_intel.py
@@ -90,8 +90,8 @@ class TestThreatIntel(object):
                 },
                 'source': '1.1.1.2',
                 'streamalert:normalization': {
-                    'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
-                    'userName': [['detail', 'userIdentity', 'userName']]
+                    'sourceAddress': {'1.1.1.2'},
+                    'userName': {'alice'}
                 }
             }
         }
@@ -123,8 +123,8 @@ class TestThreatIntel(object):
             },
             'source': '1.1.1.2',
             'streamalert:normalization': {
-                'sourceAddress': [['detail', 'sourceIPAddress'], ['source']],
-                'userName': [['detail', 'userIdentity', 'userName']]
+                'sourceAddress': {'1.1.1.2'},
+                'userName': {'alice'}
             },
             'streamalert:ioc': {
                 'ip': {'1.1.1.2'}
@@ -409,26 +409,6 @@ class TestThreatIntel(object):
         }
         assert_equal(self._threat_intel._is_excluded_ioc('ip', '1.2.3.20'), False)
         assert_equal(self._threat_intel._is_excluded_ioc('ip', '1.2.3.15'), True)
-
-    def test_extract_values_by_keys(self):
-        """ThreatIntel - Extract Values By Keys"""
-        record = {
-            'region': 'us-east-1',
-            'detail': {
-                'eventName': 'ConsoleLogin',
-                'sourceIPAddress': None
-            },
-            'source': '1.1.1.2'
-        }
-
-        keys = [['detail', 'sourceIPAddress'], ['source']]
-
-        expected_result = [
-            '1.1.1.2'
-        ]
-
-        result = list(ThreatIntel._extract_values_by_keys(record, keys))
-        assert_equal(result, expected_result)
 
     def test_extract_ioc_values(self):
         """ThreatIntel - Extract IOC Values"""


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

# Breaking Change

Rules using `datatypes` (aka normalization) will break with this change. Rule tests should identify this, but all rules should be updated to use the `Normalizer` class like so:

```python
from stream_alert.shared.rule import rule
from stream_alert.shared.normalize import Normalizer

@rule(...)
def test_rule(rec):
    value = Normalizer.get_values_for_normalized_type(rec, 'normalized_type')
    return value == 'bad_value'
```

## Background

The current data normalization stores _paths_ to values instead of the raw values. In turn, this requires more overhead when performing lookups for the actual normalized value.

## Changes

* Moving the normalization logic (ie: `Normalizer` class) to the shared module.
* Migrating the `fetch_values_by_datatype` method to the `Normalizer` class and rebranding as `get_values_for_normalized_type`
  * As a side effect - rules must now import the Normalizer when performing normalized data lookups.
* Moving the `NORMALIZATION_KEY` onto the `Normalizer` class, as it makes sense to have this as a class attribute vs a global constant. Updating all imports that previously referenced the global constant.
* Updating the community rule (`obfuscated_files_or_information/right_to_left_character.py`) that was previously using normalization to use the new format.

## Testing

* Updated all unit tests and added new ones as necessary.
