### PR TITLE
Adds optional prefix to SQS URL

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -35,6 +35,9 @@
         "read_capacity": 20,
         "write_capacity": 5
       }
+    },
+    "classifier_sqs": {
+      "use_prefix": null
     }
   },
   "s3_access_logging": {

--- a/stream_alert_cli/terraform/classifier.py
+++ b/stream_alert_cli/terraform/classifier.py
@@ -70,7 +70,6 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),
         'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
-        'classifier_sqs_queue_url': '${module.globals.classifier_sqs_queue_url}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
     }
 

--- a/stream_alert_cli/terraform/common.py
+++ b/stream_alert_cli/terraform/common.py
@@ -48,4 +48,3 @@ def monitoring_topic_arn(config):
 
 class MisconfigurationError(ValueError):
     """This error is thrown when StreamAlert is misconfigured."""
-    pass

--- a/stream_alert_cli/terraform/common.py
+++ b/stream_alert_cli/terraform/common.py
@@ -44,3 +44,8 @@ def monitoring_topic_arn(config):
         account_id=config['global']['account']['aws_account_id'],
         topic=topic_name
     )
+
+
+class MisconfigurationError(ValueError):
+    """This error is thrown when StreamAlert is misconfigured."""
+    pass

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -528,7 +528,9 @@ def _generate_global_module(config):
     #
     #   In version 3.0.0+, StreamAlert will default to always using the prefix, when "use_prefix"
     #   is not present.
-    use_prefix = config['infrastructure'].get('classifier_sqs', {}).get('use_prefix', None)
+    use_prefix = config['global']['infrastructure'].get('classifier_sqs', {}).get(
+        'use_prefix', None
+    )
     if use_prefix is None:
         message = (
             '[WARNING] '

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -536,7 +536,7 @@ def _generate_global_module(config):
             'in global.json. '
             'For existing/legacy deployments, change this value to False. '
             'For new deployments, change this value to True. '
-            'For more information, refer to THIS PULL REQUEST.'
+            'For more information, refer to https://github.com/airbnb/streamalert/pull/960.'
         )
         raise MisconfigurationError(message)
 

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -534,7 +534,7 @@ def _generate_global_module(config):
     if use_prefix is None:
         message = (
             '[WARNING] '
-            'As of StreamAlert 2.4.0+ you must specify the classifier_sqs.use_prefix parameter '
+            'As of StreamAlert v2.3.0+ you must specify the classifier_sqs.use_prefix parameter '
             'in global.json. '
             'For existing/legacy deployments, change this value to False. '
             'For new deployments, change this value to True. '

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -22,7 +22,8 @@ from stream_alert_cli.helpers import check_credentials
 from stream_alert_cli.terraform.common import (
     DEFAULT_SNS_MONITORING_TOPIC,
     InvalidClusterName,
-    infinitedict
+    infinitedict,
+    MisconfigurationError,
 )
 from stream_alert_cli.terraform.alert_merger import generate_alert_merger
 from stream_alert_cli.terraform.alert_processor import generate_alert_processor
@@ -161,26 +162,24 @@ def generate_main(config, init=False):
             'acl': 'private',
             'kms_key_id': 'alias/{}'.format(config['global']['account']['kms_key_alias'])}
 
-    logging_bucket = config['global']['s3_access_logging']['logging_bucket']
-
     # Configure initial S3 buckets
     main_dict['resource']['aws_s3_bucket'] = {
         'stream_alert_secrets': generate_s3_bucket(
             # FIXME (derek.wang) DRY out by using OutputCredentialsProvider?
             bucket='{}.streamalert.secrets'.format(config['global']['account']['prefix']),
-            logging=logging_bucket
+            logging=_config_get_logging_bucket(config)
         ),
         'streamalerts': generate_s3_bucket(
             bucket='{}.streamalerts'.format(config['global']['account']['prefix']),
-            logging=logging_bucket
+            logging=_config_get_logging_bucket(config)
         )
     }
 
     # Create bucket for S3 access logs (if applicable)
     if config['global']['s3_access_logging'].get('create_bucket', True):
         main_dict['resource']['aws_s3_bucket']['logging_bucket'] = generate_s3_bucket(
-            bucket=logging_bucket,
-            logging=logging_bucket,
+            bucket=_config_get_logging_bucket(config),
+            logging=_config_get_logging_bucket(config),
             acl='log-delivery-write',
             lifecycle_rule={
                 'prefix': '/',
@@ -197,34 +196,14 @@ def generate_main(config, init=False):
     if config['global']['terraform'].get('create_bucket', True):
         main_dict['resource']['aws_s3_bucket']['terraform_remote_state'] = generate_s3_bucket(
             bucket=config['global']['terraform']['tfstate_bucket'],
-            logging=logging_bucket
+            logging=_config_get_logging_bucket(config)
         )
 
     # Setup Firehose Delivery Streams
-    generate_firehose(logging_bucket, main_dict, config)
+    generate_firehose(_config_get_logging_bucket(config), main_dict, config)
 
     # Configure global resources like Firehose alert delivery and alerts table
-    global_module = {
-        'source': 'modules/tf_stream_alert_globals',
-        'account_id': config['global']['account']['aws_account_id'],
-        'region': config['global']['account']['region'],
-        'prefix': config['global']['account']['prefix'],
-        'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
-        'alerts_table_read_capacity': (
-            config['global']['infrastructure']['alerts_table']['read_capacity']),
-        'alerts_table_write_capacity': (
-            config['global']['infrastructure']['alerts_table']['write_capacity']),
-        'rules_engine_timeout': config['lambda']['rules_engine_config']['timeout']
-    }
-
-    if config['global']['infrastructure']['rule_staging'].get('enabled'):
-        global_module['enable_rule_staging'] = True
-        global_module['rules_table_read_capacity'] = (
-            config['global']['infrastructure']['rule_staging']['table']['read_capacity'])
-        global_module['rules_table_write_capacity'] = (
-            config['global']['infrastructure']['rule_staging']['table']['write_capacity'])
-
-    main_dict['module']['globals'] = global_module
+    main_dict['module']['globals'] = _generate_global_module(config)
 
     # KMS Key and Alias creation
     main_dict['resource']['aws_kms_key']['server_side_encryption'] = {
@@ -532,3 +511,60 @@ def remove_temp_terraform_file(tf_tmp_file, message):
     if os.path.isfile(tf_tmp_file):
         LOGGER.info(message)
         os.remove(tf_tmp_file)
+
+
+def _generate_global_module(config):
+    # 2019-07-30 (Ryxias)
+    #   This variable is left here to accommodate for a bug that misses the prefix on the SQS
+    #   queue name.
+    #   See: https://github.com/airbnb/streamalert/issues/885
+    #
+    #   Because of the possibility of data loss, and the difficulty of doing a resource migration,
+    #   we offer this option to maintain an account's un-prefixed SQS resource name.
+    #
+    #   The default value provided in global.json is 'None'. For all versions that are <3.0.0,
+    #   in order to facilitate a graceful upgrade, we require the StreamAlert instance modify this
+    #   value to True or False, to explicitly state whether or not to use the SQS prefix.
+    #
+    #   In version 3.0.0+, StreamAlert will default to always using the prefix, when "use_prefix"
+    #   is not present.
+    use_prefix = config['infrastructure'].get('classifier_sqs', {}).get('use_prefix', None)
+    if use_prefix is None:
+        message = (
+            '[WARNING] '
+            'As of StreamAlert 2.4.0+ you must specify the classifier_sqs.use_prefix parameter '
+            'in global.json. '
+            'For existing/legacy deployments, change this value to False. '
+            'For new deployments, change this value to True. '
+            'For more information, refer to THIS PULL REQUEST.'
+        )
+        raise MisconfigurationError(message)
+
+    global_module = {
+        'source': 'modules/tf_stream_alert_globals',
+        'account_id': config['global']['account']['aws_account_id'],
+        'region': config['global']['account']['region'],
+        'prefix': config['global']['account']['prefix'],
+        'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+        'alerts_table_read_capacity': (
+            config['global']['infrastructure']['alerts_table']['read_capacity']
+        ),
+        'alerts_table_write_capacity': (
+            config['global']['infrastructure']['alerts_table']['write_capacity']
+        ),
+        'rules_engine_timeout': config['lambda']['rules_engine_config']['timeout'],
+        'sqs_use_prefix': use_prefix,
+    }
+
+    if config['global']['infrastructure']['rule_staging'].get('enabled'):
+        global_module['enable_rule_staging'] = True
+        global_module['rules_table_read_capacity'] = (
+            config['global']['infrastructure']['rule_staging']['table']['read_capacity'])
+        global_module['rules_table_write_capacity'] = (
+            config['global']['infrastructure']['rule_staging']['table']['write_capacity'])
+
+    return global_module
+
+
+def _config_get_logging_bucket(config):
+    return config['global']['s3_access_logging']['logging_bucket']

--- a/terraform/modules/tf_classifier/variables.tf
+++ b/terraform/modules/tf_classifier/variables.tf
@@ -28,10 +28,6 @@ variable "classifier_sqs_queue_arn" {
   description = "ARN of the SQS queue to which classified logs should be sent"
 }
 
-variable "classifier_sqs_queue_url" {
-  description = "URL of the SQS queue to which classified logs should be sent"
-}
-
 variable "classifier_sqs_sse_kms_key_arn" {
-  description = "URL of the SQS queue to which classified logs should be sent"
+  description = "ARN of the KMS key that handles server-side-encryption of classifier SQS frames"
 }

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -46,5 +46,5 @@ data "aws_iam_policy_document" "classifier_queue" {
 }
 
 locals {
-  aws_sqs_queue_name = "${var.use_prefix ? join("", [var.prefix, "_"]) : ""}streamalert_classified_logs"
+  aws_sqs_queue_name = "${var.use_prefix ? "${var.prefix}_" : ""}streamalert_classified_logs"
 }

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -1,6 +1,6 @@
 // SQS Queue: Send logs from the Classifier to the SQS queue
 resource "aws_sqs_queue" "classifier_queue" {
-  name = "streamalert_classified_logs"
+  name = "${var.use_prefix ? "${var.prefix}_" : ""}streamalert_classified_logs"
 
   # The amount of time messages are hidden after being received from a consumer
   # Default this to 2 seconds longer than the maximum AWS Lambda duration
@@ -43,8 +43,4 @@ data "aws_iam_policy_document" "classifier_queue" {
       ]
     }
   }
-}
-
-locals {
-  aws_sqs_queue_name = "${var.use_prefix ? "${var.prefix}_" : ""}streamalert_classified_logs"
 }

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/sqs.tf
@@ -44,3 +44,7 @@ data "aws_iam_policy_document" "classifier_queue" {
     }
   }
 }
+
+locals {
+  aws_sqs_queue_name = "${var.use_prefix ? join("", [var.prefix, "_"]) : ""}streamalert_classified_logs"
+}

--- a/terraform/modules/tf_stream_alert_globals/classifier_queue/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/classifier_queue/variables.tf
@@ -5,3 +5,7 @@ variable "region" {}
 variable "prefix" {}
 
 variable "rules_engine_timeout" {}
+
+variable "use_prefix" {
+  description = "When true, prepends the StreamAlert prefix to SQS resource name."
+}

--- a/terraform/modules/tf_stream_alert_globals/main.tf
+++ b/terraform/modules/tf_stream_alert_globals/main.tf
@@ -12,6 +12,7 @@ module "classifier_queue" {
   prefix               = "${var.prefix}"
   region               = "${var.region}"
   rules_engine_timeout = "${var.rules_engine_timeout}"
+  use_prefix           = "${var.sqs_use_prefix}"
 }
 
 // TODO: Autoscaling

--- a/terraform/modules/tf_stream_alert_globals/variables.tf
+++ b/terraform/modules/tf_stream_alert_globals/variables.tf
@@ -25,3 +25,7 @@ variable "rules_table_write_capacity" {
 variable "rules_engine_timeout" {
   default = 300
 }
+
+variable "sqs_use_prefix" {
+  default = false
+}

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -15,7 +15,7 @@
       "write_capacity": 5
     },
     "classifier_sqs": {
-      "use_prefix": false
+      "use_prefix": true
     },
     "firehose": {
       "buffer_interval": 900,

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -14,6 +14,9 @@
       "read_capacity": 5,
       "write_capacity": 5
     },
+    "classifier_sqs": {
+      "use_prefix": false
+    },
     "firehose": {
       "buffer_interval": 900,
       "buffer_size": 128,

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -95,7 +95,6 @@ class TestTerraformGenerateClassifier(object):
                     'function_alias_arn': '${module.classifier_test_lambda.function_alias_arn}',
                     'function_name': '${module.classifier_test_lambda.function_name}',
                     'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
-                    'classifier_sqs_queue_url': '${module.globals.classifier_sqs_queue_url}',
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'
                     ),


### PR DESCRIPTION
to: @ryandeivert  @chunyong-lin 

cc: @airbnb/streamalert-maintainers
related to: #955 
resolves: #885 

## Background
As explained in #885, there is a bug in StreamAlert where the classifier SQS resource does not properly adopt the `PREFIX`.

This problem is complicated by the fact that AWS SQS is stateful, and the resource cannot be renamed without destroying it.


## Changes
To address the issue, we adopted the suggestion in #955; allowing for the SQS resource name to be conditionally specified.

Now, users can add the StreamAlert prefix to _**NEW**_ classifier SQS deployments. This is configured on `global.json` through the parameter:

`globals.json`
```
  ...
  "infrastructure": {
    "classifier_sqs": {
      "use_prefix": null
    }
  },
  ..
```

The default value currently is `None`/`null`. This is not actually a valid value and will crash during `manage.py generate`. The error message instructs StreamAlert users to specify a value of `true` or `false`:

> (venv) ~/extrepos/streamalert-deploy (dw--sqs-url)$ ./manage.py generate
    raise MisconfigurationError(message)
stream_alert_cli.terraform.common.MisconfigurationError: [WARNING] As of StreamAlert 2.3.0+ you must specify the classifier_sqs.use_prefix parameter in global.json. For existing/legacy deployments, change this value to False. For new deployments, change this value to True. For more information, refer to https://github.com/airbnb/streamalert/pull/960.


For existing production deployments of StreamAlert, the value must be specified as `false`. This PR will not rename the existing resource.

For all new deployments of StreamAlert, the value should be specified as `true`. In a future 3.0.0+ release, prefixing will be the "default" behavior.


## Testing

Deployed to stage; following cases:

### Case 1: New deploy, `use_prefix` = true
Correctly creates a prefixed SQS

### Case 2: Old deploy, `use_prefix` not specified
Errors (correctly)

### Case 3: Old deploy, `use_prefix` = false
On stage it just errors because it resource conflicts with another StreamAlert's un-prefixed SQS (which is correct)

### Case 4: Old deploy, `use_prefix` = true
Completely renames the old SQS queue, destroying the old resource. (Correct)