### PR TITLE
[bug] fixing bug with custom metric alarm generation

### DIFF
--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -417,7 +417,7 @@ def terraform_generate_handler(config, init=False, check_tf=True, check_creds=Tr
     metric_alarms = generate_aggregate_cloudwatch_metric_alarms(config)
     if metric_alarms:
         with open('terraform/metric_alarms.tf.json', 'w') as tf_file:
-            json.dump(metric_filters, tf_file, indent=2, sort_keys=True)
+            json.dump(metric_alarms, tf_file, indent=2, sort_keys=True)
 
     # Setup Athena
     generate_global_lambda_settings(

--- a/stream_alert_cli/terraform/metrics.py
+++ b/stream_alert_cli/terraform/metrics.py
@@ -102,7 +102,7 @@ def generate_aggregate_cloudwatch_metric_alarms(config):
 
         for idx, name in enumerate(metric_alarms):
             alarm_settings = metric_alarms[name]
-            alarm_settings['source'] = 'modules/tf_metric_alarms',
+            alarm_settings['source'] = 'modules/tf_metric_alarms'
             alarm_settings['sns_topic_arn'] = sns_topic_arn
             alarm_settings['alarm_name'] = name
             result['module']['metric_alarm_{}_{}'.format(func, idx)] = alarm_settings
@@ -184,6 +184,6 @@ def generate_cluster_cloudwatch_metric_alarms(cluster_name, cluster_dict, config
     ]
 
     for idx, metric_alarm in enumerate(metric_alarms):
-        metric_alarm['source'] = 'modules/tf_metric_alarms',
+        metric_alarm['source'] = 'modules/tf_metric_alarms'
         metric_alarm['sns_topic_arn'] = sns_topic_arn
         cluster_dict['module']['metric_alarm_{}_{}'.format(cluster_name, idx)] = metric_alarm

--- a/stream_alert_cli/terraform/metrics.py
+++ b/stream_alert_cli/terraform/metrics.py
@@ -66,12 +66,13 @@ def generate_aggregate_cloudwatch_metric_filters(config):
                 if not is_global else '${{module.{}_lambda.log_group_name}}'.format(function)
             )
 
+            cluster = cluster.upper()
+            if not is_global:
+                cluster = '{}_AGGREGATE'.format(cluster)
+
             # Add filters for the cluster and aggregate
             for metric, filter_settings in current_metrics[function].iteritems():
-                module_name = (
-                    'metric_filters_{}_{}_{}'.format(metric_prefix, metric, cluster)
-                    if is_global else 'metric_filters_{}_{}'.format(metric_prefix, metric)
-                )
+                module_name = 'metric_filters_{}_{}_{}'.format(metric_prefix, metric, cluster)
                 result['module'][module_name] = {
                     'source': 'modules/tf_metric_filters',
                     'log_group_name': log_group_name,


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

A bug where the wrong value is being used for custom metric alarms prevent custom alarms from being created. I also discovered a bug with the `source` key in the custom metric alarm generation. A trailing comma was causing the value to become a list when dumped to json.

Error from Terraform: `Error loading configuration: Error loading /Users/ryan_deivert/airrepos/streamalert/terraform/metric_alarms.tf.json: Error parsing source for metric_alarm_alert_merger_0: At -: root: unknown type for string *ast.ListType`

## Changes

* Fixing variable for json dumping.
* Removing trailing comma.
