### PR TITLE
[rule_promotion] Change default value of alert_count to -1

### DIFF
--- a/stream_alert/rule_promotion/statistic.py
+++ b/stream_alert/rule_promotion/statistic.py
@@ -18,7 +18,7 @@ limitations under the License.
 class StagingStatistic:
     """Store information on generated alerts."""
 
-    _ALERT_COUNT_UNKOWN = 'unknown'
+    _ALERT_COUNT_UNKOWN = -1
 
     _COUNT_QUERY_TEMPLATE = (
         "SELECT rule_name, count(*) AS count FROM alerts WHERE {where_clause} GROUP BY rule_name"

--- a/stream_alert/rule_promotion/statistic.py
+++ b/stream_alert/rule_promotion/statistic.py
@@ -114,6 +114,8 @@ class StagingStatistic:
             else 'n/a'
         )
 
+        info['alert_count'] = 'unknown' if info['alert_count'] == -1 else info['alert_count']
+
         # \u25E6 is unicode for a bullet
         return (
             '\u25E6 {_rule_name}\n'

--- a/tests/unit/stream_alert_rule_promotion/test_statistic.py
+++ b/tests/unit/stream_alert_rule_promotion/test_statistic.py
@@ -100,3 +100,26 @@ home#query/history/678cc350-d4e1-4296-86d5-9351b7f92ed4'''
         second_stat.alert_count = 100
 
         assert_equal(self.statistic > second_stat, True)
+
+    def test_comp_no_alert_count(self):
+        """StagingStatistic - Comparison when alert_count is default value"""
+        # self.statistic.alert_count = 200
+        second_stat = StagingStatistic(
+            staged_at='fake_staged_at_time',
+            staged_until='fake_staged_until_time',
+            current_time='fake_current_time',
+            rule='test_rule'
+        )
+        second_stat.alert_count = 100
+
+        assert_equal(self.statistic > second_stat, False)
+
+        self.statistic._current_time += timedelta(days=2, hours=10)
+        expected_string = '''\u25E6 test_rule
+	- Staged At:					2000-01-01 01:01:01 UTC
+	- Staged Until:					2000-01-03 01:01:01 UTC
+	- Time Past Staging:			1d 10h 0m
+	- Alert Count:					unknown
+	- Alert Info:					n/a'''
+
+        assert_equal(str(self.statistic), expected_string)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #974 
resolves: #1000 

## Background
See [issue #1000 python3 throws TypeError: '<' not supported between instances of 'str' and 'int'](https://github.com/airbnb/streamalert/issues/1000) for the details and root cause.

## Changes

* Change default value of alert_count from a string to an integer `-1`.

## Testing
See the reproduce step in issue #1000
