### PR TITLE
[Publishers] Adds support for images on Pagerduty v2

### DIFF
--- a/publishers/community/pagerduty/pagerduty_layout.py
+++ b/publishers/community/pagerduty/pagerduty_layout.py
@@ -106,3 +106,45 @@ class PrettyPrintArrays(StringifyArrays):
         hello world
     """
     DELIMITER = '\n\n----------\n\n'
+
+
+@Register
+class AttachImage(StringifyArrays):
+    """Attaches the given image to the PagerDuty request
+
+    Works for both the v1 and v2 event api integrations.
+
+    It is recommended to subclass this class with your own implementation of _image_url(),
+    _click_url() and _alt_text() so that you can customize your own image.
+    """
+    IMAGE_URL = 'https://streamalert.io/en/stable/_images/sa-banner.png'
+    IMAGE_CLICK_URL = 'https://streamalert.io/en/stable/'
+    IMAGE_ALT_TEXT = 'StreamAlert Docs'
+
+    def publish(self, alert, publication):
+        publication['@pagerduty-v2.images'] = publication.get('@pagerduty-v2.images', [])
+        publication['@pagerduty-v2.images'].append({
+            'src': self._image_url(),
+            'href': self._click_url(),
+            'alt': self._alt_text(),
+        })
+
+        publication['@pagerduty.contexts'] = publication.get('@pagerduty.contexts', [])
+        publication['@pagerduty.contexts'].append({
+            'type': 'image',
+            'src': self._image_url(),
+        })
+
+        return publication
+
+    @classmethod
+    def _image_url(cls):
+        return cls.IMAGE_URL
+
+    @classmethod
+    def _click_url(cls):
+        return cls.IMAGE_CLICK_URL
+
+    @classmethod
+    def _alt_text(cls):
+        return cls.IMAGE_ALT_TEXT

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -312,7 +312,7 @@ class PagerDutyOutput(OutputDispatcher):
                 return False
 
             if context['type'] == 'link':
-                if 'href' not in context:
+                if 'href' not in context or 'text' not in context:
                     return False
             elif context['type'] == 'image':
                 if 'src' not in context:
@@ -322,7 +322,19 @@ class PagerDutyOutput(OutputDispatcher):
 
             return True
 
-        return [x for x in contexts if is_valid_context(x)]
+        def standardize_context(context):
+            if context['type'] == 'link':
+                return {
+                    'type': 'link',
+                    'href': context['href'],
+                    'text': context['text'],
+                }
+            return {
+                'type': 'image',
+                'src': context['src'],
+            }
+
+        return [standardize_context(x) for x in contexts if is_valid_context(x)]
 
 
 @StreamAlertOutput

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -102,6 +102,12 @@ class EventsV2DataProvider(object):
         summary = publication.get('@pagerduty-v2.summary', default_summary)
         details = publication.get('@pagerduty-v2.custom_details', default_custom_details)
         severity = publication.get('@pagerduty-v2.severity', default_severity)
+        client_url = publication.get('@pagerduty-v2.client_url', None)
+        images = self._standardize_images(publication.get('@pagerduty-v2.images', []))
+        links = self._standardize_links(publication.get('@pagerduty-v2.links', []))
+        component = publication.get('@pagerduty-v2.component', None)
+        group = publication.get('@pagerduty-v2.group', None)
+        alert_class = publication.get('@pagerduty-v2.class', None)
 
         # Structure: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         return {
@@ -120,14 +126,59 @@ class EventsV2DataProvider(object):
 
                 # When provided, must be in valid ISO 8601 format
                 # 'timestamp': '',
-                # 'component': '',
-                # 'group': '',
-                # 'class': '',
-                # 'images': [],
-                # 'links': [],
+                'component': component,
+                'group': group,
+                'class': alert_class,
             },
-            'client': 'StreamAlert'
+            'client': 'StreamAlert',
+            'client_url': client_url,
+            'images': images,
+            'links': links,
         }
+
+    @staticmethod
+    def _standardize_images(images):
+        """Strips invalid images out of the images argument
+
+        Images should be dicts with 3 keys:
+            - src: The full http URL of the image
+            - href: A URL that the image opens when clicked (Optional)
+            - alt: Alt text (Optional)
+        """
+        if not isinstance(images, list):
+            return []
+
+        return [
+            {
+                # Notably, if href is provided but is an invalid URL, the entire image will
+                # be entirely omitted from the incident... beware.
+                'src': image['src'],
+                'href': image['href'] if 'href' in image else '',
+                'alt': image['alt'] if 'alt' in image else '',
+            }
+            for image in images
+            if isinstance(image, dict) and 'src' in image
+        ]
+
+    @staticmethod
+    def _standardize_links(links):
+        """Strips invalid links out of the links argument
+
+        Images should be dicts with 2 keys:
+           - href: A URL of the link
+           - text: Text of the link (Optional: Defaults to the href if no text given)
+        """
+        if not isinstance(links, list):
+            return []
+
+        return [
+            {
+                'href': link['href'],
+                'text': link['text'] if 'text' in link else link['href'],
+            }
+            for link in links
+            if isinstance(link, dict) and 'href' in link
+        ]
 
 
 @StreamAlertOutput

--- a/stream_alert/shared/publisher.py
+++ b/stream_alert/shared/publisher.py
@@ -94,7 +94,7 @@ class CompositePublisher(AlertPublisher):
             except KeyError:
                 LOGGER.exception(
                     'CompositePublisher encountered KeyError with publisher: %s',
-                    publisher.__name__
+                    publisher.__class__.__name__
                 )
                 raise
 

--- a/tests/unit/publishers/community/pagerduty/test_pagerduty_layout.py
+++ b/tests/unit/publishers/community/pagerduty/test_pagerduty_layout.py
@@ -193,3 +193,37 @@ def test_pretty_print_arrays():
         'cb_server': 'cbserver'
     }
     assert_equal(publication, expectation)
+
+
+def test_attach_image():
+    """Publishers - PagerDuty - AttachImage"""
+    alert = get_alert()
+    alert.created = datetime(2019, 1, 1)
+    alert.publishers = {
+        'pagerduty': [
+            'publishers.community.pagerduty.pagerduty_layout.AttachImage'
+        ]
+    }
+
+    output = MagicMock(spec=OutputDispatcher)
+    output.__service__ = 'pagerduty'
+    descriptor = 'unit_test_channel'
+
+    publication = compose_alert(alert, output, descriptor)
+
+    expectation = {
+        '@pagerduty-v2.images': [
+            {
+                'src': 'https://streamalert.io/en/stable/_images/sa-banner.png',
+                'alt': 'StreamAlert Docs',
+                'href': 'https://streamalert.io/en/stable/'
+            }
+        ],
+        '@pagerduty.contexts': [
+            {
+                'src': 'https://streamalert.io/en/stable/_images/sa-banner.png',
+                'type': 'image'
+            }
+        ]
+    }
+    assert_equal(publication, expectation)

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -149,7 +149,9 @@ class TestPagerDutyOutputV2(object):
             'http://pagerduty.foo.bar/create_event.json',
             headers=None,
             json={
-                'event_action': 'trigger', 'client': 'StreamAlert',
+                'event_action': 'trigger',
+                'client': 'StreamAlert',
+                'client_url': None,
                 'payload': {
                     'custom_details': OrderedDict(
                         [
@@ -166,9 +168,14 @@ class TestPagerDutyOutputV2(object):
                     ),
                     'source': 'carbonblack:binarystore.file.added',
                     'severity': 'critical',
-                    'summary': 'StreamAlert Rule Triggered - cb_binarystore_file_added'
+                    'summary': 'StreamAlert Rule Triggered - cb_binarystore_file_added',
+                    'component': None,
+                    'group': None,
+                    'class': None,
                 },
                 'routing_key': 'mocked_routing_key',
+                'images': [],
+                'links': [],
             },
             timeout=3.05, verify=True
         )
@@ -487,6 +494,7 @@ class TestPagerDutyIncidentOutput(object):
             json={
                 'event_action': 'trigger',
                 'client': 'StreamAlert',
+                'client_url': None,
                 'payload': {
                     'custom_details': OrderedDict(
                         [
@@ -503,9 +511,14 @@ class TestPagerDutyIncidentOutput(object):
                     ),
                     'source': 'carbonblack:binarystore.file.added',
                     'severity': 'critical',
-                    'summary': 'StreamAlert Rule Triggered - cb_binarystore_file_added'
+                    'summary': 'StreamAlert Rule Triggered - cb_binarystore_file_added',
+                    'component': None,
+                    'group': None,
+                    'class': None,
                 },
                 'routing_key': 'mocked_key',
+                'images': [],
+                'links': [],
             },
             timeout=3.05, verify=True
         )


### PR DESCRIPTION
to: @chunyong-lin or @ryandeivert 
cc: @airbnb/streamalert-maintainers

## Background

Nice to have

## Changes

* Add code support for images on pagerduty-v2. v1 was already supported.
* Adds a new publisher, `AttachImage` that attaches images. It's meant to be subclassed.
* (MInor) adds support for `component`, `group`, and `class` on Pagerduty v2, which aren't really major features but they're nice to have.

## Testing

CI + Tested on Staging
