### PR TITLE
[bug] retrying ReadTimeoutError via HTTPClientError in sqs and firehose clients

### DIFF
--- a/stream_alert/classifier/clients/firehose.py
+++ b/stream_alert/classifier/clients/firehose.py
@@ -19,7 +19,7 @@ import re
 
 import backoff
 import boto3
-from botocore.exceptions import ClientError, ConnectionClosedError, ConnectionError
+from botocore.exceptions import ClientError, ConnectionError, HTTPClientError
 
 from stream_alert.shared import CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
 import stream_alert.shared.helpers.boto as boto_helpers
@@ -54,7 +54,7 @@ class FirehoseClient(object):
     DEFAULT_FIREHOSE_PREFIX = 'streamalert_data_{}'
 
     # Exception for which backoff operations should be performed
-    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionClosedError, ConnectionError)
+    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionError, HTTPClientError)
 
     # Set of enabled log types for firehose, loaded from configs
     _ENABLED_LOGS = dict()

--- a/stream_alert/classifier/clients/sqs.py
+++ b/stream_alert/classifier/clients/sqs.py
@@ -18,7 +18,7 @@ import os
 
 import backoff
 import boto3
-from botocore.exceptions import ClientError, ConnectionClosedError, ConnectionError
+from botocore.exceptions import ClientError, ConnectionError, HTTPClientError
 
 from stream_alert.shared import CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
 from stream_alert.shared.helpers import boto
@@ -40,7 +40,7 @@ class SQSClientError(Exception):
 class SQSClient(object):
     """SQSClient for sending batches of classified records to the Rules Engine function"""
     # Exception for which backoff operations should be performed
-    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionClosedError, ConnectionError)
+    EXCEPTIONS_TO_BACKOFF = (ClientError, ConnectionError, HTTPClientError)
 
     # Maximum amount of times to retry with backoff
     MAX_BACKOFF_ATTEMPTS = 5


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/streamalert-maintainers
resolves: #896 
resolves: #910 

## Background

See #896, #910

## Changes

* Adding [`HTTPClientError`](https://github.com/boto/botocore/blob/b55f926bdf73d8783133da851919f5feffc7b655/botocore/exceptions.py#L79) to the list of exceptions to catch and retry.
* This exception now covers both the `ConnectionClosedError` and `ReadTimeoutError` exceptions.

