### PR TITLE
[conf] Remove duplicated policyuniverse dep from lambda conf

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -103,8 +103,7 @@
     },
     "sqs_record_batch_size": 10,
     "third_party_libraries": [
-      "pathlib2",
-      "policyuniverse"
+      "pathlib2"
     ],
     "timeout": 60,
     "vpc_config": {


### PR DESCRIPTION
to: @ryandeivert @Ryxias 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #964 

## Background
I split PR #970 into two PRs, because it includes different bug fixes and we want to check in different fixes to different branch, `master` vs `release-2-3-0`.

This new PR fixes a duplicated dependency `policyuniverse` causes `rules_engine` deployment to be failed when it builds dependencies for `rules_engine` with error message 
```
ERROR: Double requirement given: policyuniverse==1.3.2.0 (already in policyuniverse, name='policyuniverse')
```

## Changes

* Remove `policyuniverse` from `third_party_libraries` list in `conf/lambda.json`. This dependency is hardcoded in [package.py source file](https://github.com/airbnb/streamalert/blob/master/stream_alert_cli/manage_lambda/package.py#L214), that will be called when generating source code package for rules_engine lambda function.

## Testing
There is no more error when deploy a new StreamAlert to staging environment.
