### PR TITLE
[apps] Handle JSONDecoderError

### DIFF
--- a/stream_alert/apps/app_base.py
+++ b/stream_alert/apps/app_base.py
@@ -322,8 +322,10 @@ class AppIntegration(metaclass=ABCMeta):
         """Method for returning the json loaded response for this POST request
 
         Returns:
-            tuple (bool, dict): False if the was an error performing the request,
-                and the dictionary loaded from the json response
+            tuple (bool, dict|None): The first return value will be False if there
+                was an error performing the request.
+                The second return value will be None if JSONDecodeError raised,
+                otherwise it will be the dictionary loaded from the json response.
         """
         LOGGER.debug('[%s] Making POST request on poll #%d', self, self._poll_count)
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #974 
resolves: #998 

## Background
See the details in issue #998 

## Changes

* Handle `JSONDecoderError` by returning `False, None` without calling to `.json()` method in `response` object
* Add unit test case

## Testing
* Added following unit test case to reproduce `JSONDecoderError` exception we see in issue #998.
```
@patch('requests.sessions.Session.request')
    def test_make_post_request_gateway_timeout(self, requests_mock):
        """App Integration - Make Post Request when gateway timed out"""
        # set the return value to an empty response
        # the reponse's content defaults to None, which returns an empty str
        requests_mock.return_value = requests.Response()

        # need to set status_code in the response
        requests_mock.return_value.status_code = 504
        assert_raises(JSONDecodeError, self._app._make_post_request, '', None, None, False)
```
* After we reproduce and well catch the issue, we add current unit test case to test the exception handling flow.
