### PR TITLE
Migration Commit to add resource prefix to Classified logs SQS

### DIFF
--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -69,8 +69,8 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'function_role_id': '${{module.{}_lambda.role_id}}'.format(tf_module_prefix),
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),
-        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
-        'classifier_sqs_queue_url': '${module.globals.classifier_sqs_queue_url}',
+        'classifier_sqs_queue_arn': '${module.globals.classifier_destination_sqs_queue_arn}',
+        'classifier_sqs_queue_url': '${module.globals.classifier_destination_sqs_queue_url}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
     }
 

--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -95,7 +95,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         config,
         environment={
             'CLUSTER': cluster_name,
-            'SQS_QUEUE_URL': '${module.globals.classifier_sqs_queue_url}',
+            'SQS_QUEUE_URL': '${module.globals.classifier_destination_sqs_queue_url}',
         },
         tags={
             'Cluster': cluster_name

--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -69,10 +69,8 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'function_role_id': '${{module.{}_lambda.role_id}}'.format(tf_module_prefix),
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),
-        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
-        'classifier_destination_sqs_queue_arn': (
-            '${module.globals.classifier_destination_sqs_queue_arn}'
-        ),
+        'legacy_classifier_sqs_queue_arn': '${module.globals.legacy_classifier_sqs_queue_arn}',
+        'new_classifier_sqs_queue_arn': '${module.globals.new_classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
     }
 
@@ -95,7 +93,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         config,
         environment={
             'CLUSTER': cluster_name,
-            'SQS_QUEUE_URL': '${module.globals.classifier_destination_sqs_queue_url}',
+            'SQS_QUEUE_URL': '${module.globals.new_classifier_sqs_queue_url}',
         },
         tags={
             'Cluster': cluster_name

--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -69,8 +69,10 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'function_role_id': '${{module.{}_lambda.role_id}}'.format(tf_module_prefix),
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),
-        'classifier_sqs_queue_arn': '${module.globals.classifier_destination_sqs_queue_arn}',
-        'classifier_sqs_queue_url': '${module.globals.classifier_destination_sqs_queue_url}',
+        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
+        'classifier_destination_sqs_queue_arn': (
+            '${module.globals.classifier_destination_sqs_queue_arn}'
+        ),
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
     }
 

--- a/stream_alert_cli/terraform/rules_engine.py
+++ b/stream_alert_cli/terraform/rules_engine.py
@@ -44,6 +44,9 @@ def generate_rules_engine(config):
         'rules_table_arn': '${module.globals.rules_table_arn}',
         'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
+        'classifier_destination_sqs_queue_arn': (
+            '${module.globals.classifier_destination_sqs_queue_arn}'
+        ),
         'sqs_record_batch_size': min(config.get('sqs_record_batch_size', 10), 10)
     }
 

--- a/stream_alert_cli/terraform/rules_engine.py
+++ b/stream_alert_cli/terraform/rules_engine.py
@@ -42,11 +42,9 @@ def generate_rules_engine(config):
         'threat_intel_enabled': config.get('threat_intel', {}).get('enabled'),
         'dynamodb_table_name': config.get('threat_intel', {}).get('dynamodb_table_name'),
         'rules_table_arn': '${module.globals.rules_table_arn}',
-        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
+        'legacy_classifier_sqs_queue_arn': '${module.globals.legacy_classifier_sqs_queue_arn}',
+        'new_classifier_sqs_queue_arn': '${module.globals.new_classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
-        'classifier_destination_sqs_queue_arn': (
-            '${module.globals.classifier_destination_sqs_queue_arn}'
-        ),
         'sqs_record_batch_size': min(config.get('sqs_record_batch_size', 10), 10)
     }
 

--- a/terraform/modules/tf_classifier/iam.tf
+++ b/terraform/modules/tf_classifier/iam.tf
@@ -21,8 +21,11 @@ data "aws_iam_policy_document" "classifier_policy" {
     sid       = "AllowPublishToQueue"
     actions   = ["sqs:SendMessage*"]
     resources = [
-      "${var.classifier_sqs_queue_arn}",
-      "${var.classifier_destination_sqs_queue_arn}",
+      # FIXME (derek.wang) We temporarily grant the classifier privilege to publish to both.
+      # this is because there might be in-flight records during deployment that we don't want
+      # to get stuck.
+      "${var.legacy_classifier_sqs_queue_arn}",
+      "${var.new_classifier_sqs_queue_arn}",
     ]
   }
 }

--- a/terraform/modules/tf_classifier/iam.tf
+++ b/terraform/modules/tf_classifier/iam.tf
@@ -20,6 +20,9 @@ data "aws_iam_policy_document" "classifier_policy" {
   statement {
     sid       = "AllowPublishToQueue"
     actions   = ["sqs:SendMessage*"]
-    resources = ["${var.classifier_sqs_queue_arn}"]
+    resources = [
+      "${var.classifier_sqs_queue_arn}",
+      "${var.classifier_destination_sqs_queue_arn}",
+    ]
   }
 }

--- a/terraform/modules/tf_classifier/variables.tf
+++ b/terraform/modules/tf_classifier/variables.tf
@@ -24,14 +24,15 @@ variable "input_sns_topics" {
   default     = []
 }
 
-variable "classifier_sqs_queue_arn" {
+# FIXME (derek.wang) remove this old one
+variable "legacy_classifier_sqs_queue_arn" {
+  description = "ARN of the SQS queue to which classified logs should be sent"
+}
+
+variable "new_classifier_sqs_queue_arn" {
   description = "ARN of the SQS queue to which classified logs should be sent"
 }
 
 variable "classifier_sqs_sse_kms_key_arn" {
   description = "URL of the SQS queue to which classified logs should be sent"
-}
-
-variable "classifier_destination_sqs_queue_arn" {
-  description = "ARN of the SQS queue to which classified logs should be sent"
 }

--- a/terraform/modules/tf_classifier/variables.tf
+++ b/terraform/modules/tf_classifier/variables.tf
@@ -28,10 +28,10 @@ variable "classifier_sqs_queue_arn" {
   description = "ARN of the SQS queue to which classified logs should be sent"
 }
 
-variable "classifier_sqs_queue_url" {
+variable "classifier_sqs_sse_kms_key_arn" {
   description = "URL of the SQS queue to which classified logs should be sent"
 }
 
-variable "classifier_sqs_sse_kms_key_arn" {
-  description = "URL of the SQS queue to which classified logs should be sent"
+variable "classifier_destination_sqs_queue_arn" {
+  description = "ARN of the SQS queue to which classified logs should be sent"
 }

--- a/terraform/modules/tf_rules_engine/iam.tf
+++ b/terraform/modules/tf_rules_engine/iam.tf
@@ -71,8 +71,8 @@ data "aws_iam_policy_document" "rules_engine_policy" {
 
     resources = [
       # FIXME (derek.wang) Temporarily grant access to both old + new SQS
-      "${var.classifier_sqs_queue_arn}",
-      "${var.classifier_destination_sqs_queue_arn}"
+      "${var.legacy_classifier_sqs_queue_arn}",
+      "${var.new_classifier_sqs_queue_arn}"
     ]
   }
 }

--- a/terraform/modules/tf_rules_engine/iam.tf
+++ b/terraform/modules/tf_rules_engine/iam.tf
@@ -69,7 +69,11 @@ data "aws_iam_policy_document" "rules_engine_policy" {
       "sqs:ReceiveMessage",
     ]
 
-    resources = ["${var.classifier_sqs_queue_arn}"]
+    resources = [
+      # FIXME (derek.wang) Temporarily grant access to both old + new SQS
+      "${var.classifier_sqs_queue_arn}",
+      "${var.classifier_destination_sqs_queue_arn}"
+    ]
   }
 }
 

--- a/terraform/modules/tf_rules_engine/lambda.tf
+++ b/terraform/modules/tf_rules_engine/lambda.tf
@@ -1,6 +1,14 @@
 // Invoke rules engine Lambda from downloader SQS queue
+
+# FIXME (derek.wang) Temporarily trigger from both old + new SQS; delete after migration
 resource "aws_lambda_event_source_mapping" "invoke_via_sqs" {
   batch_size       = "${var.sqs_record_batch_size}"
   event_source_arn = "${var.classifier_sqs_queue_arn}"
+  function_name    = "${var.function_alias_arn}"
+}
+
+resource "aws_lambda_event_source_mapping" "invoke_rules_via_sqs" {
+  batch_size       = "${var.sqs_record_batch_size}"
+  event_source_arn = "${var.classifier_destination_sqs_queue_arn}"
   function_name    = "${var.function_alias_arn}"
 }

--- a/terraform/modules/tf_rules_engine/lambda.tf
+++ b/terraform/modules/tf_rules_engine/lambda.tf
@@ -3,12 +3,12 @@
 # FIXME (derek.wang) Temporarily trigger from both old + new SQS; delete after migration
 resource "aws_lambda_event_source_mapping" "invoke_via_sqs" {
   batch_size       = "${var.sqs_record_batch_size}"
-  event_source_arn = "${var.classifier_sqs_queue_arn}"
+  event_source_arn = "${var.legacy_classifier_sqs_queue_arn}"
   function_name    = "${var.function_alias_arn}"
 }
 
 resource "aws_lambda_event_source_mapping" "invoke_rules_via_sqs" {
   batch_size       = "${var.sqs_record_batch_size}"
-  event_source_arn = "${var.classifier_destination_sqs_queue_arn}"
+  event_source_arn = "${var.new_classifier_sqs_queue_arn}"
   function_name    = "${var.function_alias_arn}"
 }

--- a/terraform/modules/tf_rules_engine/variables.tf
+++ b/terraform/modules/tf_rules_engine/variables.tf
@@ -34,14 +34,20 @@ variable "rules_table_arn" {
   description = "ARN of the rules table for reading rule staging information"
 }
 
-variable "classifier_sqs_queue_arn" {
-  description = "ARN of the SQS queue to which classified logs should be sent"
-}
-
-variable "classifier_sqs_sse_kms_key_arn" {
-  description = "URL of the SQS queue to which classified logs should be sent"
-}
-
 variable "sqs_record_batch_size" {
   description = "Number of records the Lambda function should read from the SQS queue each time (max=10)"
 }
+
+# FIXME (derek.wang) Remove these two variables post-migration
+variable "classifier_sqs_queue_arn" {
+  description = "(deprecated) ARN of the SQS queue to which classified logs should be sent"
+}
+
+variable "classifier_sqs_sse_kms_key_arn" {
+  description = "ARN of KMS key responsible for SQS Serverside Encryption"
+}
+
+variable "classifier_destination_sqs_queue_arn" {
+  description = "ARN of the SQS queue to which classified logs should be sent"
+}
+

--- a/terraform/modules/tf_rules_engine/variables.tf
+++ b/terraform/modules/tf_rules_engine/variables.tf
@@ -38,16 +38,15 @@ variable "sqs_record_batch_size" {
   description = "Number of records the Lambda function should read from the SQS queue each time (max=10)"
 }
 
-# FIXME (derek.wang) Remove these two variables post-migration
-variable "classifier_sqs_queue_arn" {
+# FIXME (derek.wang) Remove the legacy variable post-migration
+variable "legacy_classifier_sqs_queue_arn" {
   description = "(deprecated) ARN of the SQS queue to which classified logs should be sent"
+}
+
+variable "new_classifier_sqs_queue_arn" {
+  description = "ARN of the SQS queue to which classified logs should be sent"
 }
 
 variable "classifier_sqs_sse_kms_key_arn" {
   description = "ARN of KMS key responsible for SQS Serverside Encryption"
 }
-
-variable "classifier_destination_sqs_queue_arn" {
-  description = "ARN of the SQS queue to which classified logs should be sent"
-}
-

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
@@ -1,11 +1,21 @@
 # Using a list concat since terraform destroy throws errors if this does not exist
+
+# FIXME (derek.wang) These two outputs are deprecated as the "classifier_queue" is deprecated
 output "sqs_queue_url" {
   value = "${element(concat(aws_sqs_queue.classifier_queue.*.id, list("")), 0)}"
 }
-
 # Using a list concat since terraform destroy throws errors if this does not exist
 output "sqs_queue_arn" {
   value = "${element(concat(aws_sqs_queue.classifier_queue.*.arn, list("")), 0)}"
+}
+
+output "destination_sqs_queue_url" {
+  value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.id, list("")), 0)}"
+}
+
+# Using a list concat since terraform destroy throws errors if this does not exist
+output "destination_sqs_queue_arn" {
+  value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.arn, list("")), 0)}"
 }
 
 # Using a list concat since terraform destroy throws errors if this does not exist

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
@@ -1,20 +1,20 @@
 # Using a list concat since terraform destroy throws errors if this does not exist
 
 # FIXME (derek.wang) These two outputs are deprecated as the "classifier_queue" is deprecated
-output "sqs_queue_url" {
+output "legacy_sqs_queue_url" {
   value = "${element(concat(aws_sqs_queue.classifier_queue.*.id, list("")), 0)}"
 }
 # Using a list concat since terraform destroy throws errors if this does not exist
-output "sqs_queue_arn" {
+output "legacy_sqs_queue_arn" {
   value = "${element(concat(aws_sqs_queue.classifier_queue.*.arn, list("")), 0)}"
 }
 
-output "destination_sqs_queue_url" {
+output "new_sqs_queue_url" {
   value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.id, list("")), 0)}"
 }
 
 # Using a list concat since terraform destroy throws errors if this does not exist
-output "destination_sqs_queue_arn" {
+output "new_sqs_queue_arn" {
   value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.arn, list("")), 0)}"
 }
 

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,6 +1,23 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
+
+# FIXME (derek.wang) This old queue has an un-prefixed name and is deprecated
 resource "aws_sqs_queue" "classifier_queue" {
   name = "streamalert_classified_logs"
+
+  # The amount of time messages are hidden after being received from a consumer
+  # Default this to 2 seconds longer than the maximum AWS Lambda duration
+  visibility_timeout_seconds = "${var.rules_engine_timeout + 2}"
+
+  # Enable queue encryption of messages in the queue
+  kms_master_key_id = "${aws_kms_key.sqs_sse.arn}"
+
+  tags {
+    Name = "StreamAlert"
+  }
+}
+
+resource "aws_sqs_queue" "classifier_destination_queue" {
+  name = "${var.prefix}_streamalert_classified_logs"
 
   # The amount of time messages are hidden after being received from a consumer
   # Default this to 2 seconds longer than the maximum AWS Lambda duration

--- a/terraform/modules/tf_stream_alert_globals/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/output.tf
@@ -3,21 +3,21 @@ output "rules_table_arn" {
 }
 
 # FIXME (derek.wang) Remove these post-migration
-output "classifier_sqs_queue_url" {
-  value = "${module.classifier_queue.sqs_queue_url}"
+output "legacy_classifier_sqs_queue_url" {
+  value = "${module.classifier_queue.legacy_sqs_queue_url}"
 }
-output "classifier_sqs_queue_arn" {
-  value = "${module.classifier_queue.sqs_queue_arn}"
+output "legacy_classifier_sqs_queue_arn" {
+  value = "${module.classifier_queue.legacy_sqs_queue_arn}"
+}
+
+output "new_classifier_sqs_queue_url" {
+  value = "${module.classifier_queue.new_sqs_queue_url}"
+}
+
+output "new_classifier_sqs_queue_arn" {
+  value = "${module.classifier_queue.new_sqs_queue_arn}"
 }
 
 output "classifier_sqs_sse_kms_key_arn" {
   value = "${module.classifier_queue.sqs_sse_kms_key_arn}"
-}
-
-output "classifier_destination_sqs_queue_url" {
-  value = "${module.classifier_queue.destination_sqs_queue_url}"
-}
-
-output "classifier_destination_sqs_queue_arn" {
-  value = "${module.classifier_queue.destination_sqs_queue_arn}"
 }

--- a/terraform/modules/tf_stream_alert_globals/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/output.tf
@@ -2,14 +2,22 @@ output "rules_table_arn" {
   value = "${element(concat(aws_dynamodb_table.rules_table.*.arn, list("")), 0)}"
 }
 
+# FIXME (derek.wang) Remove these post-migration
 output "classifier_sqs_queue_url" {
   value = "${module.classifier_queue.sqs_queue_url}"
 }
-
 output "classifier_sqs_queue_arn" {
   value = "${module.classifier_queue.sqs_queue_arn}"
 }
 
 output "classifier_sqs_sse_kms_key_arn" {
   value = "${module.classifier_queue.sqs_sse_kms_key_arn}"
+}
+
+output "classifier_destination_sqs_queue_url" {
+  value = "${module.classifier_queue.destination_sqs_queue_url}"
+}
+
+output "classifier_destination_sqs_queue_arn" {
+  value = "${module.classifier_queue.destination_sqs_queue_arn}"
 }

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -20,6 +20,7 @@ from stream_alert_cli.terraform import common, classifier
 
 class TestTerraformGenerateClassifier(object):
     """CLI Terraform Generate, Classifier"""
+
     # pylint: disable=no-self-use,attribute-defined-outside-init
 
     def setup(self):
@@ -94,8 +95,12 @@ class TestTerraformGenerateClassifier(object):
                     'function_role_id': '${module.classifier_test_lambda.role_id}',
                     'function_alias_arn': '${module.classifier_test_lambda.function_alias_arn}',
                     'function_name': '${module.classifier_test_lambda.function_name}',
-                    'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
-                    'classifier_sqs_queue_url': '${module.globals.classifier_sqs_queue_url}',
+                    'legacy_classifier_sqs_queue_arn': (
+                        '${module.globals.legacy_classifier_sqs_queue_arn}'
+                    ),
+                    'new_classifier_sqs_queue_arn': (
+                        '${module.globals.new_classifier_sqs_queue_arn}'
+                    ),
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'
                     ),
@@ -108,7 +113,7 @@ class TestTerraformGenerateClassifier(object):
                     'description': 'Unit-Test Streamalert Classifier Test',
                     'environment_variables': {
                         'CLUSTER': 'test',
-                        'SQS_QUEUE_URL': '${module.globals.classifier_sqs_queue_url}',
+                        'SQS_QUEUE_URL': '${module.globals.new_classifier_sqs_queue_url}',
                         'LOGGER_LEVEL': 'info',
                         'ENABLE_METRICS': '0'
                     },

--- a/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
@@ -86,7 +86,12 @@ class TestTerraformGenerateRuleEngine(object):
                     'threat_intel_enabled': self.config['threat_intel']['enabled'],
                     'dynamodb_table_name': self.config['threat_intel']['dynamodb_table_name'],
                     'rules_table_arn': '${module.globals.rules_table_arn}',
-                    'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
+                    'legacy_classifier_sqs_queue_arn': (
+                        '${module.globals.legacy_classifier_sqs_queue_arn}'
+                    ),
+                    'new_classifier_sqs_queue_arn': (
+                        '${module.globals.new_classifier_sqs_queue_arn}'
+                    ),
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'
                     ),


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to: #955 
resolves: #885 

## Background

During our SQS migration some time late in 2018, we introduced the use of AWS SQS as a dispatch layer between the `classifier` functions and the `rules_engine` functions.

However, the SQS resource had a minor bug that caused to be missing a resource prefix (it's currently named `streamalert_classified_logs`).

This is not a problem on any AWS environment where there is only 1 deployment of StreamAlert. When you need to deploy 2 copies in parallel, however, this causes resource conflict issues.

## Changes

This is **THE FIRST COMMIT OF TWO** that will be involved in the migration process.

## Upgrade Process
Due to the stateful nature of AWS SQS, the "renaming" of the SQS queue cannot be done safely. This is because Terraform does not rename resources; it destroys the old one and creates a new one.

Doing so on a production environment where there are SQS records in-flight will permanently lose unprocessed records on the SQS, when it is destroyed.

This PR is intended to offer a migration path to allow users to upgrade StreamAlert 2.x.x —> 3.0.0 (fixing the prefix problem) without losing data.

If you don't care about data loss, then you can skip this migration completely.

### Step 1: Upgrade to latest 2.x.x StreamAlert
Not mandatory but this was tested against `master` so there's less chance for problems if you start the migration at 2.3.0+.

### Step 2: Check out **this specific commit**
This commit cannot be skipped without risking losing data.

### Step 3: Build SQS
`$ ./manage.py build -t globals`

This commit creates a second, identical SQS queue in StreamAlert that operates in parallel to the original `streamalert_classified_logs` queue. This new queue is named properly, incorporating the `$var.prefix`.

Initially after being built, this SQS queue will just sit as it is not connected to anything. That comes later...

### Step 4: Build other stuff
`$ ./manage.py build`

This goes ahead and builds all of the rest of the stuff, including attaching SQS to the `rules_engine` and the `classifier`.

However, it is notable that, despite having the new `SQS_QUEUE_URL` on the `classifier` Lambda environment variables, this only applies to the newest Lambda versions. The kinesis streams (and other cluster ingress points) are still attached to old versions of the `classifier` Lambda, which means their records will continue to go to the old SQS queue until...

### Step 5: Deploy the classifier
`$ ./manage.py deploy --function classifier`

From here on, all new records from the classifiers will be sent to the new SQS queue, whereas the old SQS queue will continue to trigger the `rules_engine`.

### Step 6: Wait until the old SQS Drains
Watch the number of "messages in flight" drain away in the old SQS queue. This should not take very long... probably.


### Step 7: Deploy the NEXT COMMIT 
Now go ahead and checkout #959 and build/deploy that. (The 2nd one is at #959)


## Testing

Painfully. Next time ideally with more alcohol