### PR TITLE
fixing trash logging in cloudwatch logs

### DIFF
--- a/stream_alert/shared/logger.py
+++ b/stream_alert/shared/logger.py
@@ -16,6 +16,44 @@ limitations under the License.
 import logging
 import os
 
+LOCAL_LOGGER_FMT = '[%(levelname)s %(asctime)s (%(name)s:%(lineno)d)]: %(message)s'
+
+
+class LogFormatter(logging.Formatter):
+
+    def formatException(self, ei):
+        """Override the default exception logger so it looks nice in CloudWatch Logs"""
+        value = super().formatException(ei)
+
+        # Replace the newlines with carriage returns
+        return value.replace('\n', '\r')
+
+
+def set_formatter(logger):
+    """
+    The Lambda execution environment injects a default `LambdaLoggerHandler`
+    into the root logger, so we just want to update the traceback formatter on
+    it without changing the actual logging format.
+
+    Alternatively, locally the root logger will not have any handlers. In this case,
+    we create a logging.StreamHandler and add the formatter to it.
+
+    Args:
+        logger (logging.Logger): An instance of a logger for which to update the formatter
+    """
+    # Update the LambdaLoggerHandler formatter
+    if logger.hasHandlers():
+        formatter = LogFormatter()
+        for handler in logger.handlers + logger.parent.handlers:
+            handler.setFormatter(formatter)
+        return
+
+    # Otherwise, create a handler with the desired formatter
+    formatter = LogFormatter(fmt=LOCAL_LOGGER_FMT)
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
 
 def get_logger(name, level=None):
     """Get a logger instance for the specified name.
@@ -31,8 +69,9 @@ def get_logger(name, level=None):
     if not level:
         level = os.environ.get('LOGGER_LEVEL', 'INFO')
 
-    logging.basicConfig(format='[%(levelname)s %(asctime)s (%(name)s:%(lineno)d)]: %(message)s')
     logger = logging.getLogger(name)
+
+    set_formatter(logger)
 
     try:
         logger.setLevel(level.upper())


### PR DESCRIPTION
to: @Ryxias or @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

I discovered that tracebacks in the python3 Lambda environment log in a terrible format to CloudWatch Logs. One line gets logged per-entry, instead of a uniform stack trace.

![image](https://user-images.githubusercontent.com/13773789/64051864-7186b380-cb31-11e9-8f3d-a42b758b8cb1.png)

## Changes

* Adding a custom formatter that replaces new lines with carriage returns.
* Applying formatting to applicable handlers (inside and outside of Lambda env).

## Testing

Adding unit tests for new formatter logic.
