### PR TITLE
fix bug with joining non-string values

### DIFF
--- a/stream_alert/classifier/parsers.py
+++ b/stream_alert/classifier/parsers.py
@@ -252,11 +252,19 @@ class ParserBase(metaclass=ABCMeta):
         if not is_envelope and keys != schema_keys:
             expected = schema_keys - keys
             if expected:
-                LOGGER.debug('Expected keys not found in record: %s', ', '.join(sorted(expected)))
+                LOGGER.debug(
+                    'Expected keys not found in record: %s', ', '.join(
+                        str(val) for val in sorted(expected, key=str)
+                    )
+                )
 
             found = keys - schema_keys
             if found:
-                LOGGER.debug('Found keys not expected in record: %s', ', '.join(sorted(found)))
+                LOGGER.debug(
+                    'Found keys not expected in record: %s', ', '.join(
+                        str(val) for val in sorted(found, key=str)
+                    )
+                )
             return False
 
         # Nested key check

--- a/tests/unit/streamalert/classifier/test_parsers_base.py
+++ b/tests/unit/streamalert/classifier/test_parsers_base.py
@@ -268,6 +268,19 @@ class TestParserBaseClassMethods:
         assert_equal(ParserBase._key_check(record, schema), False)
         log_mock.assert_called_with('Found keys not expected in record: %s', 'not_key')
 
+    @patch('logging.Logger.debug')
+    def test_key_check_mismatch_non_str_key(self, log_mock):
+        """ParserBase - Key Check, Mismatch; Non-String Key"""
+        schema = {
+            'key': 'string'
+        }
+        record = {
+            100: 'test',
+            200: 'test'
+        }
+        assert_equal(ParserBase._key_check(record, schema), False)
+        log_mock.assert_called_with('Found keys not expected in record: %s', '100, 200')
+
     def test_key_check_nested(self):
         """ParserBase - Key Check, Nested"""
         schema = {


### PR DESCRIPTION
to: @chunyong-lin / @Ryxias 
cc: @airbnb/streamalert-maintainers


Discovered bug in classifier when joining a list of not strictly integers:

```
[ERROR] TypeError: sequence item 0: expected str instance, int found
Traceback (most recent call last):
  File "/var/task/stream_alert/classifier/main.py", line 26, in handler
    Classifier().run(event.get('Records', []))
  File "/var/task/stream_alert/classifier/classifier.py", line 244, in run
    self._classify_payload(payload)
  File "/var/task/stream_alert/classifier/classifier.py", line 164, in _classify_payload
    self._process_log_schemas(record, logs_config)
  File "/var/task/stream_alert/classifier/classifier.py", line 129, in _process_log_schemas
    parsed = parser.parse(payload_record.data)
  File "/var/task/stream_alert/classifier/parsers.py", line 482, in parse
    valid = valid and self._key_check(record, self._schema, self._optional_top_level_keys)
  File "/var/task/stream_alert/classifier/parsers.py", line 259, in _key_check
    LOGGER.debug('Found keys not expected in record: %s', ', '.join(sorted(found)))
```

## Changes

* Casting items in list to string.

## Testing

Added unit test for this.
