### PR TITLE
Fixed classifier log output if payload record is a string

### DIFF
--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -64,15 +64,17 @@ class PayloadRecord(object):
     def __repr__(self):
         record_data = self._record_data
         invalid_records = self.invalid_records
+
         try:
-            if not isinstance(self._record_data, str):
-                record_data = json.dumps(self._record_data)
+            if isinstance(record_data, dict):
+                record_data = json.dumps(record_data)
         except (TypeError, ValueError):
             LOGGER.debug('A PayloadRecord has data that is not serializable as JSON')
 
         try:
-            if not isinstance(invalid_records, str):
-                invalid_records = json.dumps(self.invalid_records)
+            #Build a JSON string if data is a dict or non-empty list of dicts
+            if isinstance(invalid_records, dict) or (isinstance(invalid_records, list) and invalid_records and isinstance(invalid_records[0], dict)):
+                invalid_records = json.dumps(invalid_records)
         except (TypeError, ValueError):
             LOGGER.debug('A PayloadRecord has invalid records that are not serializable as JSON')
 
@@ -229,7 +231,7 @@ class StreamPayload(object):
             )
         raw_record = self.raw_record
         try:
-            if not isinstance(raw_record, str):
+            if isinstance(raw_record, dict):
                 raw_record = json.dumps(self.raw_record)
         except (TypeError, ValueError):
             LOGGER.debug('A StreamPayload has data that is not serializable as JSON')

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -62,13 +62,19 @@ class PayloadRecord(object):
         )
 
     def __repr__(self):
+        record_data = self._record_data
+        invalid_records = self.invalid_records
         try:
-            record_data = json.dumps(self._record_data)
-            invalid_records = json.dumps(self.invalid_records)
+            if not isinstance(self._record_data, str):
+                record_data = json.dumps(self._record_data)
         except (TypeError, ValueError):
-            record_data = self._record_data
-            invalid_records = self.invalid_records
             LOGGER.debug('A PayloadRecord has data that is not serializable as JSON')
+
+        try:
+            if not isinstance(invalid_records, str):
+                invalid_records = json.dumps(self.invalid_records)
+        except (TypeError, ValueError):
+            LOGGER.debug('A PayloadRecord has invalid records that are not serializable as JSON')
 
         if not self:
             return '<{} valid:{}; raw record:{};>'.format(
@@ -221,10 +227,11 @@ class StreamPayload(object):
                 bool(self),
                 self.resource
             )
+        raw_record = self.raw_record
         try:
-            raw_record = json.dumps(self.raw_record)
+            if not isinstance(raw_record, str):
+                raw_record = json.dumps(self.raw_record)
         except (TypeError, ValueError):
-            raw_record = self.raw_record
             LOGGER.debug('A StreamPayload has data that is not serializable as JSON')
 
         return '<{} valid:{}; resource:{}; raw record:{};>'.format(

--- a/stream_alert/classifier/payload/payload_base.py
+++ b/stream_alert/classifier/payload/payload_base.py
@@ -73,7 +73,9 @@ class PayloadRecord(object):
 
         try:
             #Build a JSON string if data is a dict or non-empty list of dicts
-            if isinstance(invalid_records, dict) or (isinstance(invalid_records, list) and invalid_records and isinstance(invalid_records[0], dict)):
+            if (isinstance(invalid_records, dict) or
+                    (isinstance(invalid_records, list) and
+                     invalid_records and isinstance(invalid_records[0], dict))):
                 invalid_records = json.dumps(invalid_records)
         except (TypeError, ValueError):
             LOGGER.debug('A PayloadRecord has invalid records that are not serializable as JSON')

--- a/tests/unit/streamalert/classifier/payload/test_payload_base.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_base.py
@@ -99,6 +99,16 @@ class TestStreamPayload(object):
         )
         assert_equal(repr(self._payload), expected_result)
 
+    @patch.object(StreamPayload, '__abstractmethods__', frozenset())
+    def test_repr_invalid_str(self):
+        """StreamPayload - Repr, Invalid, Str Payload"""
+        payload = StreamPayload('foobar', '{"key": "value"}')
+        payload.fully_classified = False
+        expected_result = (
+            '<StreamPayload valid:False; resource:foobar; raw record:{"key": "value"};>'
+        )
+        assert_equal(repr(payload), expected_result)
+
     def test_load_from_raw_record_kinesis(self):
         """StreamPayload - Load from Raw Record, Kinesis"""
         record = {

--- a/tests/unit/streamalert/classifier/payload/test_payload_base.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_base.py
@@ -102,6 +102,7 @@ class TestStreamPayload(object):
     @patch.object(StreamPayload, '__abstractmethods__', frozenset())
     def test_repr_invalid_str(self):
         """StreamPayload - Repr, Invalid, Str Payload"""
+        # pylint: disable=abstract-class-instantiated
         payload = StreamPayload('foobar', '{"key": "value"}')
         payload.fully_classified = False
         expected_result = (

--- a/tests/unit/streamalert/classifier/payload/test_payload_record.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_record.py
@@ -81,6 +81,18 @@ class TestPayloadRecord(object):
         )
         assert_equal(repr(self._payload_record), expected_result)
 
+    def test_repr_invalid_records_str(self):
+        """PayloadRecord - Repr, Invalid, Str Payload"""
+        self._payload_record._parser = self._mock_parser(
+            records=['{"key": "value"}'],
+            invalid_records=['{"key": "value"}']
+        )
+        expected_result = (
+            '<PayloadRecord valid:True; log type:foo:bar; parsed records:1; invalid records:1 '
+            '([\'{"key": "value"}\']); raw record:{"key": "value"};>'
+        )
+        assert_equal(repr(self._payload_record), expected_result)
+
     def test_data_property(self):
         """PayloadRecord - Data Property"""
         assert_equal(self._payload_record.data, self._record)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: https://github.com/airbnb/streamalert/pull/965
resolves:

## Background

The previous change fixed the case where the payload record stored its data as a dictionary, but did not account for the situation where the payload is valid JSON, but is stored as a string already. This caused some messy output for failed classifications.

## Changes

* Will now only attempt conversion if the payload data is not stored as a string.

## Testing

Passed unit/integration tests locally.
