### PR TITLE
sending records to sqs in blobs vs individual messages to improve performance

### DIFF
--- a/stream_alert/rules_engine/main.py
+++ b/stream_alert/rules_engine/main.py
@@ -24,7 +24,13 @@ from stream_alert.shared import logger
 def handler(event, _):
     """Main Lambda handler function"""
     try:
-        records = [json.loads(record['body']) for record in event.get('Records', [])]
+        records = []
+        for record in event.get('Records', []):
+            body = json.loads(record['body'])
+            if isinstance(body, list):
+                records.extend(body)
+            else:
+                records.append(body)
         RulesEngine().run(records)
     except Exception:
         logger.get_logger(__name__).error('Invocation event: %s', json.dumps(event))

--- a/stream_alert_cli/test/handler.py
+++ b/stream_alert_cli/test/handler.py
@@ -51,12 +51,14 @@ def test_handler(options, config):
         bool: False if errors occurred, True otherwise
     """
     result = True
-    for i in range(options.repeat):
-        if options.repeat != 1:
+    opts = vars(options)
+    repeat = opts.get('repeat', 1)
+    for i in range(repeat):
+        if repeat != 1:
             print('\nRepetition #', i+1)
         result = result and TestRunner(options, config).run()
 
-    if options.stats:
+    if opts.get('stats'):
         print(get_rule_stats())
     return result
 

--- a/stream_alert_cli/test/mocks.py
+++ b/stream_alert_cli/test/mocks.py
@@ -18,17 +18,31 @@ import os
 
 
 def mock_threat_intel_query_results():
-    """Load test fixtures for Threat Intel to use with rule testing"""
-    mock_ioc_values = set()
+    """Load test fixtures for Threat Intel to use with rule testing
+
+    Fixture files should be in the following JSON format:
+        [
+          {
+            "ioc_value": "1.1.1.2",
+            "ioc_type": "ip",
+            "sub_type": "mal_ip"
+          }
+        ]
+    """
+    mock_ioc_values = dict()
     for root, _, fixture_files in os.walk('tests/integration/fixtures/threat_intel/'):
         for fixture_file in fixture_files:
             with open(os.path.join(root, fixture_file), 'r') as json_file:
-                mock_ioc_values.update(value['ioc_value'] for value in json.load(json_file))
+                mock_ioc_values.update(
+                    {value['ioc_value']: value for value in json.load(json_file)}
+                )
 
     # Return the function to mock out ThreatIntel._query
     # This simply returns values from the log that are in the mock_ioc_values
     def _query(values):
-        return list(set(values).intersection(mock_ioc_values))
+        return [
+            mock_ioc_values[value] for value in values if value in mock_ioc_values
+        ]
 
     return _query
 

--- a/tests/unit/streamalert/classifier/clients/test_sqs.py
+++ b/tests/unit/streamalert/classifier/clients/test_sqs.py
@@ -37,13 +37,6 @@ class TestSQSClient(object):
         """Teardown after each method"""
         SQSClient._queue = None
 
-    @classmethod
-    def _sample_batch(cls, count=1):
-        return [
-            {'Id': str(i), 'MessageBody': 'value_{}'.format(i)}
-            for i in range(count)
-        ]
-
     def _sample_payloads(self, count=1):
         return [
             Mock(
@@ -58,13 +51,6 @@ class TestSQSClient(object):
             ) for i in range(count)
         ]
 
-    @classmethod
-    def _sample_raw_records(cls, count=2):
-        return [
-            {'key_{}'.format(i): 'value_{}'.format(i)}
-            for i in range(count)
-        ]
-
     def test_init_no_queue_url(self):
         """SQSClient - Init, No URL in Environment"""
         assert_raises(SQSClientError, SQSClient)
@@ -75,326 +61,139 @@ class TestSQSClient(object):
         SQSClient._queue = queue
         assert_equal(self._client.queue, queue)
 
-    def test_log_failed(self):
-        """SQSClient - Log Failed"""
-        with patch.object(sqs.MetricLogger, 'log_metric') as metric_mock:
-            SQSClient._log_failed(1)
-            metric_mock.assert_called_with('classifier', 'SQSFailedRecords', 1)
+    @patch('logging.Logger.debug')
+    def test_segment_records_no_segmentation(self, log_mock):
+        """SQSClient - Segment Records, No Segmentation"""
+        records = ['{"key":"value"}']
+        result = list(SQSClient._segment_records(records))
+        expected_result = [(['{"key":"value"}'], 1)]
+        assert_equal(result, expected_result)
+        log_mock.assert_not_called()
 
-    def test_message_batches(self):
-        """SQSClient - Message Batches"""
-        records = self._sample_raw_records()
+    @patch('logging.Logger.error')
+    def test_segment_records_too_large(self, log_mock):
+        """SQSClient - Segment Records, Single Record Too Large"""
+        large_value = 'value' * 52428
+        records = ['{{"key":"{}"}}'.format(large_value)]  # a single record that exceeds max size
+        recs = records[:]
+        result = list(SQSClient._segment_records(records))
+        assert_equal(result, [])
+        log_mock.assert_called_with('Record is too large to send to SQS:\n%s', recs[0])
+
+    @patch('logging.Logger.error')
+    def test_segment_records_one_too_large(self, log_mock):
+        """SQSClient - Segment Records, Record Too Large"""
+        # A record that exceeds max size and one that does not
+        large_value = 'value' * 52428
+        records = ['{{"key":"{}"}}'.format(large_value), '{"key":"value"}']
+        result = list(SQSClient._segment_records(records))
+        expected_result = [(['{"key":"value"}'], 1)]
+        assert_equal(result, expected_result)
+        log_mock.assert_called_with('Record is too large to send to SQS:\n%s', records[0])
+
+    def test_segment_records_multiple_sets(self):
+        """SQSClient - Segment Records, Multiple Sets"""
+        # A record that exceeds max size and some that do not
+        large_rec = '{{"key":"{}"}}'.format('value' * 52426)
+        small_rec = '{"key":"value"}'
+        records = [large_rec] + ([small_rec] * 3)
+
+        result = list(SQSClient._segment_records(records))
 
         expected_result = [
-            [
-                '{"key_0":"value_0"}',
-                '{"key_1":"value_1"}'
-            ]
+            ([large_rec], 1),
+            ([small_rec] * 3, 3)
         ]
 
-        result = list(SQSClient._message_batches(records))
         assert_equal(result, expected_result)
 
-    @patch.object(SQSClient, '_log_failed')
-    def test_message_batches_rec_too_large(self, failure_mock):
-        """SQSClient - Message Batches, Record Too Large"""
-        records = [
-            {'key': 'test' * 1000 * 100}
+    def test_segment_records_last_record(self):
+        """SQSClient - Segment Records, Last Record"""
+        # A record that exceeds max size and some that do not
+        large_rec = '{{"key":"{}"}}'.format('value' * 52426)
+        small_rec = '{"key":"value"}'
+        records = [large_rec, small_rec]
+
+        result = list(SQSClient._segment_records(records))
+
+        expected_result = [
+            ([large_rec], 1),
+            ([small_rec], 1)
         ]
 
-        result = list(SQSClient._message_batches(records))
-        assert_equal(result, [[]])
-        failure_mock.assert_called_with(1)
+        assert_equal(result, expected_result)
 
-    def test_message_batches_max_batch_count(self):
-        """SQSClient - Message Batches, Max Batch Count"""
-        records = self._sample_raw_records(count=11)
-
-        result = list(SQSClient._message_batches(records))
-        assert_equal(len(result), 2)
-        assert_equal(len(result[0]), 10)
-        assert_equal(len(result[1]), 1)
-
-    def test_message_batches_max_batch_size(self):
-        """SQSClient - Message Batches, Max Batch Size"""
-        records = [
-            {'key_{}'.format(i): 'test' * 10000}
-            for i in range(10)
-        ]
-        result = list(SQSClient._message_batches(records))
-        assert_equal(len(result), 2)
-        assert_equal(len(result[0]), 6)
-        assert_equal(len(result[1]), 4)
-        batch_size_01 = sum(len(rec) for rec in result[0])
-        batch_size_02 = sum(len(rec) for rec in result[1])
-        assert_equal(batch_size_01 < SQSClient.MAX_BATCH_SIZE, True)
-        assert_equal(batch_size_02 < SQSClient.MAX_BATCH_SIZE, True)
-        assert_equal(batch_size_01 + batch_size_02 > SQSClient.MAX_BATCH_SIZE, True)
-
-    def test_format_failure_message(self):
-        """SQSClient - Format Failure Message"""
-        failure = {
-            'Id': '1',
-            'Code': 'error code',
-            'Message': 'error message',
-            'SenderFault': True
-        }
-        expected_result = (
-            'Record failed to send to SQS. ID: 1, SenderFault: True, '
-            'Code: error code, Error: error message'
-        )
-
-        message = SQSClient._format_failure_message(failure)
-        assert_equal(message, expected_result)
-
-    def test_format_failure_message_with_record(self):
-        """SQSClient - Format Failure Message, With Record"""
-        failure = {
-            'Id': '1',
-            'Code': 'error code',
-            'Message': 'error message',
-            'SenderFault': True
-        }
-
-        record = 'data'
-        expected_result = (
-            'Record failed to send to SQS. ID: 1, SenderFault: True, '
-            'Code: error code, Error: error message, Record:\ndata'
-        )
-
-        message = SQSClient._format_failure_message(failure, record)
-        assert_equal(message, expected_result)
-
-    @patch('logging.Logger.info')
-    @patch.object(SQSClient, '_log_failed')
-    def test_finalize_failures(self, failure_mock, log_mock):
+    @patch.object(sqs.MetricLogger, 'log_metric')
+    def test_finalize_failures(self, metric_mock):
         """SQSClient - Finalize, With Failures"""
-        batch = self._sample_batch(2)
-        response = {
-            'Successful': [
-                {
-                    'Id': '0'
-                }
-            ],
-            'Failed': [
-                {
-                    'Id': '1',
-                    'SenderFault': False,
-                    'Code': 'error code',
-                    'Message': 'error message'
-                }
-            ]
-        }
+        self._client._finalize(False, 10)  # None, None to represent 2 records
+        metric_mock.assert_called_with('classifier', 'SQSFailedRecords', 10)
 
-        url = 'test_url'
-        SQSClient._queue.url = url
-        self._client._finalize(response, batch)  # None, None to represent 2 records
-
-        failure_mock.assert_called_with(1)
-        log_mock.assert_called_with('Successfully sent %d message(s) to queue %s', 1, url)
-
-    @patch('logging.Logger.info')
+    @patch('logging.Logger.debug')
     def test_finalize_success(self, log_mock):
         """SQSClient - Finalize, Success"""
-        batch = self._sample_batch(1)
-        response = {
-            'Successful': [
-                {
-                    'Id': '0'
-                }
-            ]
-        }
-
+        response = '8fb984ee-b44c-4a68-992f-4f7aae23ae07'
         url = 'test_url'
         SQSClient._queue.url = url
-        self._client._finalize(response, batch)
+        self._client._finalize(response, 10)
 
-        log_mock.assert_called_with('Successfully sent %d message(s) to queue %s', 1, url)
-
-    def test_strip_successful_records(self):
-        """SQSClient - Strip Successful Records"""
-        batch = self._sample_batch(2)
-        response = {
-            'Successful': [
-                {
-                    'Id': '0'
-                }
-            ],
-            'Failed': [
-                {
-                    'Id': '1',
-                    'SenderFault': False,
-                    'Code': 'error code',
-                    'Message': 'error message'
-                }
-            ]
-        }
-
-        expected_batch = [{'Id': '1', 'MessageBody': 'value_1'}]
-        SQSClient._strip_successful_records(batch, response)
-
-        assert_equal(batch, expected_batch)
-
-    def test_extract_message_by_id(self):
-        """SQSClient - Extract Message by ID"""
-        batch = self._sample_batch(2)
-        expected_message = batch[1]
-
-        result = SQSClient._extract_message_by_id(batch, '1')
-        assert_equal(result, expected_message)
-
-    @patch('logging.Logger.error')
-    def test_extract_message_by_id_invalid(self, log_mock):
-        """SQSClient - Extract Message by ID, Invalid"""
-        batch = self._sample_batch(2)
-
-        result = SQSClient._extract_message_by_id(batch, '2')
-        assert_equal(result, None)
-        log_mock.assert_called_with('SQS message with ID \'%s\' not found in batch', '2')
-
-    def test_check_failures_none(self):
-        """SQSClient - Check Failures, None"""
-        response = {
-            'Successful': [
-                {
-                    'Id': '0'
-                }
-            ],
-            'Failed': []
-        }
-
-        result = self._client._check_failures(response)
-        assert_equal(result, 0)
-
-    def test_check_failures_sender_fault(self):
-        """SQSClient - Check Failures, Sender Fault"""
-        response = {
-            'Successful': [],
-            'Failed': [
-                {
-                    'Id': '1',
-                    'SenderFault': True,
-                    'Code': 'error code',
-                    'Message': 'error message'
-                }
-            ]
-        }
-        assert_raises(SQSClientError, self._client._check_failures, response)
-
-    def test_check_failures_not_sender_fault(self):
-        """SQSClient - Check Failures, Not Sender Fault"""
-        response = {
-            'Successful': [],
-            'Failed': [
-                {
-                    'Id': '1',
-                    'SenderFault': False,
-                    'Code': 'error code',
-                    'Message': 'error message'
-                }
-            ]
-        }
-        result = self._client._check_failures(response)
-        assert_equal(result, 1)
-
-    @patch('logging.Logger.error')
-    def test_check_failures_with_record(self, log_mock):
-        """SQSClient - Check Failures, With Record"""
-        batch = self._sample_batch(2)
-        response = {
-            'Successful': [],
-            'Failed': [
-                {
-                    'Id': '1',
-                    'SenderFault': False,
-                    'Code': 'error code',
-                    'Message': 'error message'
-                }
-            ]
-        }
-
-        SQSClient._queue.url = 'test_url'
-        result = self._client._check_failures(response, batch)
-
-        assert_equal(result, 1)
         log_mock.assert_called_with(
-            'Record failed to send to SQS. ID: 1, SenderFault: False, Code: error code, '
-            'Error: error message, Record:\n{\'Id\': \'1\', \'MessageBody\': \'value_1\'}'
+            'Successfully sent message with %d records to %s with MessageId %s',
+            10,
+            url,
+            response
         )
 
     @patch.object(SQSClient, 'MAX_BACKOFF_ATTEMPTS', 1)
-    def test_send_messages(self):
+    def test_send_message(self):
         """SQSClient - Send Messages"""
         records = [
             'test_message_00',
-            'test_message_01',
-            'test_message_02'
+            'test_message_01'
         ]
 
-        SQSClient._queue.send_messages.side_effect = [
+        SQSClient._queue.send_message.side_effect = [
             {
-                'Successful': [
-                    {'Id': '0', 'MessageId': '34f89f00-1b9f-4a06-b4e7-f0dfa85ad547'},
-                    {'Id': '2', 'MessageId': '1b9f34f8-4a06-9f00-b4e7-f0dfa85ad547'}
-                ],
-                'Failed': [
-                    {
-                        'Id': '1',
-                        'Code': 'error',
-                        'Message': 'message',
-                        'SenderFault': False
-                    }
-                ]
-            },
-            {
-                'Successful': [
-                    {'Id': '1'}
-                ]
+                'MD5OfMessageBody': '8d110f3d795665a3b26cac774b995170',
+                'MD5OfMessageAttributes': '8cac774b995170d110f3d795665a3b26',
+                'MessageId': '8fb984ee-b44c-4a68-992f-4f7aae23ae07',
+                'SequenceNumber': '0'
             }
         ]
 
-        expected_second_call = [
-            {
-                'Id': '1',
-                'MessageBody': 'test_message_01'
-            }
-        ]
+        expected_call = {
+            'MessageBody': '[test_message_00,test_message_01]'
+        }
 
-        self._client._send_messages(records)
+        self._client._send_message(records)
 
-        SQSClient._queue.send_messages.assert_called_with(
-            Entries=expected_second_call
-        )
+        SQSClient._queue.send_message.assert_called_with(**expected_call)
 
     @patch('logging.Logger.exception')
     @patch.object(SQSClient, 'MAX_BACKOFF_ATTEMPTS', 1)
     def test_send_messages_error(self, log_mock):
         """SQSClient - Send Messages, Error"""
         error = ClientError({'Error': {'Code': 10}}, 'InvalidRequestException')
-        SQSClient._queue.send_messages.side_effect = error
+        SQSClient._queue.send_message.side_effect = error
 
-        self._client._send_messages(['data'])
-
+        assert_equal(self._client._send_message(['data']), False)
         log_mock.assert_called_with('SQS request failed')
 
     def test_payload_messages(self):
         """SQSClient - Payload Records"""
         payloads = self._sample_payloads()
-        expected_result = [{
-            'log_schema_type': 'log_type_0',
-            'record': {
-                'key_0': 'value_0'
-            }
-        }]
+        expected_result = [
+            '{"log_schema_type":"log_type_0","record":{"key_0":"value_0"}}'
+        ]
         result = SQSClient._payload_messages(payloads)
         assert_equal(result, expected_result)
 
-    @patch.object(SQSClient, '_send_messages')
-    def test_send(self, send_messages_mock):
+    @patch.object(SQSClient, '_send_message')
+    def test_send(self, send_message_mock):
         """SQSClient - Send"""
         payloads = self._sample_payloads()
         expected_batch = [
             '{"log_schema_type":"log_type_0","record":{"key_0":"value_0"}}'
         ]
         self._client.send(payloads)
-        send_messages_mock.assert_called_with(expected_batch)
+        send_message_mock.assert_called_with(expected_batch)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
cc: @patrickod 
resolves #857 

# BREAKING CHANGE
This is a breaking change due to the way messages are batched/parsed off of the queue. In order to ensure your pipeline is not affected, you should deploy the `rules` function before deploying any classifiers. Steps to upgrade:

1. `python manage.py deploy -f rule`
   * This will put the rules engine in place with forward compatible code
2. `python manage.py deploy -f classifier`

## Background

With very high throughput, the messages being sent to SQS can be insane. With an SSE (server-side encrypted) queue, this can result in more calls to KMS to encrypt/decrypt data, as well as more `send_message` calls in general. Both of these will add up in cost over time. Since SQS limits are the same for individual message size AND total payload size, we can alter how this is done.

## Changes

* Instead of sending 1:1 record/message, we now send a blob of records serialized into a single message. This can reduce our calls to SQS `send_message(_batch)` by 90%.
* 

## Other
* Fixing bug @patrickod found in the CLI refactor related to repetition designed to be used with `rules` testing and not classification. If there is objection to this change and belief that the repetition should also be possible for the classification, we can always add it.

## Testing

* All new unit tests for new batching.
* Deployed and verified working as expected.
