### PR TITLE
Fixed logging output for failed classifications

### DIFF
--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -68,7 +68,7 @@ class PayloadRecord(object):
         except (TypeError, ValueError):
             record_data = self._record_data
             invalid_records = self.invalid_records
-            LOGGER.warning('A PayloadRecord has records that is not serializable as JSON')
+            LOGGER.debug('A PayloadRecord has data that is not serializable as JSON')
 
         if not self:
             return '<{} valid:{}; raw record:{};>'.format(
@@ -225,7 +225,7 @@ class StreamPayload(object):
             raw_record = json.dumps(self.raw_record)
         except (TypeError, ValueError):
             raw_record = self.raw_record
-            LOGGER.warning('A StreamPayload has a raw record that is not serializable as JSON')
+            LOGGER.debug('A StreamPayload has data that is not serializable as JSON')
 
         return '<{} valid:{}; resource:{}; raw record:{};>'.format(
             self.__class__.__name__,

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -62,11 +62,19 @@ class PayloadRecord(object):
         )
 
     def __repr__(self):
+        try:
+            record_data = json.dumps(self._record_data)
+            invalid_records = json.dumps(self.invalid_records)
+        except (TypeError, ValueError):
+            record_data = self._record_data
+            invalid_records = self.invalid_records
+            LOGGER.warning('A PayloadRecord has records that is not serializable as JSON')
+
         if not self:
             return '<{} valid:{}; raw record:{};>'.format(
                 self.__class__.__name__,
                 bool(self),
-                self._record_data
+                record_data
             )
 
         if self.invalid_records:
@@ -79,8 +87,8 @@ class PayloadRecord(object):
                 self.log_schema_type,
                 len(self.parsed_records),
                 len(self.invalid_records),
-                self.invalid_records,
-                self._record_data
+                invalid_records,
+                record_data
             )
 
         return '<{} valid:{}; log type:{}; parsed records:{};>'.format(
@@ -213,12 +221,17 @@ class StreamPayload(object):
                 bool(self),
                 self.resource
             )
+        try:
+            raw_record = json.dumps(self.raw_record)
+        except (TypeError, ValueError):
+            raw_record = self.raw_record
+            LOGGER.warning('A StreamPayload has a raw record that is not serializable as JSON')
 
         return '<{} valid:{}; resource:{}; raw record:{};>'.format(
             self.__class__.__name__,
             bool(self),
             self.resource,
-            self.raw_record
+            raw_record
         )
 
     @classmethod

--- a/tests/unit/streamalert/classifier/payload/test_payload_base.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_base.py
@@ -95,7 +95,7 @@ class TestStreamPayload(object):
         """StreamPayload - Repr, Invalid"""
         self._payload.fully_classified = False
         expected_result = (
-            '<StreamPayload valid:False; resource:foobar; raw record:{\'key\': \'value\'};>'
+            '<StreamPayload valid:False; resource:foobar; raw record:{"key": "value"};>'
         )
         assert_equal(repr(self._payload), expected_result)
 

--- a/tests/unit/streamalert/classifier/payload/test_payload_record.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_record.py
@@ -66,7 +66,7 @@ class TestPayloadRecord(object):
 
     def test_repr_invalid(self):
         """PayloadRecord - Repr, Invalid"""
-        expected_result = '<PayloadRecord valid:False; raw record:{\'key\': \'value\'};>'
+        expected_result = '<PayloadRecord valid:False; raw record:{"key": "value"};>'
         assert_equal(repr(self._payload_record), expected_result)
 
     def test_repr_invalid_records(self):
@@ -77,7 +77,7 @@ class TestPayloadRecord(object):
         )
         expected_result = (
             '<PayloadRecord valid:True; log type:foo:bar; parsed records:1; invalid records:1 '
-            '([{\'key\': \'value\'}]); raw record:{\'key\': \'value\'};>'
+            '([{"key": "value"}]); raw record:{"key": "value"};>'
         )
         assert_equal(repr(self._payload_record), expected_result)
 


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

When a record cannot be classified it is logged to CloudWatch. In the current state when printing out a payload, the code relies on the underlying data type to format itself as a string. However this can lead to inconsistent behavior with dictionaries especially when python thinks that there is unicode in the dictionary. This makes working with failed classifications a pain because the output varies. Sometimes it gets output as an actual JSON string, sometimes it gets output as a unicode python dictionary.

## Changes

* Updated payload_base to encode the record as a JSON string using json.dumps
* Updated tests to reflect the change in output(actual JSON string versus python representation of a dictionary)

## Testing

Passed unit and integration tests locally.
