### PR TITLE
enforce ssl access only on all S3 buckets

### DIFF
--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -89,7 +89,27 @@ def generate_s3_bucket(bucket, logging, **kwargs):
                     'sse_algorithm': sse_algorithm
                 }
             }
-        }
+        },
+        'policy': json.dumps({
+            'Version': '2012-10-17',
+            'Statement': [
+                {
+                    'Sid': 'ForceSSLOnlyAccess',
+                    'Effect': 'Deny',
+                    'Principal': '*',
+                    'Action': 's3:*',
+                    'Resource': [
+                        'arn:aws:s3:::{}/*'.format(bucket),
+                        'arn:aws:s3:::{}'.format(bucket)
+                    ],
+                    'Condition': {
+                        'Bool': {
+                            'aws:SecureTransport': 'false'
+                        }
+                    }
+                }
+            ]
+        })
     }
 
     if sse_algorithm == 'aws:kms':

--- a/terraform/modules/tf_stream_alert_kinesis_firehose_setup/main.tf
+++ b/terraform/modules/tf_stream_alert_kinesis_firehose_setup/main.tf
@@ -1,6 +1,35 @@
+// Policy for S3 bucket
+data "aws_iam_policy_document" "stream_alert_data" {
+  # Force SSL access only
+  statement {
+    sid = "ForceSSLOnlyAccess"
+
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}",
+      "arn:aws:s3:::${var.s3_bucket_name}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
 resource "aws_s3_bucket" "stream_alert_data" {
   bucket        = "${var.s3_bucket_name}"
   acl           = "private"
+  policy        = "${data.aws_iam_policy_document.stream_alert_data.json}"
   force_destroy = false
 
   versioning {

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -50,7 +50,8 @@ class TestTerraformGenerate(object):
             'force_destroy',
             'versioning',
             'logging',
-            'server_side_encryption_configuration'
+            'server_side_encryption_configuration',
+            'policy'
         }
 
         assert_equal(type(bucket), dict)
@@ -142,7 +143,15 @@ class TestTerraformGenerate(object):
                                         '${aws_kms_key.server_side_encryption.key_id}')
                                 }
                             }
-                        }
+                        },
+                        'policy': (
+                            '{"Version": "2012-10-17", "Statement": [{"Resource": '
+                            '["arn:aws:s3:::unit-testing.streamalert.secrets/*", '
+                            '"arn:aws:s3:::unit-testing.streamalert.secrets"], "Effect": '
+                            '"Deny", "Sid": "ForceSSLOnlyAccess", "Action": "s3:*", '
+                            '"Condition": {"Bool": {"aws:SecureTransport": "false"}}, '
+                            '"Principal": "*"}]}'
+                        )
                     },
                     'terraform_remote_state': {
                         'bucket': 'unit-testing.streamalert.terraform.state',
@@ -163,7 +172,15 @@ class TestTerraformGenerate(object):
                                         '${aws_kms_key.server_side_encryption.key_id}')
                                 }
                             }
-                        }
+                        },
+                        'policy': (
+                            '{"Version": "2012-10-17", "Statement": [{"Resource": '
+                            '["arn:aws:s3:::unit-testing.streamalert.terraform.state/*", '
+                            '"arn:aws:s3:::unit-testing.streamalert.terraform.state"], "Effect": '
+                            '"Deny", "Sid": "ForceSSLOnlyAccess", "Action": "s3:*", '
+                            '"Condition": {"Bool": {"aws:SecureTransport": "false"}}, '
+                            '"Principal": "*"}]}'
+                        )
                     },
                     'logging_bucket': {
                         'bucket': 'unit-testing.streamalert.s3-logging',
@@ -190,7 +207,15 @@ class TestTerraformGenerate(object):
                                     'sse_algorithm': 'AES256'
                                 }
                             }
-                        }
+                        },
+                        'policy': (
+                            '{"Version": "2012-10-17", "Statement": [{"Resource": '
+                            '["arn:aws:s3:::unit-testing.streamalert.s3-logging/*", '
+                            '"arn:aws:s3:::unit-testing.streamalert.s3-logging"], "Effect": '
+                            '"Deny", "Sid": "ForceSSLOnlyAccess", "Action": "s3:*", '
+                            '"Condition": {"Bool": {"aws:SecureTransport": "false"}}, '
+                            '"Principal": "*"}]}'
+                        )
                     },
                     'streamalerts': {
                         'bucket': 'unit-testing.streamalerts',
@@ -211,7 +236,15 @@ class TestTerraformGenerate(object):
                                         '${aws_kms_key.server_side_encryption.key_id}')
                                 }
                             }
-                        }
+                        },
+                        'policy': (
+                            '{"Version": "2012-10-17", "Statement": [{"Resource": '
+                            '["arn:aws:s3:::unit-testing.streamalerts/*", '
+                            '"arn:aws:s3:::unit-testing.streamalerts"], "Effect": '
+                            '"Deny", "Sid": "ForceSSLOnlyAccess", "Action": "s3:*", '
+                            '"Condition": {"Bool": {"aws:SecureTransport": "false"}}, '
+                            '"Principal": "*"}]}'
+                        )
                     }
                 },
                 'aws_sns_topic': {


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/streamalert-maintainers

## Changes

* Enforcing SSL access only to all StreamAlert S3 buckets.

## Testing

Updating unit tests to reflect new S3 bucket policy on resources.
