### PR TITLE
Make PagerDuty output idempotent; adds support for responder requests

### DIFF
--- a/stream_alert/alert_processor/outputs/output_base.py
+++ b/stream_alert/alert_processor/outputs/output_base.py
@@ -43,6 +43,10 @@ OutputProperty.__new__.__defaults__ = ('', '', {' ', ':'}, False, False)
 class OutputRequestFailure(Exception):
     """OutputRequestFailure handles any HTTP failures"""
 
+    def __init__(self, response):
+        super(OutputRequestFailure, self).__init__()
+        self.response = response
+
 
 def retry_on_exception(exceptions):
     """Decorator function to attempt retry based on passed exceptions"""
@@ -222,7 +226,7 @@ class OutputDispatcher(object):
             resp = cls._put_request(url, params, headers, verify)
             success = cls._check_http_response(resp)
             if not success:
-                raise OutputRequestFailure()
+                raise OutputRequestFailure(resp)
 
             return resp
         return do_put_request()
@@ -263,7 +267,7 @@ class OutputDispatcher(object):
             resp = cls._get_request(url, params, headers, verify)
             success = cls._check_http_response(resp)
             if not success:
-                raise OutputRequestFailure()
+                raise OutputRequestFailure(resp)
 
             return resp
         return do_get_request()
@@ -304,7 +308,7 @@ class OutputDispatcher(object):
             resp = cls._post_request(url, data, headers, verify)
             success = cls._check_http_response(resp)
             if not success:
-                raise OutputRequestFailure()
+                raise OutputRequestFailure(resp)
 
             return resp
         return do_post_request()

--- a/stream_alert/alert_processor/outputs/pagerduty.py
+++ b/stream_alert/alert_processor/outputs/pagerduty.py
@@ -264,6 +264,7 @@ class PagerDutyOutput(OutputDispatcher):
                         {
                             'type': 'link',
                             'href': 'https://streamalert.io/',
+                            'text': 'Link Text'
                         }
 
                     Image embed

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -16,7 +16,7 @@ limitations under the License.
 # pylint: disable=protected-access,attribute-defined-outside-init,too-many-lines,invalid-name
 import re
 from collections import OrderedDict
-from mock import patch, PropertyMock, Mock, MagicMock, call
+from mock import patch, Mock, MagicMock, call
 from nose.tools import assert_equal, assert_false, assert_true
 
 from stream_alert.alert_processor.outputs.output_base import OutputDispatcher, OutputRequestFailure
@@ -1245,7 +1245,7 @@ class RequestMocker(object):
 
                 if is_condition_match:
                     _mock_response = MagicMock()
-                    _mock_response.status_code = 200
+                    _mock_response.status_code = status_code
                     _mock_response.json.return_value = response
                     return _mock_response
 
@@ -1254,4 +1254,3 @@ class RequestMocker(object):
             return _404_response
 
         get_mock.side_effect = _mocked_call
-

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -145,8 +145,14 @@ class TestPagerDutyOutput(object):
                 'client_url': '',
                 'event_type': 'trigger',
                 'contexts': [
-                    {'text': 'Link text', 'href': 'https://streamalert.io', 'type': 'link'},
-                    {'src': 'https://streamalert.io/en/stable/_images/sa-complete-arch.png', 'type': 'image'}
+                    {
+                        'text': 'Link text',
+                        'href': 'https://streamalert.io', 'type': 'link'
+                    },
+                    {
+                        'src': 'https://streamalert.io/en/stable/_images/sa-complete-arch.png',
+                        'type': 'image'
+                    }
                 ],
                 'client': 'streamalert',
                 'details': {

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -1019,7 +1019,7 @@ class TestPagerDutyIncidentOutput(object):
             },
             json={
                 'requester_id': 'valid_user_id',
-                'message': 'I am tea kettle short and stout',
+                'message': 'An incident was reported that requires your attention.',
                 'responder_request_targets': [
                     {
                         'responder_request_target': {


### PR DESCRIPTION
to: @ryandeivert or @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

The `pagerduty-incident` code used to have a serious bug where, due to the way it would sequence multiple write methods non-atomically, it could result in a situation where a Pagerduty alert is sent but the output fails. This results in the alert retrying, creating *another* Pagerduty alert, then failing again... repeating ad infinitum.

## Changes

This PR introduces two concepts:

### Reduced number of write calls

PagerDuty's code used to do the following:

* `POST /incidents` (Create an incident container)
* `POST /events/enqueue` (Create an alert)
* `GET /incidents?dedup_key=???` (Find the alert-incident)
* `PUT /incidents/#/merge?incident_id=???` (Merge the alert-incident into the incident container)

I found that this was redundant; the workflow is optimized now:

* `POST /events/enqueue` (Create an alert)
* `GET /incidents?dedup_key=???` (Find the alert's incident)
* `PUT /incidents` (Modify the alert's incident)

Fewer API calls means the code is cleaner and easier to understand. Also it only has `POST` method, which reduces the number of non-idempotent write API calls.

### Idempotency

PagerDuty's `pagerduty-incident` output is now idempotent. The `POST /events/enqueue` API call
now leverages a `dedup_key` that is equal to the **Alert ID**.

The usage of a `dedup_key` ensures that any unique StreamAlert alert will only ever create a single PagerDuty alert. Subsequent retries will cause PagerDuty to return the previously created alert.


### Responder Requests

I added a new PagerDuty feature that allows the Alert to leverage [Responder Requests](https://api-reference.pagerduty.com/#!/Incidents/post_incidents_id_responder_requests). This is a neat feature that allows you to invite people **other** than the assignee to join in the PagerDuty.

It shows up like this on the PD UI.

![image](https://user-images.githubusercontent.com/13323701/57155056-4b255700-6d8f-11e9-8137-1ead72a558b5.png)

All members of the response team get all notification (push notification/SMS/etc) related to the Alert **_except_** escalation notices. These stay with the assignee.

The awesome benefit here is that we can have PagerDuty alerts stick to a single escalation policy, but attach more watchers.

You can add responder requests to an alert using `context`:

```
context={
  responders=['derek1@email.com', 'derek2@email.com' ...],
  responder_message='This message shows up on their request',
}
```



## Testing

CI, Plus I tried
it on Stage A lot. I think 
it bothered people


