### PR TITLE
[apps] add Intercom app integration

### DIFF
--- a/docs/source/app-configuration.rst
+++ b/docs/source/app-configuration.rst
@@ -54,6 +54,10 @@ Supported Services
   - Access Logs
   - Integrations Logs
 
+* `Intercom <https://developers.intercom.com/intercom-api-reference/reference#view-admin-activity-logs>`_
+
+- Admin Activity Logs
+
 * *More to come*
 
 
@@ -163,3 +167,11 @@ The Aliyun API requires an access key and access key secret for an authorized us
 To obtain the access key and access key secret, an authorized user of the Aliyun account should follow their directions to `Create an Access Key <https://www.alibabacloud.com/help/doc-detail/53045.htm>`_.
 
 Additionly, the user for whom the access key was created must have sufficient privileges to make use of ActionTrail; follow the directions on the `Grant ActionTrail permissions to RAM users <https://www.alibabacloud.com/help/doc-detail/28818.htm>`_ page.
+
+How to set up the Intercom App
+------------------------------
+
+The Intercom API requires an access token. Get an access token by following these `instructions <https://developers.intercom.com/building-apps/docs/authorization#section-how-to-get-an-access-token>`_.
+
+To specify an API version, follow `these instructions <https://developers.intercom.com/building-apps/docs/api-versioning>`_ to do so through Intercom's Developer Hub. 
+The default will be the latest stable version. The Intercom app works on versions 1.2 or later. 

--- a/stream_alert/apps/_apps/README.rst
+++ b/stream_alert/apps/_apps/README.rst
@@ -8,11 +8,11 @@ To obtain the access key and access key secret, an authorized user of the Aliyun
 Additionly, the user for whom the access key was created must have sufficient privileges to make use of ActionTrail; follow the directions on the `Grant ActionTrail permissions to RAM users <https://www.alibabacloud.com/help/doc-detail/28818.htm>`_ page.
 
 How to set up the intercom app
-###########################
+##############################
 
-The Intercom API requires an access token. Get an access token by following `these instructions <https://developers.intercom.com/building-apps/docs/authorization#section-how-to-get-an-access-token>`.
+The Intercom API requires an access token. Get an access token by following `these instructions <https://developers.intercom.com/building-apps/docs/authorization#section-how-to-get-an-access-token>`_.
 
-To specify an API version, follow `these instructions <https://developers.intercom.com/building-apps/docs/api-versioning>` to do so through Intercom's Developer Hub. 
+To specify an API version, follow `these instructions <https://developers.intercom.com/building-apps/docs/api-versioning>`_ to do so through Intercom's Developer Hub. 
 The default will be the latest stable version. The Intercom app works on versions 1.2 or later. 
 
 How to set up the slack app

--- a/stream_alert/apps/_apps/README.rst
+++ b/stream_alert/apps/_apps/README.rst
@@ -7,6 +7,14 @@ To obtain the access key and access key secret, an authorized user of the Aliyun
 
 Additionly, the user for whom the access key was created must have sufficient privileges to make use of ActionTrail; follow the directions on the `Grant ActionTrail permissions to RAM users <https://www.alibabacloud.com/help/doc-detail/28818.htm>`_ page.
 
+How to set up the intercom app
+###########################
+
+The Intercom API requires an access token. Get an access token by following `these instructions <https://developers.intercom.com/building-apps/docs/authorization#section-how-to-get-an-access-token>`.
+
+To specify an API version, follow `these instructions <https://developers.intercom.com/building-apps/docs/api-versioning>` to do so through Intercom's Developer Hub. 
+The default will be the latest stable version. The Intercom app works on versions 1.2 or later. 
+
 How to set up the slack app
 ###########################
 

--- a/stream_alert/apps/_apps/intercom.py
+++ b/stream_alert/apps/_apps/intercom.py
@@ -1,0 +1,103 @@
+import time
+import re
+
+import requests
+
+from . import AppIntegration, StreamAlertApp, get_logger
+
+
+LOGGER = get_logger(__name__)
+
+
+@StreamAlertApp
+class IntercomApp(AppIntegration):
+    """Intercom StreamAlert app"""
+    _INTERCOM_LOGS_URL = 'https://api.intercom.io/admins/activity_logs'
+
+    def __init__(self, event, config):
+        super(IntercomApp, self).__init__(event, config)
+        self._next_page = None
+
+    @classmethod
+    def _type(cls):
+        return 'admin_activity_logs'
+
+    @classmethod
+    def service(cls):
+        return 'intercom'
+
+    @classmethod
+    def _required_auth_info(cls):
+        return {
+            'token': {
+                'description': 'the OAuth token for this Intercom app',
+                'format': re.compile(r'.*')
+            }
+        }
+
+    def _sleep_seconds(self):
+        """Return the number of seconds this polling function should sleep for
+        between requests to avoid failed requests. Intercom API allows for a default of 500 requests
+        every minute, distributed over 10 seconds periods. This means for a default rate limit of
+        500 per minute, you can send a maximum of 83 operations per 10 second period.
+
+        Resource(s):
+            https://developers.intercom.com/intercom-api-reference/reference#rate-limiting
+
+        Returns:
+            int: Number of seconds that this function should sleep for between requests
+        """
+        return 10
+
+    def _gather_logs(self):
+        # Generate headers
+        headers = {'Authorization': "Bearer %s" % self._config.auth['token'],
+                   'Accept': 'application/json'}
+
+        # Results are paginated with a page url field provided that is used in subsequent queries.
+        # If this field exists, make a a query to the page url, and if not, make a fresh query to
+        # the default _INTERCOM_LOGS_URL with the required created_at_before and created_at_after
+        # parameters
+        if self._next_page:
+            params = None
+            url = self._next_page
+        else:
+            params = {'created_at_before': int(time.time()),
+                      'created_at_after': self._last_timestamp}
+            url = self._INTERCOM_LOGS_URL
+
+        LOGGER.info("Requesting events from: %s params: %s", url, params)
+
+        try:
+            result, response = self._make_get_request(url, headers=headers, params=params)
+        except requests.exceptions.ConnectionError:
+            LOGGER.exception('Received bad response from Intercom')
+            return False
+
+        if not result:
+            return False
+
+        activities = [
+            activity
+            for activity
+            in response['activity_logs']
+            if int(activity['created_at']) > self._last_timestamp]
+
+        if not activities:
+            return False
+
+        # Save next page url if any for paginated results
+        if response['pages']['next'] is not None:
+            self._more_to_poll = True
+            self._next_page = response['pages']['next']
+        else:
+            self._more_to_poll = False
+            self._next_page = None
+
+        most_recent_timestamp = max(int(activity['created_at']) for activity in activities)
+
+        # Save most recent time stamp for the next query
+        if most_recent_timestamp > self._last_timestamp:
+            self._last_timestamp = most_recent_timestamp
+
+        return activities

--- a/stream_alert/apps/_apps/intercom.py
+++ b/stream_alert/apps/_apps/intercom.py
@@ -1,3 +1,4 @@
+import calendar
 import time
 import re
 
@@ -30,7 +31,7 @@ class IntercomApp(AppIntegration):
     def _required_auth_info(cls):
         return {
             'token': {
-                'description': 'the OAuth token for this Intercom app',
+                'description': 'the access token for this Intercom app',
                 'format': re.compile(r'.*')
             }
         }
@@ -39,7 +40,8 @@ class IntercomApp(AppIntegration):
         """Return the number of seconds this polling function should sleep for
         between requests to avoid failed requests. Intercom API allows for a default of 500 requests
         every minute, distributed over 10 seconds periods. This means for a default rate limit of
-        500 per minute, you can send a maximum of 83 operations per 10 second period.
+        500 per minute, you can send a maximum of 83 operations per 10 second period. It's unlikely
+        we will hit that limit, so this can default to 0.
 
         Resource(s):
             https://developers.intercom.com/intercom-api-reference/reference#rate-limiting
@@ -47,7 +49,7 @@ class IntercomApp(AppIntegration):
         Returns:
             int: Number of seconds that this function should sleep for between requests
         """
-        return 10
+        return 0
 
     def _gather_logs(self):
         # Generate headers
@@ -62,7 +64,7 @@ class IntercomApp(AppIntegration):
             params = None
             url = self._next_page
         else:
-            params = {'created_at_before': int(time.time()),
+            params = {'created_at_before': int(calendar.timegm(time.gmtime())),
                       'created_at_after': self._last_timestamp}
             url = self._INTERCOM_LOGS_URL
 

--- a/stream_alert/apps/_apps/intercom.py
+++ b/stream_alert/apps/_apps/intercom.py
@@ -32,7 +32,7 @@ class IntercomApp(AppIntegration):
         return {
             'token': {
                 'description': 'the access token for this Intercom app',
-                'format': re.compile(r'.*')
+                'format': re.compile(r'^dG9r([0-9A-Za-z+\/=]*)$')
             }
         }
 

--- a/tests/unit/stream_alert_apps/test_apps/test_app_base.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_app_base.py
@@ -56,6 +56,7 @@ class TestStreamAlertApp(object):
             'gsuite_rules',
             'gsuite_saml',
             'gsuite_token',
+            'intercom_admin_activity_logs',
             'onelogin_events',
             'salesforce_console',
             'salesforce_login',

--- a/tests/unit/stream_alert_apps/test_apps/test_intercom.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_intercom.py
@@ -1,0 +1,237 @@
+import os
+
+from mock import Mock, patch
+from moto import mock_ssm
+from nose.tools import (
+    assert_equal, assert_false, assert_items_equal, assert_is_none
+)
+# import requests
+
+from stream_alert.apps._apps.intercom import IntercomApp
+from tests.unit.stream_alert_apps.test_helpers import (
+    get_event,
+    put_mock_params
+)
+from tests.unit.stream_alert_shared.test_config import get_mock_lambda_context
+
+
+@mock_ssm
+class TestIntercomApp(object):
+    """Test class for the IntercomApp"""
+    # pylint: disable=protected-access
+
+    @patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'us-east-1'})
+    def setup(self):
+        """Setup before each method"""
+        # pylint: disable=abstract-class-instantiated,attribute-defined-outside-init
+        self._test_app_name = 'intercom'
+        put_mock_params(self._test_app_name)
+        self._event = get_event(self._test_app_name)
+        self._context = get_mock_lambda_context(self._test_app_name)
+        self._app = IntercomApp(self._event, self._context)
+        self._app._config.auth['token'] = 'good_token'
+
+    def test_required_auth_info(self):
+        """IntercomApp - Required Auth Info"""
+        assert_items_equal(self._app._required_auth_info().keys(),
+                           {'token'})
+
+    @staticmethod
+    def _get_sample_access_logs():
+        """Sample logs"""
+        return {
+            'type': 'activity_log.list',
+            'pages': {
+                'type': 'pages',
+                'next': None,
+                'page': 1,
+                'per_page': 20,
+                'total_pages': 1
+            },
+            'activity_logs': [
+                {
+                    'id': '1234',
+                    'performed_by': {
+                        'type': 'admin',
+                        'id': '4321',
+                        'email': 'cool.admin@company.com',
+                        'ip': '10.27.91.27'
+                    },
+                    'metadata': {
+                        'sign_in_method': 'email'
+                    },
+                    'created_at': '1537130098',
+                    'activity_type': 'admin_login_success',
+                    'activity_description': 'Cool Admin successfully logged in.'
+                },
+                {
+                    'id': '1235',
+                    'performed_by': {
+                        'type': 'admin',
+                        'id': '5321',
+                        'email': 'also.cool.admin@company.com',
+                        'ip': '79.120.152.79'
+                    },
+                    'metadata': {
+                        'message': {
+                            'id': '5678',
+                            'title': 'All things cool'
+                        },
+                        'before': 'draft',
+                        'after': 'live'
+                    },
+                    'created_at': '1537218403',
+                    'activity_type': 'message_state_change',
+                    'activity_description':
+                    'Also Cool Admin changed your All things cool message from draft to live.'
+                },
+            ]
+        }
+
+    def test_headers(self):
+        return {'Authorization': "Bearer %s" % self._app._config.auth['token'],
+                'Accept': 'application/json'}
+
+    @patch('requests.get')
+    def test_gather_intercom_logs_bad_response(self, requests_mock):
+        """IntercomApp - Gather Logs, Bad Response"""
+        requests_mock.return_value = Mock(
+            status_code=404,
+            content='something went wrong')
+
+        assert_false(self._app._gather_logs())
+
+        # The .json should be called on the response once, to return the response.
+        assert_equal(requests_mock.return_value.json.call_count, 1)
+
+    @patch('time.time')
+    @patch('requests.get')
+    def test_gather_intercom_logs_no_pagination(self, requests_mock, time_mock):
+        """IntercomApp - Gather Logs No Pagination"""
+        logs = self._get_sample_access_logs()
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=logs)
+        )
+
+        time_mock.return_value = 100
+
+        gathered_logs = self._app._gather_logs()
+
+        params = {
+            'created_at_before': 100,
+            'created_at_after': 0
+        }
+
+        assert_equal(len(gathered_logs), 2)
+        assert_false(self._app._more_to_poll)
+        assert_is_none(self._app._next_page)
+        requests_mock.assert_called_once_with(
+            self._app._INTERCOM_LOGS_URL,
+            headers=self.test_headers(),
+            params=params,
+            timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
+
+    @patch('time.time')
+    @patch('requests.get')
+    def test_gather_intercom_logs_response_with_next_page(self, requests_mock, time_mock):
+        """IntercomApp - Gather Logs Next Page"""
+        logs = self._get_sample_access_logs()
+        logs['pages']['next'] = '1234abc'
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=logs)
+        )
+
+        time_mock.return_value = 100
+
+        gathered_logs = self._app._gather_logs()
+
+        params = {
+            'created_at_before': 100,
+            'created_at_after': 0
+        }
+
+        assert_equal(len(gathered_logs), 2)
+        assert_equal(self._app._more_to_poll, True)
+        assert_equal(self._app._next_page, '1234abc')
+        requests_mock.assert_called_once_with(
+            self._app._INTERCOM_LOGS_URL,
+            headers=self.test_headers(),
+            params=params,
+            timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
+
+    @patch('requests.get')
+    def test_gather_intercom_logs_pagination(self, requests_mock):
+        """IntercomApp - Gather Logs Pagination"""
+        logs = self._get_sample_access_logs()
+        self._app._next_page = '567cde'
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=logs)
+        )
+
+        gathered_logs = self._app._gather_logs()
+
+        assert_equal(len(gathered_logs), 2)
+        requests_mock.assert_called_once_with(
+            '567cde',
+            headers=self.test_headers(),
+            params=None,
+            timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
+
+    @patch('time.time')
+    @patch('requests.get')
+    def test_gather_intercom_logs_setting_last_timestamp(self, requests_mock, time_mock):
+        """IntercomApp - Gather Logs Setting _last_timestamp"""
+        logs = self._get_sample_access_logs()
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=logs)
+        )
+
+        time_mock.return_value = 100
+        assert_equal(self._app._last_timestamp, 0)
+
+        gathered_logs = self._app._gather_logs()
+
+        params = {
+            'created_at_before': 100,
+            'created_at_after': 0
+        }
+
+        assert_equal(len(gathered_logs), 2)
+        assert_equal(self._app._last_timestamp, 1537218403)
+        requests_mock.assert_called_once_with(
+            self._app._INTERCOM_LOGS_URL,
+            headers=self.test_headers(),
+            params=params,
+            timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
+
+    @patch('time.time')
+    @patch('requests.get')
+    def test_gather_intercom_logs_by_last_timestamp(self, requests_mock, time_mock):
+        """IntercomApp - Gather Logs Filtering By _last_timestamp"""
+        logs = self._get_sample_access_logs()
+        self._app._last_timestamp = 1537218402
+        requests_mock.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=logs)
+        )
+
+        time_mock.return_value = 100
+
+        gathered_logs = self._app._gather_logs()
+
+        params = {
+            'created_at_before': 100,
+            'created_at_after': 1537218402
+        }
+
+        assert_equal(len(gathered_logs), 1)
+        assert_equal(self._app._last_timestamp, 1537218403)
+        requests_mock.assert_called_once_with(
+            self._app._INTERCOM_LOGS_URL,
+            headers=self.test_headers(),
+            params=params,
+            timeout=self._app._DEFAULT_REQUEST_TIMEOUT)

--- a/tests/unit/stream_alert_apps/test_apps/test_intercom.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_intercom.py
@@ -104,7 +104,7 @@ class TestIntercomApp(object):
         # The .json should be called on the response once, to return the response.
         assert_equal(requests_mock.return_value.json.call_count, 1)
 
-    @patch('time.time')
+    @patch('calendar.timegm')
     @patch('requests.get')
     def test_gather_intercom_logs_no_pagination(self, requests_mock, time_mock):
         """IntercomApp - Gather Logs No Pagination"""
@@ -132,7 +132,7 @@ class TestIntercomApp(object):
             params=params,
             timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
 
-    @patch('time.time')
+    @patch('calendar.timegm')
     @patch('requests.get')
     def test_gather_intercom_logs_response_with_next_page(self, requests_mock, time_mock):
         """IntercomApp - Gather Logs Next Page"""
@@ -180,7 +180,7 @@ class TestIntercomApp(object):
             params=None,
             timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
 
-    @patch('time.time')
+    @patch('calendar.timegm')
     @patch('requests.get')
     def test_gather_intercom_logs_setting_last_timestamp(self, requests_mock, time_mock):
         """IntercomApp - Gather Logs Setting _last_timestamp"""
@@ -208,7 +208,7 @@ class TestIntercomApp(object):
             params=params,
             timeout=self._app._DEFAULT_REQUEST_TIMEOUT)
 
-    @patch('time.time')
+    @patch('calendar.timegm')
     @patch('requests.get')
     def test_gather_intercom_logs_by_last_timestamp(self, requests_mock, time_mock):
         """IntercomApp - Gather Logs Filtering By _last_timestamp"""


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
cc: @patrickod  

## Background

[Intercom](https://github.com/intercom) recently made V1.2 of our API stable. V1.2 introduces a new [**Activity Logs** endpoint](https://developers.intercom.com/building-apps/docs/api-changelog#section-view-activity-logs-for-admins-through-our-api). This endpoint makes it possible to get a log of activities taken by all admins in an app via a GET request. 

We (@catpham on behalf of Intercom Security team) are opening this PR to add an Intercom app integration to Streamalert. We think this would be a useful integration for customers who want to automate and further facilitate their Intercom app activity auditing and alarming.

## Changes

This PR has 3 commits:

1. Adding the Intercom app integration
2. Adding unit tests for the Intercom app integration
3. Updating the README to include instructions on how to use the Intercom app integration

## Testing

We've added unit tests. We've also been using the [**Activity Logs** endpoint](https://developers.intercom.com/building-apps/docs/api-changelog#section-view-activity-logs-for-admins-through-our-api) with the Intercom app integration in our private fork of [Airbnb's Streamalert](https://github.com/airbnb/streamalert) for the past 6 weeks. 