### PR TITLE
fixing threat intel bug that caused exception when records contain no potential IOCs

### DIFF
--- a/stream_alert/rules_engine/threat_intel.py
+++ b/stream_alert/rules_engine/threat_intel.py
@@ -91,6 +91,10 @@ class ThreatIntel(object):
         # Extract information from the records for IOC detection
         potential_iocs = self._extract_ioc_values(records)
 
+        if not potential_iocs:
+            LOGGER.debug('No IOCs extracted from records for processing')
+            return
+
         # Query DynamoDB IOC type to verify if the extracted info are malicious IOC(s)
         for valid_ioc in self._process_ioc_values(list(potential_iocs)):
             value = valid_ioc['ioc_value']

--- a/tests/unit/streamalert/rules_engine/test_threat_intel.py
+++ b/tests/unit/streamalert/rules_engine/test_threat_intel.py
@@ -136,6 +136,34 @@ class TestThreatIntel(object):
             self._threat_intel.threat_detection(payloads)
             assert_equal(payloads[0]['record'], expected_result)
 
+    def test_threat_detection_no_iocs(self):
+        """ThreatIntel - Threat Detection, No IOCs"""
+        payloads = [self._sample_payload]
+
+        expected_result = {
+            'account': 12345,
+            'region': 'us-east-1',
+            'detail': {
+                'eventName': 'ConsoleLogin',
+                'userIdentity': {
+                    'userName': 'alice',
+                    'accountId': '12345'
+                },
+                'sourceIPAddress': '1.1.1.2',
+                'recipientAccountId': '12345'
+            },
+            'source': '1.1.1.2',
+            'streamalert:normalization': {
+                'sourceAddress': {'1.1.1.2'},
+                'userName': {'alice'}
+            }
+        }
+
+        with patch.object(self._threat_intel, '_process_ioc_values') as process_mock:
+            process_mock.return_value = []
+            self._threat_intel.threat_detection(payloads)
+            assert_equal(payloads[0]['record'], expected_result)
+
     def test_insert_ioc_info(self):
         """ThreatIntel - Insert IOC Info"""
         record = {


### PR DESCRIPTION
to: @chunyong-lin or @Ryxias 
cc: @airbnb/streamalert-maintainers\
resolves: #942 

## Background

See #942

## Changes

* The param validation error that was occurring happened because there were no "keys" being queried against [here](https://github.com/airbnb/streamalert/blob/60e6e7c8f8de631b4ae3c5e4f6177ac2d360d451/stream_alert/rules_engine/threat_intel.py#L204).

## Testing

Adding a simple unit test to ensure this should be working.
