### PR TITLE
Add prefix to classifed logs queue

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -1,6 +1,7 @@
 {
   "account": {
     "aws_account_id": "AWS_ACCOUNT_ID_GOES_HERE",
+    "classifier_use_prefix": "false",
     "kms_key_alias": "PREFIX_GOES_HERE_streamalert_secrets",
     "prefix": "PREFIX_GOES_HERE",
     "region": "us-east-1"

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -209,6 +209,7 @@ def generate_main(config, init=False):
         'account_id': config['global']['account']['aws_account_id'],
         'region': config['global']['account']['region'],
         'prefix': config['global']['account']['prefix'],
+        'classifier_use_prefix': config['global']['account']['classifier_use_prefix'],
         'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
         'alerts_table_read_capacity': (
             config['global']['infrastructure']['alerts_table']['read_capacity']),

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,28 +1,10 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
-# resource "aws_sqs_queue" "classifier_queue_prefixed" {
-#   count = "${var.use_prefix == "true" ? 1 : 0}"
-#   name = "${var.prefix}_streamalert_classified_logs"
-
-#   # The amount of time messages are hidden after being received from a consumer
-#   # Default this to 2 seconds longer than the maximum AWS Lambda duration
-#   visibility_timeout_seconds = "${var.rules_engine_timeout + 2}"
-
-#   # Enable queue encryption of messages in the queue
-#   kms_master_key_id = "${aws_kms_key.sqs_sse.arn}"
-
-#   tags {
-#     Name = "StreamAlert"
-#   }
-# }
-
 locals {
   classifier_prefix = "${var.prefix}_"
 }
 
 resource "aws_sqs_queue" "classifier_queue" {
-  # count = "${var.use_prefix == "true" ?  : 1}"
   name = "${var.classifier_use_prefix == "true" ? local.classifier_prefix : ""}streamalert_classified_logs"
-  # name = "streamalert_classified_logs"
 
   # The amount of time messages are hidden after being received from a consumer
   # Default this to 2 seconds longer than the maximum AWS Lambda duration

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,6 +1,6 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
 resource "aws_sqs_queue" "classifier_queue" {
-  name = "streamalert_classified_logs"
+  name = "${var.prefix}_streamalert_classified_logs"
 
   # The amount of time messages are hidden after being received from a consumer
   # Default this to 2 seconds longer than the maximum AWS Lambda duration

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,6 +1,28 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
+# resource "aws_sqs_queue" "classifier_queue_prefixed" {
+#   count = "${var.use_prefix == "true" ? 1 : 0}"
+#   name = "${var.prefix}_streamalert_classified_logs"
+
+#   # The amount of time messages are hidden after being received from a consumer
+#   # Default this to 2 seconds longer than the maximum AWS Lambda duration
+#   visibility_timeout_seconds = "${var.rules_engine_timeout + 2}"
+
+#   # Enable queue encryption of messages in the queue
+#   kms_master_key_id = "${aws_kms_key.sqs_sse.arn}"
+
+#   tags {
+#     Name = "StreamAlert"
+#   }
+# }
+
+locals {
+  classifier_prefix = "${var.prefix}_"
+}
+
 resource "aws_sqs_queue" "classifier_queue" {
-  name = "${var.prefix}_streamalert_classified_logs"
+  # count = "${var.use_prefix == "true" ?  : 1}"
+  name = "${var.classifier_use_prefix == "true" ? local.classifier_prefix : ""}streamalert_classified_logs"
+  # name = "streamalert_classified_logs"
 
   # The amount of time messages are hidden after being received from a consumer
   # Default this to 2 seconds longer than the maximum AWS Lambda duration

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/variables.tf
@@ -5,3 +5,7 @@ variable "region" {}
 variable "prefix" {}
 
 variable "rules_engine_timeout" {}
+
+variable "classifier_use_prefix" {
+  description = "Allows support for multiple instances of StreamAlert on one account"
+}

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -7,11 +7,12 @@ module "alerts_firehose" {
 }
 
 module "classifier_queue" {
-  source               = "classifier_queue"
-  account_id           = "${var.account_id}"
-  prefix               = "${var.prefix}"
-  region               = "${var.region}"
-  rules_engine_timeout = "${var.rules_engine_timeout}"
+  source                = "classifier_queue"
+  account_id            = "${var.account_id}"
+  prefix                = "${var.prefix}"
+  region                = "${var.region}"
+  rules_engine_timeout  = "${var.rules_engine_timeout}"
+  classifier_use_prefix = "${var.classifier_use_prefix}"
 }
 
 // TODO: Autoscaling

--- a/terraform/modules/tf_stream_alert_globals/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/variables.tf
@@ -2,6 +2,10 @@ variable "account_id" {}
 
 variable "prefix" {}
 
+variable "classifier_use_prefix" {
+   description = "Allows support for multiple instances of StreamAlert on one account"
+}
+
 variable "region" {}
 
 variable "kms_key_arn" {}


### PR DESCRIPTION
to:@airbnb/streamalert-maintainers
resolves: #885

## Background
One AWS account is unable to handle multiple instances of StreamAlert due to the name of the classified logs queue.

This issue was found with running ./manage.py init on a second instance of StreamAlert when there was already an instance set up on an AWS account. The specific error was this:
```Error: Error applying plan:

1 error occurred:
    * module.globals.module.classifier_queue.aws_sqs_queue.classifier_queue: 1 error occurred:
    * aws_sqs_queue.classifier_queue: Error creating SQS queue: QueueAlreadyExists: A queue already exists with the same name and a different value for attribute KmsMasterKeyId
    status code: 400, request id: 1e4d6ff7-2f84-5741-8efb-3a8c6d65b95a
```

## Changes
* Added the prefix to the streamalert_classified_log queue to remove a QueueAlreadyExists conflict

## Testing
After adding a prefix to the classifier queue, I initialized two instances of StreamAlert and ran the following command to test if it worked
`./manage.py test rules`

The 77 provided tests all passed, and here is the full output of the tests below
<details><summary>Full Output</summary>
<p>

```File: cloudwatch/cloudtrail_via_cloudwatch.json

Test #01: Pass

File: cloudwatch/rds_aurora_via_cloudwatch.json

Test #01: Pass
Test #02: Pass
Test #03: Pass

File: box/box_admin_events.json

Test #01: Pass

File: aliyun/aliyun_basic.json

Test #01: Pass
Test #02: Pass
Test #03: Pass
Test #04: Pass

File: mitre_attack/right_to_left_character.json

Test #01: Pass
Test #02: Pass
Test #03: Pass
Test #04: Pass

File: gsuite/gsuite_admin.json

Test #01: Pass

File: binaryalert/binaryalert_yara_match.json

Test #01: Pass
Test #02: Pass

File: onelogin/onelogin_events_assumed_role.json

Test #01: Pass
Test #02: Pass

File: cloudtrail/cloudtrail_critical_api_calls.json

Test #01: Pass
Test #02: Pass
Test #03: Pass
Test #04: Pass
Test #05: Pass
Test #06: Pass
Test #07: Pass
Test #08: Pass

File: cloudtrail/cloudtrail_ec2_image_creation.json

Test #01: Pass
Test #02: Pass

File: cloudtrail/cloudtrail_mfa_policy_abuse_attempt.json

Test #01: Pass
Test #02: Pass
Test #03: Pass
Test #04: Pass

File: cloudtrail/cloudtrail_network_acl_ingress_anywhere.json

Test #01: Pass
Test #02: Pass

File: cloudtrail/cloudtrail_put_bucket_acl.json

Test #01: Pass
Test #02: Pass

File: cloudtrail/cloudtrail_put_object_acl_public.json

Test #01: Pass
Test #02: Pass
Test #03: Pass
Test #04: Pass

File: cloudtrail/cloudtrail_root_account_usage.json

Test #01: Pass
Test #02: Pass

File: cloudtrail/cloudtrail_security_group_ingress_anywhere.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_dismiss_stale_pull_request_approvals.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_protect_this_branch.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_required_pull_request_reviews.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_required_status_checks.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_two_factor_requirement_org.json

Test #01: Pass
Test #02: Pass

File: github/github_disable_two_factor_requirement_user.json

Test #01: Pass
Test #02: Pass

File: github/github_oauth_application_create.json

Test #01: Pass
Test #02: Pass

File: github/github_site_admin_action.json

Test #01: Pass
Test #02: Pass

File: github/github_site_admin_user_promotion.json

Test #01: Pass
Test #02: Pass

File: slack/slack_basic.json

Test #01: Pass
Test #02: Pass
Test #03: Pass

File: guardduty/guard_duty_all.json

Test #01: Pass

File: duo/duo_anonymous_ip_failure.json

Test #01: Pass
Test #02: Pass

File: duo/duo_bypass_code_create_non_auto_generated.json

Test #01: Pass
Test #02: Pass

File: duo/duo_bypass_code_create_non_expiring.json

Test #01: Pass
Test #02: Pass

File: duo/duo_bypass_code_create_unlimited_use.json

Test #01: Pass
Test #02: Pass

File: duo/duo_fraud.json

Test #01: Pass
Test #02: Pass

Summary:

Total Tests: 77
Pass: 77
Fail: 0
```

</p>
</details>
