### PR TITLE
[Alert Publishers] Standardizes magic fields with @-sign prefix

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -103,12 +103,10 @@ Adding support for a new service involves five steps:
     output.
 
     In addition, adding output-specific fields can be useful to offer more fine-grained control
-    of the look and feel of an alert. Prefix all such fields with the output's service name and
-    delimit the field with a period.
+    of the look and feel of an alert.
 
     For example, an optional field that directly controls a PagerDuty incident's title:
-
-    - 'pagerduty.incident_title'
+    - '@pagerduty.incident_title'
 
 
     When referencing an alert's attributes, reference the alert's field directly (e.g.

--- a/docs/source/publishers.rst
+++ b/docs/source/publishers.rst
@@ -121,9 +121,12 @@ should offer a default implementation:
 Outputs can be implemented to offer custom fields that can be filled in by Publishers. This (optionally)
 grants fine-grained control of outputs to Publishers. Such fields should follow the following conventions:
 
-* They are fields on the publication dictionary
-* Keys are strings, with the ``output.__service__`` as a prefix
-* The key should be delimited by period, and the suffix should describe the function of the field
+* They are top level keys on the final publication dictionary
+* Keys are strings, following the format: ``@{output_service}.{field_name}``
+* Keys MUST begin with an at-sign
+* The ``output_service`` should match the current outputs ``cls.__service__`` value
+* The ``field_name`` should describe its function
+* Example: ``@slack.attachments``
 
 Below is an example of how you could implement an output:
 
@@ -136,8 +139,8 @@ Below is an example of how you could implement an output:
     default_title = 'Incident Title: #{}'.format(alert.alert_id)
     default_html = '<html><body>Rule: {}</body></html>'.format(alert.rule_description)
 
-    title = publication.get('pagerduty.title', default_title)
-    body_html = publication.get('pagerduty.body_html', default_html)
+    title = publication.get('@pagerduty.title', default_title)
+    body_html = publication.get('@pagerduty.body_html', default_html)
 
     make_api_call(title, body_html, data=publication)
 
@@ -248,12 +251,12 @@ The publisher can also simplify the PagerDuty title:
   @Register
   def simplify_pagerduty_output(alert, publication):
     return {
-      'record': {
+      '@pagerduty.record': {
           'source_ip': alert.record['source_ip'],
           'time': alert.record['timestamp'],
           'username': alert.record['user'],
       },
-      'pagerduty.summary': 'Machine SSH: {}'.format(alert.record['user']),
+      '@pagerduty.summary': 'Machine SSH: {}'.format(alert.record['user']),
     }
 
 Suppose this rule is being output to both PagerDuty and Slack, but you only wish to simplify the PagerDuty

--- a/publishers/community/slack/slack_layout.py
+++ b/publishers/community/slack/slack_layout.py
@@ -48,8 +48,8 @@ class Summary(AlertPublisher):
         author = rule_presentation['author']
 
         return {
-            'slack.text': 'Rule triggered',
-            'slack.attachments': [
+            '@slack.text': 'Rule triggered',
+            '@slack.attachments': [
                 {
                     'fallback': 'Rule triggered: {}'.format(rule_name),
                     'color': self._color(),
@@ -116,12 +116,12 @@ class AttachRuleInfo(AlertPublisher):
     """
 
     def publish(self, alert, publication):
-        publication['slack.attachments'] = publication.get('slack.attachments', [])
+        publication['@slack.attachments'] = publication.get('@slack.attachments', [])
 
         rule_description = alert.rule_description
         rule_presentation = RuleDescriptionParser.present(rule_description)
 
-        publication['slack.attachments'].append({
+        publication['@slack.attachments'].append({
             'color': self._color(),
             'fields': [
                 {'title': key.capitalize(), 'value': rule_presentation['fields'][key]}
@@ -141,7 +141,7 @@ class AttachPublication(AlertPublisher):
     """A publisher run after PrettyLayout that attaches previous publications as an attachment"""
 
     def publish(self, alert, publication):
-        if '_previous_publication' not in publication or 'slack.attachments' not in publication:
+        if '_previous_publication' not in publication or '@slack.attachments' not in publication:
             # This publisher cannot be run except immediately after PrettyLayout
             return publication
 
@@ -154,7 +154,7 @@ class AttachPublication(AlertPublisher):
             )
         )
 
-        publication['slack.attachments'].append({
+        publication['@slack.attachments'].append({
             'color': self._color(),
             'title': 'Alert Data:',
             'text': cgi.escape(publication_block),
@@ -186,7 +186,7 @@ class AttachFullRecord(AlertPublisher):
     _LENGTH_PADDING = 10
 
     def publish(self, alert, publication):
-        publication['slack.attachments'] = publication.get('slack.attachments', [])
+        publication['@slack.attachments'] = publication.get('@slack.attachments', [])
 
         # Generate the record and then dice it up into parts
         record_document = json.dumps(alert.record, indent=2, sort_keys=True, separators=(',', ': '))
@@ -234,7 +234,7 @@ class AttachFullRecord(AlertPublisher):
             next_length = next_item_length + len(next_document)
             if next_document and next_length > character_limit:
                 # Do not pop off the item just yet.
-                publication['slack.attachments'].append(
+                publication['@slack.attachments'].append(
                     make_attachment(next_document, is_first_document, False)
                 )
                 next_document = ''
@@ -244,7 +244,7 @@ class AttachFullRecord(AlertPublisher):
 
         # Attach last document, if any remains
         if next_document:
-            publication['slack.attachments'].append(
+            publication['@slack.attachments'].append(
                 make_attachment(next_document, is_first_document, True)
             )
 

--- a/stream_alert/alert_processor/outputs/aws.py
+++ b/stream_alert/alert_processor/outputs/aws.py
@@ -100,6 +100,10 @@ class KinesisFirehoseOutput(AWSOutput):
     def _dispatch(self, alert, descriptor):
         """Send alert to a Kinesis Firehose Delivery Stream
 
+        Publishing:
+            By default this output sends the current publication in JSON to Kinesis.
+            There is no "magic" field to "override" it: Simply publish what you want to send!
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -187,6 +191,14 @@ class LambdaOutput(AWSOutput):
 
         The alert gets dumped to a JSON string to be sent to the Lambda function
 
+        Publishing:
+            By default this output sends the JSON-serialized alert record as the payload to the
+            lambda function. You can override this:
+
+            - @aws-lambda.alert_data (dict):
+                    Overrides the alert record. Will instead send this dict, JSON-serialized, to
+                    Lambda as the payload.
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -195,9 +207,14 @@ class LambdaOutput(AWSOutput):
             bool: True if alert was sent successfully, False otherwise
         """
         publication = compose_alert(alert, self, descriptor)
-        record = publication.get('record', {})
 
-        alert_string = json.dumps(record, separators=(',', ':'))
+        # Defaults
+        default_alert_data = alert.record
+
+        # Override with publisher
+        alert_data = publication.get('@aws-lambda.alert_data', default_alert_data)
+
+        alert_string = json.dumps(alert_data, separators=(',', ':'))
         function_name = self.config[self.__service__][descriptor]
 
         # Check to see if there is an optional qualifier included here
@@ -272,6 +289,10 @@ class S3Output(AWSOutput):
             service/entity/rule_name/datetime.json
         The alert gets dumped to a JSON string
 
+        Publishing:
+            By default this output sends the current publication in JSON to S3.
+            There is no "magic" field to "override" it: Simply publish what you want to send!
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -312,6 +333,16 @@ class SNSOutput(AWSOutput):
     def get_user_defined_properties(cls):
         """Properties assigned by the user when configuring a new SNS output.
 
+        Publishing:
+            By default this output sets a default subject and sends a message body that is the
+            JSON-serialized publication including indents/newlines. You can override this behavior:
+
+            - @aws-sns.topic (str):
+                    Sends a custom subject
+
+            - @aws-sns.message (str);
+                    Send a custom message body.
+
         Returns:
             OrderedDict: With 'descriptor' and 'aws_value' OutputProperty tuples
         """
@@ -344,8 +375,8 @@ class SNSOutput(AWSOutput):
 
         # Published presentation fields
         # Subject must be < 100 characters long;
-        subject = elide_string_middle(publication.get('aws-sns.topic', default_subject), 99)
-        message = publication.get('aws-sns.message', default_message)
+        subject = elide_string_middle(publication.get('@aws-sns.topic', default_subject), 99)
+        message = publication.get('@aws-sns.message', default_message)
 
         topic.publish(
             Message=message,
@@ -380,6 +411,14 @@ class SQSOutput(AWSOutput):
     def _dispatch(self, alert, descriptor):
         """Send alert to an SQS queue
 
+        Publishing:
+            By default it sends the alert.record to SQS as a JSON string. You can override
+            it with the following fields:
+
+            - @aws-sqs.message_data (dict):
+                    Replace alert.record with your own JSON-serializable dict. Will send this
+                    as a JSON string to SQS.
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -394,13 +433,14 @@ class SQSOutput(AWSOutput):
         publication = compose_alert(alert, self, descriptor)
 
         # Presentation defaults
-        record = publication.get('record', {})
-        default_message_body = json.dumps(record, separators=(',', ':'))
+        default_message_data = alert.record
 
         # Presentation values
-        message_body = publication.get('aws-sqs:message_body', default_message_body)
+        message_data = publication.get('@aws-sqs.message_data', default_message_data)
 
-        queue.send_message(MessageBody=message_body)
+        # Transform the body from a dict to a string for SQS
+        sqs_message = json.dumps(message_data, separators=(',', ':'))
+        queue.send_message(MessageBody=sqs_message)
 
         return True
 
@@ -413,6 +453,11 @@ class CloudwatchLogOutput(AWSOutput):
     @classmethod
     def get_user_defined_properties(cls):
         """Get properties that must be assigned by the user when configuring a new Lambda
+
+        Publishing:
+            By default this output sends the current publication in JSON to CloudWatch.
+            There is no "magic" field to "override" it: Simply publish what you want to send!
+
         Returns:
             OrderedDict: Contains various OutputProperty items
         """

--- a/stream_alert/alert_processor/outputs/carbonblack.py
+++ b/stream_alert/alert_processor/outputs/carbonblack.py
@@ -60,6 +60,9 @@ class CarbonBlackOutput(OutputDispatcher):
     def _dispatch(self, alert, descriptor):
         """Send ban hash command to CarbonBlack
 
+        Publishing:
+            There is currently no method to control carbonblack's behavior with publishers.
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor

--- a/stream_alert/alert_processor/outputs/github.py
+++ b/stream_alert/alert_processor/outputs/github.py
@@ -76,6 +76,17 @@ class GithubOutput(OutputDispatcher):
     def _dispatch(self, alert, descriptor):
         """Send alert to Github
 
+        Publishing:
+            This output provides a default issue title and a very basic issue body containing
+            the alert record. To override:
+
+            - @github.title (str):
+                    Override the Issue's title
+
+            - @github.body (str):
+                    Overrides the default github issue body. Remember: this string is in Github's
+                    syntax, so it supports markdown and respects linebreaks characters (e.g. \n).
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -95,19 +106,22 @@ class GithubOutput(OutputDispatcher):
                                           credentials['repository'])
 
         publication = compose_alert(alert, self, descriptor)
-        record = publication.get('record', {})
 
         # Default presentation to the output
         default_title = "StreamAlert: {}".format(alert.rule_name)
         default_body = "### Description\n{}\n\n### Event data\n\n```\n{}\n```".format(
             alert.rule_description,
-            json.dumps(record, indent=2, sort_keys=True)
+            json.dumps(alert.record, indent=2, sort_keys=True)
         )
+
+        # Override presentation defaults
+        issue_title = publication.get('@github.title', default_title)
+        issue_body = publication.get('@github.body', default_body)
 
         # Github Issue to be created
         issue = {
-            'title': publication.get('github.title', default_title),
-            'body': publication.get('github.body', default_body),
+            'title': issue_title,
+            'body': issue_body,
             'labels': credentials['labels'].split(',')
         }
 

--- a/stream_alert/alert_processor/outputs/jira.py
+++ b/stream_alert/alert_processor/outputs/jira.py
@@ -279,6 +279,18 @@ class JiraOutput(OutputDispatcher):
     def _dispatch(self, alert, descriptor):
         """Send alert to Jira
 
+        Publishing:
+            This output uses a default issue summary and sends the entire publication into the
+            issue body as a {{code}} block. To override:
+
+            - @jira.issue_summary (str):
+                    Overrides the issue title that shows up at the top on the JIRA UI
+
+            - @jira.description (str):
+                    Send your own custom description. Remember: This field is in JIRA's syntax,
+                    so it supports their custom markdown-like formatting and respects newline
+                    characters (e.g. \n).
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor
@@ -299,8 +311,8 @@ class JiraOutput(OutputDispatcher):
         )
 
         # True Presentation values
-        issue_summary = publication.get('jira.issue_summary', default_issue_summary)
-        description = publication.get('jira.description', default_alert_body)
+        issue_summary = publication.get('@jira.issue_summary', default_issue_summary)
+        description = publication.get('@jira.description', default_alert_body)
 
         issue_id = None
         comment_id = None

--- a/stream_alert/alert_processor/outputs/komand.py
+++ b/stream_alert/alert_processor/outputs/komand.py
@@ -63,6 +63,10 @@ class KomandOutput(OutputDispatcher):
     def _dispatch(self, alert, descriptor):
         """Send alert to Komand
 
+        Publishing:
+            By default this output sends the current publication to Komand.
+            There is no "magic" field to "override" it: Simply publish what you want to send!
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor

--- a/stream_alert/alert_processor/outputs/phantom.py
+++ b/stream_alert/alert_processor/outputs/phantom.py
@@ -136,6 +136,10 @@ class PhantomOutput(OutputDispatcher):
     def _dispatch(self, alert, descriptor):
         """Send alert to Phantom
 
+        Publishing:
+            By default this output sends the current publication in as JSON to Phantom.
+            There is no "magic" field to "override" it: Simply publish what you want to send!
+
         Args:
             alert (Alert): Alert instance which triggered a rule
             descriptor (str): Output descriptor

--- a/stream_alert/alert_processor/outputs/slack.py
+++ b/stream_alert/alert_processor/outputs/slack.py
@@ -305,11 +305,11 @@ class SlackOutput(OutputDispatcher):
                     ...
         """
         default_header_text = '*StreamAlert Rule Triggered: {}*'.format(alert.rule_name)
-        header_text = alert_publication.get('slack.text', default_header_text)
+        header_text = alert_publication.get('@slack.text', default_header_text)
 
-        if 'slack.attachments' in alert_publication:
+        if '@slack.attachments' in alert_publication:
             attachments = cls._standardize_custom_attachments(
-                alert_publication.get('slack.attachments')
+                alert_publication.get('@slack.attachments')
             )
         else:
             # Default attachments
@@ -409,6 +409,25 @@ class SlackOutput(OutputDispatcher):
 
     def _dispatch(self, alert, descriptor):
         """Send alert text to Slack
+
+        Publishing:
+            By default the slack output sends a slack message comprising some default intro text
+            and a series of attachments containing:
+            * alert description
+            * alert record, chunked into pieces if it's too long
+
+            To override this behavior use the following fields:
+
+            - @slack.text (str):
+                    Replaces the text that appears as the first line in the slack message.
+
+            - @slack.attachments (list[dict]):
+                    A list of individual slack attachments to include in the message. Each
+                    element of this list is a dict that must adhere to the syntax of attachments
+                    on Slack's API.
+
+                    @see cls._standardize_custom_attachments() for some insight into how individual
+                    attachments can be written.
 
         Args:
             alert (Alert): Alert instance which triggered a rule

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_slack.py
@@ -67,7 +67,7 @@ class TestSlackOutput(object):
         alert = get_random_alert(25, rule_name)
         output = MagicMock(spec=SlackOutput)
         alert_publication = compose_alert(alert, output, 'asdf')
-        alert_publication['slack.text'] = 'Lorem ipsum foobar'
+        alert_publication['@slack.text'] = 'Lorem ipsum foobar'
 
         loaded_message = SlackOutput._format_message(alert, alert_publication)
 
@@ -82,7 +82,7 @@ class TestSlackOutput(object):
         alert = get_random_alert(10, rule_name, True)
         output = MagicMock(spec=SlackOutput)
         alert_publication = compose_alert(alert, output, 'asdf')
-        alert_publication['slack.attachments'] = [
+        alert_publication['@slack.attachments'] = [
             {'text': 'aasdfkjadfj'}
         ]
 
@@ -101,7 +101,7 @@ class TestSlackOutput(object):
         alert_publication = compose_alert(alert, output, 'asdf')
 
         long_message = 'a'*(SlackOutput.MAX_MESSAGE_SIZE + 1)
-        alert_publication['slack.attachments'] = [
+        alert_publication['@slack.attachments'] = [
             {'text': long_message}
         ]
 
@@ -121,7 +121,7 @@ class TestSlackOutput(object):
         alert = get_random_alert(10, rule_name, True)
         output = MagicMock(spec=SlackOutput)
         alert_publication = compose_alert(alert, output, 'asdf')
-        alert_publication['slack.attachments'] = [
+        alert_publication['@slack.attachments'] = [
             {'text': 'attachment text1'},
             {'text': 'attachment text2'},
         ]
@@ -140,9 +140,9 @@ class TestSlackOutput(object):
         alert = get_random_alert(10, rule_name, True)
         output = MagicMock(spec=SlackOutput)
         alert_publication = compose_alert(alert, output, 'asdf')
-        alert_publication['slack.attachments'] = []
+        alert_publication['@slack.attachments'] = []
         for _ in range(SlackOutput.MAX_ATTACHMENTS + 1):
-            alert_publication['slack.attachments'].append({'text': 'yay'})
+            alert_publication['@slack.attachments'].append({'text': 'yay'})
 
         loaded_message = SlackOutput._format_message(alert, alert_publication)
 

--- a/tests/unit/stream_alert_alert_processor/test_publishers/slack/test_slack_layout.py
+++ b/tests/unit/stream_alert_alert_processor/test_publishers/slack/test_slack_layout.py
@@ -36,9 +36,9 @@ class TestSummary(object):
         publication = self._publisher.publish(alert, {})
 
         expectation = {
-            'slack.text': 'Rule triggered',
+            '@slack.text': 'Rule triggered',
             '_previous_publication': {},
-            'slack.attachments': [
+            '@slack.attachments': [
                 {
                     'author_link': '',
                     'color': '#ff5a5f',
@@ -61,14 +61,14 @@ class TestSummary(object):
             ]
         }
 
-        assert_equal(publication['slack.text'], expectation['slack.text'])
+        assert_equal(publication['@slack.text'], expectation['@slack.text'])
         assert_equal(publication['_previous_publication'], expectation['_previous_publication'])
-        assert_equal(len(publication['slack.attachments']), len(expectation['slack.attachments']))
+        assert_equal(len(publication['@slack.attachments']), len(expectation['@slack.attachments']))
         assert_equal(
-            publication['slack.attachments'][0].keys(),
-            expectation['slack.attachments'][0].keys()
+            publication['@slack.attachments'][0].keys(),
+            expectation['@slack.attachments'][0].keys()
         )
-        assert_equal(publication['slack.attachments'][0], expectation['slack.attachments'][0])
+        assert_equal(publication['@slack.attachments'][0], expectation['@slack.attachments'][0])
 
 
 class TestAttachRuleInfo(object):
@@ -90,7 +90,7 @@ Att&ck vector:  Assuming direct control
         publication = self._publisher.publish(alert, {})
 
         expectation = {
-            'slack.attachments': [
+            '@slack.attachments': [
                 {
                     'color': '#8ce071',
                     'fields': [
@@ -122,7 +122,7 @@ class TestAttachPublication(object):
 
         previous = {
             '_previous_publication': {'foo': 'bar'},
-            'slack.attachments': [
+            '@slack.attachments': [
                 {
                     'text': 'attachment1',
                 },
@@ -132,7 +132,7 @@ class TestAttachPublication(object):
 
         expectation = {
             '_previous_publication': {'foo': 'bar'},
-            'slack.attachments': [
+            '@slack.attachments': [
                 {'text': 'attachment1'},
                 {
                     'color': '#00d1c1',
@@ -159,7 +159,7 @@ class TestAttachFullRecord(object):
         publication = self._publisher.publish(alert, {})
 
         expectation = {
-            'slack.attachments': [
+            '@slack.attachments': [
                 {
                     'footer': 'via <https://console.aws.amazon.com/s3/home|s3>',
                     'fields': [
@@ -198,7 +198,7 @@ class TestAttachFullRecord(object):
 
         publication = self._publisher.publish(alert, {})
 
-        attachments = publication['slack.attachments']
+        attachments = publication['@slack.attachments']
 
         assert_equal(len(attachments), 14)
         for attachment in attachments:


### PR DESCRIPTION
to: @ryandeivert 

## Background

I decided that having magic fields like `pagerduty-incident:asdf` were too easy to get mixed up with normal top-level keys.

*NOTE* I did NOT update the PagerDuty output because I'm currently messing with that on #911  and I don't want to deal with the merge conflicts. They're all going into `2.2.0` anyway.

## Changes

I introduced a standard to publisher keys: All of them must start with an at-sign `@`.

