### PR TITLE
bumping slack app timeout to 30 seconds

### DIFF
--- a/stream_alert/apps/_apps/slack.py
+++ b/stream_alert/apps/_apps/slack.py
@@ -35,7 +35,7 @@ class SlackApp(AppIntegration):
         contain details about your workspace's integrated apps
     """
 
-    _DEFAULT_REQUEST_TIMEOUT = 10
+    _DEFAULT_REQUEST_TIMEOUT = 30
     _SLACK_API_BASE_URL = 'https://slack.com/api/'
     _SLACK_API_MAX_ENTRY_COUNT = 1000
     _SLACK_API_MAX_PAGE_COUNT = 100


### PR DESCRIPTION
to: @chunyong-lin, @ryandeivert 
cc: @airbnb/streamalert-maintainers

## Background

The slack app was still timing out with a 10s api request timeout causing the app to constantly fall behind on data. Bumping the timeout to 30s resolved this issue.

## Changes

* Bumped default slack request timeout from 10s to 30s.

## Testing

Unit and integration tests passing locally.
