### PR TITLE
fixing storage of empty values in normalization

### DIFF
--- a/stream_alert/shared/normalize.py
+++ b/stream_alert/shared/normalize.py
@@ -57,10 +57,23 @@ class Normalizer(object):
                 'region': ['us-east-1', 'us-west-2']
             }
         """
-        return {
-            key: sorted(set(cls._extract_values(record, set(keys_to_normalize))))
-            for key, keys_to_normalize in normalized_types.iteritems()
-        }
+        result = {}
+        for key, keys_to_normalize in normalized_types.iteritems():
+            values = set()
+            for value in cls._extract_values(record, set(keys_to_normalize)):
+                # Skip emtpy values
+                if value is None or value == '':
+                    continue
+
+                values.add(value)
+
+            if not values:
+                continue
+
+            result[key] = sorted(values)
+
+        return result
+
 
     @classmethod
     def _extract_values(cls, record, keys_to_normalize):


### PR DESCRIPTION
to: @Ryxias or @chunyong-lin 
cc: @airbnb/streamalert-maintainers
resolves: #942 (actually this time)

## Background

Normalization will currently store empty values, like so:

```
'streamalert:normalization': {
    'userName': [],
    'processPath': []
}
```

and even:
```
'streamalert:normalization': {
    'userName': [''],
}
```
... if there is an empty value for the key.

## Changes

* Updating normalization so it only stores _keys_ if there is in fact a non-empty value to normalize.

## Testing

Adding some unit tests and removing one that is no longer relevant.
