### PR TITLE
small hack to retain original lambda formatter

### DIFF
--- a/stream_alert/shared/logger.py
+++ b/stream_alert/shared/logger.py
@@ -45,7 +45,9 @@ def set_formatter(logger):
     if logger.hasHandlers():
         for handler in logger.handlers + logger.parent.handlers:
             # pylint: disable=protected-access
-            handler.setFormatter(LogFormatter(fmt=handler.formatter._fmt))
+            # Retain the handlers format spec if it has one
+            fmt = handler.formatter._fmt if handler.formatter else None
+            handler.setFormatter(LogFormatter(fmt=fmt))
         return
 
     # Otherwise, create a handler with the desired formatter

--- a/stream_alert/shared/logger.py
+++ b/stream_alert/shared/logger.py
@@ -43,9 +43,9 @@ def set_formatter(logger):
     """
     # Update the LambdaLoggerHandler formatter
     if logger.hasHandlers():
-        formatter = LogFormatter()
         for handler in logger.handlers + logger.parent.handlers:
-            handler.setFormatter(formatter)
+            # pylint: disable=protected-access
+            handler.setFormatter(LogFormatter(fmt=handler.formatter._fmt))
         return
 
     # Otherwise, create a handler with the desired formatter


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Changes made in #988 stripped the formatting within the lambda execution environment.

## Changes

* Making change to retain the original formatter's format.
* As specified by the AWS Lambda logging handler, this will now be:

`[%(levelname)s]	%(asctime)s.%(msecs)dZ	%(aws_request_id)s	%(message)s`
