### PR TITLE
StreamAlert SQS missing prefixes migration cleanup

### DIFF
--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -92,7 +92,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         config,
         environment={
             'CLUSTER': cluster_name,
-            'SQS_QUEUE_URL': '${module.globals.new_classifier_sqs_queue_url}',
+            'SQS_QUEUE_URL': '${module.globals.classifier_sqs_queue_url}',
         },
         tags={
             'Cluster': cluster_name

--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -69,8 +69,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'function_role_id': '${{module.{}_lambda.role_id}}'.format(tf_module_prefix),
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),
-        'legacy_classifier_sqs_queue_arn': '${module.globals.legacy_classifier_sqs_queue_arn}',
-        'new_classifier_sqs_queue_arn': '${module.globals.new_classifier_sqs_queue_arn}',
+        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
     }
 

--- a/stream_alert_cli/terraform/rules_engine.py
+++ b/stream_alert_cli/terraform/rules_engine.py
@@ -42,8 +42,7 @@ def generate_rules_engine(config):
         'threat_intel_enabled': config.get('threat_intel', {}).get('enabled'),
         'dynamodb_table_name': config.get('threat_intel', {}).get('dynamodb_table_name'),
         'rules_table_arn': '${module.globals.rules_table_arn}',
-        'legacy_classifier_sqs_queue_arn': '${module.globals.legacy_classifier_sqs_queue_arn}',
-        'new_classifier_sqs_queue_arn': '${module.globals.new_classifier_sqs_queue_arn}',
+        'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
         'sqs_record_batch_size': min(config.get('sqs_record_batch_size', 10), 10)
     }

--- a/terraform/modules/tf_classifier/iam.tf
+++ b/terraform/modules/tf_classifier/iam.tf
@@ -21,11 +21,7 @@ data "aws_iam_policy_document" "classifier_policy" {
     sid       = "AllowPublishToQueue"
     actions   = ["sqs:SendMessage*"]
     resources = [
-      # FIXME (derek.wang) We temporarily grant the classifier privilege to publish to both.
-      # this is because there might be in-flight records during deployment that we don't want
-      # to get stuck.
-      "${var.legacy_classifier_sqs_queue_arn}",
-      "${var.new_classifier_sqs_queue_arn}",
+      "${var.classifier_sqs_queue_arn}",
     ]
   }
 }

--- a/terraform/modules/tf_classifier/variables.tf
+++ b/terraform/modules/tf_classifier/variables.tf
@@ -24,12 +24,7 @@ variable "input_sns_topics" {
   default     = []
 }
 
-# FIXME (derek.wang) remove this old one
-variable "legacy_classifier_sqs_queue_arn" {
-  description = "ARN of the SQS queue to which classified logs should be sent"
-}
-
-variable "new_classifier_sqs_queue_arn" {
+variable "classifier_sqs_queue_arn" {
   description = "ARN of the SQS queue to which classified logs should be sent"
 }
 

--- a/terraform/modules/tf_rules_engine/iam.tf
+++ b/terraform/modules/tf_rules_engine/iam.tf
@@ -69,11 +69,7 @@ data "aws_iam_policy_document" "rules_engine_policy" {
       "sqs:ReceiveMessage",
     ]
 
-    resources = [
-      # FIXME (derek.wang) Temporarily grant access to both old + new SQS
-      "${var.legacy_classifier_sqs_queue_arn}",
-      "${var.new_classifier_sqs_queue_arn}"
-    ]
+    resources = ["${var.classifier_sqs_queue_arn}"]
   }
 }
 

--- a/terraform/modules/tf_rules_engine/lambda.tf
+++ b/terraform/modules/tf_rules_engine/lambda.tf
@@ -1,14 +1,6 @@
 // Invoke rules engine Lambda from downloader SQS queue
-
-# FIXME (derek.wang) Temporarily trigger from both old + new SQS; delete after migration
-resource "aws_lambda_event_source_mapping" "invoke_via_sqs" {
-  batch_size       = "${var.sqs_record_batch_size}"
-  event_source_arn = "${var.legacy_classifier_sqs_queue_arn}"
-  function_name    = "${var.function_alias_arn}"
-}
-
 resource "aws_lambda_event_source_mapping" "invoke_rules_via_sqs" {
   batch_size       = "${var.sqs_record_batch_size}"
-  event_source_arn = "${var.new_classifier_sqs_queue_arn}"
+  event_source_arn = "${var.classifier_sqs_queue_arn}"
   function_name    = "${var.function_alias_arn}"
 }

--- a/terraform/modules/tf_rules_engine/variables.tf
+++ b/terraform/modules/tf_rules_engine/variables.tf
@@ -38,12 +38,7 @@ variable "sqs_record_batch_size" {
   description = "Number of records the Lambda function should read from the SQS queue each time (max=10)"
 }
 
-# FIXME (derek.wang) Remove the legacy variable post-migration
-variable "legacy_classifier_sqs_queue_arn" {
-  description = "(deprecated) ARN of the SQS queue to which classified logs should be sent"
-}
-
-variable "new_classifier_sqs_queue_arn" {
+variable "classifier_sqs_queue_arn" {
   description = "ARN of the SQS queue to which classified logs should be sent"
 }
 

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/output.tf
@@ -1,20 +1,10 @@
 # Using a list concat since terraform destroy throws errors if this does not exist
-
-# FIXME (derek.wang) These two outputs are deprecated as the "classifier_queue" is deprecated
-output "legacy_sqs_queue_url" {
-  value = "${element(concat(aws_sqs_queue.classifier_queue.*.id, list("")), 0)}"
-}
-# Using a list concat since terraform destroy throws errors if this does not exist
-output "legacy_sqs_queue_arn" {
-  value = "${element(concat(aws_sqs_queue.classifier_queue.*.arn, list("")), 0)}"
-}
-
-output "new_sqs_queue_url" {
+output "sqs_queue_url" {
   value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.id, list("")), 0)}"
 }
 
 # Using a list concat since terraform destroy throws errors if this does not exist
-output "new_sqs_queue_arn" {
+output "sqs_queue_arn" {
   value = "${element(concat(aws_sqs_queue.classifier_destination_queue.*.arn, list("")), 0)}"
 }
 

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,24 +1,4 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
-
-# FIXME (derek.wang) This old queue has an un-prefixed name and is deprecated
-# We CANNOT change the resource id as Terraform uses this id to determine whether or not to
-# Destroy it. If we change it to something like "classifier_queue_OLD" Terraform will destroy
-# the original and create anew, which is not what we want.
-resource "aws_sqs_queue" "classifier_queue" {
-  name = "streamalert_classified_logs"
-
-  # The amount of time messages are hidden after being received from a consumer
-  # Default this to 2 seconds longer than the maximum AWS Lambda duration
-  visibility_timeout_seconds = "${var.rules_engine_timeout + 2}"
-
-  # Enable queue encryption of messages in the queue
-  kms_master_key_id = "${aws_kms_key.sqs_sse.arn}"
-
-  tags {
-    Name = "StreamAlert"
-  }
-}
-
 resource "aws_sqs_queue" "classifier_destination_queue" {
   name = "${var.prefix}_streamalert_classified_logs"
 
@@ -35,46 +15,12 @@ resource "aws_sqs_queue" "classifier_destination_queue" {
 }
 
 // SQS Queue Policy: Allow the Classifiers to send messages to SQS
-# FIXME (derek.wang) get rid of this old one later.
-resource "aws_sqs_queue_policy" "classifier_queue" {
-  queue_url = "${aws_sqs_queue.classifier_queue.id}"
-  policy    = "${data.aws_iam_policy_document.classifier_queue.json}"
-}
-
 resource "aws_sqs_queue_policy" "classifier_destination_queue" {
   queue_url = "${aws_sqs_queue.classifier_destination_queue.id}"
   policy    = "${data.aws_iam_policy_document.classifier_destination_queue.json}"
 }
 
 // IAM Policy Doc: Allow Classifiers to send messages to SQS
-
-# FIXME (derek.wang) Delete this post-migration
-data "aws_iam_policy_document" "classifier_queue" {
-  statement {
-    effect = "Allow"
-    sid    = "AllowPublishToQueue"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions   = ["sqs:SendMessage"]
-    # FIXME (derek.wang) The policy document is duplicated below because for some reason AWS
-    #       Forces there to only be 1 resource in a SQS Policy document.
-    resources = ["${aws_sqs_queue.classifier_queue.arn}"]
-
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-
-      values = [
-        "arn:aws:lambda:${var.region}:${var.account_id}:function:${var.prefix}_streamalert_classifier_*",
-      ]
-    }
-  }
-}
-
 data "aws_iam_policy_document" "classifier_destination_queue" {
   statement {
     effect = "Allow"

--- a/terraform/modules/tf_stream_alert_globals/output.tf
+++ b/terraform/modules/tf_stream_alert_globals/output.tf
@@ -2,20 +2,12 @@ output "rules_table_arn" {
   value = "${element(concat(aws_dynamodb_table.rules_table.*.arn, list("")), 0)}"
 }
 
-# FIXME (derek.wang) Remove these post-migration
-output "legacy_classifier_sqs_queue_url" {
-  value = "${module.classifier_queue.legacy_sqs_queue_url}"
-}
-output "legacy_classifier_sqs_queue_arn" {
-  value = "${module.classifier_queue.legacy_sqs_queue_arn}"
+output "classifier_sqs_queue_url" {
+  value = "${module.classifier_queue.sqs_queue_url}"
 }
 
-output "new_classifier_sqs_queue_url" {
-  value = "${module.classifier_queue.new_sqs_queue_url}"
-}
-
-output "new_classifier_sqs_queue_arn" {
-  value = "${module.classifier_queue.new_sqs_queue_arn}"
+output "classifier_sqs_queue_arn" {
+  value = "${module.classifier_queue.sqs_queue_arn}"
 }
 
 output "classifier_sqs_sse_kms_key_arn" {

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -95,11 +95,8 @@ class TestTerraformGenerateClassifier(object):
                     'function_role_id': '${module.classifier_test_lambda.role_id}',
                     'function_alias_arn': '${module.classifier_test_lambda.function_alias_arn}',
                     'function_name': '${module.classifier_test_lambda.function_name}',
-                    'legacy_classifier_sqs_queue_arn': (
-                        '${module.globals.legacy_classifier_sqs_queue_arn}'
-                    ),
-                    'new_classifier_sqs_queue_arn': (
-                        '${module.globals.new_classifier_sqs_queue_arn}'
+                    'classifier_sqs_queue_arn': (
+                        '${module.globals.classifier_sqs_queue_arn}'
                     ),
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -110,7 +110,7 @@ class TestTerraformGenerateClassifier(object):
                     'description': 'Unit-Test Streamalert Classifier Test',
                     'environment_variables': {
                         'CLUSTER': 'test',
-                        'SQS_QUEUE_URL': '${module.globals.new_classifier_sqs_queue_url}',
+                        'SQS_QUEUE_URL': '${module.globals.classifier_sqs_queue_url}',
                         'LOGGER_LEVEL': 'info',
                         'ENABLE_METRICS': '0'
                     },

--- a/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
@@ -86,11 +86,8 @@ class TestTerraformGenerateRuleEngine(object):
                     'threat_intel_enabled': self.config['threat_intel']['enabled'],
                     'dynamodb_table_name': self.config['threat_intel']['dynamodb_table_name'],
                     'rules_table_arn': '${module.globals.rules_table_arn}',
-                    'legacy_classifier_sqs_queue_arn': (
-                        '${module.globals.legacy_classifier_sqs_queue_arn}'
-                    ),
-                    'new_classifier_sqs_queue_arn': (
-                        '${module.globals.new_classifier_sqs_queue_arn}'
+                    'classifier_sqs_queue_arn': (
+                        '${module.globals.classifier_sqs_queue_arn}'
                     ),
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to: #958 

## Background

Cleans up the code in the migration commit and destroys the SQS queue that is no longer needed.

## Changes

This is the **SECOND COMMIT OF TWO**. If you're here and haven't read #958 yet, YOU NEED TO GO OVER THERE TO UNDERSTAND WHAT'S GOING ON!!!!!!

In this PR, the old SQS resource that was improperly named without a prefix is deleted, along with other supporting resources.

### If you did the migration...
Doing `$ ./manage.py build` will destroy the old, now unused SQS Queue `streamalert_classified_logs`.

### If you did not do the migration...
**If you did not do the migration you are at risk of losing data. You've been warned!!!**

To do the deployment correctly **_you will need build twice AND deploy the classifier_**

```
$ ./manage.py build
$ ....
$ ./manage.py build
$ ....
$ ./manage.py deploy --function classifier
```

This has to do with the generation of SQS URLs and other lame stuff.

## Testing

TODO (haven't gotten to this yet).
