### PR TITLE
Small fixes; pass cli args to rule_test.sh

### DIFF
--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -151,7 +151,7 @@ class AthenaRefresher(object):
         """
         partitions = self._get_partitions_from_keys()
         if not partitions:
-            LOGGER.error('No partitons to add')
+            LOGGER.error('No partitions to add')
             return False
 
         for athena_table in partitions:

--- a/stream_alert/rules_engine/alert_forwarder.py
+++ b/stream_alert/rules_engine/alert_forwarder.py
@@ -47,7 +47,7 @@ class AlertForwarder(object):
         except ClientError:
             # add_alerts() automatically retries transient errors - any raised ClientError
             # is likely unrecoverable. Log an exception and metric
-            LOGGER.exception('An error occurred when sending alerts to DynamoBD')
+            LOGGER.exception('An error occurred when sending alerts to DynamoDB')
             MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.FAILED_DYNAMO_WRITES, 1)
             return
 

--- a/tests/scripts/rule_test.sh
+++ b/tests/scripts/rule_test.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-./manage.py test rules
+./manage.py test rules $@

--- a/tests/unit/stream_alert_athena_partition_refresh/test_main.py
+++ b/tests/unit/stream_alert_athena_partition_refresh/test_main.py
@@ -70,7 +70,7 @@ class TestAthenaRefresher(object):
     def test_add_partitions_none(self, log_mock):
         """AthenaRefresher - Add Partitions, None to Add"""
         result = self._refresher._add_partitions()
-        log_mock.assert_called_with('No partitons to add')
+        log_mock.assert_called_with('No partitions to add')
         assert_equal(result, False)
 
     def test_get_partitions_from_keys(self):
@@ -200,4 +200,4 @@ class TestAthenaRefresher(object):
         s3_record['Records'][0]['s3']['bucket']['name'] = 'bad.bucket.name'
         event['Records'][0]['body'] = json.dumps(s3_record)
         assert_raises(AthenaRefreshError, self._refresher.run, event)
-        log_mock.assert_called_with('No partitons to add')
+        log_mock.assert_called_with('No partitions to add')


### PR DESCRIPTION
to: 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

Fix some small spelling mistakes. For rule_test.sh script, forward bash arguments for convenience.

## Changes

Only major change is passing `$@` to `rule_test.sh`. I found it convenient to use `./tests/scripts/rule_test.sh` as a layer of indirection to `./manage.py test rules`, but would require me to write out the special options, such as `./manage.py test rules --test-files xxxxyyyyzzzz.json`.

If the intention of the `rule_test.sh` script is NOT to indirect `manage.py` then my logic is probably wrong and I can get rid of this stuff.

## Testing

`rule_test.sh`
```
Summary:

Total Tests: 77
Pass: 77
Fail: 0

[INFO 2019-01-07 17:46:41,715 (stream_alert_cli.runner:85)]: Completed
```

`unit_test.sh`
```
...
stream_alert/threat_intel_downloader/__init__.py          0      0   100%
stream_alert/threat_intel_downloader/exceptions.py        4      0   100%
stream_alert/threat_intel_downloader/main.py            134      1    99%   348
-----------------------------------------------------------------------------------
TOTAL                                                  4400     96    98%
[success] 1.57% tests.unit.stream_alert_alert_merger.test_main.TestAlertMerger.test_dispatch: 0.2690s
[success] 1.45% tests.unit.streamalert.classifier.clients.test_firehose.TestFirehoseClient.test_send_batch: 0.2477s
[success] 1.32% tests.unit.stream_alert_cli.test_cli_config.TestCLIConfig.test_add_threat_intel_with_table_name: 0.2261s
[success] 0.99% tests.unit.stream_alert_alert_processor.test_outputs.test_pagerduty.TestPagerDutyIncidentOutput.test_dispatch_success_bad_user: 0.1702s
[success] 0.93% tests.unit.stream_alert_alert_processor.test_outputs.test_pagerduty.TestPagerDutyOutput.test_dispatch_success: 0.1596s
[success] 0.92% tests.unit.stream_alert_alert_processor.test_outputs.test_phantom.TestPhantomOutput.test_dispatch_setup_container_error: 0.1577s
[success] 0.89% tests.unit.stream_alert_shared.test_rule_table.TestRuleTable.test_dynamo_record: 0.1526s
[success] 0.88% tests.unit.stream_alert_alert_processor.test_outputs.test_github.TestGithubOutput.test_dispatch_failure: 0.1508s
[success] 0.79% tests.unit.stream_alert_shared.test_alert_table.TestAlertTable.test_paginate_multiple: 0.1359s
[success] 0.79% tests.unit.stream_alert_cli.test_cli_config.TestCLIConfig.test_add_threat_intel_without_table_name: 0.1351s
----------------------------------------------------------------------
Ran 877 tests in 17.240s

OK

```
