### PR TITLE
[bug] remove 'helpers' from alert merger and processor package files

### DIFF
--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -231,7 +231,6 @@ class AlertMergerPackage(LambdaPackage):
     config_key = 'alert_merger_config'
     lambda_handler = 'stream_alert.alert_merger.main.handler'
     package_files = {
-        'conf',
         'stream_alert/__init__.py',
         'stream_alert/alert_merger',
         'stream_alert/shared'

--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -218,7 +218,6 @@ class AlertProcessorPackage(LambdaPackage):
     lambda_handler = 'stream_alert.alert_processor.main.handler'
     package_files = {
         'conf',
-        'helpers',
         'stream_alert/__init__.py',
         'stream_alert/alert_processor',
         'stream_alert/shared'
@@ -233,7 +232,6 @@ class AlertMergerPackage(LambdaPackage):
     lambda_handler = 'stream_alert.alert_merger.main.handler'
     package_files = {
         'conf',
-        'helpers',
         'stream_alert/__init__.py',
         'stream_alert/alert_merger',
         'stream_alert/shared'


### PR DESCRIPTION
related to: #859 

Remove mention of the 'helpers' directory from the list of package files for
the AlertMerger and AlertProcessor packages, fixing runtime exceptions that
prevent them from being built.

to: @airbnb/streamalert-maintainers
size: small

## Background

## Changes

Fixes broken package builds introduced by the refactor of the matcher/rule codebase and associated directory structure

## Testing

Confirmed packages build locally & are executing correctly when deployed