### PR TITLE
[apps] Correctly update aliyun timestamp

### DIFF
--- a/stream_alert/apps/app_base.py
+++ b/stream_alert/apps/app_base.py
@@ -200,7 +200,7 @@ class AppIntegration(object):
         """Method for performing any startup steps, like setting state to running"""
         # Perform another safety check to make sure this is not being invoked already
         if self._config.is_running:
-            LOGGER.error('[%s] App already running', self)
+            LOGGER.warning('[%s] App already running', self)
             return False
 
         # Check if this is an invocation spawned from a previous partial execution

--- a/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import json
 import os
 
 from mock import patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal
+from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true
 
 from aliyunsdkcore.acs_exception.exceptions import ServerException
 
@@ -39,7 +40,7 @@ class TestAliyunApp(object):
         self._test_app_name = 'aliyun'
         put_mock_params(self._test_app_name)
         self._event = get_event(self._test_app_name)
-        self._context = get_mock_lambda_context(self._test_app_name)
+        self._context = get_mock_lambda_context(self._test_app_name, milliseconds=100000)
         self._app = AliyunApp(self._event, self._context)
 
     def test_sleep_seconds(self):
@@ -94,10 +95,79 @@ class TestAliyunApp(object):
         """AliyunApp - Gather Logs with some entries"""
         client_mock.return_value = '{"NextToken":"20","RequestId":'\
                                    '"B1DE97F8-5450-4593-AB38-FB61B799E91D",' \
-                                   '"Events":["filler data","filler data"],' \
+                                   '"Events":[{"eventTime":"123"},{"eventTime":"123"}],' \
                                    '"EndTime":"2018-07-23T19:28:00Z",' \
                                    '"StartTime":"2018-06-23T19:28:30Z"}'
         logs = self._app._gather_logs()
         assert_equal(2, len(logs))
-        assert self._app._more_to_poll # nosec
+        assert_true(self._app._more_to_poll)
         assert_equal(self._app.request.get_NextToken(), "20")
+
+    @patch('stream_alert.apps.app_base.AppIntegration._invoke_successive_app')
+    @patch('stream_alert.apps.batcher.Batcher._send_logs_to_lambda')
+    @patch('stream_alert.apps._apps.aliyun.AliyunApp._sleep_seconds')
+    @patch('aliyunsdkcore.client.AcsClient.do_action_with_exception')
+    def test_gather_logs_last_timestamp(self, client_mock, sleep_mock, batcher_mock, _):
+        """AliyunApp - Test last_timestamp"""
+        # mock 3 responses
+        mock_resps = [
+            {
+                'NextToken': '50',
+                'RequestId': 'AAAAAAAA',
+                'Events': [
+                    {
+                        'eventTime': '2018-06-23T19:29:00Z'
+                    },
+                    {
+                        'eventTime': '2018-06-23T19:28:00Z'
+                    }
+                ],
+                'EndTime': '2018-07-23T19:28:00Z',
+                'StartTime': '2018-06-23T19:28:30Z'
+            },
+            {
+                'NextToken': '100',
+                'RequestId': 'BBBBBBBBB',
+                'Events': [
+                    {
+                        'eventTime': '2018-06-24T19:29:00Z'
+                    },
+                    {
+                        'eventTime': '2018-06-24T19:28:00Z'
+                    }
+                ],
+                'EndTime': '2018-07-23T19:28:00Z',
+                'StartTime': '2018-06-23T19:28:30Z'
+            },
+            {
+                'NextToken': '150',
+                'RequestId': 'CCCCCCCC',
+                'Events': [
+                    {
+                        'eventTime': '2018-06-25T19:29:00Z'
+                    },
+                    {
+                        'eventTime': '2018-06-25T19:28:00Z'
+                    }
+                ],
+                'EndTime': '2018-07-23T19:28:00Z',
+                'StartTime': '2018-06-23T19:28:30Z'
+            }
+        ]
+        client_mock.side_effect = [json.dumps(r, separators=(',', ':')) for r in mock_resps]
+
+        # Mock remaining time. _sleep_seconds() methods will be called twice when
+        # make a call to gather logs via Aliyun API. Set sleep second to a large number
+        # to mimic corner case that there are still more logs to pull while lambda function
+        # timeout is reached. In this case, the _last_timestamp stamp should be updated
+        # correctly.
+        sleep_mock.side_effect = [0, 0, 0, 0, 1000000, 0]
+
+        # Mock 3 batcher call to invoke successive lambda function since there are more logs
+        batcher_mock.side_effect = [True, True, True]
+
+        self._app.gather()
+        assert_equal(self._app._poll_count, 3)
+        assert_true(self._app._more_to_poll)
+        assert_equal(self._app.request.get_NextToken(), "150")
+        assert_equal(self._app._last_timestamp, '2018-07-23T19:28:00Z')

--- a/tests/unit/stream_alert_apps/test_apps/test_app_base.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_app_base.py
@@ -165,7 +165,7 @@ class TestAppIntegration(object):
         """App Integration - Initialize, Valid"""
         assert_true(self._app._initialize())
 
-    @patch('logging.Logger.error')
+    @patch('logging.Logger.warning')
     def test_initialize_running(self, log_mock):
         """App Integration - Initialize, Already Running"""
         self._app._config.current_state = 'running'


### PR DESCRIPTION
to: @ryandeivert @Ryxias 
cc: @airbnb/streamalert-maintainers
related to: #970
resolves:

## Background
#970 only fixes partial issue related to Aliyun. During troubleshooting, I discovered the `_last_timestamp` will never be updated if there are more logs to pull but the timeout of Aliyun app lambda function is reached and the lambda function will be finished with starting timestamp. During next Aliyun app run, it will pull same logs over and over again.

This PR is to update `_last_timestamp` correctly, but it will still has small possibility to lose partial ActionTrail events at the same condition that there are more logs to pull but the timeout of Aliyun app lambda function is reached. 

To lower the data loss possibility, suggest to have longer timeout (e.g. 300 sec) for lambda function (aliyun app) and set app schedule more frequently, e.g. every 10 mins

## Changes

* Update Aliyun App `_last_timestamp` earlier, right after get response from server
* Add unit test case to reproduce issue and test the code change.

## Testing
* Add unit test case.
* Tested in staging environment.
