### PR TITLE
[Output] Standardize outputs around `publish_for()` method

### DIFF
--- a/stream_alert/alert_processor/outputs/carbonblack.py
+++ b/stream_alert/alert_processor/outputs/carbonblack.py
@@ -67,10 +67,7 @@ class CarbonBlackOutput(OutputDispatcher):
         Returns:
             bool: True if alert was sent successfully, False otherwise
         """
-        publication = alert.publish_for(self, descriptor)
-
-        context = publication.get('context', False)
-        if not context:
+        if not alert.context:
             LOGGER.error('[%s] Alert must contain context to run actions', self.__service__)
             return False
 
@@ -79,11 +76,12 @@ class CarbonBlackOutput(OutputDispatcher):
             return False
 
         client = CbResponseAPI(**creds)
+        carbonblack_context = alert.context.get('carbonblack', {})
 
         # Get md5 hash 'value' passed from the rules engine function
-        action = context.get('carbonblack', {}).get('action')
+        action = carbonblack_context.get('action')
         if action == 'ban':
-            binary_hash = context.get('carbonblack', {}).get('value')
+            binary_hash = carbonblack_context.get('value')
             # The binary should already exist in CarbonBlack
             binary = client.select(Binary, binary_hash)
             # Determine if the binary is currenty listed as banned

--- a/stream_alert/alert_processor/outputs/carbonblack.py
+++ b/stream_alert/alert_processor/outputs/carbonblack.py
@@ -67,7 +67,10 @@ class CarbonBlackOutput(OutputDispatcher):
         Returns:
             bool: True if alert was sent successfully, False otherwise
         """
-        if not alert.context:
+        publication = alert.publish_for(self, descriptor)
+
+        context = publication.get('context', False)
+        if not context:
             LOGGER.error('[%s] Alert must contain context to run actions', self.__service__)
             return False
 
@@ -78,9 +81,9 @@ class CarbonBlackOutput(OutputDispatcher):
         client = CbResponseAPI(**creds)
 
         # Get md5 hash 'value' passed from the rules engine function
-        action = alert.context.get('carbonblack', {}).get('action')
+        action = context.get('carbonblack', {}).get('action')
         if action == 'ban':
-            binary_hash = alert.context.get('carbonblack', {}).get('value')
+            binary_hash = context.get('carbonblack', {}).get('value')
             # The binary should already exist in CarbonBlack
             binary = client.select(Binary, binary_hash)
             # Determine if the binary is currenty listed as banned

--- a/stream_alert/alert_processor/outputs/demisto.py
+++ b/stream_alert/alert_processor/outputs/demisto.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from collections import OrderedDict
-import json
 
 from stream_alert.alert_processor.outputs.output_base import (
     OutputDispatcher,

--- a/stream_alert/alert_processor/outputs/demisto.py
+++ b/stream_alert/alert_processor/outputs/demisto.py
@@ -218,18 +218,18 @@ class DemistoCreateIncidentRequest(object):
             return cls.SEVERITY_UNKNOWN
 
         lc_severity_string = severity_string.lower()
-        if 'info' == lc_severity_string or 'informational' == lc_severity_string:
+        if lc_severity_string == 'info' or lc_severity_string == 'informational':
             return cls.SEVERITY_INFORMATIONAL
-        elif 'low' == lc_severity_string:
+        elif lc_severity_string == 'low':
             return cls.SEVERITY_LOW
-        elif 'med' == lc_severity_string or 'medium' == lc_severity_string:
+        elif lc_severity_string == 'med' or lc_severity_string == 'medium':
             return cls.SEVERITY_MEDIUM
-        elif 'high' == lc_severity_string:
+        elif lc_severity_string == 'high':
             return cls.SEVERITY_HIGH
-        elif 'critical' == lc_severity_string:
+        elif lc_severity_string == 'critical':
             return cls.SEVERITY_CRITICAL
-        else:
-            return cls.SEVERITY_UNKNOWN
+
+        return cls.SEVERITY_UNKNOWN
 
 
 class DemistoRequestAssembler(object):

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -94,14 +94,21 @@ class GithubOutput(OutputDispatcher):
                                           credentials['repository'])
 
         publication = alert.publish_for(self, descriptor)
-        rule_name = publication.get('rule_name', 'Unspecified Rule')
-        rule_description = publication.get('rule_description', 'N/A')
         record = publication.get('record', {})
 
-        title = "StreamAlert: {}".format(rule_name)
-        body_template = "### Description\n{}\n\n### Event data\n\n```\n{}\n```"
-        body = body_template.format(rule_description, json.dumps(record, indent=2, sort_keys=True))
-        issue = {'title': title, 'body': body, 'labels': credentials['labels'].split(',')}
+        # Default presentation to the output
+        default_title = "StreamAlert: {}".format(alert.rule_name)
+        default_body = "### Description\n{}\n\n### Event data\n\n```\n{}\n```".format(
+            alert.rule_description,
+            json.dumps(record, indent=2, sort_keys=True)
+        )
+
+        # Github Issue to be created
+        issue = {
+            'title': publication.get('github.title', default_title),
+            'body': publication.get('github.body', default_body),
+            'labels': credentials['labels'].split(',')
+        }
 
         LOGGER.debug('sending alert to Github repository %s', credentials['repository'])
 

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -93,10 +93,14 @@ class GithubOutput(OutputDispatcher):
         url = '{}/repos/{}/issues'.format(credentials['api'],
                                           credentials['repository'])
 
-        title = "StreamAlert: {}".format(alert.rule_name)
+        publication = alert.publish_for(self, descriptor)
+        rule_name = publication.get('rule_name', 'Unspecified Rule')
+        rule_description = publication.get('rule_description', 'N/A')
+        record = publication.get('record', {})
+
+        title = "StreamAlert: {}".format(rule_name)
         body_template = "### Description\n{}\n\n### Event data\n\n```\n{}\n```"
-        body = body_template.format(
-            alert.rule_description, json.dumps(alert.record, indent=2, sort_keys=True))
+        body = body_template.format(rule_description, json.dumps(record, indent=2, sort_keys=True))
         issue = {'title': title, 'body': body, 'labels': credentials['labels'].split(',')}
 
         LOGGER.debug('sending alert to Github repository %s', credentials['repository'])

--- a/stream_alert/alert_processor/outputs/jira.py
+++ b/stream_alert/alert_processor/outputs/jira.py
@@ -289,11 +289,12 @@ class JiraOutput(OutputDispatcher):
         if not creds:
             return False
 
+        publication = alert.publish_for(self, descriptor)
+
         issue_id = None
         comment_id = None
-        issue_summary = 'StreamAlert {}'.format(alert.rule_name)
-        alert_body = '{{code:JSON}}{}{{code}}'.format(
-            json.dumps(alert.output_dict(), sort_keys=True))
+        issue_summary = 'StreamAlert {}'.format(publication.get('rule_name', ''))
+        alert_body = '{{code:JSON}}{}{{code}}'.format(json.dumps(publication, sort_keys=True))
         self._base_url = creds['url']
         self._auth_cookie = self._establish_session(creds['username'], creds['password'])
 

--- a/stream_alert/alert_processor/outputs/jira.py
+++ b/stream_alert/alert_processor/outputs/jira.py
@@ -205,12 +205,12 @@ class JiraOutput(OutputDispatcher):
 
         return jira_id
 
-    def _create_issue(self, issue_name, project_key, issue_type, description):
+    def _create_issue(self, summary, project_key, issue_type, description):
         """Create a Jira issue to write alerts to. Alert is written to the "description"
         field of an issue.
 
         Args:
-            issue_name (str): The name of the Jira issue
+            summary (str): The name of the Jira issue
             project_key (str): The Jira project key which issues will be associated with
             issue_type (str): The type of issue being created
             description (str): The body of text which describes the issue
@@ -224,7 +224,7 @@ class JiraOutput(OutputDispatcher):
                 'project': {
                     'key': project_key
                 },
-                'summary': issue_name,
+                'summary': summary,
                 'description': description,
                 'issuetype': {
                     'name': issue_type
@@ -291,10 +291,19 @@ class JiraOutput(OutputDispatcher):
 
         publication = alert.publish_for(self, descriptor)
 
+        # Presentation defaults
+        default_issue_summary = 'StreamAlert {}'.format(alert.rule_name)
+        default_alert_body = '{{code:JSON}}{}{{code}}'.format(
+            json.dumps(publication, sort_keys=True)
+        )
+
+        # True Presentation values
+        issue_summary = publication.get('jira.issue_summary', default_issue_summary)
+        description = publication.get('jira.description', default_alert_body)
+
         issue_id = None
         comment_id = None
-        issue_summary = 'StreamAlert {}'.format(publication.get('rule_name', ''))
-        alert_body = '{{code:JSON}}{}{{code}}'.format(json.dumps(publication, sort_keys=True))
+
         self._base_url = creds['url']
         self._auth_cookie = self._establish_session(creds['username'], creds['password'])
 
@@ -307,7 +316,7 @@ class JiraOutput(OutputDispatcher):
         if creds.get('aggregate', '').lower() == 'yes':
             issue_id = self._get_existing_issue(issue_summary, creds['project_key'])
             if issue_id:
-                comment_id = self._create_comment(issue_id, alert_body)
+                comment_id = self._create_comment(issue_id, description)
                 if comment_id:
                     LOGGER.debug('Sending alert to an existing Jira issue %s with comment %s',
                                  issue_id,
@@ -322,7 +331,7 @@ class JiraOutput(OutputDispatcher):
         issue_id = self._create_issue(issue_summary,
                                       creds['project_key'],
                                       creds['issue_type'],
-                                      alert_body)
+                                      description)
         if issue_id:
             LOGGER.debug('Sending alert to a new Jira issue %s', issue_id)
 

--- a/stream_alert/alert_processor/outputs/komand.py
+++ b/stream_alert/alert_processor/outputs/komand.py
@@ -77,5 +77,7 @@ class KomandOutput(OutputDispatcher):
 
         LOGGER.debug('sending alert to Komand')
 
-        resp = self._post_request(creds['url'], {'data': alert.output_dict()}, headers, False)
+        publication = alert.publish_for(self, descriptor)
+        resp = self._post_request(creds['url'], {'data': publication}, headers, False)
+
         return self._check_http_response(resp)

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -49,7 +49,11 @@ def events_v2_data(output_dispatcher, descriptor, alert, routing_key, with_recor
     """
     publication = alert.publish_for(output_dispatcher, descriptor)
 
-    summary = 'StreamAlert Rule Triggered - {}'.format(publication.get('rule_name', ''))
+    # Special field that Publishers can use to customize the header
+    summary = publication.get(
+        'pagerduty_summary',
+        'StreamAlert Rule Triggered - {}'.format(publication.get('rule_name', ''))
+    )
     details = OrderedDict()
     details['description'] = publication.get('rule_description', '')
     if with_record:

--- a/stream_alert/alert_processor/outputs/phantom.py
+++ b/stream_alert/alert_processor/outputs/phantom.py
@@ -146,18 +146,22 @@ class PhantomOutput(OutputDispatcher):
         if not creds:
             return False
 
+        publication = alert.publish_for(self, descriptor)
+        rule_name = publication.get('rule_name', '')
+        rule_description = publication.get('rule_description', '')
+        record = publication.get('record', {})
+
         headers = {"ph-auth-token": creds['ph_auth_token']}
-        container_id = self._setup_container(
-            alert.rule_name, alert.rule_description, creds['url'], headers)
+        container_id = self._setup_container(rule_name, rule_description, creds['url'], headers)
 
         LOGGER.debug('sending alert to Phantom container with id %s', container_id)
 
         if not container_id:
             return False
 
-        artifact = {'cef': alert.record,
+        artifact = {'cef': record,
                     'container_id': container_id,
-                    'data': alert.output_dict(),
+                    'data': publication,
                     'name': 'Phantom Artifact',
                     'label': 'Alert'}
         artifact_url = os.path.join(creds['url'], self.ARTIFACT_ENDPOINT)

--- a/stream_alert/alert_processor/outputs/phantom.py
+++ b/stream_alert/alert_processor/outputs/phantom.py
@@ -147,12 +147,15 @@ class PhantomOutput(OutputDispatcher):
             return False
 
         publication = alert.publish_for(self, descriptor)
-        rule_name = publication.get('rule_name', '')
-        rule_description = publication.get('rule_description', '')
-        record = publication.get('record', {})
+        record = alert.record
 
         headers = {"ph-auth-token": creds['ph_auth_token']}
-        container_id = self._setup_container(rule_name, rule_description, creds['url'], headers)
+        container_id = self._setup_container(
+            alert.rule_name,
+            alert.rule_description,
+            creds['url'],
+            headers
+        )
 
         LOGGER.debug('sending alert to Phantom container with id %s', container_id)
 

--- a/stream_alert/shared/alert.py
+++ b/stream_alert/shared/alert.py
@@ -224,6 +224,15 @@ class Alert(object):
         }
 
     def publish_for(self, output_class, descriptor):  # pylint: disable=unused-argument
+        """Presents the current alert as a dict of information for OutputDispatchers to send.
+
+        Args:
+            output_class (OutputDispatcher): The output dispatching service
+            descriptor (string): The output's descriptor
+
+        Returns:
+            dict: A dict of published data
+        """
         # FIXME (derek.wang) Currently, this completely disregards the output_class and descriptor
         # as this Alert entity does not yet have the "publishers" field available to determine
         # how to publish itself.

--- a/stream_alert/shared/alert.py
+++ b/stream_alert/shared/alert.py
@@ -223,6 +223,12 @@ class Alert(object):
             'staged': self.staged
         }
 
+    def publish_for(self, output_class, descriptor):  # pylint: disable=unused-argument
+        # FIXME (derek.wang) Currently, this completely disregards the output_class and descriptor
+        # as this Alert entity does not yet have the "publishers" field available to determine
+        # how to publish itself.
+        return self.output_dict()
+
     # ---------- Alert Merging ----------
 
     def can_merge(self, other):

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
@@ -182,7 +182,7 @@ def test_assemble():
 
     alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
 
-    request = DemistoRequestAssembler.assemble(alert_publication)
+    request = DemistoRequestAssembler.assemble(alert, alert_publication)
 
     assert_equal(request.incident_name, 'cb_binarystore_file_added')
     assert_equal(request.incident_type, 'Unclassified')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_demisto.py
@@ -46,7 +46,7 @@ SAMPLE_CONTEXT = {
 }
 EXPECTED_LABELS_FOR_SAMPLE_ALERT = [
     {'type': 'alert.alert_id', 'value': '79192344-4a6d-4850-8d06-9c3fef1060a4'},
-    {'type': 'alert.cluster', 'value': 'None'},
+    {'type': 'alert.cluster', 'value': ''},
     {'type': 'alert.descriptor', 'value': 'unit_test_demisto'},
     {'type': 'alert.log_type', 'value': 'json'},
     {
@@ -166,7 +166,9 @@ def test_assemble():
     alert = get_alert(context=SAMPLE_CONTEXT)
     descriptor = 'unit_test_demisto'
 
-    request = DemistoRequestAssembler.assemble(alert, descriptor)
+    alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+
+    request = DemistoRequestAssembler.assemble(alert_publication, descriptor)
 
     assert_equal(request.incident_name, 'cb_binarystore_file_added')
     assert_equal(request.incident_type, 'Unclassified')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -49,7 +49,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Single Message - Slack"""
         rule_name = 'test_rule_single'
         alert = get_random_alert(25, rule_name)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -62,7 +63,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Multi-Message"""
         rule_name = 'test_rule_multi-part'
         alert = get_random_alert(30, rule_name)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         assert_set_equal(set(loaded_message.keys()), {'text', 'mrkdwn', 'attachments'})
@@ -74,7 +76,8 @@ class TestSlackOutput(object):
         """SlackOutput - Format Message, Default Rule Description"""
         rule_name = 'test_empty_rule_description'
         alert = get_random_alert(10, rule_name, True)
-        loaded_message = SlackOutput._format_message(rule_name, alert)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        loaded_message = SlackOutput._format_message(rule_name, alert_publication)
 
         # tests
         default_rule_description = '*Rule Description:*\nNo rule description provided\n'
@@ -191,8 +194,14 @@ class TestSlackOutput(object):
         """SlackOutput - Max Attachment Reached"""
         alert = get_alert()
         alert.record = {'info': 'test' * 20000}
-        list(SlackOutput._format_attachments(alert, 'foo'))
-        log_mock.assert_called_with('%s: %d-part message truncated to %d parts', alert, 21, 20)
+        alert_publication = alert.publish_for(None, None)  # FIXME (derek.wang)
+        list(SlackOutput._format_attachments(alert_publication, 'foo'))
+        log_mock.assert_called_with(
+            '%s: %d-part message truncated to %d parts',
+            alert_publication,
+            21,
+            20
+        )
 
     @patch('logging.Logger.info')
     @patch('requests.post')


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers


## Background

Small improvement over #898

This is done as step 1 in preparation for _Alert Publishers_. In order to implement a proper interface between _Alerts_ and _Outputs_ we need to have this layer communicate across a common vocabulary.

## Changes

### OutputDispatchers standardize around `publish_for(output, descriptor)`
Instead of referencing fields on the alert directly, all `OutputDispatchers` now reference `alert.publish_for(---, ----)`. Currently it has an empty implementation, but in the near future _Alert Publishers_ will be used to modify the return value of this.

This (more or less) replaces `output_dict()`.

### OutputDispatchers offer a default presentation, but can be overridden using magic fields
All OutputDispatchers offer a simple default integration with some default summary/title/priority/severity. 

However, they also can be overridden by certain fields. You can see an example of this here: https://github.com/airbnb/streamalert/pull/899/files#diff-1102db3770def41b73a2a49ea0304899R347.

This allows Outputs to be *both* easy to use as well as highly customizable.

### Demisto Outputs change _slightly_
Some Demisto label keys have moved around. I'm fairly confident nobody is using Demisto yet, so this should be okay for now. 

