### PR TITLE
Best practice rules

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -103,7 +103,8 @@
     },
     "sqs_record_batch_size": 10,
     "third_party_libraries": [
-      "pathlib2"
+      "pathlib2",
+      "policyuniverse=1.3.2.0"
     ],
     "timeout": 60,
     "vpc_config": {

--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -104,7 +104,7 @@
     "sqs_record_batch_size": 10,
     "third_party_libraries": [
       "pathlib2",
-      "policyuniverse=1.3.2.0"
+      "policyuniverse"
     ],
     "timeout": 60,
     "vpc_config": {

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -18,6 +18,7 @@ netaddr
 nose
 nose-timer
 pathlib2
+policyuniverse==1.3.2.0
 pyfakefs
 pylint
 requests

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -18,7 +18,7 @@ netaddr
 nose
 nose-timer
 pathlib2
-policyuniverse==1.3.2.0
+policyuniverse
 pyfakefs
 pylint
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ netaddr==0.7.19
 nose==1.3.7
 nose-timer==0.7.3
 pathlib2==2.3.2
+policyuniverse==1.3.2.0
 pyfakefs==3.5.3
 pylint==1.9.3
 requests==2.20.1

--- a/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
+++ b/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
@@ -24,8 +24,9 @@ _CRITICAL_EVENTS = {
     # S3 Public Access Block
     'DeleteAccountPublicAccessBlock',
     # EBS default encryption
-    'DisableEbsEncryptionByDefault'
+    'DisableEbsEncryptionByDefault',
 }
+
 
 @rule(logs=['cloudtrail:events'])
 def cloudtrail_critical_api_calls(rec):
@@ -51,17 +52,20 @@ def cloudtrail_critical_api_calls(rec):
     if rec['eventName'] == 'PutBucketPublicAccessBlock':
         # Check if any of the types of public access for a bucket have been disabled
         config = rec.get('requestParameters', {}).get(
-            'PublicAccessBlockConfiguration', {})
-        if (not config.get('RestrictPublicBuckets', False) and 
-            not config.get('BlockPublicPolicy', False) and 
-            not config.get('BlockPublicPolicy', False) and 
-            not config.get('BlockPublicPolicy', False)):
+            'PublicAccessBlockConfiguration', {}
+        )
+        if (
+                not config.get('RestrictPublicBuckets', False)
+                and not config.get('BlockPublicPolicy', False)
+                and not config.get('BlockPublicPolicy', False)
+                and not config.get('BlockPublicPolicy', False)
+        ):
             return True
 
     # PutAccountPublicAccessBlock does not indicate if the account is
-    # enabling or disabling this feature so to reduce FPs, 
+    # enabling or disabling this feature so to reduce FPs,
     # for now this is not being detected.
-    # This issue was reported to aws-security@amazon.com by spiper 
+    # This issue was reported to aws-security@amazon.com by spiper
     # on 2019.07.09
 
     return False

--- a/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
+++ b/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
@@ -60,7 +60,7 @@ def cloudtrail_critical_api_calls(rec):
                 or config.get('BlockPublicPolicy', False) is False
                 or config.get('BlockPublicAcls', False) is False
                 or config.get('IgnorePublicAcls', False) is False
-        ):
+           ):
             return True
 
     # PutAccountPublicAccessBlock does not indicate if the account is

--- a/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
+++ b/rules/community/cloudtrail/cloudtrail_critical_api_calls.py
@@ -50,15 +50,16 @@ def cloudtrail_critical_api_calls(rec):
             return True
 
     if rec['eventName'] == 'PutBucketPublicAccessBlock':
-        # Check if any of the types of public access for a bucket have been disabled
+        # The call to PutBucketPublicAccessBlock sets the policy for what to
+        # block for a bucket. We need to get the configuration and see if any
+        # of the items are set to False.
         config = rec.get('requestParameters', {}).get(
             'PublicAccessBlockConfiguration', {}
         )
-        if (
-                not config.get('RestrictPublicBuckets', False)
-                and not config.get('BlockPublicPolicy', False)
-                and not config.get('BlockPublicPolicy', False)
-                and not config.get('BlockPublicPolicy', False)
+        if (config.get('RestrictPublicBuckets', False) is False
+                or config.get('BlockPublicPolicy', False) is False
+                or config.get('BlockPublicAcls', False) is False
+                or config.get('IgnorePublicAcls', False) is False
         ):
             return True
 

--- a/rules/community/cloudtrail/cloudtrail_public_resources.py
+++ b/rules/community/cloudtrail/cloudtrail_public_resources.py
@@ -13,63 +13,63 @@ def cloudtrail_public_resources(rec):
                       (b) identify what resource(s) are impacted by the API call
                       (c) determine if the intent is valid, malicious or accidental
     """
-    # Get the policy string for each resource
-    policy_string = ''
-
     # Check S3
     if rec['eventName'] == 'PutBucketPolicy':
         # S3 doesn't use a policy string, but actual json, unlike all
         # other commands
         policy = rec.get('requestParameters', {}).get('bucketPolicy', None)
-        if policy is None:
+        if not policy:
             return False
         policy = Policy(policy)
         if policy.is_internet_accessible():
             return True
+    
+    # Get the policy string for each resource
+    policy_string = ''
 
     # Check ElasticSearch
     if rec['eventName'] == 'CreateElasticsearchDomain':
         policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
-    if rec['eventName'] == 'UpdateElasticsearchDomainConfig':
+    elif rec['eventName'] == 'UpdateElasticsearchDomainConfig':
         policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
 
     # Check Glacier Vaults
-    if rec['eventName'] == 'SetVaultAccessPolicy':
+    elif rec['eventName'] == 'SetVaultAccessPolicy':
         policy_string = (
             rec.get('requestParameters', {}).get('policy', {}).get('policy', '')
         )
 
     # Check SQS
-    if rec['eventName'] == 'SetQueueAttributes':
+    elif rec['eventName'] == 'SetQueueAttributes':
         policy_string = (
             rec.get('requestParameters', {}).get('attributes', {}).get('Policy', '')
         )
 
     # Check SNS
-    if rec['eventName'] == 'SetTopicAttributes':
+    elif rec['eventName'] == 'SetTopicAttributes':
         if rec.get('requestParameters', {}).get('attributeName', '') == 'Policy':
             policy_string = rec['requestParameters'].get('attributeValue', '')
-    if rec['eventName'] == 'CreateTopic':
+    elif rec['eventName'] == 'CreateTopic':
         policy_string = (
             rec.get('requestParameters', {}).get('attributes', '').get('Policy', '')
         )
 
     # Check ECR
-    if rec['eventName'] == 'SetRepositoryPolicy':
+    elif rec['eventName'] == 'SetRepositoryPolicy':
         policy_string = rec.get('requestParameters', {}).get('policyText', '')
 
     # Check KMS
-    if rec['eventName'] == 'PutKeyPolicy':
+    elif rec['eventName'] == 'PutKeyPolicy':
         policy_string = rec.get('requestParameters', {}).get('policy', '')
-    if rec['eventName'] == 'CreateKey':
+    elif rec['eventName'] == 'CreateKey':
         policy_string = rec.get('requestParameters', {}).get('policy', '')
 
     # Check SecretsManager
-    if rec['eventName'] == 'PutResourcePolicy':
+    elif rec['eventName'] == 'PutResourcePolicy':
         policy_string = rec.get('requestParameters', {}).get('resourcePolicy', '')
 
     # Check the policy
-    if policy_string != '':
+    if policy_string:
         policy = json.loads(policy_string)
         policy = Policy(policy)
         if policy.is_internet_accessible():

--- a/rules/community/cloudtrail/cloudtrail_public_resources.py
+++ b/rules/community/cloudtrail/cloudtrail_public_resources.py
@@ -23,7 +23,7 @@ def cloudtrail_public_resources(rec):
         policy = Policy(policy)
         if policy.is_internet_accessible():
             return True
-    
+
     # Get the policy string for each resource
     policy_string = ''
 

--- a/rules/community/cloudtrail/cloudtrail_public_resources.py
+++ b/rules/community/cloudtrail/cloudtrail_public_resources.py
@@ -1,0 +1,75 @@
+"""Alert when resources are made public."""
+from stream_alert.shared.rule import rule
+from policyuniverse.policy import Policy
+import json
+
+
+@rule(logs=['cloudtrail:events'])
+def cloudtrail_public_resources(rec):
+    """
+    author:           spiper
+    description:      Detect resources being made public.
+    
+    playbook:         (a) identify the AWS account in the log
+                      (b) identify what resource(s) are impacted by the API call
+                      (c) determine if the intent is valid, malicious or accidental
+    """
+    # Get the policy string for each resource
+    policy_string = ''
+
+    # Check S3
+    if rec['eventName'] == 'PutBucketPolicy':
+        # S3 doesn't use a policy string, but actual json, unlike all
+        # other commands
+        policy = rec.get('requestParameters', {}).get('bucketPolicy', None)
+        if policy is None:
+            return False
+        policy = Policy(policy)
+        if policy.is_internet_accessible():
+            return True
+
+    # Check ElasticSearch
+    if rec['eventName'] == 'CreateElasticsearchDomain':
+        policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
+    if rec['eventName'] == 'UpdateElasticsearchDomainConfig':
+        policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
+    
+    # Check Glacier Vaults
+    if rec['eventName'] == 'SetVaultAccessPolicy':
+        policy_string = rec.get('requestParameters', {}).get('policy', {}).get('policy', '')
+    
+    # Check SQS
+    if rec['eventName'] == 'SetQueueAttributes':
+        policy_string = rec.get('requestParameters', {}).get('attributes', {}).get('Policy', '')
+
+    # Check SNS
+    if rec['eventName'] == 'SetTopicAttributes':
+        if rec.get('requestParameters', {}).get('attributeName', '') == 'Policy':
+            policy_string = rec['requestParameters'].get('attributeValue','')
+    if rec['eventName'] == 'CreateTopic':
+        policy_string = rec.get('requestParameters', {}).get('attributes', '').get('Policy', '')
+    
+    # Check ECR
+    if rec['eventName'] == 'SetRepositoryPolicy':
+        policy_string = rec.get('requestParameters', {}).get('policyText', '')
+    
+    # Check KMS
+    if rec['eventName'] == 'PutKeyPolicy':
+        policy_string = rec.get('requestParameters', {}).get('policy', '')
+    if rec['eventName'] == 'CreateKey':
+        policy_string = rec.get('requestParameters', {}).get('policy', '')
+    
+    # Check SecretsManager
+    if rec['eventName'] == 'PutResourcePolicy':
+        policy_string = rec.get('requestParameters', {}).get('resourcePolicy', '')
+
+    # Check the policy
+    if policy_string != '':    
+        policy = json.loads(policy_string)
+        policy = Policy(policy)
+        if policy.is_internet_accessible():
+            return True
+
+    return False
+    
+

--- a/rules/community/cloudtrail/cloudtrail_public_resources.py
+++ b/rules/community/cloudtrail/cloudtrail_public_resources.py
@@ -1,15 +1,14 @@
 """Alert when resources are made public."""
-from stream_alert.shared.rule import rule
-from policyuniverse.policy import Policy
 import json
-
+from policyuniverse.policy import Policy
+from stream_alert.shared.rule import rule
 
 @rule(logs=['cloudtrail:events'])
 def cloudtrail_public_resources(rec):
     """
     author:           spiper
     description:      Detect resources being made public.
-    
+
     playbook:         (a) identify the AWS account in the log
                       (b) identify what resource(s) are impacted by the API call
                       (c) determine if the intent is valid, malicious or accidental
@@ -33,43 +32,47 @@ def cloudtrail_public_resources(rec):
         policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
     if rec['eventName'] == 'UpdateElasticsearchDomainConfig':
         policy_string = rec.get('requestParameters', {}).get('accessPolicies', '')
-    
+
     # Check Glacier Vaults
     if rec['eventName'] == 'SetVaultAccessPolicy':
-        policy_string = rec.get('requestParameters', {}).get('policy', {}).get('policy', '')
-    
+        policy_string = (
+            rec.get('requestParameters', {}).get('policy', {}).get('policy', '')
+        )
+
     # Check SQS
     if rec['eventName'] == 'SetQueueAttributes':
-        policy_string = rec.get('requestParameters', {}).get('attributes', {}).get('Policy', '')
+        policy_string = (
+            rec.get('requestParameters', {}).get('attributes', {}).get('Policy', '')
+        )
 
     # Check SNS
     if rec['eventName'] == 'SetTopicAttributes':
         if rec.get('requestParameters', {}).get('attributeName', '') == 'Policy':
-            policy_string = rec['requestParameters'].get('attributeValue','')
+            policy_string = rec['requestParameters'].get('attributeValue', '')
     if rec['eventName'] == 'CreateTopic':
-        policy_string = rec.get('requestParameters', {}).get('attributes', '').get('Policy', '')
-    
+        policy_string = (
+            rec.get('requestParameters', {}).get('attributes', '').get('Policy', '')
+        )
+
     # Check ECR
     if rec['eventName'] == 'SetRepositoryPolicy':
         policy_string = rec.get('requestParameters', {}).get('policyText', '')
-    
+
     # Check KMS
     if rec['eventName'] == 'PutKeyPolicy':
         policy_string = rec.get('requestParameters', {}).get('policy', '')
     if rec['eventName'] == 'CreateKey':
         policy_string = rec.get('requestParameters', {}).get('policy', '')
-    
+
     # Check SecretsManager
     if rec['eventName'] == 'PutResourcePolicy':
         policy_string = rec.get('requestParameters', {}).get('resourcePolicy', '')
 
     # Check the policy
-    if policy_string != '':    
+    if policy_string != '':
         policy = json.loads(policy_string)
         policy = Policy(policy)
         if policy.is_internet_accessible():
             return True
 
     return False
-    
-

--- a/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
+++ b/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
@@ -1,4 +1,4 @@
-"""Alert on destructive AWS API calls."""
+"""Alert on resources made public"""
 from stream_alert.shared.rule import rule
 
 @rule(logs=['cloudtrail:events'])

--- a/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
+++ b/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
@@ -22,7 +22,7 @@ def cloudtrail_snapshot_or_ami_made_public(rec):
         params = rec.get('requestParameters', {})
         if params.get('attributeType', '') == 'launchPermission':
             if 'add' in params.get('launchPermission', {}):
-                items = params['launchPermission']['add']['items']
+                items = params['launchPermission']['add'].get('items', [])
                 for item in items:
                     if item.get('group', '') == 'all':
                         return True
@@ -32,7 +32,7 @@ def cloudtrail_snapshot_or_ami_made_public(rec):
         params = rec.get('requestParameters', {})
         if params.get('attributeType', '') == 'CREATE_VOLUME_PERMISSION':
             if 'add' in params.get('createVolumePermission', {}):
-                items = params['createVolumePermission']['add']['items']
+                items = params['createVolumePermission']['add'].get('items', [])
                 for item in items:
                     if item.get('group', '') == 'all':
                         return True

--- a/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
+++ b/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
@@ -1,11 +1,12 @@
 """Alert on resources made public"""
 from stream_alert.shared.rule import rule
 
+
 @rule(logs=['cloudtrail:events'])
 def cloudtrail_snapshot_or_ami_made_public(rec):
     """
     author:           spiper
-    description:      Alert on AWS API calls that make EBS snapshots, 
+    description:      Alert on AWS API calls that make EBS snapshots,
                         RDS snapshots, or AMIs public.
     playbook:         (a) identify the AWS account in the log
                       (b) identify what resource(s) are impacted by the API call
@@ -13,12 +14,12 @@ def cloudtrail_snapshot_or_ami_made_public(rec):
     """
 
     # For each resouce walk through through the request parameters to check
-    # if this is adding permissions for "all"
+    # if this is adding permissions for 'all'
 
     # Check AMIs
     if rec['eventName'] == 'ModifyImageAttribute':
         # For AMIs
-        params = rec.get('requestParameters', {}) 
+        params = rec.get('requestParameters', {})
         if params.get('attributeType', '') == 'launchPermission':
             if 'add' in params.get('launchPermission', {}):
                 items = params['launchPermission']['add']['items']
@@ -28,18 +29,18 @@ def cloudtrail_snapshot_or_ami_made_public(rec):
 
     # Check EBS snapshots
     if rec['eventName'] == 'ModifySnapshotAttribute':
-        params = rec.get('requestParameters', {}) 
+        params = rec.get('requestParameters', {})
         if params.get('attributeType', '') == 'CREATE_VOLUME_PERMISSION':
             if 'add' in params.get('createVolumePermission', {}):
                 items = params['createVolumePermission']['add']['items']
                 for item in items:
                     if item.get('group', '') == 'all':
                         return True
-    
+
     # Check RDS snapshots
     if rec['eventName'] == 'ModifyDBClusterSnapshotAttribute':
-        params = rec.get('requestParameters', {}) 
+        params = rec.get('requestParameters', {})
         if 'all' in params.get('valuesToAdd', []):
             return True
-    
+
     return False

--- a/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
+++ b/rules/community/cloudtrail/cloudtrail_snapshot_or_ami_made_public.py
@@ -1,0 +1,45 @@
+"""Alert on destructive AWS API calls."""
+from stream_alert.shared.rule import rule
+
+@rule(logs=['cloudtrail:events'])
+def cloudtrail_snapshot_or_ami_made_public(rec):
+    """
+    author:           spiper
+    description:      Alert on AWS API calls that make EBS snapshots, 
+                        RDS snapshots, or AMIs public.
+    playbook:         (a) identify the AWS account in the log
+                      (b) identify what resource(s) are impacted by the API call
+                      (c) determine if the intent is valid, malicious or accidental
+    """
+
+    # For each resouce walk through through the request parameters to check
+    # if this is adding permissions for "all"
+
+    # Check AMIs
+    if rec['eventName'] == 'ModifyImageAttribute':
+        # For AMIs
+        params = rec.get('requestParameters', {}) 
+        if params.get('attributeType', '') == 'launchPermission':
+            if 'add' in params.get('launchPermission', {}):
+                items = params['launchPermission']['add']['items']
+                for item in items:
+                    if item.get('group', '') == 'all':
+                        return True
+
+    # Check EBS snapshots
+    if rec['eventName'] == 'ModifySnapshotAttribute':
+        params = rec.get('requestParameters', {}) 
+        if params.get('attributeType', '') == 'CREATE_VOLUME_PERMISSION':
+            if 'add' in params.get('createVolumePermission', {}):
+                items = params['createVolumePermission']['add']['items']
+                for item in items:
+                    if item.get('group', '') == 'all':
+                        return True
+    
+    # Check RDS snapshots
+    if rec['eventName'] == 'ModifyDBClusterSnapshotAttribute':
+        params = rec.get('requestParameters', {}) 
+        if 'all' in params.get('valuesToAdd', []):
+            return True
+    
+    return False

--- a/stream_alert_cli/manage_lambda/package.py
+++ b/stream_alert_cli/manage_lambda/package.py
@@ -52,6 +52,7 @@ class LambdaPackage(object):
         'jsonlines': 'jsonlines==1.2.0',
         'netaddr': 'netaddr==0.7.19',
         'oauth2client': 'oauth2client==4.1.3',
+        'policyuniverse': 'policyuniverse=1.3.2.0',
         'requests': 'requests==2.20.1',
     }
 
@@ -210,7 +211,7 @@ class RulesEnginePackage(LambdaPackage):
         'stream_alert/shared',
     }
     package_name = 'rules_engine'
-    package_libs = {'netaddr'}
+    package_libs = {'netaddr', 'policyuniverse'}
 
 
 class AlertProcessorPackage(LambdaPackage):

--- a/tests/integration/rules/cloudtrail/cloudtrail_critical_api_calls.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_critical_api_calls.json
@@ -421,5 +421,367 @@
     "service": "s3",
     "source": "prefix.cluster.sample.bucket",
     "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-08T19:44:37Z",
+          "eventSource": "guardduty.amazonaws.com",
+          "eventName": "DeleteDetector",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "",
+          "userAgent": "...",
+          "requestParameters": {
+            "detectorId": ""
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "123aaac1-123d-456a-1k29a4dd2kea",
+          "readOnly": false,
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+        }
+      ]
+    },
+    "description": "Stopping GuardDuty",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_critical_api_calls"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-08T19:44:25Z",
+          "eventSource": "guardduty.amazonaws.com",
+          "eventName": "UpdateDetector",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "detectorId": "...",
+            "enable": false
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "readOnly": false,
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+        }
+      ]
+    },
+    "description": "Disabling GuardDuty",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_critical_api_calls"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-08T19:44:28Z",
+          "eventSource": "guardduty.amazonaws.com",
+          "eventName": "UpdateDetector",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "detectorId": "00000000000000000000000000000000",
+            "enable": true
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "readOnly": false,
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+        }
+      ]
+    },
+    "description": "Enabling GuardDuty. Do not alert",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T15:37:48Z",
+          "eventSource": "s3.amazonaws.com",
+          "eventName": "DeleteAccountPublicAccessBlock",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "host": [
+                  "954574370272.s3-control.us-east-1.amazonaws.com"
+              ]
+          },
+          "responseElements": null,
+          "additionalEventData": {
+              "SignatureVersion": "SigV4",
+              "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+              "AuthenticationMethod": "AuthHeader"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Turning off S3 PublicAccessBlock for an entire account",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_critical_api_calls"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-08T19:50:33Z",
+          "eventSource": "s3.amazonaws.com",
+          "eventName": "PutBucketPublicAccessBlock",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "publicAccessBlock": [
+              ""
+            ],
+            "PublicAccessBlockConfiguration": {
+              "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+              "RestrictPublicBuckets": false,
+              "BlockPublicPolicy": false,
+              "BlockPublicAcls": false,
+              "IgnorePublicAcls": false
+            },
+            "bucketName": "...",
+            "host": [
+              "s3.amazonaws.com"
+            ]
+          },
+          "responseElements": null,
+          "additionalEventData": {
+            "SignatureVersion": "SigV4",
+            "CipherSuite": "ECDHE-RSA-AES128-SHA",
+            "AuthenticationMethod": "AuthHeader",
+            "vpcEndpointId": "..."
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123",
+          "vpcEndpointId": "..."
+        }
+      ]
+    },
+    "description": "Turning off S3 PublicAccessBlock for a single bucket",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_critical_api_calls"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-08T19:50:33Z",
+          "eventSource": "s3.amazonaws.com",
+          "eventName": "PutBucketPublicAccessBlock",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "publicAccessBlock": [
+              ""
+            ],
+            "PublicAccessBlockConfiguration": {
+              "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+              "RestrictPublicBuckets": true,
+              "BlockPublicPolicy": true,
+              "BlockPublicAcls": true,
+              "IgnorePublicAcls": true
+            },
+            "bucketName": "test",
+            "host": [
+              "s3.amazonaws.com"
+            ]
+          },
+          "responseElements": null,
+          "additionalEventData": {
+            "SignatureVersion": "SigV4",
+            "CipherSuite": "ECDHE-RSA-AES128-SHA",
+            "AuthenticationMethod": "AuthHeader",
+            "vpcEndpointId": "..."
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123",
+          "vpcEndpointId": "..."
+        }
+      ]
+    },
+    "description": "Turning on S3 PublicAccessBlock for a single bucket - Do not alert",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "invokedBy": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T16:59:01Z",
+          "eventSource": "ec2.amazonaws.com",
+          "eventName": "DisableEbsEncryptionByDefault",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "DisableEbsEncryptionByDefaultRequest": {}
+          },
+          "responseElements": {
+              "DisableEbsEncryptionByDefaultResponse": {
+                  "xmlns": "http://ec2.amazonaws.com/doc/2016-11-15/",
+                  "ebsEncryptionByDefault": false,
+                  "requestId": "19a19cd8-5f1b-4d5e-8af4-3e826fa03d0f"
+              }
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Disabling default EBS encryption",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_critical_api_calls"
+    ]
   }
 ]

--- a/tests/integration/rules/cloudtrail/cloudtrail_public_resources.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_public_resources.json
@@ -1,0 +1,813 @@
+[
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T21:13:33Z",
+          "eventSource": "s3.amazonaws.com",
+          "eventName": "PutBucketPolicy",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "bucketName": "test",
+              "bucketPolicy": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                          "Effect": "Allow",
+                          "Principal": "*",
+                          "Action": "s3:GetObject",
+                          "Resource": "arn:aws:s3:::test/*"
+                      }
+                  ],
+                  "Id": "Policy1562365274513"
+              },
+              "host": [
+                  "s3.amazonaws.com"
+              ],
+              "policy": [
+                  ""
+              ]
+          },
+          "responseElements": null,
+          "additionalEventData": {
+              "SignatureVersion": "SigV4",
+              "CipherSuite": "ECDHE-RSA-AES128-SHA",
+              "AuthenticationMethod": "AuthHeader",
+              "vpcEndpointId": "vpce-00000000"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123",
+          "vpcEndpointId": "vpce-00000000"
+      }
+      ]
+    },
+    "description": "S3 made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:48:29Z",
+          "eventSource": "es.amazonaws.com",
+          "eventName": "CreateElasticsearchDomain",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "elasticsearchVersion": "6.7",
+              "elasticsearchClusterConfig": {
+                  "zoneAwarenessEnabled": false,
+                  "instanceType": "t2.small.elasticsearch",
+                  "dedicatedMasterEnabled": false,
+                  "instanceCount": 1
+              },
+              "nodeToNodeEncryptionOptions": {},
+              "snapshotOptions": {
+                  "automatedSnapshotStartHour": 0
+              },
+              "domainName": "test",
+              "encryptionAtRestOptions": {},
+              "eBSOptions": {
+                  "eBSEnabled": true,
+                  "volumeSize": 10,
+                  "volumeType": "gp2"
+              },
+              "accessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"*\"]},\"Action\":[\"es:*\"],\"Resource\":\"arn:aws:es:us-east-1:123456789123:domain/test/*\"}]}",
+              "advancedOptions": {
+                  "rest.action.multi.allow_explicit_index": "true"
+              }
+          },
+          "responseElements": {
+              "domainStatus": {
+                  "created": true,
+                  "serviceSoftwareOptions": {
+                      "description": "There is no software update available for this domain.",
+                      "currentVersion": "",
+                      "newVersion": "",
+                      "updateAvailable": false,
+                      "automatedUpdateDate": "Dec 31, 1969 4:00:00 PM",
+                      "updateStatus": "COMPLETED",
+                      "cancellable": false
+                  },
+                  "elasticsearchClusterConfig": {
+                      "zoneAwarenessEnabled": false,
+                      "instanceType": "t2.small.elasticsearch",
+                      "dedicatedMasterEnabled": false,
+                      "instanceCount": 1
+                  },
+                  "cognitoOptions": {
+                      "enabled": false
+                  },
+                  "encryptionAtRestOptions": {
+                      "enabled": false
+                  },
+                  "advancedOptions": {
+                      "rest.action.multi.allow_explicit_index": "true"
+                  },
+                  "upgradeProcessing": false,
+                  "snapshotOptions": {
+                      "automatedSnapshotStartHour": 0
+                  },
+                  "eBSOptions": {
+                      "eBSEnabled": true,
+                      "volumeSize": 10,
+                      "volumeType": "gp2"
+                  },
+                  "elasticsearchVersion": "6.7",
+                  "nodeToNodeEncryptionOptions": {
+                      "enabled": false
+                  },
+                  "processing": true,
+                  "aRN": "arn:aws:es:us-east-1:123456789123:domain/test",
+                  "domainId": "123456789123/test",
+                  "deleted": false,
+                  "domainName": "test",
+                  "accessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:123456789123:domain/test/*\"}]}"
+              }
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "ElasticSearch cluster made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T15:51:27Z",
+          "eventSource": "es.amazonaws.com",
+          "eventName": "UpdateElasticsearchDomainConfig",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "domainName": "test",
+              "accessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"*\"]},\"Action\":[\"es:*\"],\"Resource\":\"arn:aws:es:us-east-1:123456789123:domain/test/*\"}]}"
+          },
+          "responseElements": {
+              "domainConfig": {
+                  "eBSOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      },
+                      "options": {
+                          "eBSEnabled": true,
+                          "volumeSize": 10,
+                          "volumeType": "gp2"
+                      }
+                  },
+                  "snapshotOptions": {
+                      "options": {
+                          "automatedSnapshotStartHour": 0
+                      },
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      }
+                  },
+                  "nodeToNodeEncryptionOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      },
+                      "options": {
+                          "enabled": false
+                      }
+                  },
+                  "vPCOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:51:27 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:51:27 AM",
+                          "updateVersion": 10,
+                          "state": "Active"
+                      },
+                      "options": {}
+                  },
+                  "cognitoOptions": {
+                      "options": {
+                          "enabled": false
+                      },
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:51:27 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:51:27 AM",
+                          "updateVersion": 10,
+                          "state": "Active"
+                      }
+                  },
+                  "logPublishingOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:51:27 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:51:27 AM",
+                          "updateVersion": 10,
+                          "state": "Active"
+                      },
+                      "options": {}
+                  },
+                  "elasticsearchClusterConfig": {
+                      "options": {
+                          "zoneAwarenessEnabled": false,
+                          "instanceType": "t2.small.elasticsearch",
+                          "dedicatedMasterEnabled": false,
+                          "instanceCount": 1
+                      },
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      }
+                  },
+                  "elasticsearchVersion": {
+                      "options": "6.7",
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      }
+                  },
+                  "encryptionAtRestOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      },
+                      "options": {
+                          "enabled": false
+                      }
+                  },
+                  "accessPolicies": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:51:27 AM",
+                          "updateVersion": 10,
+                          "state": "Processing"
+                      },
+                      "options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:123456789123:domain/test/*\"}]}"
+                  },
+                  "advancedOptions": {
+                      "status": {
+                          "creationDate": "Jul 10, 2019 8:22:00 AM",
+                          "pendingDeletion": false,
+                          "updateDate": "Jul 10, 2019 8:37:36 AM",
+                          "updateVersion": 6,
+                          "state": "Active"
+                      },
+                      "options": {
+                          "rest.action.multi.allow_explicit_index": "true"
+                      }
+                  }
+              }
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "ElasticSearch cluster made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:49:24Z",
+          "eventSource": "glacier.amazonaws.com",
+          "eventName": "SetVaultAccessPolicy",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "accountId": "-",
+              "vaultName": "test",
+              "policy": {
+                  "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"glacier:InitiateJob\",\"Resource\":\"arn:aws:glacier:us-east-1:123456789123:vaults/test\"}]}"
+              }
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Glacier vault made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:45:07Z",
+          "eventSource": "sqs.amazonaws.com",
+          "eventName": "SetQueueAttributes",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "attributes": {
+                  "Policy": "{\"Version\":\"2012-10-17\", \"Id\":\"arn:aws:sqs:us-east-1:123456789123:tmp/SQSDefaultPolicy\", \"Statement\":[{\"Effect\":\"Allow\", \"Principal\":\"*\", \"Action\":\"SQS:SendMessage\", \"Resource\":\"arn:aws:sqs:us-east-1:123456789123:tmp\", \"Sid\":\"Sid1562723107715\"}]}"
+              },
+              "queueUrl": "https://sqs.us-east-1.amazonaws.com/123456789123/tmp"
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "SQS made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:47:00Z",
+          "eventSource": "sns.amazonaws.com",
+          "eventName": "SetTopicAttributes",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "attributeName": "Policy",
+              "topicArn": "arn:aws:sns:us-east-1:123456789123:test",
+              "attributeValue": "{\n  \"Version\": \"2008-10-17\",\n  \"Id\": \"__default_policy_ID\",\n  \"Statement\": [\n    {\n      \"Sid\": \"__default_statement_ID\",\n      \"Effect\": \"Allow\",\n      \"Principal\": {\n        \"AWS\": \"*\"\n      },\n      \"Action\": [\n        \"SNS:Publish\",\n        \"SNS:RemovePermission\",\n        \"SNS:SetTopicAttributes\",\n        \"SNS:DeleteTopic\",\n        \"SNS:ListSubscriptionsByTopic\",\n        \"SNS:GetTopicAttributes\",\n        \"SNS:Receive\",\n        \"SNS:AddPermission\",\n        \"SNS:Subscribe\"\n      ],\n      \"Resource\": \"arn:aws:sns:us-east-1:123456789123:test\",\n      \"Condition\": {\n        \"StringEquals\": {\n          \"AWS:SourceOwner\": \"123456789123\"\n        }\n      }\n    }\n  ]\n}"
+          },
+          "responseElements": null,
+          "requestID": "a873a3c8-061a-564c-893a-f65743ce7c88",
+          "eventID": "f7a98acd-245d-4850-92db-e249dd98ed63",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "SNS policy changed, but private - Do not alert",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:47:00Z",
+          "eventSource": "sns.amazonaws.com",
+          "eventName": "SetTopicAttributes",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "attributeName": "Policy",
+              "topicArn": "arn:aws:sns:us-east-1:123456789123:test",
+              "attributeValue": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Publish\",\"SNS:RemovePermission\",\"SNS:SetTopicAttributes\",\"SNS:DeleteTopic\",\"SNS:ListSubscriptionsByTopic\",\"SNS:GetTopicAttributes\",\"SNS:Receive\",\"SNS:AddPermission\",\"SNS:Subscribe\"],\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"123456789123\"}}},{\"Sid\":\"__console_pub_0\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"SNS:Publish\",\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\"},{\"Sid\":\"__console_sub_0\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Subscribe\",\"SNS:Receive\"],\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\"}]}"
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "SNS policy changed, made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T01:45:41Z",
+          "eventSource": "sns.amazonaws.com",
+          "eventName": "CreateTopic",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "name": "test",
+              "attributes": {
+                  "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Publish\",\"SNS:RemovePermission\",\"SNS:SetTopicAttributes\",\"SNS:DeleteTopic\",\"SNS:ListSubscriptionsByTopic\",\"SNS:GetTopicAttributes\",\"SNS:Receive\",\"SNS:AddPermission\",\"SNS:Subscribe\"],\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"123456789123\"}}},{\"Sid\":\"__console_pub_0\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"SNS:Publish\",\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\"},{\"Sid\":\"__console_sub_0\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Subscribe\",\"SNS:Receive\"],\"Resource\":\"arn:aws:sns:us-east-1:123456789123:test\"}]}"
+              },
+              "tags": []
+          },
+          "responseElements": {
+              "topicArn": "arn:aws:sns:us-east-1:123456789123:test"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "SNS created as public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T15:38:02Z",
+          "eventSource": "ecr.amazonaws.com",
+          "eventName": "SetRepositoryPolicy",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "repositoryName": "test",
+              "policyText": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"new statement\",\"Action\":[\"ecr:DescribeImages\"],\"Effect\":\"Allow\",\"Principal\":\"*\"}]}",
+              "force": false
+          },
+          "responseElements": {
+              "policyText": "{\n  \"Version\" : \"2008-10-17\",\n  \"Statement\" : [ {\n    \"Sid\" : \"new statement\",\n    \"Effect\" : \"Allow\",\n    \"Principal\" : \"*\",\n    \"Action\" : \"ecr:DescribeImages\"\n  } ]\n}",
+              "repositoryName": "test",
+              "registryId": "123456789123"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "resources": [
+              {
+                  "accountId": "123456789123",
+                  "ARN": "arn:aws:ecr:us-east-1:123456789123:repository/test"
+              }
+          ],
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "ECR made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T15:30:56Z",
+          "eventSource": "kms.amazonaws.com",
+          "eventName": "PutKeyPolicy",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "keyId": "0000000-0000-0000-0000-0000000000000",
+              "policyName": "default",
+              "policy": "{\n    \"Id\": \"key-consolepolicy-3\",\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow access for Key Administrators\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:user/bob\"\n            },\n            \"Action\": [\n                \"kms:Create*\",\n                \"kms:Describe*\",\n                \"kms:Enable*\",\n                \"kms:List*\",\n                \"kms:Put*\",\n                \"kms:Update*\",\n                \"kms:Revoke*\",\n                \"kms:Disable*\",\n                \"kms:Get*\",\n                \"kms:Delete*\",\n                \"kms:TagResource\",\n                \"kms:UntagResource\",\n                \"kms:ScheduleKeyDeletion\",\n                \"kms:CancelKeyDeletion\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow use of the key\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"*\"\n            },\n            \"Action\": [\n                \"kms:Encrypt\",\n                \"kms:Decrypt\",\n                \"kms:ReEncrypt*\",\n                \"kms:GenerateDataKey*\",\n                \"kms:DescribeKey\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow attachment of persistent resources\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:user/bob\"\n            },\n            \"Action\": [\n                \"kms:CreateGrant\",\n                \"kms:ListGrants\",\n                \"kms:RevokeGrant\"\n            ],\n            \"Resource\": \"*\",\n            \"Condition\": {\n                \"Bool\": {\n                    \"kms:GrantIsForAWSResource\": \"true\"\n                }\n            }\n        }\n    ]\n}",
+              "bypassPolicyLockoutSafetyCheck": false
+          },
+          "responseElements": null,
+          "requestID": "...",
+          "eventID": "...",
+          "readOnly": false,
+          "resources": [
+              {
+                  "ARN": "arn:aws:kms:us-east-1:123456789123:key/0000000-0000-0000-0000-0000000000000",
+                  "accountId": "123456789123",
+                  "type": "AWS::KMS::Key"
+              }
+          ],
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "KMS made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T15:29:54Z",
+          "eventSource": "kms.amazonaws.com",
+          "eventName": "CreateKey",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "policy": "{\n    \"Id\": \"key-consolepolicy-3\",\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow access for Key Administrators\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:user/bob\"\n            },\n            \"Action\": [\n                \"kms:Create*\",\n                \"kms:Describe*\",\n                \"kms:Enable*\",\n                \"kms:List*\",\n                \"kms:Put*\",\n                \"kms:Update*\",\n                \"kms:Revoke*\",\n                \"kms:Disable*\",\n                \"kms:Get*\",\n                \"kms:Delete*\",\n                \"kms:TagResource\",\n                \"kms:UntagResource\",\n                \"kms:ScheduleKeyDeletion\",\n                \"kms:CancelKeyDeletion\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow use of the key\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"*\"\n            },\n            \"Action\": [\n                \"kms:Encrypt\",\n                \"kms:Decrypt\",\n                \"kms:ReEncrypt*\",\n                \"kms:GenerateDataKey*\",\n                \"kms:DescribeKey\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow attachment of persistent resources\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::123456789123:user/bob\"\n            },\n            \"Action\": [\n                \"kms:CreateGrant\",\n                \"kms:ListGrants\",\n                \"kms:RevokeGrant\"\n            ],\n            \"Resource\": \"*\",\n            \"Condition\": {\n                \"Bool\": {\n                    \"kms:GrantIsForAWSResource\": \"true\"\n                }\n            }\n        }\n    ]\n}",
+              "description": "",
+              "keyUsage": "ENCRYPT_DECRYPT",
+              "origin": "AWS_KMS",
+              "bypassPolicyLockoutSafetyCheck": false,
+              "tags": []
+          },
+          "responseElements": {
+              "keyMetadata": {
+                  "aWSAccountId": "123456789123",
+                  "keyId": "0000000-0000-0000-0000-0000000000000",
+                  "arn": "arn:aws:kms:us-east-1:123456789123:key/0000000-0000-0000-0000-0000000000000",
+                  "creationDate": "Jul 10, 2019 3:29:54 PM",
+                  "enabled": true,
+                  "description": "",
+                  "keyUsage": "ENCRYPT_DECRYPT",
+                  "keyState": "Enabled",
+                  "origin": "AWS_KMS",
+                  "keyManager": "CUSTOMER",
+                  "keySpec": "SYMMETRIC_DEFAULT"
+              }
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "readOnly": false,
+          "resources": [
+              {
+                  "ARN": "arn:aws:kms:us-east-1:123456789123:key/0000000-0000-0000-0000-0000000000000",
+                  "accountId": "123456789123",
+                  "type": "AWS::KMS::Key"
+              }
+          ],
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "KMS made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-10T18:00:58Z",
+          "eventSource": "secretsmanager.amazonaws.com",
+          "eventName": "PutResourcePolicy",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "secretId": "test",
+              "resourcePolicy": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Action\":[\"secretsmanager:GetSecretValue\"],\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\": \"arn:aws:secretsmanager:us-east-1:123456789123:secret:test-zeCISw\"}]}"
+          },
+          "responseElements": {
+              "aRN": "arn:aws:secretsmanager:us-east-1:123456789123:secret:test-zeCISw",
+              "name": "test"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Secrets manager secret made public",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_public_resources"
+    ]
+  }
+]

--- a/tests/integration/rules/cloudtrail/cloudtrail_snapshot_or_ami_made_public.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_snapshot_or_ami_made_public.json
@@ -1,0 +1,281 @@
+[
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T19:32:47Z",
+          "eventSource": "ec2.amazonaws.com",
+          "eventName": "ModifyImageAttribute",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "imageId": "ami-00000000000000000",
+              "launchPermission": {
+                  "remove": {
+                      "items": [
+                          {
+                              "group": "all"
+                          }
+                      ]
+                  }
+              },
+              "attributeType": "launchPermission"
+          },
+          "responseElements": {
+              "_return": true
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Removing public permission from AMI - Do not alert",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T19:32:47Z",
+          "eventSource": "ec2.amazonaws.com",
+          "eventName": "ModifyImageAttribute",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+            "imageId": "ami-00000000000000000",
+            "launchPermission": {
+                "add": {
+                    "items": [
+                        {
+                            "group": "all"
+                        }
+                    ]
+                }
+            },
+            "attributeType": "launchPermission"
+          },
+          "responseElements": {
+              "_return": true
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Adding public permission to AMI",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_snapshot_or_ami_made_public"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T19:30:04Z",
+          "eventSource": "ec2.amazonaws.com",
+          "eventName": "ModifySnapshotAttribute",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "snapshotId": "snap-00000000000000000",
+              "createVolumePermission": {
+                  "add": {
+                      "items": [
+                          {
+                              "group": "all"
+                          }
+                      ]
+                  }
+              },
+              "attributeType": "CREATE_VOLUME_PERMISSION"
+          },
+          "responseElements": {
+              "requestId": "...",
+              "_return": true
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789123"
+      }
+      ]
+    },
+    "description": "Adding public permission to EBS Snapshot",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_snapshot_or_ami_made_public"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T19:54:37Z",
+          "eventSource": "rds.amazonaws.com",
+          "eventName": "ModifyDBClusterSnapshotAttribute",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "dBClusterSnapshotIdentifier": "mysnapshot",
+              "attributeName": "restore",
+              "valuesToAdd": [
+                  "123456789013"
+              ]
+          },
+          "responseElements": {
+              "dBClusterSnapshotIdentifier": "mysnapshot",
+              "dBClusterSnapshotAttributes": [
+                  {
+                      "attributeName": "restore",
+                      "attributeValues": [
+                          "123456789013"
+                      ]
+                  }
+              ]
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+      
+      ]
+    },
+    "description": "Adding permission to RDS Snapshot to only a single other account - Do not alert",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.05",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "12345",
+            "arn": "...",
+            "principalId": "12345",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "...",
+                "mfaAuthenticated": "true"
+              }
+            },
+            "type": "..."
+          },
+          "eventTime": "2019-07-09T21:04:07Z",
+          "eventSource": "rds.amazonaws.com",
+          "eventName": "ModifyDBClusterSnapshotAttribute",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "requestParameters": {
+              "valuesToAdd": [
+                  "all"
+              ],
+              "attributeName": "restore",
+              "dBClusterSnapshotIdentifier": "mysnapshot"
+          },
+          "responseElements": {
+              "dBClusterSnapshotAttributes": [
+                  {
+                      "attributeName": "restore",
+                      "attributeValues": [
+                          "all"
+                      ]
+                  }
+              ],
+              "dBClusterSnapshotIdentifier": "mysnapshot"
+          },
+          "requestID": "...",
+          "eventID": "...",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+      ]
+    },
+    "description": "Adding public permission to RDS Snapshot",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "cloudtrail_snapshot_or_ami_made_public"
+    ]
+  }
+
+
+]


### PR DESCRIPTION
to:
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

This uses the CloudTrail logs to detect potential misconfigurations and violations of best practices.  It does the following:
- Detects when additional features are turned off (GuardDuty, S3 Public Block Access, and EBS Default Encryption).
- Detects when EBS snapshots, RDS snapshots, or AMIs are made public.
- Detects when resources that use resource policies are made public, the most important being S3 buckets (previously only S3 buckets made public via ACLs were detected) and ElasticSearch clusters.  Additionally it detects Glacier, SQS, SNS, ECR, KMS, and SecretsManager being made public.

## Changes

- Adds the library `policyuniverse` which was created by Patrick Kelley of Netflix (who also created Security Monkey where that library was primarily used) https://github.com/Netflix-Skunkworks/policyuniverse . This is added to the rule checking lambda.
- Extends the rule for detecting critical APIs and adds additional logic so other critical APIs can be detected.
- Adds two more rules.  One for snapshots + AMIs and one for the resources that use resource policies (which is what `policyuniverse` was added for).

## Testing

Steps for how this change was tested and verified.
- Various APIs were called from the AWS console and the logs of the events recovered from CloudTrail Event History in the UI in order to create the test data, which was then used to create the rules.  I have run `rule_test.sh` successfully.  I have not yet been able to deploy this into a production environment to test live.
