### PR TITLE
removing ushlex due to py3 incompatibility

### DIFF
--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -24,5 +24,4 @@ pylint
 requests
 Sphinx
 sphinx-rtd-theme
-ushlex
 yapf

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,6 @@ typed-ast==1.4.0
 typing==3.6.6
 uritemplate==3.0.0
 urllib3==1.25.3
-ushlex==0.99.1
 validators==0.13.0
 wcwidth==0.1.7
 websocket-client==0.56.0


### PR DESCRIPTION
to: @chunyong-lin / @Ryxias 
cc: @airbnb/streamalert-maintainers

## Background

The default shlex supports unicode now, and ushlex is not a thing in python3.

## Changes

* Removing the ushlex package.
