### PR TITLE
[bug] adding list serialization for sets to messages sent to sqs

### DIFF
--- a/stream_alert/__init__.py
+++ b/stream_alert/__init__.py
@@ -1,2 +1,2 @@
 """StreamAlert version."""
-__version__ = '2.1.3'
+__version__ = '2.1.4'

--- a/stream_alert/alert_merger/main.py
+++ b/stream_alert/alert_merger/main.py
@@ -120,8 +120,8 @@ class AlertMerger(object):
         LOGGER.info('Dispatching %s to %s (attempt %d)', alert, self.alert_proc, alert.attempts)
         MetricLogger.log_metric(ALERT_MERGER_NAME, MetricLogger.ALERT_ATTEMPTS, alert.attempts)
 
-        record_payload = json.dumps(
-            alert.dynamo_record(), cls=Alert.Encoder, separators=(',', ':'))
+        record_payload = json.dumps(alert.dynamo_record(), default=list, separators=(',', ':'))
+
         if len(record_payload) <= self.MAX_LAMBDA_PAYLOAD_SIZE:
             # The entire alert fits in the Lambda payload - send it all
             payload = record_payload

--- a/stream_alert/classifier/clients/sqs.py
+++ b/stream_alert/classifier/clients/sqs.py
@@ -161,7 +161,7 @@ class SQSClient(object):
             list<dict>: All messages formatted for ingestion by the Rules Engine function
         """
         return [
-            json.dumps(message, separators=(',', ':'), default=list) for payload in payloads
+            json.dumps(message, separators=(',', ':')) for payload in payloads
             for message in payload.sqs_messages
         ]
 

--- a/stream_alert/classifier/clients/sqs.py
+++ b/stream_alert/classifier/clients/sqs.py
@@ -161,7 +161,7 @@ class SQSClient(object):
             list<dict>: All messages formatted for ingestion by the Rules Engine function
         """
         return [
-            json.dumps(message, separators=(',', ':')) for payload in payloads
+            json.dumps(message, separators=(',', ':'), default=list) for payload in payloads
             for message in payload.sqs_messages
         ]
 

--- a/stream_alert/shared/normalize.py
+++ b/stream_alert/shared/normalize.py
@@ -58,7 +58,7 @@ class Normalizer(object):
             }
         """
         return {
-            key: set(cls._extract_values(record, set(keys_to_normalize)))
+            key: sorted(set(cls._extract_values(record, set(keys_to_normalize))))
             for key, keys_to_normalize in normalized_types.iteritems()
         }
 

--- a/tests/unit/stream_alert_shared/test_alert.py
+++ b/tests/unit/stream_alert_shared/test_alert.py
@@ -62,7 +62,7 @@ class TestAlert(object):
 
     def test_alert_encoder_invalid_json(self):
         """Alert Class - Alert Encoder - Invalid JSON raises parent exception"""
-        assert_raises(TypeError, json.dumps, RuntimeWarning, cls=Alert.Encoder)
+        assert_raises(TypeError, json.dumps, RuntimeWarning, default=list)
 
     def test_init_invalid_kwargs(self):
         """Alert Class - Init With Invalid Kwargs"""

--- a/tests/unit/stream_alert_shared/test_normalizer.py
+++ b/tests/unit/stream_alert_shared/test_normalizer.py
@@ -50,9 +50,9 @@ class TestNormalizer(object):
             'ipv4': ['destination', 'source', 'sourceIPAddress']
         }
         expected_results = {
-            'sourceAccount': {123456},
-            'ipv4': {'1.1.1.2', '1.1.1.3'},
-            'region': {'region_name'}
+            'sourceAccount': [123456],
+            'ipv4': ['1.1.1.2', '1.1.1.3'],
+            'region': ['region_name']
         }
 
         results = Normalizer.match_types(self._test_record(), normalized_types)
@@ -67,10 +67,10 @@ class TestNormalizer(object):
             'userName': ['userName', 'owner', 'invokedBy']
         }
         expected_results = {
-            'account': {123456},
-            'ipv4': {'1.1.1.2', '1.1.1.3'},
-            'region': {'region_name'},
-            'userName': {'Alice', 'signin.amazonaws.com'}
+            'account': [123456],
+            'ipv4': ['1.1.1.2', '1.1.1.3'],
+            'region': ['region_name'],
+            'userName': ['Alice', 'signin.amazonaws.com']
         }
 
         results = Normalizer.match_types(self._test_record(), normalized_types)
@@ -82,7 +82,7 @@ class TestNormalizer(object):
             'ipv4': ['sourceIPAddress'],
         }
         expected_results = {
-            'ipv4': {'1.1.1.2', '1.1.1.3'}
+            'ipv4': ['1.1.1.2', '1.1.1.3']
         }
 
         test_record = {
@@ -124,8 +124,8 @@ class TestNormalizer(object):
             },
             'sourceIPAddress': '1.1.1.3',
             'streamalert:normalization': {
-                'region': {'region_name'},
-                'sourceAccount': {123456}
+                'region': ['region_name'],
+                'sourceAccount': [123456]
             }
         }
 
@@ -164,7 +164,7 @@ class TestNormalizer(object):
             },
             'sourceIPAddress': '1.1.1.3',
             'streamalert:normalization': {
-                'bad_type': set(),
+                'bad_type': list(),
             }
         }
 


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers, @patrickod 

## Background

Current messages being sent to SQS can contain sets that are a result of inserting 'normalized' data into the record. This is byproduct of changes made [here](https://github.com/airbnb/streamalert/pull/854/files#diff-4c63584097304cf3ed86ce070f20b238R61).

Traceback provided by @patrickod:
```
set(['INSERT_IP_HERE']) is not JSON serializable: TypeError
Traceback (most recent call last):
File "/var/task/stream_alert/classifier/main.py", line 27, in handler
Classifier().run(event.get('Records', []))
File "/var/task/stream_alert/classifier/classifier.py", line 249, in run
self.sqs.send(self._payloads)
File "/var/task/stream_alert/classifier/clients/sqs.py", line 178, in send
records = self._payload_messages(payloads)
File "/var/task/stream_alert/classifier/clients/sqs.py", line 165, in _payload_messages
for message in payload.sqs_messages
File "/usr/lib64/python2.7/json/__init__.py", line 251, in dumps
sort_keys=sort_keys, **kw).encode(obj)
File "/usr/lib64/python2.7/json/encoder.py", line 207, in encode
chunks = self.iterencode(o, _one_shot=True)
File "/usr/lib64/python2.7/json/encoder.py", line 270, in iterencode
return _iterencode(o, 0)
File "/usr/lib64/python2.7/json/encoder.py", line 184, in default
raise TypeError(repr(o) + " is not JSON serializable")
TypeError: set(['INSERT_IP_HERE']) is not JSON serializable
```

## Changes

* Serializing `set` values to `list` types when dumping to json.
* Removing the usage of the `cls` keyword argument in json dumping that serializes sets to lists since it's overkill.

## Testing

Updating unit tests.
