### PR TITLE
Changes 3.0.0+ behavior to by default include SQS prefix

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -37,7 +37,7 @@
       }
     },
     "classifier_sqs": {
-      "use_prefix": null
+      "use_prefix": true
     }
   },
   "s3_access_logging": {

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -518,7 +518,7 @@ def _generate_global_module(config):
     #   In version 3.0.0+, StreamAlert will default to always using the prefix, when "use_prefix"
     #   is not present.
     #
-    #   Refer to this PR for more information:
+    #   Refer to this PR for more information: https://github.com/airbnb/streamalert/pull/979
     use_prefix = config['global']['infrastructure'].get('classifier_sqs', {}).get(
         'use_prefix', True
     )

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -514,33 +514,14 @@ def remove_temp_terraform_file(tf_tmp_file, message):
 
 
 def _generate_global_module(config):
-    # 2019-07-30 (Ryxias)
-    #   This variable is left here to accommodate for a bug that misses the prefix on the SQS
-    #   queue name.
-    #   See: https://github.com/airbnb/streamalert/issues/885
-    #
-    #   Because of the possibility of data loss, and the difficulty of doing a resource migration,
-    #   we offer this option to maintain an account's un-prefixed SQS resource name.
-    #
-    #   The default value provided in global.json is 'None'. For all versions that are <3.0.0,
-    #   in order to facilitate a graceful upgrade, we require the StreamAlert instance modify this
-    #   value to True or False, to explicitly state whether or not to use the SQS prefix.
-    #
+    # 2019-08-22 (Ryxias)
     #   In version 3.0.0+, StreamAlert will default to always using the prefix, when "use_prefix"
     #   is not present.
+    #
+    #   Refer to this PR for more information:
     use_prefix = config['global']['infrastructure'].get('classifier_sqs', {}).get(
-        'use_prefix', None
+        'use_prefix', True
     )
-    if use_prefix is None:
-        message = (
-            '[WARNING] '
-            'As of StreamAlert v2.3.0+ you must specify the classifier_sqs.use_prefix parameter '
-            'in global.json. '
-            'For existing/legacy deployments, change this value to False. '
-            'For new deployments, change this value to True. '
-            'For more information, refer to https://github.com/airbnb/streamalert/pull/960.'
-        )
-        raise MisconfigurationError(message)
 
     global_module = {
         'source': 'modules/tf_stream_alert_globals',

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -23,7 +23,6 @@ from stream_alert_cli.terraform.common import (
     DEFAULT_SNS_MONITORING_TOPIC,
     InvalidClusterName,
     infinitedict,
-    MisconfigurationError,
 )
 from stream_alert_cli.terraform.alert_merger import generate_alert_merger
 from stream_alert_cli.terraform.alert_processor import generate_alert_processor

--- a/tests/unit/stream_alert_cli/terraform/test_generate.py
+++ b/tests/unit/stream_alert_cli/terraform/test_generate.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from mock import ANY, patch
-from nose.tools import assert_equal, assert_false, assert_raises, assert_true
+from nose.tools import assert_equal, assert_false, assert_true
 
 from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.terraform import (
@@ -24,7 +24,6 @@ from stream_alert_cli.terraform import (
     flow_logs,
     generate
 )
-from stream_alert_cli.terraform.common import MisconfigurationError
 
 
 class TestTerraformGenerate(object):
@@ -495,12 +494,10 @@ class TestTerraformGenerate(object):
         """CLI - Terraform Generate Main with unspecified classifier_sqs.use_prefix"""
         del self.config['global']['infrastructure']['classifier_sqs']['use_prefix']
 
-        assert_raises(
-            MisconfigurationError,
-            generate.generate_main,
-            config=self.config,
-            init=False
-        )
+        result = generate.generate_main(config=self.config, init=False)
+
+        assert_equal(result['module']['globals']['source'], 'modules/tf_stream_alert_globals')
+        assert_true(result['module']['globals']['sqs_use_prefix'])
 
     def test_generate_main_with_sqs_url_true(self):
         """CLI - Terraform Generate Main with classifier_sqs.use_prefix = True"""


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers
related to: #885 

## Background
In #960 I added the classifier SQS resource prefix as an optional variable. The default behavior was _"you must specify this or I will error"_.

As promised, in `3.0.0`+, the default behavior now uses SQS resource prefix by default.