### PR TITLE
[bug] fixing a bug with matchers and helpers packaging in the rules engine

### DIFF
--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -203,8 +203,6 @@ class RulesEnginePackage(LambdaPackage):
     lambda_handler = 'stream_alert.rules_engine.main.handler'
     package_files = {
         'conf',
-        'helpers',
-        'matchers',
         'rules',
         'stream_alert/__init__.py',
         'stream_alert/rules_engine',


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Changes

* Fixing a bug identified by a user related to packaging of matchers/helpers that are no longer in the same place as previous defined.
