### PR TITLE
Bumped the slack request timeout to 10

### DIFF
--- a/stream_alert/apps/_apps/slack.py
+++ b/stream_alert/apps/_apps/slack.py
@@ -35,7 +35,7 @@ class SlackApp(AppIntegration):
         contain details about your workspace's integrated apps
     """
 
-    _DEFAULT_REQUEST_TIMEOUT = 6.05
+    _DEFAULT_REQUEST_TIMEOUT = 10
     _SLACK_API_BASE_URL = 'https://slack.com/api/'
     _SLACK_API_MAX_ENTRY_COUNT = 1000
     _SLACK_API_MAX_PAGE_COUNT = 100


### PR DESCRIPTION
to: @chunyong-lin @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The slack app has been failing consistently due to a read timeout. This also occurs locally when testing the endpoint. Additionally the timeout did not appear to change even if the count param was lowered. Therefore we need to bump the default timeout for the app. 10 was chosen to give it some headroom above 8.5 which is around when the timeout stopped happening in local testing. 

## Changes

* Changed the slack app default request timeout to 10 up from 6.05

## Testing

Integration and unit tests passed locally.
