### PR TITLE
make Terraform version compatibility more explicit

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -10,12 +10,12 @@ Install Dependencies
 1. Install Python 2.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
 2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X: 
 
-.. note:: Terraform versions newer than 0.11.X are not currently supported.
-
 .. code-block:: bash
 
   brew install terraform  # MacOS Homebrew
   terraform --version     # Must be v0.11.X
+  
+.. note:: Terraform versions >= 0.12.X are not currently supported.
 
 3. Install `virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -10,7 +10,7 @@ Install Dependencies
 1. Install Python 2.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
 2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X: 
 
-**NOTE**: Terraform versions newer than 0.11.X are not currently supported.
+.. note:: Terraform versions newer than 0.11.X are not currently supported.
 
 .. code-block:: bash
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -8,7 +8,7 @@ Install Dependencies
 --------------------
 
 1. Install Python 2.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
-2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X: 
+2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X:
 
 .. code-block:: bash
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -8,7 +8,9 @@ Install Dependencies
 --------------------
 
 1. Install Python 2.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
-2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X:
+2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X: 
+
+**NOTE**: Terraform versions newer than 0.11.X are not currently supported.
 
 .. code-block:: bash
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

Terraform 0.12.X requires explicit relative paths (using a ./ prefix). See: poseidon/typhoon#457. This breaks things, so we should be more explicit about required version.

## Changes

* Adding terraform required version note
