### PR TITLE
[demisto] Fixes a bug where demisto rejects non-string types

### DIFF
--- a/stream_alert/alert_processor/outputs/demisto.py
+++ b/stream_alert/alert_processor/outputs/demisto.py
@@ -145,38 +145,39 @@ class DemistoCreateIncidentRequest(object):
                  details='Details not specified.',
                  create_investigation=False):
         # Default request parameters
-        self._incident_name = incident_name
+        self._incident_name = str(incident_name)
 
         # Incident type maps to the Demisto incident "type". It comes from a discrete set that
         # is defined on the Demisto account configuration. If the provided incident type does not
         # exactly match one in the configured set, it will appear on the Demisto UI as
         # "Unclassified".
-        self._incident_type = incident_type
+        self._incident_type = str(incident_type)
 
         # Severity is an integer. Use the constants above.
         self._severity = severity
 
         # The Owner appears verbatim on the Incident list, regardless of whether the owner
         # exists or not.
-        self._owner = owner
+        self._owner = str(owner)
 
         # An array of Dicts, with keys "type" and "value".
         self._labels = []
 
         # A string that appears in the details section.
-        self._details = details
+        self._details = str(details)
 
         # FIXME: (!) Demisto currently does not seem to render these fields properly on their UI.
         self._custom_fields = {}
 
         # When set to True, the creation of this incident will also trigger the creation of an
         # investigation. This will cause playbooks to trigger automatically.
-        self._create_investigation = create_investigation
+        self._create_investigation = bool(create_investigation)
 
     def add_label(self, label, value):
+        # Demisto rejects non-string values; so type-cast everything to strings first
         self._labels.append({
-            "type": label,
-            "value": value,
+            "type": str(label),
+            "value": str(value),
         })
         self._labels.sort(key=lambda x: x["type"])
 

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
@@ -34,13 +34,19 @@ SAMPLE_CONTEXT = {
             },
             {
                 "key": "value2",
-            }
+            },
+            {
+                "integer": 0,
+            },
+            {
+                "bool": True,
+            },
         ]
     }
 }
 EXPECTED_LABELS_FOR_SAMPLE_ALERT = [
     {'type': 'alert.alert_id', 'value': '79192344-4a6d-4850-8d06-9c3fef1060a4'},
-    {'type': 'alert.cluster', 'value': None},
+    {'type': 'alert.cluster', 'value': 'None'},
     {'type': 'alert.descriptor', 'value': 'unit_test_demisto'},
     {'type': 'alert.log_type', 'value': 'json'},
     {
@@ -61,6 +67,8 @@ EXPECTED_LABELS_FOR_SAMPLE_ALERT = [
     {'type': 'context.demisto.baz', 'value': 'buzz'},
     {'type': 'context.demisto.deepArray[0].key', 'value': 'value'},
     {'type': 'context.demisto.deepArray[1].key', 'value': 'value2'},
+    {'type': 'context.demisto.deepArray[2].integer', 'value': '0'},
+    {'type': 'context.demisto.deepArray[3].bool', 'value': 'True'},
     {'type': 'context.demisto.foo', 'value': 'bar'},
     {'type': 'record.cb_server', 'value': 'cbserver'},
     {'type': 'record.compressed_size', 'value': '9982'},


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Changes

For whatever reason, Demisto considers integers to be invalid JSON inputs for some specific fields. Example, if you send a label:
```
{ 
  "labels": [
    {
      "type": "this_type",
      "value": 0,
    }
  ]
}
```

It just rejects the request entirely:
```
{
    "id": "bad_request",
    "status": 400,
    "title": "Bad request",
    "detail": "Request body is not well-formed. It must be JSON.",
    "error": "json: cannot unmarshal number into Go value of type string",
    "encrypted": false,
    "multires": null
}
```

The fix is to type-cast all JSON values to strings.

## Testing

```
--------------------------------------------------------------------------------------------
TOTAL                                                           4732    104    98%
[success] 6.60% tests.unit.streamalert.classifier.clients.test_firehose.TestFirehoseClient.test_send_batch: 0.8501s
[success] 3.14% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestS3Driver.test_save_credentials_into_s3_blank_credentials: 0.4051s
[success] 2.17% tests.unit.stream_alert_alert_merger.test_main.TestAlertMerger.test_dispatch: 0.2797s
[success] 1.58% tests.unit.stream_alert_shared.test_lookup_tables.TestLookupTables.test_download_s3_object_bucket_exception: 0.2032s
[success] 1.53% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestOutputCredentialsProvider.test_load_credentials_multiple: 0.1967s
[success] 1.47% tests.unit.stream_alert_apps.test_apps.test_aliyun.TestAliyunApp.test_date_formatter: 0.1900s
[success] 1.47% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestS3DriverWithFileDriver.test_load_credentials: 0.1899s
[success] 1.47% tests.unit.stream_alert_shared.test_rule.RuleImportTest.test_import_rules: 0.1897s
[success] 1.41% tests.unit.stream_alert_shared.test_rule_table.TestRuleTable.test_toggle_staged_state_false: 0.1821s
[success] 1.14% tests.unit.stream_alert_rule_promotion.test_promoter.TestRulePromoter.test_promote_rules: 0.1475s
----------------------------------------------------------------------
Ran 921 tests in 13.001s

OK
```