### PR TITLE
Automatically generates AWS IAM Policies for LookupTables

### DIFF
--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -514,6 +514,15 @@ def _generate_lookup_tables_settings(config):
             dynamodb_tables.append(table_config['table'])
             continue
 
+    roles = [
+        '${module.alert_processor_lambda.role_id}',
+        '${module.alert_merger_lambda.role_id}',
+        '${module.rules_engine_lambda.role_id}',
+    ]
+
+    for cluster in config.clusters():
+        roles.append('${{module.classifier_{}_lambda.role_id}}'.format(cluster))
+
     generated_config = {
         'module': {
             'lookup_tables_iam': {
@@ -522,7 +531,8 @@ def _generate_lookup_tables_settings(config):
                 'region': config['global']['account']['region'],
                 'prefix': config['global']['account']['prefix'],
                 'dynamodb_tables': dynamodb_tables,
-                's3_buckets': s3_buckets
+                's3_buckets': s3_buckets,
+                'roles': roles,
             }
         }
     }

--- a/stream_alert_cli/terraform/generate.py
+++ b/stream_alert_cli/terraform/generate.py
@@ -496,10 +496,10 @@ def _generate_lookup_tables_settings(config):
     """
     Generates .tf.json file for LookupTables
     """
-    tf_file = 'terraform/lookup_tables.tf.json'
+    tf_file_name = 'terraform/lookup_tables.tf.json'
 
     if not config['lookup_tables'].get('enabled', False):
-        remove_temp_terraform_file(tf_file, 'Removing old LookupTables Terraform file')
+        remove_temp_terraform_file(tf_file_name, 'Removing old LookupTables Terraform file')
         return
 
     dynamodb_tables = []
@@ -511,7 +511,7 @@ def _generate_lookup_tables_settings(config):
             continue
 
         if table_config['driver'] == 'dynamodb':
-            s3_buckets.append(table_config['table'])
+            dynamodb_tables.append(table_config['table'])
             continue
 
     generated_config = {
@@ -526,7 +526,8 @@ def _generate_lookup_tables_settings(config):
             }
         }
     }
-    json.dump(generated_config, tf_file, indent=2, sort_keys=True)
+    with open(tf_file_name, 'w') as tf_file:
+        json.dump(generated_config, tf_file, indent=2, sort_keys=True)
 
 
 def generate_global_lambda_settings(config, config_name, generate_func, tf_tmp_file, message):

--- a/stream_alert_cli/terraform/handlers.py
+++ b/stream_alert_cli/terraform/handlers.py
@@ -109,7 +109,6 @@ class TerraformInitCommand(CLICommand):
         LOGGER.info('Building remainding infrastructure')
         return tf_runner(refresh=False)
 
-
     @staticmethod
     def _terraform_init_backend():
         """Initialize the infrastructure backend (S3) using Terraform

--- a/terraform/modules/tf_lookup_tables/README.md
+++ b/terraform/modules/tf_lookup_tables/README.md
@@ -1,0 +1,3 @@
+# Lookup Tables Terraform
+This module adds IAM permissions to read from LookupTables's DynamoDB and S3 resources. It grants
+these permissions to all StreamAlert Lambda functions.

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "streamalert_read_objects_from_lookup_tables_s3" {
+  statement {
+    actions   = ["s3:List*"]
+    resources = "${local.s3_bucket_arns}"
+  }
+
+  statement {
+    actions   = ["s3:Get*"]
+    resources = "${local.s3_bucket_arn_star}"
+  }
+}
+
+data "aws_iam_policy_document" "streamalert_read_items_from_lookup_tables_dynamodb" {
+  statement {
+    actions   = [
+      "dynamodb:GetItem",
+      "dynamodb:DescribedTable"
+    ]
+    resources = "${local.dynamodb_table_arns}"
+  }
+}
+
+
+resource "aws_iam_policy" "streamalert_read_from_lookup_tables_policy" {
+  name   = "StreamAlertReadFromLookupTablesPolicy"
+  policy = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables_dynamodb.json}"
+}
+
+resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
+  name       = "StreamAlertPermissionReadFromLookupTAbles"
+  roles      = "${local.lambda_roles}"
+  policy_arn = "${aws_iam_policy.streamalert_read_from_lookup_tables_policy.arn}"
+}
+
+locals {
+  lambda_roles = [
+    "airbnb_streamalert_rules_engine_role",
+    "airbnb_streamalert_alert_processor_role",
+    "airbnb_streamalert_classifier_*_role",
+  ]
+
+  s3_bucket_arns = "${formatlist("arn:aws:s3:::%s", var.s3_buckets)}"
+  s3_bucket_arn_star = "${formatlist("arn:aws:s3:::%s/*", var.s3_buckets)}"
+
+  dynamodb_table_arns = "${formatlist("arn:aws:dynamodb:%s:%s:%s", var.account_id, var.region, var.dynamodb_tables)}"
+}

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -31,11 +31,7 @@ resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
 }
 
 locals {
-  lambda_roles = [
-    "${var.prefix}_streamalert_rules_engine_role",
-    "${var.prefix}_streamalert_alert_processor_role",
-    "${var.prefix}_streamalert_classifier_prod_role", # FIXME (derek.wang) dynamically generate these
-  ]
+  lambda_roles = "${var.roles}"
 
   s3_bucket_arns = "${formatlist("arn:aws:s3:::%s", var.s3_buckets)}"
   s3_bucket_arn_star = "${formatlist("arn:aws:s3:::%s/*", var.s3_buckets)}"

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "streamalert_read_items_from_lookup_tables_dynamo
   statement {
     actions   = [
       "dynamodb:GetItem",
-      "dynamodb:DescribedTable"
+      "dynamodb:DescribeTable"
     ]
     resources = "${local.dynamodb_table_arns}"
   }
@@ -27,7 +27,7 @@ resource "aws_iam_policy" "streamalert_read_from_lookup_tables_policy" {
 }
 
 resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
-  name       = "StreamAlertPermissionReadFromLookupTAbles"
+  name       = "StreamAlertPermissionReadFromLookupTables"
   roles      = "${local.lambda_roles}"
   policy_arn = "${aws_iam_policy.streamalert_read_from_lookup_tables_policy.arn}"
 }
@@ -42,5 +42,5 @@ locals {
   s3_bucket_arns = "${formatlist("arn:aws:s3:::%s", var.s3_buckets)}"
   s3_bucket_arn_star = "${formatlist("arn:aws:s3:::%s/*", var.s3_buckets)}"
 
-  dynamodb_table_arns = "${formatlist("arn:aws:dynamodb:%s:%s:%s", var.account_id, var.region, var.dynamodb_tables)}"
+  dynamodb_table_arns = "${formatlist("arn:aws:dynamodb:%s:%s:table/%s", var.region, var.account_id, var.dynamodb_tables)}"
 }

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -1,4 +1,12 @@
-data "aws_iam_policy_document" "streamalert_read_objects_from_lookup_tables_s3" {
+data "aws_iam_policy_document" "streamalert_read_items_from_lookup_tables" {
+  statement {
+    actions   = [
+      "dynamodb:GetItem",
+      "dynamodb:DescribeTable"
+    ]
+    resources = "${local.dynamodb_table_arns}"
+  }
+
   statement {
     actions   = ["s3:List*"]
     resources = "${local.s3_bucket_arns}"
@@ -10,20 +18,10 @@ data "aws_iam_policy_document" "streamalert_read_objects_from_lookup_tables_s3" 
   }
 }
 
-data "aws_iam_policy_document" "streamalert_read_items_from_lookup_tables_dynamodb" {
-  statement {
-    actions   = [
-      "dynamodb:GetItem",
-      "dynamodb:DescribeTable"
-    ]
-    resources = "${local.dynamodb_table_arns}"
-  }
-}
-
 
 resource "aws_iam_policy" "streamalert_read_from_lookup_tables_policy" {
   name   = "StreamAlertReadFromLookupTablesPolicy"
-  policy = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables_dynamodb.json}"
+  policy = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables.json}"
 }
 
 resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -24,9 +24,9 @@ resource "aws_iam_policy" "streamalert_read_from_lookup_tables_policy" {
   policy = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables.json}"
 }
 
-resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
-  name       = "StreamAlertPermissionReadFromLookupTables"
-  roles      = ["${var.roles}"]
+resource "aws_iam_role_policy_attachment" "streamalert_read_from_lookup_tables" {
+  count      = "${length(var.roles)}"
+  role       = "${element(var.roles, count.index)}"
   policy_arn = "${aws_iam_policy.streamalert_read_from_lookup_tables_policy.arn}"
 }
 

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -34,9 +34,9 @@ resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
 
 locals {
   lambda_roles = [
-    "airbnb_streamalert_rules_engine_role",
-    "airbnb_streamalert_alert_processor_role",
-    "airbnb_streamalert_classifier_*_role",
+    "${var.prefix}_streamalert_rules_engine_role",
+    "${var.prefix}_streamalert_alert_processor_role",
+    "${var.prefix}_streamalert_classifier_prod_role", # FIXME (derek.wang) dynamically generate these
   ]
 
   s3_bucket_arns = "${formatlist("arn:aws:s3:::%s", var.s3_buckets)}"

--- a/terraform/modules/tf_lookup_tables/main.tf
+++ b/terraform/modules/tf_lookup_tables/main.tf
@@ -26,13 +26,11 @@ resource "aws_iam_policy" "streamalert_read_from_lookup_tables_policy" {
 
 resource "aws_iam_policy_attachment" "streamalert_read_from_lookup_tables" {
   name       = "StreamAlertPermissionReadFromLookupTables"
-  roles      = "${local.lambda_roles}"
+  roles      = ["${var.roles}"]
   policy_arn = "${aws_iam_policy.streamalert_read_from_lookup_tables_policy.arn}"
 }
 
 locals {
-  lambda_roles = "${var.roles}"
-
   s3_bucket_arns = "${formatlist("arn:aws:s3:::%s", var.s3_buckets)}"
   s3_bucket_arn_star = "${formatlist("arn:aws:s3:::%s/*", var.s3_buckets)}"
 

--- a/terraform/modules/tf_lookup_tables/variables.tf
+++ b/terraform/modules/tf_lookup_tables/variables.tf
@@ -8,6 +8,11 @@ variable "s3_buckets" {
   type        = "list"
 }
 
+variable "roles" {
+  description = "Role ids to grant LookupTable access to"
+  type        = "list"
+}
+
 variable "account_id" {
   type = "string"
 }

--- a/terraform/modules/tf_lookup_tables/variables.tf
+++ b/terraform/modules/tf_lookup_tables/variables.tf
@@ -1,13 +1,11 @@
 variable "dynamodb_tables" {
   description = "DynamoDb tables to grant LookupTable access to"
   type        = "list"
-  default     = []
 }
 
 variable "s3_buckets" {
   description = "S3 buckets to grant LookupTable access to"
   type        = "list"
-  default     = []
 }
 
 variable "account_id" {
@@ -15,5 +13,9 @@ variable "account_id" {
 }
 
 variable "region" {
+  type = "string"
+}
+
+variable "prefix" {
   type = "string"
 }

--- a/terraform/modules/tf_lookup_tables/variables.tf
+++ b/terraform/modules/tf_lookup_tables/variables.tf
@@ -1,0 +1,19 @@
+variable "dynamodb_tables" {
+  description = "DynamoDb tables to grant LookupTable access to"
+  type        = "list"
+  default     = []
+}
+
+variable "s3_buckets" {
+  description = "S3 buckets to grant LookupTable access to"
+  type        = "list"
+  default     = []
+}
+
+variable "account_id" {
+  type = "string"
+}
+
+variable "region" {
+  type = "string"
+}


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers


## Changes

* The `manage.py generate` process now will automatically generate IAM Policies for all of the `classifiers`, `rule_engine`, `alert_processor`, and `alert_merger` to access LookupTables. It uses the `lookup_tables.json` configurations to determine which resources to grant access to.

## Testing

A long, time consuming process on Staging environment
