### PR TITLE
LookupTables management via manage.py

### DIFF
--- a/conf/lookup_tables.json
+++ b/conf/lookup_tables.json
@@ -1,5 +1,21 @@
 {
-  "enabled": false,
+  "enabled": true,
   "tables": {
+    "bar": {
+      "bucket": "bucket_name",
+      "cache_refresh_minutes": 10,
+      "compression": "gzip",
+      "driver": "s3",
+      "key": "bar.json"
+    },
+    "dinosaur": {
+      "driver": "dynamodb",
+      "table": "ryxias-test-dinosaur",
+      "partition_key": "pkey",
+      "value_key": "DinoValue",
+      "cache_maximum_key_count": 3,
+      "cache_refresh_minutes": 3,
+      "consistent_read": false
+    }
   }
 }

--- a/conf/lookup_tables.json
+++ b/conf/lookup_tables.json
@@ -1,25 +1,18 @@
 {
-  "enabled": true,
+  "enabled": false,
   "tables": {
-    "bar": {
-      "bucket": "bucket_name",
-      "cache_refresh_minutes": 10,
-      "compression": "gzip",
-      "driver": "s3",
-      "key": "bar.json"
-    },
-    "dinosaur": {
+    "dynamo-backed-table": {
       "driver": "dynamodb",
-      "table": "ryxias-test-dinosaur",
-      "partition_key": "pkey",
-      "value_key": "DinoValue",
+      "table": "dynamodb-table-name",
+      "partition_key": "partition-key",
+      "value_key": "value-column",
       "cache_maximum_key_count": 3,
       "cache_refresh_minutes": 3,
       "consistent_read": false
     },
-    "dragonite": {
+    "s3-backed-table": {
       "driver": "s3",
-      "bucket": "ryxias-test-lookuptables",
+      "bucket": "s3-bucket-name",
       "key": "file.json",
       "compression": false,
       "cache_refresh_minutes": 10

--- a/conf/lookup_tables.json
+++ b/conf/lookup_tables.json
@@ -16,6 +16,13 @@
       "cache_maximum_key_count": 3,
       "cache_refresh_minutes": 3,
       "consistent_read": false
+    },
+    "dragonite": {
+      "driver": "s3",
+      "bucket": "ryxias-test-lookuptables",
+      "key": "file.json",
+      "compression": false,
+      "cache_refresh_minutes": 10
     }
   }
 }

--- a/stream_alert/shared/lookup_tables/cache.py
+++ b/stream_alert/shared/lookup_tables/cache.py
@@ -131,6 +131,9 @@ class DriverCache:
         for key in keyvalue_data.keys():
             self._ttls[key] = ttl
 
+    def getall(self):
+        return self._data
+
 
 class DriverCacheClock:
     """

--- a/stream_alert/shared/lookup_tables/cache.py
+++ b/stream_alert/shared/lookup_tables/cache.py
@@ -1,5 +1,25 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import copy
 from datetime import datetime, timedelta
 import random
+
+from stream_alert.shared.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 class DriverCache:
@@ -88,10 +108,7 @@ class DriverCache:
             value (mixed)
             ttl_minutes (int)
         """
-        self._data[key] = value
-        self._ttls[key] = self._clock.utcnow() + timedelta(minutes=ttl_minutes)
-
-        if 0 < self._maximum_key_count < len(self._data):
+        if 0 < self._maximum_key_count < len(self._data) + 1:
             # Cache is too full, evict a random record
             # The reason for RANDOM eviction is that for a LRU cache replacement policy,
             # Cache pollution can occur for Lambdas that experience extremely deterministic
@@ -99,6 +116,9 @@ class DriverCache:
             selected_key = random.choice(self._ttls.keys())
             del self._ttls[selected_key]
             del self._data[selected_key]
+
+        self._data[key] = value
+        self._ttls[key] = self._clock.utcnow() + timedelta(minutes=ttl_minutes)
 
     def set_blank(self, key, ttl_minutes):
         """
@@ -132,7 +152,7 @@ class DriverCache:
             self._ttls[key] = ttl
 
     def getall(self):
-        return self._data
+        return copy.copy(self._data)
 
 
 class DriverCacheClock:

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -232,9 +232,9 @@ class DynamoDBDriver(PersistenceDriver):
             components = key.split(self._key_delimiter, 2)
             if len(components) != 2:
                 message = (
-                    'LookupTable (%s): Invalid key. The requested table requires a sort key, '
-                    'which the provided key \'%s\' does not provide, given the configured '
-                    'delimiter: (%s)'
+                    'LookupTable ({}): Invalid key. The requested table requires a sort key, '
+                    'which the provided key \'{}\' does not provide, given the configured '
+                    'delimiter: ({})'
                 ).format(self.id, key, self._key_delimiter)
                 raise LookupTablesInitializationError(message)
 

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -123,7 +123,7 @@ class DynamoDBDriver(PersistenceDriver):
                 #       /dynamodb.html#DynamoDB.Table.put_item
                 self._table.put_item(**put_item_args)
 
-            except (ConnectTimeoutError, ReadTimeoutError):
+            except (ClientError, ConnectTimeoutError, ReadTimeoutError):
                 raise LookupTablesInitializationError(
                     'LookupTable ({}): Failure to set key'.format(self.id)
                 )
@@ -235,8 +235,8 @@ class DynamoDBDriver(PersistenceDriver):
             if len(components) != 2:
                 message = (
                     'LookupTable ({}): Invalid key. The requested table requires a sort key, '
-                    'which the provided key \'{}\' does not provide, given the configured '
-                    'delimiter: ({})'
+                    'which the provided key (\'{}\') does not provide, given the configured '
+                    'delimiter: \'{}\''
                 ).format(self.id, key, self._key_delimiter)
                 raise LookupTablesInitializationError(message)
 

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -242,7 +242,7 @@ class DynamoDBDriver(PersistenceDriver):
                 self._dynamo_db_partition_key: components[0],
                 self._dynamo_db_sort_key: components[1],
             }
-        else:
-            return {
-                self._dynamo_db_partition_key: key,
-            }
+
+        return {
+            self._dynamo_db_partition_key: key,
+        }

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -96,7 +96,7 @@ class DynamoDBDriver(PersistenceDriver):
             raise LookupTablesInitializationError(message)
 
     def commit(self):
-        for key, value in self._dirty_rows.iteritems():
+        for key, value in self._dirty_rows.items():
             key_schema = self._convert_key_to_key_schema(key)
 
             if LOGGER_DEBUG_ENABLED:

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -231,15 +231,12 @@ class DynamoDBDriver(PersistenceDriver):
         if self._dynamo_db_sort_key:
             components = key.split(self._key_delimiter, 2)
             if len(components) != 2:
-                LOGGER.error(
+                message = (
                     'LookupTable (%s): Invalid key. The requested table requires a sort key, '
                     'which the provided key \'%s\' does not provide, given the configured '
-                    'delimiter: (%s)',
-                    self.id,
-                    key,
-                    self._key_delimiter
-                )
-                return
+                    'delimiter: (%s)'
+                ).format(self.id, key, self._key_delimiter)
+                raise LookupTablesInitializationError(message)
 
             return {
                 self._dynamo_db_partition_key: components[0],

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -122,12 +122,13 @@ class DynamoDBDriver(PersistenceDriver):
                 # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services
                 #       /dynamodb.html#DynamoDB.Table.put_item
                 self._table.put_item(**put_item_args)
-                del self._dirty_rows[key]
 
             except (ConnectTimeoutError, ReadTimeoutError):
                 raise LookupTablesInitializationError(
                     'LookupTable ({}): Failure to set key'.format(self.id)
                 )
+
+        self._dirty_rows = {}
 
     def get(self, key, default=None):
         self._reload_if_necessary(key)

--- a/stream_alert/shared/lookup_tables/driver_dynamodb.py
+++ b/stream_alert/shared/lookup_tables/driver_dynamodb.py
@@ -122,6 +122,7 @@ class DynamoDBDriver(PersistenceDriver):
                 # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services
                 #       /dynamodb.html#DynamoDB.Table.put_item
                 self._table.put_item(**put_item_args)
+                del self._dirty_rows[key]
 
             except (ConnectTimeoutError, ReadTimeoutError):
                 raise LookupTablesInitializationError(

--- a/stream_alert/shared/lookup_tables/driver_s3.py
+++ b/stream_alert/shared/lookup_tables/driver_s3.py
@@ -10,7 +10,8 @@ import stream_alert.shared.helpers.boto as boto_helpers
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.cache import DriverCache
 from stream_alert.shared.lookup_tables.drivers import PersistenceDriver
-from stream_alert.shared.lookup_tables.errors import LookupTablesInitializationError
+from stream_alert.shared.lookup_tables.errors import LookupTablesInitializationError, \
+    LookupTablesCommitError
 
 LOGGER = get_logger(__name__)
 
@@ -61,7 +62,13 @@ class S3Driver(PersistenceDriver):
 
         # Explicitly set timeout for S3 connection. The boto default timeout is 60 seconds.
         boto_config = boto_helpers.default_config(timeout=10)
-        self._s3_client = boto3.resource('s3', config=boto_config)
+
+        self._s3_adapter = S3Adapter(
+            self,
+            boto3.resource('s3', config=boto_config),
+            self._s3_bucket,
+            self._s3_key
+        )
 
     @property
     def driver_type(self):
@@ -80,7 +87,18 @@ class S3Driver(PersistenceDriver):
             LOGGER.warning('LookupTable (%s): Empty commit; no records dirtied', self.id)
             return
 
-        raise NotImplementedError('Help derek you screwed me')
+        data = Encoding.json_encode(self, self._cache.getall())
+
+        # Compression
+        if self._compression:
+            data = Compression.gz_compress(self, data)
+        else:
+            LOGGER.debug('LookupTable (%s): File does not need decompression')
+
+        # Upload to S3
+        self._s3_adapter.upload(data)
+
+        LOGGER.info('LookupTable (%s): Successfully uploaded new data', self.id)
 
     def get(self, key, default=None):
         self._reload_if_necessary()
@@ -91,6 +109,8 @@ class S3Driver(PersistenceDriver):
         Under construction
         FIXME (derek.wang)
         """
+        self._reload_if_necessary()
+        self._cache.set(key, value, self._cache_refresh_minutes)
         self._dirty = True
 
     def _reload_if_necessary(self):
@@ -120,6 +140,126 @@ class S3Driver(PersistenceDriver):
         the file's contents into memory.
         """
         # First, download the item from S3
+        data = self._s3_adapter.download()
+
+        # The lookup data can optionally be compressed, so try to decompress
+        # This will fall back and use the original data if decompression fails
+        if self._compression:
+            data = Compression.gz_decompress(self, data)
+        else:
+            LOGGER.debug('LookupTable (%s): File does not need decompression')
+
+        # Decode the data; right now we make the assumption that the data is always encoded
+        # as JSON.
+        data = Encoding.json_decode(self, data)
+
+        self._cache.setall(data, self._cache_refresh_minutes)
+        self._cache.set(self._MAGIC_CACHE_TTL_KEY, 'True', self._cache_refresh_minutes)
+        LOGGER.info('LookupTable (%s): Successfully loaded', self.id)
+
+
+class Compression(object):
+
+    @staticmethod
+    def gz_decompress(driver, data):
+        try:
+            data = zlib.decompress(data, 47)
+            LOGGER.debug(
+                'LookupTable (%s): Object decompressed to %d byte payload',
+                driver.id,
+                sys.getsizeof(data)
+            )
+        except zlib.error:
+            LOGGER.warn(
+                'LookupTable (%s): Data is not compressed; defaulting to original payload',
+                driver.id
+            )
+        return data
+
+    @staticmethod
+    def gz_compress(driver, data):
+        try:
+            original_size = sys.getsizeof(data)
+            data = zlib.compress(data, level=zlib.Z_BEST_COMPRESSION)
+            LOGGER.debug(
+                'LookupTable (%s): Successfully compressed input data from %d to %d bytes',
+                driver.id,
+                original_size,
+                sys.getsizeof(data)
+            )
+            return data
+        except zlib.error:
+            LOGGER.exception('LookupTable (%s): Data compression error.', driver.id)
+
+
+class Encoding(object):
+
+    @staticmethod
+    def json_encode(driver, data):
+        try:
+            return json.dumps(data)
+        except (ValueError, TypeError):
+            LOGGER.exception(
+                'LookupTable (%s): Failed to json encode data', driver.id
+            )
+
+    @staticmethod
+    def json_decode(driver, data):
+        try:
+            data = json.loads(data)
+            LOGGER.debug(
+                'LookupTable (%s): File successfully JSON decoded. Discovered %s keys.',
+                driver.id,
+                len(data)
+            )
+            return data
+        except ValueError:
+            LOGGER.exception(
+                'LookupTable (%s): Failed to json decode data', driver.id
+            )
+
+
+class S3Adapter(object):
+
+    def __init__(self, driver, boto_s3_client, s3_bucket, s3_key):
+        self._driver = driver
+        self._s3_client = boto_s3_client
+        self._s3_bucket = s3_bucket
+        self._s3_key = s3_key
+
+    def upload(self, data):
+        try:
+            self._s3_client.put_object(
+                Bucket=self._s3_bucket,
+                Key=self._s3_key,
+                Body=data
+            )
+            LOGGER.debug(
+                'LookupTable (%s): Object successfully uploaded to S3',
+                self._driver.id
+            )
+        except ClientError as err:
+            LOGGER.error(
+                'LookupTable (%s): Failed to upload to S3. Error message: %s',
+                self._driver.id,
+                err.response['Error']['Message']
+            )
+            raise LookupTablesCommitError(
+                'LookupTable S3 Driver Failed with Message: {}'.format(
+                    err.response['Error']['Message']
+                )
+            )
+        except (ConnectTimeoutError, ReadTimeoutError):
+            # Catching ConnectTimeoutError and ReadTimeoutError from botocore
+            LOGGER.error(
+                'LookupTable (%s): Reading from S3 timed out',
+                self._driver.id
+            )
+            raise LookupTablesCommitError(
+                'LookupTable ({}): Reading from S3 timed out'.format(self._driver.id)
+            )
+
+    def download(self):
         try:
             start_time = time.time()
             s3_object = self._s3_client.Object(self._s3_bucket, self._s3_key).get()
@@ -130,14 +270,16 @@ class S3Driver(PersistenceDriver):
             size_mb = round(size_kb / 1024.0, 2)
             LOGGER.debug(
                 'LookupTable (%s): Downloaded S3 file size %s in %s seconds',
-                self.id,
+                self._driver.id,
                 '{}MB'.format(size_mb) if size_mb else '{}KB'.format(size_kb),
                 round(total_time, 2)
             )
+
+            return data
         except ClientError as err:
             LOGGER.error(
                 'LookupTable (%s): Encountered error while downloading %s from %s: %s',
-                self.id,
+                self._driver.id,
                 self._s3_key,
                 self._s3_bucket,
                 err.response['Error']['Message']
@@ -152,44 +294,8 @@ class S3Driver(PersistenceDriver):
             # Catching ConnectTimeoutError and ReadTimeoutError from botocore
             LOGGER.error(
                 'LookupTable (%s): Reading from S3 timed out',
-                self.id
+                self._driver.id
             )
             raise LookupTablesInitializationError(
-                'LookupTable ({}): Reading from S3 timed out'.format(self.id)
+                'LookupTable ({}): Reading from S3 timed out'.format(self._driver.id)
             )
-
-        # The lookup data can optionally be compressed, so try to decompress
-        # This will fall back and use the original data if decompression fails
-        if self._compression:
-            try:
-                data = zlib.decompress(data, 47)
-                LOGGER.debug(
-                    'LookupTable (%s): Object decompressed to %d byte payload',
-                    self.id,
-                    sys.getsizeof(data)
-                )
-            except zlib.error:
-                LOGGER.warning(
-                    'LookupTable (%s): Data is not compressed; defaulting to original payload',
-                    self.id
-                )
-        else:
-            LOGGER.debug('LookupTable (%s): File does not need decompression')
-
-        # Decode the data; right now we make the assumption that the data is always encoded
-        # as JSON.
-        try:
-            data = json.loads(data)
-            self._cache.setall(data, self._cache_refresh_minutes)
-            self._cache.set(self._MAGIC_CACHE_TTL_KEY, 'True', self._cache_refresh_minutes)
-            LOGGER.debug(
-                'LookupTable (%s): File successfully JSON decoded. Discovered %s keys.',
-                self.id,
-                len(data)
-            )
-        except ValueError:
-            LOGGER.exception(
-                'LookupTable (%s): Failed to json decode data', self.id
-            )
-
-        LOGGER.info('LookupTable (%s): Successfully loaded', self.id)

--- a/stream_alert/shared/lookup_tables/driver_s3.py
+++ b/stream_alert/shared/lookup_tables/driver_s3.py
@@ -162,7 +162,7 @@ class S3Driver(PersistenceDriver):
         LOGGER.info('LookupTable (%s): Successfully loaded', self.id)
 
 
-class Compression(object):
+class Compression:
 
     @staticmethod
     def gz_decompress(driver, data):
@@ -174,7 +174,7 @@ class Compression(object):
                 sys.getsizeof(data)
             )
         except zlib.error:
-            LOGGER.warn(
+            LOGGER.warning(
                 'LookupTable (%s): Data is not compressed; defaulting to original payload',
                 driver.id
             )
@@ -196,7 +196,7 @@ class Compression(object):
             LOGGER.exception('LookupTable (%s): Data compression error.', driver.id)
 
 
-class Encoding(object):
+class Encoding:
     """
     Encapsulation of encoding algorithms for S3 data.
 
@@ -228,7 +228,7 @@ class Encoding(object):
             )
 
 
-class S3Adapter(object):
+class S3Adapter:
     """Adapter class that manages uploading data to and downloading data from AWS S3"""
 
     def __init__(self, driver, boto_s3_client, s3_bucket, s3_key):

--- a/stream_alert/shared/lookup_tables/driver_s3.py
+++ b/stream_alert/shared/lookup_tables/driver_s3.py
@@ -229,8 +229,7 @@ class S3Adapter(object):
 
     def upload(self, data):
         try:
-            self._s3_client.put_object(
-                Bucket=self._s3_bucket,
+            self._s3_client.Bucket(self._s3_bucket).put_object(
                 Key=self._s3_key,
                 Body=data
             )

--- a/stream_alert/shared/lookup_tables/driver_s3.py
+++ b/stream_alert/shared/lookup_tables/driver_s3.py
@@ -123,9 +123,8 @@ class S3Driver(PersistenceDriver):
 
         If it needs a reload, this method will appropriately call reload.
         """
-        if (
-            self._cache.has(self._MAGIC_CACHE_TTL_KEY) and self._cache.get(self._MAGIC_CACHE_TTL_KEY)
-        ):
+        if self._cache.has(self._MAGIC_CACHE_TTL_KEY) and \
+                self._cache.get(self._MAGIC_CACHE_TTL_KEY):
             LOGGER.debug(
                 'LookupTable (%s): Does not need refresh. TTL: %s',
                 self.id,

--- a/stream_alert/shared/lookup_tables/driver_s3.py
+++ b/stream_alert/shared/lookup_tables/driver_s3.py
@@ -1,6 +1,21 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 import json
-import time
 import sys
+import time
 import zlib
 
 import boto3
@@ -10,8 +25,10 @@ import stream_alert.shared.helpers.boto as boto_helpers
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.cache import DriverCache
 from stream_alert.shared.lookup_tables.drivers import PersistenceDriver
-from stream_alert.shared.lookup_tables.errors import LookupTablesInitializationError, \
-    LookupTablesCommitError
+from stream_alert.shared.lookup_tables.errors import (
+    LookupTablesCommitError,
+    LookupTablesInitializationError,
+)
 
 LOGGER = get_logger(__name__)
 

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -1,0 +1,189 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from stream_alert.shared.logger import get_logger
+from stream_alert.shared.lookup_tables.core import LookupTables
+from stream_alert_cli.utils import CliCommand, generate_subparser
+
+LOGGER = get_logger(__name__)
+
+
+class LookupTablesCommand(CliCommand):
+
+    description = 'Describe and manage your LookupTables'
+
+    @classmethod
+    def setup_subparser(cls, subparser):
+        """Add subparser for LookupTables"""
+        lookup_tables_subparsers = subparser.add_subparsers()
+
+        cls._setup_describe_tables_subparser(lookup_tables_subparsers)
+        cls._setup_get_subparser(lookup_tables_subparsers)
+        cls._setup_set_subparser(lookup_tables_subparsers)
+
+    @classmethod
+    def _setup_describe_tables_subparser(cls, subparsers):
+        generate_subparser(
+            subparsers,
+            'describe-tables',
+            description='Show tables',
+            subcommand=True
+        )
+
+    @classmethod
+    def _setup_get_subparser(cls, subparsers):
+        """
+        Get subcommand:
+
+        $ ./manage.py lookup-tables get -t [table] -k [key]
+        """
+        get_parser = generate_subparser(
+            subparsers,
+            'get',
+            description='Validate defined log schemas using integration test files',
+            subcommand=True
+        )
+
+        get_parser.add_argument(
+            '-t',
+            '--table',
+            help='Name of the LookupTable',
+            required=True,
+            default=None
+        )
+
+        get_parser.add_argument(
+            '-k',
+            '--key',
+            help='Key to fetch on the LookupTable',
+            required=True,
+            default=None
+        )
+
+    @classmethod
+    def _setup_set_subparser(cls, subparsers):
+        """
+        Set subcommand:
+
+        $ ./manage.py lookup-tables set -t [table] -k [key] -v [value]
+        """
+        set_parser = generate_subparser(
+            subparsers,
+            'set',
+            description='Validate defined log schemas using integration test files',
+            subcommand=True
+        )
+
+        set_parser.add_argument(
+            '-t',
+            '--table',
+            help='Name of the LookupTable',
+            required=True,
+            default=None
+        )
+
+        set_parser.add_argument(
+            '-k',
+            '--key',
+            help='Key to set on the LookupTable',
+            required=True,
+            default=None
+        )
+
+        set_parser.add_argument(
+            '-v',
+            '--value',
+            help='Value to save into LookupTable',
+            required=True,
+            default=None
+        )
+
+    @classmethod
+    def handler(cls, options, config):
+        subcommand = options.subcommand
+        if subcommand == 'describe-tables':
+            return cls._describe_tables_handler(config)
+        elif subcommand == 'get':
+            return cls._get_handler(options, config)
+        elif subcommand == 'set':
+            return cls._set_handler(options, config)
+        else:
+            LOGGER.error('Unhandled lookup-tables subcommand %s', subcommand)
+
+    # pylint: disable=protected-access
+    @staticmethod
+    def _describe_tables_handler(config):
+        LOGGER.info('==== LookupTables; Describe Tables ====\n')
+
+        lookup_tables = LookupTables.get_instance(config=config)
+
+        LOGGER.info('%d Tables:\n', len(lookup_tables._tables))
+        for _, table in lookup_tables._tables.iteritems():
+            LOGGER.info(' Table Name: %s', table.table_name)
+            LOGGER.info(' Driver Id: %s', table.driver_id)
+            LOGGER.info(' Driver Type: %s\n', table.driver_type)
+
+    @staticmethod
+    def _show_keys_handler(options, config):
+        LOGGER.info('==== LookupTables; Show Keys ====\n')
+
+    @staticmethod
+    def _get_handler(options, config):
+        """
+
+
+        """
+
+        table_name = options.table
+        key = options.key
+
+        LOGGER.info('==== LookupTables; Get Key ====')
+
+        LookupTables.get_instance(config=config)
+
+        LOGGER.info('  Table: %s', table_name)
+        LOGGER.info('  Key:   %s', key)
+
+        value = LookupTables.get(table_name, key)
+
+        LOGGER.info('  Value: %s', value)
+
+        return True
+
+    @staticmethod
+    def _set_handler(options, config):
+        """
+
+        """
+        table_name = options.table
+        key = options.key
+        new_value = options.value
+
+        LOGGER.info('==== LookupTables; Set Key ====')
+
+        core = LookupTables.get_instance(config=config)
+
+        LOGGER.info('  Table: %s', table_name)
+        LOGGER.info('  Key:   %s', key)
+
+        table = core.table(table_name)
+        old_value = table.get(key)
+
+        LOGGER.info('  Value: %s --> %s', old_value, new_value)
+
+        table._driver.set(key, new_value)
+        table._driver.commit()
+
+        return True

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -132,7 +132,7 @@ class LookupTablesCommand(CliCommand):
         lookup_tables = LookupTables.get_instance(config=config)
 
         LOGGER.info('%d Tables:\n', len(lookup_tables._tables))
-        for _, table in lookup_tables._tables.iteritems():
+        for _, table in lookup_tables._tables.items():
             LOGGER.info(' Table Name: %s', table.table_name)
             LOGGER.info(' Driver Id: %s', table.driver_id)
             LOGGER.info(' Driver Type: %s\n', table.driver_type)

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -115,12 +115,14 @@ class LookupTablesCommand(CliCommand):
         subcommand = options.subcommand
         if subcommand == 'describe-tables':
             return cls._describe_tables_handler(config)
-        elif subcommand == 'get':
+
+        if subcommand == 'get':
             return cls._get_handler(options, config)
-        elif subcommand == 'set':
+
+        if subcommand == 'set':
             return cls._set_handler(options, config)
-        else:
-            LOGGER.error('Unhandled lookup-tables subcommand %s', subcommand)
+
+        LOGGER.error('Unhandled lookup-tables subcommand %s', subcommand)
 
     # pylint: disable=protected-access
     @staticmethod

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -136,10 +136,6 @@ class LookupTablesCommand(CliCommand):
             LOGGER.info(' Driver Type: %s\n', table.driver_type)
 
     @staticmethod
-    def _show_keys_handler(options, config):
-        LOGGER.info('==== LookupTables; Show Keys ====\n')
-
-    @staticmethod
     def _get_handler(options, config):
         """
 

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -15,12 +15,12 @@ limitations under the License.
 """
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.core import LookupTables
-from stream_alert_cli.utils import CliCommand, generate_subparser
+from stream_alert_cli.utils import CLICommand, generate_subparser
 
 LOGGER = get_logger(__name__)
 
 
-class LookupTablesCommand(CliCommand):
+class LookupTablesCommand(CLICommand):
 
     description = 'Describe and manage your LookupTables'
 

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.core import LookupTables
-from stream_alert_cli.utils import CLICommand, generate_subparser
+from stream_alert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
 
 LOGGER = get_logger(__name__)
 
@@ -27,6 +27,17 @@ class LookupTablesCommand(CLICommand):
     @classmethod
     def setup_subparser(cls, subparser):
         """Add subparser for LookupTables"""
+        set_parser_epilog(
+            subparser,
+            epilog=(
+                '''\
+                Examples:
+
+                    manage.py lookup-tables [describe-tables|get|set]
+                '''
+            )
+        )
+
         lookup_tables_subparsers = subparser.add_subparsers()
 
         cls._setup_describe_tables_subparser(lookup_tables_subparsers)
@@ -35,25 +46,42 @@ class LookupTablesCommand(CLICommand):
 
     @classmethod
     def _setup_describe_tables_subparser(cls, subparsers):
-        generate_subparser(
+        describe_tables_parser = generate_subparser(
             subparsers,
             'describe-tables',
-            description='Show tables',
+            description='Shows metadata about all currently configured LookupTables',
             subcommand=True
+        )
+
+        set_parser_epilog(
+            describe_tables_parser,
+            epilog=(
+                '''\
+                Examples:
+
+                    manage.py lookup-tables describe-tables
+                '''
+            )
         )
 
     @classmethod
     def _setup_get_subparser(cls, subparsers):
-        """
-        Get subcommand:
-
-        $ ./manage.py lookup-tables get -t [table] -k [key]
-        """
         get_parser = generate_subparser(
             subparsers,
             'get',
-            description='Validate defined log schemas using integration test files',
+            description='Retrieves a key from the requested LookupTable',
             subcommand=True
+        )
+
+        set_parser_epilog(
+            get_parser,
+            epilog=(
+                '''\
+                Examples:
+
+                    manage.py lookup-tables get -t [table] -k [key]
+                '''
+            )
         )
 
         get_parser.add_argument(
@@ -74,16 +102,22 @@ class LookupTablesCommand(CLICommand):
 
     @classmethod
     def _setup_set_subparser(cls, subparsers):
-        """
-        Set subcommand:
-
-        $ ./manage.py lookup-tables set -t [table] -k [key] -v [value]
-        """
         set_parser = generate_subparser(
             subparsers,
             'set',
-            description='Validate defined log schemas using integration test files',
+            description='Sets a key on the requested LookupTable',
             subcommand=True
+        )
+
+        set_parser_epilog(
+            set_parser,
+            epilog=(
+                '''\
+                Examples:
+
+                    manage.py lookup-tables set -t [table] -k [key] -v [value]
+                '''
+            )
         )
 
         set_parser.add_argument(
@@ -127,59 +161,51 @@ class LookupTablesCommand(CLICommand):
     # pylint: disable=protected-access
     @staticmethod
     def _describe_tables_handler(config):
-        LOGGER.info('==== LookupTables; Describe Tables ====\n')
+        print('==== LookupTables; Describe Tables ====\n')
 
         lookup_tables = LookupTables.get_instance(config=config)
 
-        LOGGER.info('%d Tables:\n', len(lookup_tables._tables))
+        print('{} Tables:\n'.format(len(lookup_tables._tables)))
         for _, table in lookup_tables._tables.items():
-            LOGGER.info(' Table Name: %s', table.table_name)
-            LOGGER.info(' Driver Id: %s', table.driver_id)
-            LOGGER.info(' Driver Type: %s\n', table.driver_type)
+            print(' Table Name: {}'.format(table.table_name))
+            print(' Driver Id: {}'.format(table.driver_id))
+            print(' Driver Type: {}\n'.format(table.driver_type))
 
     @staticmethod
     def _get_handler(options, config):
-        """
-
-
-        """
-
         table_name = options.table
         key = options.key
 
-        LOGGER.info('==== LookupTables; Get Key ====')
+        print('==== LookupTables; Get Key ====')
 
         LookupTables.get_instance(config=config)
 
-        LOGGER.info('  Table: %s', table_name)
-        LOGGER.info('  Key:   %s', key)
+        print('  Table: {}'.format(table_name))
+        print('  Key:   {}'.format(key))
 
         value = LookupTables.get(table_name, key)
 
-        LOGGER.info('  Value: %s', value)
+        print('  Value: {}'.format(value))
 
         return True
 
     @staticmethod
     def _set_handler(options, config):
-        """
-
-        """
         table_name = options.table
         key = options.key
         new_value = options.value
 
-        LOGGER.info('==== LookupTables; Set Key ====')
+        print('==== LookupTables; Set Key ====')
 
         core = LookupTables.get_instance(config=config)
 
-        LOGGER.info('  Table: %s', table_name)
-        LOGGER.info('  Key:   %s', key)
+        print('  Table: {}'.format(table_name))
+        print('  Key:   {}'.format(key))
 
         table = core.table(table_name)
         old_value = table.get(key)
 
-        LOGGER.info('  Value: %s --> %s', old_value, new_value)
+        print('  Value: {} --> {}'.format(old_value, new_value))
 
         table._driver.set(key, new_value)
         table._driver.commit()

--- a/stream_alert_cli/runner.py
+++ b/stream_alert_cli/runner.py
@@ -20,12 +20,13 @@ from stream_alert_cli.config import CLIConfig
 from stream_alert_cli.configure.handler import ConfigureCommand
 from stream_alert_cli.kinesis.handler import KinesisCommand
 from stream_alert_cli.logger import set_logger_levels
+from stream_alert_cli.lookup_tables.handler import LookupTablesCommand
 from stream_alert_cli.manage_lambda.deploy import DeployCommand
 from stream_alert_cli.manage_lambda.rollback import RollbackCommand
 from stream_alert_cli.metrics_alarms.handler import (
-    CreateClusterMetricAlarmCommand,
     CreateMetricAlarmCommand,
-    CustomMetricsCommand
+    CreateClusterMetricAlarmCommand,
+    CustomMetricsCommand,
 )
 from stream_alert_cli.outputs.handler import OutputCommand
 from stream_alert_cli.rule_table import RuleStagingCommand
@@ -103,7 +104,7 @@ class StreamAlertCLICommandRepository:
             'init': TerraformInitCommand,
             'kinesis': KinesisCommand,
             'list-targets': TerraformListTargetsCommand,
-            # 'lookup-tables': LookupTablesCommand,
+            'lookup-tables': LookupTablesCommand,
             'output': OutputCommand,
             'rollback': RollbackCommand,
             'rule-staging': RuleStagingCommand,

--- a/tests/unit/stream_alert_shared/lookup_tables/test_driver_dynamodb.py
+++ b/tests/unit/stream_alert_shared/lookup_tables/test_driver_dynamodb.py
@@ -219,6 +219,20 @@ class TestDynamoDBDriver:
             'bbbb:1'
         )
 
+    def test_set_commit_get(self, ):
+        """LookupTables - Drivers - DynamoDB Driver - Set/Commmit - Can be refetched"""
+        self._driver.initialize()
+
+        self._driver.set('asdfasdf:1', 'A whole new world')
+        self._driver.commit()
+        assert_equal(self._driver.get('asdfasdf:1'), 'A whole new world')
+
+    def test_invalid_key(self, ):
+        """LookupTables - Drivers - DynamoDB Driver - Get - Invalid key raises"""
+        self._driver.initialize()
+
+        assert_raises(LookupTablesInitializationError, self._driver.get, 'invalid-key')
+
 
 # pylint: disable=protected-access,attribute-defined-outside-init,no-self-use,invalid-name
 class TestDynamoDBDriver_MultiTable:

--- a/tests/unit/stream_alert_shared/lookup_tables/test_driver_s3.py
+++ b/tests/unit/stream_alert_shared/lookup_tables/test_driver_s3.py
@@ -217,3 +217,11 @@ class TestS3Driver:
             'LookupTable (%s): Needs refresh, starting now.',
             's3:bucket_name/foo.json'
         )
+
+    def test_set_commit_get(self):
+        """LookupTables - Drivers - S3 Driver - Set Commit Get"""
+        self._foo_driver.initialize()
+
+        self._foo_driver.set('new_key', 'BazBuzz')
+        self._foo_driver.commit()
+        assert_equal(self._foo_driver.get('new_key'), 'BazBuzz')


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers 

# Background

I've added several `manage.py` commands that allow LookupTables to be managed by the CLI.

### `manage.py lookup-tables describe-tables`
Shows all currently configured tables.

### `manage.py lookup-tables get`
Using the `--table` and `--key` options, queries the respective LookupTable and returns the value at the key.

### `manage.py lookup-tables set`
Using the `--table`, `--key` and `--value` options, it sets the value into the given LookupTable's key.