### PR TITLE
tweaking .gitignore file slightly for venv and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,20 +11,14 @@ terraform/terraform.tfstate*
 terraform/*.zip
 terraform/*.tf.json
 
-# MacOS artifacts
-Thumbs.db
-.DS_Store
-*.swp
-terminal.glue
-
 # Coveralls repo token
 .coveralls.yml
 
 # nose coverage file
 .coverage
 
-# virtualenv files
-venv/
+# virtualenv files in root of repo
+/venv
 
-.vagrant/
-htmlcov/
+/vagrant
+/htmlcov


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

A `venv` directory should only be ignored if it's at the root of the repo.

## Changes

* Updating `.gitignore` to only ignore `venv` at root of repo.
* Removing IDE/environment-specific ignored items.
  * **These should be added to your [_global_ `.gitignore`](https://help.github.com/en/articles/ignoring-files#create-a-global-gitignore), not the local one**
