### PR TITLE
[OutputDispatchers] Standardizes all outputs on alert.publish_for()

### DIFF
--- a/stream_alert/alert_processor/outputs/carbonblack.py
+++ b/stream_alert/alert_processor/outputs/carbonblack.py
@@ -67,7 +67,10 @@ class CarbonBlackOutput(OutputDispatcher):
         Returns:
             bool: True if alert was sent successfully, False otherwise
         """
-        if not alert.context:
+        publication = alert.publish_for(self, descriptor)
+
+        context = publication.get('context', False)
+        if not context:
             LOGGER.error('[%s] Alert must contain context to run actions', self.__service__)
             return False
 
@@ -78,9 +81,9 @@ class CarbonBlackOutput(OutputDispatcher):
         client = CbResponseAPI(**creds)
 
         # Get md5 hash 'value' passed from the rules engine function
-        action = alert.context.get('carbonblack', {}).get('action')
+        action = context.get('carbonblack', {}).get('action')
         if action == 'ban':
-            binary_hash = alert.context.get('carbonblack', {}).get('value')
+            binary_hash = context.get('carbonblack', {}).get('value')
             # The binary should already exist in CarbonBlack
             binary = client.select(Binary, binary_hash)
             # Determine if the binary is currenty listed as banned

--- a/stream_alert/alert_processor/outputs/demisto.py
+++ b/stream_alert/alert_processor/outputs/demisto.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from collections import OrderedDict
-import json
 
 from stream_alert.alert_processor.outputs.output_base import (
     OutputDispatcher,

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -93,10 +93,14 @@ class GithubOutput(OutputDispatcher):
         url = '{}/repos/{}/issues'.format(credentials['api'],
                                           credentials['repository'])
 
-        title = "StreamAlert: {}".format(alert.rule_name)
+        publication = alert.publish_for(self, descriptor)
+        rule_name = publication.get('rule_name', 'Unspecified Rule')
+        rule_description = publication.get('rule_description', 'N/A')
+        record = publication.get('record', {})
+
+        title = "StreamAlert: {}".format(rule_name)
         body_template = "### Description\n{}\n\n### Event data\n\n```\n{}\n```"
-        body = body_template.format(
-            alert.rule_description, json.dumps(alert.record, indent=2, sort_keys=True))
+        body = body_template.format(rule_description, json.dumps(record, indent=2, sort_keys=True))
         issue = {'title': title, 'body': body, 'labels': credentials['labels'].split(',')}
 
         LOGGER.debug('sending alert to Github repository %s', credentials['repository'])

--- a/stream_alert/alert_processor/outputs/jira.py
+++ b/stream_alert/alert_processor/outputs/jira.py
@@ -289,11 +289,12 @@ class JiraOutput(OutputDispatcher):
         if not creds:
             return False
 
+        publication = alert.publish_for(self, descriptor)
+
         issue_id = None
         comment_id = None
-        issue_summary = 'StreamAlert {}'.format(alert.rule_name)
-        alert_body = '{{code:JSON}}{}{{code}}'.format(
-            json.dumps(alert.output_dict(), sort_keys=True))
+        issue_summary = 'StreamAlert {}'.format(publication.get('rule_name', ''))
+        alert_body = '{{code:JSON}}{}{{code}}'.format(json.dumps(publication, sort_keys=True))
         self._base_url = creds['url']
         self._auth_cookie = self._establish_session(creds['username'], creds['password'])
 

--- a/stream_alert/alert_processor/outputs/komand.py
+++ b/stream_alert/alert_processor/outputs/komand.py
@@ -77,5 +77,7 @@ class KomandOutput(OutputDispatcher):
 
         LOGGER.debug('sending alert to Komand')
 
-        resp = self._post_request(creds['url'], {'data': alert.output_dict()}, headers, False)
+        publication = alert.publish_for(self, descriptor)
+        resp = self._post_request(creds['url'], {'data': publication}, headers, False)
+
         return self._check_http_response(resp)

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -49,7 +49,11 @@ def events_v2_data(output_dispatcher, descriptor, alert, routing_key, with_recor
     """
     publication = alert.publish_for(output_dispatcher, descriptor)
 
-    summary = 'StreamAlert Rule Triggered - {}'.format(publication.get('rule_name', ''))
+    # Special field that Publishers can use to customize the header
+    summary = publication.get(
+        'pagerduty_summary',
+        'StreamAlert Rule Triggered - {}'.format(publication.get('rule_name', ''))
+    )
     details = OrderedDict()
     details['description'] = publication.get('rule_description', '')
     if with_record:

--- a/stream_alert/alert_processor/outputs/phantom.py
+++ b/stream_alert/alert_processor/outputs/phantom.py
@@ -146,18 +146,22 @@ class PhantomOutput(OutputDispatcher):
         if not creds:
             return False
 
+        publication = alert.publish_for(self, descriptor)
+        rule_name = publication.get('rule_name', '')
+        rule_description = publication.get('rule_description', '')
+        record = publication.get('record', {})
+
         headers = {"ph-auth-token": creds['ph_auth_token']}
-        container_id = self._setup_container(
-            alert.rule_name, alert.rule_description, creds['url'], headers)
+        container_id = self._setup_container(rule_name, rule_description, creds['url'], headers)
 
         LOGGER.debug('sending alert to Phantom container with id %s', container_id)
 
         if not container_id:
             return False
 
-        artifact = {'cef': alert.record,
+        artifact = {'cef': record,
                     'container_id': container_id,
-                    'data': alert.output_dict(),
+                    'data': publication,
                     'name': 'Phantom Artifact',
                     'label': 'Alert'}
         artifact_url = os.path.join(creds['url'], self.ARTIFACT_ENDPOINT)

--- a/stream_alert/shared/alert.py
+++ b/stream_alert/shared/alert.py
@@ -224,6 +224,15 @@ class Alert(object):
         }
 
     def publish_for(self, output_class, descriptor):  # pylint: disable=unused-argument
+        """Presents the current alert as a dict of information for OutputDispatchers to send.
+
+        Args:
+            output_class (OutputDispatcher): The output dispatching service
+            descriptor (string): The output's descriptor
+
+        Returns:
+            dict: A dict of published data
+        """
         # FIXME (derek.wang) Currently, this completely disregards the output_class and descriptor
         # as this Alert entity does not yet have the "publishers" field available to determine
         # how to publish itself.

--- a/stream_alert/shared/alert.py
+++ b/stream_alert/shared/alert.py
@@ -223,6 +223,12 @@ class Alert(object):
             'staged': self.staged
         }
 
+    def publish_for(self, output_class, descriptor):  # pylint: disable=unused-argument
+        # FIXME (derek.wang) Currently, this completely disregards the output_class and descriptor
+        # as this Alert entity does not yet have the "publishers" field available to determine
+        # how to publish itself.
+        return self.output_dict()
+
     # ---------- Alert Merging ----------
 
     def can_merge(self, other):

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
@@ -46,7 +46,7 @@ SAMPLE_CONTEXT = {
 }
 EXPECTED_LABELS_FOR_SAMPLE_ALERT = [
     {'type': 'alert.alert_id', 'value': '79192344-4a6d-4850-8d06-9c3fef1060a4'},
-    {'type': 'alert.cluster', 'value': 'None'},
+    {'type': 'alert.cluster', 'value': ''},
     {'type': 'alert.descriptor', 'value': 'unit_test_demisto'},
     {'type': 'alert.log_type', 'value': 'json'},
     {
@@ -166,7 +166,9 @@ def test_assemble():
     alert = get_alert(context=SAMPLE_CONTEXT)
     descriptor = 'unit_test_demisto'
 
-    request = DemistoRequestAssembler.assemble(alert, descriptor)
+    alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+
+    request = DemistoRequestAssembler.assemble(alert_publication, descriptor)
 
     assert_equal(request.incident_name, 'cb_binarystore_file_added')
     assert_equal(request.incident_type, 'Unclassified')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -49,7 +49,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Single Message - Slack"""
         rule_name = 'test_rule_single'
         alert = get_random_alert(25, rule_name)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -62,7 +63,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Multi-Message"""
         rule_name = 'test_rule_multi-part'
         alert = get_random_alert(30, rule_name)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -74,7 +76,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Message, Default Rule Description"""
         rule_name = 'test_empty_rule_description'
         alert = get_random_alert(10, rule_name, True)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         default_rule_description = '*Rule Description:*\nNo rule description provided\n'
@@ -191,8 +194,14 @@ class TestSlackOutput(object):
         """SlackOutput - Max Attachment Reached"""
         alert = get_alert()
         alert.record = {'info': 'test' * 20000}
-        list(SlackOutput._format_attachments(alert, 'foo'))
-        log_mock.assert_called_with('%s: %d-part message truncated to %d parts', alert, 21, 20)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        list(SlackOutput._format_attachments(alert_publication, 'foo'))
+        log_mock.assert_called_with(
+            '%s: %d-part message truncated to %d parts',
+            alert_publication,
+            21,
+            20
+        )
 
     @patch('logging.Logger.info')
     @patch('requests.post')


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers

## Background

This is done as step 1 in preparation for *Alert Publishers*. In order to implement a proper interface between *Alerts* and *Outputs* we need to have this layer communicate across a common vocabulary.

## Changes

### OutputDispatchers standardize around `publish_for()`
Instead of referencing fields on the alert directly, all `OutputDispatchers` now reference `alert.publish_for(---, ----)`. Currently it has an empty implementation, but in the near future *Alert Publishers* will be able to dynamically change the output.

### Publishers Control Certain Output Fields
Also I'm *experimenting* with having Publishers control more aspects of each Output layer... you can see a couple examples [here](https://github.com/airbnb/streamalert/pull/898/files#diff-6e737c09dbb041674665ee140c439226R52) and [here](https://github.com/airbnb/streamalert/pull/898/files#diff-0f851c392e56eb2deb2a2cec2fe04a61R231). I'm not sure if I like this *yet* but I think it's on track to fix the TIR issue of "Redundant 'StreamAlert Rule Triggered -'  headers".

### (WIP?) Remove `alert` from `_dispatch()` interface
**One thing** that I did that I'm not 100% certain of. For a lot direct references to `alert.rule_name` or alert.rule_description`, I changed them to use the `publish_for()`, knowing that an incorrectly coded Publisher might forget to include these fields. I did this because I wanted to eventually remove `alert` from the `_dispatch(alert, descriptor)` function and replace it with `_dispatch(alert_publication, descriptor)`... but it seems a little contrived. Thoughts? Example can be found [HERE](https://github.com/airbnb/streamalert/pull/898/files#diff-be02b00f457df67b4678d87aac903176R97). 

I could go ahead and keep `alert` in the `_dispatch()` interface. This seems more sensible when outputs are *directly* referencing Alert fields. The risk here is future Outputs might accidentally go around the `publish_for()` abstraction layer. The alternative is I could remove it completely, but now the risk is a badly written publisher can completely omit these fields which may make alerts render weirdly in outputs (which... might be as intended?).

## Testing

```
--------------------------------------------------------------------------------------------
TOTAL                                                           4754    104    98%
[success] 3.18% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestS3Driver.test_save_credentials_into_s3_blank_credentials: 0.4081s
[success] 2.28% tests.unit.stream_alert_alert_merger.test_main.TestAlertMerger.test_dispatch: 0.2919s
[success] 1.60% tests.unit.stream_alert_apps.test_apps.test_aliyun.TestAliyunApp.test_date_formatter: 0.2059s
[success] 1.60% tests.unit.stream_alert_shared.test_lookup_tables.TestLookupTables.test_download_s3_object_bucket_exception: 0.2058s
[success] 1.60% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestOutputCredentialsProvider.test_load_credentials_multiple: 0.2049s
[success] 1.42% tests.unit.stream_alert_shared.test_rule_table.TestRuleTable.test_toggle_staged_state_false: 0.1823s
[success] 1.42% tests.unit.streamalert.classifier.clients.test_firehose.TestFirehoseClient.test_send_batch: 0.1820s
[success] 1.42% tests.unit.stream_alert_alert_processor.test_outputs.credentials.test_provider.TestS3DriverWithFileDriver.test_load_credentials: 0.1816s
[success] 1.29% tests.unit.stream_alert_cli.test_cli_config.TestCLIConfig.test_add_threat_intel_downloader: 0.1658s
[success] 1.21% tests.unit.stream_alert_rule_promotion.test_promoter.TestRulePromoter.test_promote_rules: 0.1548s
----------------------------------------------------------------------
Ran 921 tests in 12.951s

OK
```
