### PR TITLE
Make Terraform version compatibility more explicit

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -8,7 +8,9 @@ Install Dependencies
 --------------------
 
 1. Install Python 2.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
-2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X:
+2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X: 
+
+**NOTE**: Terraform versions newer than 0.11.X are not currently supported.
 
 .. code-block:: bash
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

Terrform 0.12.X required explicit relative paths (using a `./` prefix). See: https://github.com/poseidon/typhoon/pull/457. This breaks things, so we should be more explicit about required version.

## Changes

* Adding terraform required version note

