### PR TITLE
[bug] updating terraform generate code, and deploy/rollback logic, for apps

### DIFF
--- a/stream_alert_cli/manage_lambda/deploy.py
+++ b/stream_alert_cli/manage_lambda/deploy.py
@@ -149,8 +149,10 @@ def _create(function_name, config, clusters=None):
             stream_alert_packages.AppPackage,
             {'module.app_{}_{}_{}'.format(app_info['app_name'], cluster, suffix)
              for suffix in {'lambda', 'iam'}
-             for cluster, info in config['clusters'].iteritems()
-             for app_info in info['modules'].get('stream_alert_apps', {}).values()
+             for cluster in clusters
+             for app_info in config['clusters'][cluster]['modules'].get(
+                 'stream_alert_apps', {}
+             ).itervalues()
              if 'app_name' in app_info},
             True if any(info['modules'].get('stream_alert_apps')
                         for info in config['clusters'].itervalues()) else False

--- a/stream_alert_cli/manage_lambda/rollback.py
+++ b/stream_alert_cli/manage_lambda/rollback.py
@@ -109,7 +109,7 @@ def rollback_handler(options, config):
         for cluster in clusters:
             success = success and _rollback_production(
                 client,
-                '{}_{}_streamalert_classifier'.format(prefix, cluster)
+                '{}_streamalert_classifier_{}'.format(prefix, cluster)
             )
 
     if rollback_all or 'rule' in options.function:

--- a/stream_alert_cli/terraform/apps.py
+++ b/stream_alert_cli/terraform/apps.py
@@ -36,7 +36,7 @@ def generate_apps(cluster_name, cluster_dict, config):
 
         tf_module_prefix = 'app_{}_{}'.format(app_info['app_name'], cluster_name)
 
-        destination_func = '{}_{}_streamalert_classifier'.format(prefix, cluster_name)
+        destination_func = '{}_streamalert_classifier_{}'.format(prefix, cluster_name)
 
         app_config = {
             'app_type': app_info['type'],

--- a/stream_alert_cli/terraform/monitoring.py
+++ b/stream_alert_cli/terraform/monitoring.py
@@ -66,7 +66,7 @@ def generate_monitoring(cluster_name, cluster_dict, config):
 
     if monitoring_config.get('lambda_alarms_enabled', True):
         cluster_dict['module']['cloudwatch_monitoring_{}'.format(cluster_name)].update({
-            'lambda_functions': ['{}_{}_streamalert_classifier'.format(prefix, cluster_name)],
+            'lambda_functions': ['{}_streamalert_classifier_{}'.format(prefix, cluster_name)],
             'lambda_alarms_enabled': True
         })
 

--- a/tests/unit/stream_alert_cli/manage_lambda/test_rollback.py
+++ b/tests/unit/stream_alert_cli/manage_lambda/test_rollback.py
@@ -77,8 +77,8 @@ class RollbackTest(unittest.TestCase):
             mock.call(mock.ANY, 'unit-testing_corp_box_admin_events_box_collector_app'),
             mock.call(mock.ANY, 'unit-testing_corp_duo_admin_duo_admin_collector_app'),
             mock.call(mock.ANY, 'unit-testing_streamalert_athena_partition_refresh'),
-            mock.call(mock.ANY, 'unit-testing_corp_streamalert_classifier'),
-            mock.call(mock.ANY, 'unit-testing_prod_streamalert_classifier'),
+            mock.call(mock.ANY, 'unit-testing_streamalert_classifier_corp'),
+            mock.call(mock.ANY, 'unit-testing_streamalert_classifier_prod'),
             mock.call(mock.ANY, 'unit-testing_streamalert_rules_engine'),
             mock.call(mock.ANY, 'unit-testing_streamalert_threat_intel_downloader')
         ])

--- a/tests/unit/stream_alert_cli/terraform/test_monitoring.py
+++ b/tests/unit/stream_alert_cli/terraform/test_monitoring.py
@@ -31,7 +31,7 @@ def test_generate_cloudwatch_monitoring():
     expected_cloudwatch_tf = {
         'source': 'modules/tf_stream_alert_monitoring',
         'sns_topic_arn': 'arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring',
-        'lambda_functions': ['unit-testing_test_streamalert_classifier'],
+        'lambda_functions': ['unit-testing_streamalert_classifier_test'],
         'kinesis_stream': 'unit-testing_test_stream_alert_kinesis',
         'lambda_alarms_enabled': True,
         'kinesis_alarms_enabled': True
@@ -52,7 +52,7 @@ def test_generate_cloudwatch_monitoring_with_settings():
     expected_cloudwatch_tf = {
         'source': 'modules/tf_stream_alert_monitoring',
         'sns_topic_arn': 'arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring',
-        'lambda_functions': ['unit-testing_advanced_streamalert_classifier'],
+        'lambda_functions': ['unit-testing_streamalert_classifier_advanced'],
         'kinesis_stream': 'unit-testing_advanced_stream_alert_kinesis',
         'lambda_alarms_enabled': True,
         'kinesis_alarms_enabled': True,
@@ -86,7 +86,7 @@ def test_generate_cloudwatch_monitoring_no_kinesis():
     expected_cloudwatch_tf = {
         'source': 'modules/tf_stream_alert_monitoring',
         'sns_topic_arn': 'arn:aws:sns:us-west-1:12345678910:stream_alert_monitoring',
-        'lambda_functions': ['unit-testing_test_streamalert_classifier'],
+        'lambda_functions': ['unit-testing_streamalert_classifier_test'],
         'lambda_alarms_enabled': True,
         'kinesis_alarms_enabled': False
     }
@@ -133,7 +133,7 @@ def test_generate_cloudwatch_monitoring_custom_sns():
     expected_cloudwatch_tf_custom = {
         'source': 'modules/tf_stream_alert_monitoring',
         'sns_topic_arn': 'arn:aws:sns:us-west-1:12345678910:unit_test_monitoring',
-        'lambda_functions': ['unit-testing_test_streamalert_classifier'],
+        'lambda_functions': ['unit-testing_streamalert_classifier_test'],
         'kinesis_stream': 'unit-testing_test_stream_alert_kinesis',
         'lambda_alarms_enabled': True,
         'kinesis_alarms_enabled': True


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers 

## Background

Patrick (@patrickod) reported a bug with the apps function where the destination classifier function did not exist.

## Changes

* Updating the classifier function name passed to apps in the terraform generation.
* Fixing some other issues related to deploy/rollback functionality.

## Testing

Deployed this code.
