### PR TITLE
Improvements to Slack Publishers

### DIFF
--- a/publishers/community/slack/slack_layout.py
+++ b/publishers/community/slack/slack_layout.py
@@ -25,6 +25,7 @@ RAUSCH = '#ff5a5f'
 BABU = '#00d1c1'
 LIMA = '#8ce071'
 HACKBERRY = '#7b0051'
+BEACH = '#ffb400'
 
 
 @Register
@@ -140,7 +141,8 @@ class AttachRuleInfo(AlertPublisher):
 class AttachPublication(AlertPublisher):
     """A publisher that attaches previous publications as an attachment
 
-    This publisher needs to be run after the Summary publisher
+    By default, this publisher needs to be run after the Summary publisher, as it depends on
+    the magic-magic _previous_publication field.
     """
 
     def publish(self, alert, publication):
@@ -150,7 +152,7 @@ class AttachPublication(AlertPublisher):
 
         publication_block = '```\n{}\n```'.format(
             json.dumps(
-                publication['_previous_publication'],
+                self._get_publication(alert, publication),
                 indent=2,
                 sort_keys=True,
                 separators=(',', ': ')
@@ -169,6 +171,57 @@ class AttachPublication(AlertPublisher):
     @staticmethod
     def _color():
         return BABU
+
+    @staticmethod
+    def _get_publication(_, publication):
+        return publication['_previous_publication']
+
+
+@Register
+class AttachStringTemplate(AlertPublisher):
+    """An extremely flexible publisher that simply renders an attachment as text
+
+    By default, this publisher accepts a template from the alert.context['slack_message_template']
+    which is .format()'d with the current publication. This allows individual rules to render
+    whatever they want. The template is a normal slack message, so it can support newline
+    characters, and any of slack's pseudo-markdown.
+
+    Subclass implementations of this can decide to override any of the implementation or come
+    up with their own!
+
+    By default, this publisher needs to be run after the Summary publisher, as it depends on
+    the magic-magic _previous_publication field.
+    """
+
+    def publish(self, alert, publication):
+        rendered_text = self._render_text(alert, publication)
+
+        publication['@slack.attachments'] = publication.get('@slack.attachments', [])
+        publication['@slack.attachments'].append({
+            'color': self._color(),
+            'text': cgi.escape(rendered_text),
+        })
+
+        return publication
+
+    @classmethod
+    def _render_text(cls, alert, publication):
+        template = cls._get_format_template(alert, publication)
+        args = cls._get_template_args(alert, publication)
+
+        return template.format(**args)
+
+    @staticmethod
+    def _get_format_template(alert, _):
+        return alert.context.get('slack_message_template', '[MISSING TEMPLATE]')
+
+    @staticmethod
+    def _get_template_args(_, publication):
+        return publication['_previous_publication']
+
+    @staticmethod
+    def _color():
+        return BEACH
 
 
 @Register

--- a/publishers/community/slack/slack_layout.py
+++ b/publishers/community/slack/slack_layout.py
@@ -70,7 +70,7 @@ class Summary(AlertPublisher):
             ],
 
             # This information is passed-through to future publishers.
-            '_previous_publication': publication,
+            '@slack._previous_publication': publication,
         }
 
     @staticmethod
@@ -146,7 +146,7 @@ class AttachPublication(AlertPublisher):
     """
 
     def publish(self, alert, publication):
-        if '_previous_publication' not in publication or '@slack.attachments' not in publication:
+        if '@slack._previous_publication' not in publication or '@slack.attachments' not in publication:
             # This publisher cannot be run except immediately after the Summary publisher
             return publication
 
@@ -174,7 +174,7 @@ class AttachPublication(AlertPublisher):
 
     @staticmethod
     def _get_publication(_, publication):
-        return publication['_previous_publication']
+        return publication['@slack._previous_publication']
 
 
 @Register
@@ -189,8 +189,8 @@ class AttachStringTemplate(AlertPublisher):
     Subclass implementations of this can decide to override any of the implementation or come
     up with their own!
 
-    By default, this publisher needs to be run after the Summary publisher, as it depends on
-    the magic-magic _previous_publication field.
+    If this publisher is run after the Summary publisher, it will correctly pull the original
+    publication from the @slack._previous_publication, otherwise it uses the default publication.
     """
 
     def publish(self, alert, publication):
@@ -217,7 +217,11 @@ class AttachStringTemplate(AlertPublisher):
 
     @staticmethod
     def _get_template_args(_, publication):
-        return publication['_previous_publication']
+        return (
+            publication['@slack._previous_publication']
+            if '@slack._previous_publication' in publication
+            else publication
+        )
 
     @staticmethod
     def _color():

--- a/stream_alert/shared/description.py
+++ b/stream_alert/shared/description.py
@@ -121,23 +121,23 @@ class RuleDescriptionParser(object):
             if not isinstance(lines, list) or len(lines) <= 0:
                 return ''
 
-            previous_line_empty = False
             document = None
+            buffered_newlines = ''
             for line in lines:
                 if not line:
-                    previous_line_empty = True
+                    buffered_newlines += '\n'
                     continue
 
                 if document is None:
-                    previous_line_empty = False
+                    buffered_newlines = ''
                     document = line
                 else:
                     match = cls._URL_REGEX.match(document + line)
                     if match is not None:
                         document += line
                     else:
-                        space = '\n\n' if previous_line_empty else ' '
-                        previous_line_empty = False
+                        space = buffered_newlines if buffered_newlines else ' '
+                        buffered_newlines = ''
                         document += space + line
 
             if document is None:

--- a/tests/unit/stream_alert_shared/test_description.py
+++ b/tests/unit/stream_alert_shared/test_description.py
@@ -287,6 +287,9 @@ description:
 
     However a double linebreak will cause a real newline character 
     to appear in the final product.
+
+
+    And double linebreaks cause double newlines.
 '''
 
         data = RuleDescriptionParser.present(case)
@@ -295,9 +298,11 @@ description:
             'description': (
                 'This is a long description where normal linebreaks like '
                 'this one will simply cause the sentence to continue flowing '
-                'as normal.\n\n'
+                'as normal.\n'
                 'However a double linebreak will cause a real newline character '
                 'to appear in the final product.'
+                '\n\n'
+                'And double linebreaks cause double newlines.'
             ),
             'fields': {}
         })
@@ -316,7 +321,7 @@ description:
         assert_equal(data, {
             'author': '',
             'description': (
-                'https://airbnb.com\n\n'
+                'https://airbnb.com\n'
                 'The above url is line broken from this comment.'
             ),
             'fields': {}


### PR DESCRIPTION
to: @ryandeivert or @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

A feature request to add an even-more-customizable slack message, instead of forcing a dict which is harder to read.

## Changes

* Adds new AttachStringTemplate publisher
* Minor cosmetic improvements to the rule description parser
* Better scopes the `_previous_publication` to `@slack._previous_publication` to reduce data bleeding

## Testing

CI + tested on stage
