### PR TITLE
adding ability to add `Cluster` tag to classifier lambda/cloudwatch resources

### DIFF
--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -94,5 +94,8 @@ def generate_classifier(cluster_name, cluster_dict, config):
         environment={
             'CLUSTER': cluster_name,
             'SQS_QUEUE_URL': '${module.globals.classifier_sqs_queue_url}',
-        }
+        },
+        tags={
+            'Cluster': cluster_name
+        },
     )

--- a/stream_alert_cli/terraform/lambda_module.py
+++ b/stream_alert_cli/terraform/lambda_module.py
@@ -52,7 +52,7 @@ def _tf_vpc_config(lambda_config):
 
 
 def generate_lambda(function_name, zip_file, handler, lambda_config, config,
-                    environment=None, input_event=None):
+                    environment=None, input_event=None, tags=None):
     """Generate an instance of the Lambda Terraform module.
 
     Args:
@@ -63,6 +63,7 @@ def generate_lambda(function_name, zip_file, handler, lambda_config, config,
         config (dict): Parsed config from conf/
         environment (dict): Optional environment variables to specify.
             ENABLE_METRICS and LOGGER_LEVEL are included automatically.
+        tags (dict): Optional tags to be added to this Lambda resource.
 
     Example Lambda config:
         {
@@ -117,7 +118,8 @@ def generate_lambda(function_name, zip_file, handler, lambda_config, config,
         'memory_size_mb': lambda_config['memory'],
         'timeout_sec': lambda_config['timeout'],
         'filename': zip_file,
-        'environment_variables': environment_variables
+        'environment_variables': environment_variables,
+        'tags': tags or {},
     }
 
     # Add Classifier input config from the loaded cluster file

--- a/terraform/modules/tf_lambda/cloudwatch.tf
+++ b/terraform/modules/tf_lambda/cloudwatch.tf
@@ -30,9 +30,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
   name              = "/aws/lambda/${var.function_name}"
   retention_in_days = "${var.log_retention_days}"
 
-  tags {
-    Name = "${var.name_tag}"
-  }
+  tags = "${local.tags}"
 }
 
 // Generic CloudWatch metric alarms related to this function

--- a/terraform/modules/tf_lambda/main.tf
+++ b/terraform/modules/tf_lambda/main.tf
@@ -4,6 +4,7 @@
 locals {
   schedule_enabled = "${var.schedule_expression != ""}"
   vpc_enabled      = "${length(var.vpc_subnet_ids) > 0}"
+  tags             = "${merge(var.default_tags, var.tags)}"
 }
 
 // Either the function_vpc or the function_no_vpc resource will be used
@@ -35,9 +36,7 @@ resource "aws_lambda_function" "function_vpc" {
     subnet_ids         = "${var.vpc_subnet_ids}"
   }
 
-  tags {
-    Name = "${var.name_tag}"
-  }
+  tags = "${local.tags}"
 
   // We need VPC access before the function can be created
   depends_on = ["aws_iam_role_policy_attachment.vpc_access"]
@@ -73,9 +72,7 @@ resource "aws_lambda_function" "function_no_vpc" {
     variables = "${var.environment_variables}"
   }
 
-  tags {
-    Name = "${var.name_tag}"
-  }
+  tags = "${local.tags}"
 }
 
 resource "aws_lambda_alias" "alias_no_vpc" {

--- a/terraform/modules/tf_lambda/variables.tf
+++ b/terraform/modules/tf_lambda/variables.tf
@@ -63,9 +63,20 @@ variable "vpc_security_group_ids" {
   description = "Optional list of security group IDs (for VPC)"
 }
 
-variable "name_tag" {
-  default     = "StreamAlert"
-  description = "The value for the Name cost tag associated with all applicable components"
+variable "default_tags" {
+  type = "map"
+
+  default = {
+    Name = "StreamAlert"
+  }
+
+  description = "The default tags to be associated with all applicable components"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Any dditional tags to be associated with all applicable components"
 }
 
 variable "auto_publish_versions" {

--- a/tests/unit/stream_alert_cli/terraform/test_alert_processor.py
+++ b/tests/unit/stream_alert_cli/terraform/test_alert_processor.py
@@ -60,6 +60,7 @@ class TestAlertProcessor(unittest.TestCase):
                         'ENABLE_METRICS': '0',
                         'LOGGER_LEVEL': 'info'
                     },
+                    'tags': {},
                     'errors_alarm_enabled': True,
                     'errors_alarm_evaluation_periods': 1,
                     'errors_alarm_period_secs': 2,
@@ -117,6 +118,7 @@ class TestAlertProcessor(unittest.TestCase):
                         'ENABLE_METRICS': '0',
                         'LOGGER_LEVEL': 'info'
                     },
+                    'tags': {},
                     'filename': 'alert_processor.zip',
                     'function_name': 'unit-testing_streamalert_alert_processor',
                     'handler': 'stream_alert.alert_processor.main.handler',

--- a/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/stream_alert_cli/terraform/test_rule_promotion.py
@@ -56,6 +56,7 @@ class TestRulePromotion(object):
                         'ENABLE_METRICS': '0',
                         'LOGGER_LEVEL': 'info'
                     },
+                    'tags': {},
                     'errors_alarm_enabled': True,
                     'errors_alarm_evaluation_periods': 1,
                     'errors_alarm_period_secs': 2,

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -112,6 +112,9 @@ class TestTerraformGenerateClassifier(object):
                         'LOGGER_LEVEL': 'info',
                         'ENABLE_METRICS': '0'
                     },
+                    'tags': {
+                        'Cluster': 'test'
+                    },
                     'errors_alarm_enabled': True,
                     'errors_alarm_evaluation_periods': 1,
                     'errors_alarm_period_secs': 120,

--- a/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
@@ -101,6 +101,7 @@ class TestTerraformGenerateRuleEngine(object):
                         'LOGGER_LEVEL': 'info',
                         'STREAMALERT_PREFIX': 'unit-test',
                     },
+                    'tags': {},
                     'errors_alarm_enabled': True,
                     'errors_alarm_evaluation_periods': 1,
                     'errors_alarm_period_secs': 120,


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Currently, the `tf_lambda` module does not support custom tags and will only add the `Name: StreamAlert` tag to Lambda/CloudWatch resources.

## Changes

* Adding the ability to include custom tags in the `tf_lambda` module.
* Any custom tags will be merged with the default tags (ie: `Name: StreamAlert`)
* Updating `classifier` terraform generation code to include the `Cluster` tag.

## Testing

Updating all unit test for Lambda terraform generation.
