### PR TITLE
[bug] removing threat_intel packaging third party packages from config

### DIFF
--- a/stream_alert_cli/config.py
+++ b/stream_alert_cli/config.py
@@ -502,7 +502,6 @@ class CLIConfig(object):
             'interval': 'rate(1 day)',
             'log_level': 'info',
             'memory': '128',
-            'third_party_libraries': ['requests'],
             'timeout': '120',
             'table_rcu': 10,
             'table_wcu': 10,

--- a/tests/unit/stream_alert_cli/test_cli_config.py
+++ b/tests/unit/stream_alert_cli/test_cli_config.py
@@ -242,7 +242,6 @@ class TestCLIConfig(object):
             'excluded_sub_types': [],
             'log_level': 'info',
             'memory': '128',
-            'third_party_libraries': ['requests'],
             'table_rcu': 10,
             'table_wcu': 25,
             'timeout': '240',


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Third party packages that are dependencies for the function out of the box are included in the [packaging logic](https://github.com/airbnb/streamalert/blob/master/stream_alert_cli/manage_lambda/package.py#L287) and therefore should not be included in the user config.

## Changes

* Removing duplicative dependency of `requests` for the `threat_intel_downloader` package.

## Testing

Updating unit test.