### PR TITLE
catching errors in firehose and sqs clients to be retried

### DIFF
--- a/stream_alert/classifier/clients/firehose.py
+++ b/stream_alert/classifier/clients/firehose.py
@@ -19,7 +19,7 @@ import re
 
 import backoff
 import boto3
-from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+from botocore.exceptions import ClientError, ConnectionClosedError, ConnectionError
 
 from stream_alert.shared import CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
 import stream_alert.shared.helpers.boto as boto_helpers
@@ -54,7 +54,7 @@ class FirehoseClient(object):
     DEFAULT_FIREHOSE_PREFIX = 'streamalert_data_{}'
 
     # Exception for which backoff operations should be performed
-    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectTimeoutError, ReadTimeoutError)
+    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionClosedError, ConnectionError)
 
     # Set of enabled log types for firehose, loaded from configs
     _ENABLED_LOGS = dict()

--- a/stream_alert/classifier/clients/sqs.py
+++ b/stream_alert/classifier/clients/sqs.py
@@ -18,7 +18,7 @@ import os
 
 import backoff
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ConnectionClosedError, ConnectionError
 
 from stream_alert.shared import CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
 from stream_alert.shared.helpers import boto
@@ -40,7 +40,7 @@ class SQSClientError(Exception):
 class SQSClient(object):
     """SQSClient for sending batches of classified records to the Rules Engine function"""
     # Exception for which backoff operations should be performed
-    EXCEPTIONS_TO_BACKOFF = (ClientError,)
+    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionClosedError, ConnectionError)
 
     # Maximum amount of times to retry with backoff
     MAX_BACKOFF_ATTEMPTS = 5

--- a/stream_alert_cli/helpers.py
+++ b/stream_alert_cli/helpers.py
@@ -145,6 +145,12 @@ def check_credentials():
                      'https://www.streamalert.io/getting-started.html'
                      '#configure-aws-credentials')
         return False
+    except ClientError as err:
+        # Check for an error related to an expired token
+        if err.response['Error']['Code'] == 'ExpiredToken':
+            LOGGER.error('%s. Please refresh your credentials.', err.response['Error']['Message'])
+            return False
+        raise  # Raise the error if it is anything else
 
     LOGGER.debug(
         'Using credentials for user \'%s\' with user ID \'%s\' in account '

--- a/stream_alert_cli/terraform/handlers.py
+++ b/stream_alert_cli/terraform/handlers.py
@@ -243,7 +243,7 @@ def _get_valid_tf_targets(config, targets):
 
 def get_tf_modules(config, generate=False):
     if generate:
-        if not terraform_generate_handler(config=config):
+        if not terraform_generate_handler(config=config, check_tf=False, check_creds=False):
             return False
 
     modules = set()


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers 
resolves: #863 
resolves: #865 
resolves: #866 
resolves: #873 

## Background

Some boto3 clients (sqs and firehose) experience some sporadic/transient issues that AWS has informed us should be retried.

## Changes

* Catching exceptions in `SQSClient` and `FirehoseClient` and retrying.
* Fixing bug in `list-targets` cli command that was unnecessarily checking for AWS creds.
* Better logging of errors related to expired token when checking for AWS creds.

