### PR TITLE
misc fixups to python3 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ docs/build
 
 # Compiled Python files
 *.pyc
+__pycache__
 
 # Terraform files
 *.terraform/

--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -212,7 +212,7 @@ class AthenaRefresher:
 
                 self._s3_buckets_and_keys[bucket_name].add(object_key)
 
-        if not (is_test_notification or _self._add_partitions()):
+        if not (is_test_notification or self._add_partitions()):
             raise AthenaRefreshError(
                 'Failed to add partitions: {}'.format(dict(self._s3_buckets_and_keys))
             )

--- a/stream_alert/athena_partition_refresh/main.py
+++ b/stream_alert/athena_partition_refresh/main.py
@@ -183,6 +183,7 @@ class AthenaRefresher:
                 should contain one (or maybe more) S3 bucket notification message.
         """
         # Check that the database being used exists before running queries
+        is_test_notification = False
         for sqs_rec in event['Records']:
             LOGGER.debug('Processing event with message ID \'%s\' and SentTimestamp %s',
                          sqs_rec['messageId'],
@@ -190,6 +191,7 @@ class AthenaRefresher:
 
             body = json.loads(sqs_rec['body'])
             if body.get('Event') == 's3:TestEvent':
+                is_test_notification = True
                 LOGGER.debug('Skipping S3 bucket notification test event')
                 continue
 
@@ -210,7 +212,7 @@ class AthenaRefresher:
 
                 self._s3_buckets_and_keys[bucket_name].add(object_key)
 
-        if not self._add_partitions():
+        if not (is_test_notification or _self._add_partitions()):
             raise AthenaRefreshError(
                 'Failed to add partitions: {}'.format(dict(self._s3_buckets_and_keys))
             )

--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -639,6 +639,8 @@ class CSVParser(ParserBase):
             StringIO: Open CSV reader object or False upon error
         """
         try:
+            if isinstance(data, bytes):
+                data = data.decode()
             return csv.reader(
                 io.StringIO(data),
                 delimiter=self.delimiter,

--- a/stream_alert/shared/rule.py
+++ b/stream_alert/shared/rule.py
@@ -17,6 +17,7 @@ import ast
 from copy import deepcopy
 import hashlib
 import inspect
+import json
 
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.stats import time_rule
@@ -159,6 +160,7 @@ class Rule:
             return self.func(record)
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception('Encountered error with rule: %s', self.name)
+            LOGGER.error('Record that resulted in error:\n%s', json.dumps(record))
 
         return False
 

--- a/stream_alert_cli/terraform/athena.py
+++ b/stream_alert_cli/terraform/athena.py
@@ -30,7 +30,7 @@ def generate_athena(config):
     athena_dict = infinitedict()
     athena_config = config['lambda']['athena_partition_refresh_config']
 
-    data_buckets = list(athena_config['buckets'].keys())
+    data_buckets = sorted(athena_config['buckets'])
 
     prefix = config['global']['account']['prefix']
     database = athena_config.get('database_name', '{}_streamalert'.format(prefix))

--- a/stream_alert_cli/terraform/rule_promotion.py
+++ b/stream_alert_cli/terraform/rule_promotion.py
@@ -37,7 +37,7 @@ def generate_rule_promotion(config):
     result = infinitedict()
 
     athena_config = config['lambda']['athena_partition_refresh_config']
-    data_buckets = list(athena_config['buckets'].keys())
+    data_buckets = sorted(athena_config['buckets'])
 
     # Set variables for the IAM permissions, etc module
     result['module']['rule_promotion_iam'] = {

--- a/tests/unit/streamalert/classifier/test_parsers_csv.py
+++ b/tests/unit/streamalert/classifier/test_parsers_csv.py
@@ -30,7 +30,7 @@ class TestCSVParser:
         return OrderedDict([('host', 'string'), ('date', 'string'), ('message', 'string')])
 
     def test_basic_parsing(self):
-        """CSVParser - Basic CSV data"""
+        """CSVParser - Basic CSV data, str"""
         options = {
             'schema': self._default_schema(),
             'configuration': {
@@ -38,6 +38,30 @@ class TestCSVParser:
             }
         }
         data = 'test-01.stg.foo.net,01-01-2018,test message!!!!'
+
+        # get parsed data
+        parser = CSVParser(options)
+        result = parser.parse(data)
+        assert_equal(result, True)
+
+        expected_result = [
+            {
+                'date': '01-01-2018',
+                'host': 'test-01.stg.foo.net',
+                'message': 'test message!!!!'
+            }
+        ]
+        assert_equal(parser.parsed_records, expected_result)
+
+    def test_basic_parsing_bytes(self):
+        """CSVParser - Basic CSV data, bytes"""
+        options = {
+            'schema': self._default_schema(),
+            'configuration': {
+                'delimiter': ','
+            }
+        }
+        data = b'test-01.stg.foo.net,01-01-2018,test message!!!!'
 
         # get parsed data
         parser = CSVParser(options)


### PR DESCRIPTION
to: @Ryxias  
cc: @airbnb/streamalert-maintainers

## Changes

* ensuring same order for some terraform variables
* ensuring csv reader receives str when bytes is passed
* adding record logging upon rule failure
* adding logic to not raise exception on s3 test event in athena func
* adding __pycache__ to gitignore


## Testing

* Adding unit test for csv bytes vs str