### PR TITLE
Accepts JSON from LookupTables CLI, adds `list-add` command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env python
 """
 Copyright 2017-present, Airbnb Inc.

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,4 @@
+
 #! /usr/bin/env python
 """
 Copyright 2017-present, Airbnb Inc.

--- a/stream_alert/__init__.py
+++ b/stream_alert/__init__.py
@@ -1,2 +1,2 @@
 """StreamAlert version."""
-__version__ = '2.3.0'
+__version__ = '3.0.0'

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -29,11 +29,7 @@ class LookupTablesCommand(CLICommand):
     @classmethod
     def setup_subparser(cls, subparser):
         # FIXME (derek.wang) Refactor this into a more robust command-nesting framework
-        subcommands = cls._subcommands()
-        set_parser_epilog(
-            subparser,
-            epilog=(
-                '''\
+        template = '''\
 Available Sub-Commands:
 
 {}
@@ -41,7 +37,12 @@ Available Sub-Commands:
 Examples:
 
     manage.py lookup-tables [describe-tables|get|set]
-'''.format('\n'.join([
+'''
+        subcommands = cls._subcommands()
+        set_parser_epilog(
+            subparser,
+            epilog=(
+                template.format('\n'.join([
                     '\t{command: <{pad}}{description}'.format(
                         command=command,
                         pad=30,

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import json
+
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.core import LookupTables
 from stream_alert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
@@ -186,16 +188,23 @@ class LookupTablesCommand(CLICommand):
         value = LookupTables.get(table_name, key)
 
         print('  Value: {}'.format(value))
+        print('  Type:  {}'.format(type(value)))
 
         return True
 
     @staticmethod
     def _set_handler(options, config):
+        print('==== LookupTables; Set Key ====')
+
         table_name = options.table
         key = options.key
-        new_value = options.value
 
-        print('==== LookupTables; Set Key ====')
+        try:
+            new_value = json.loads(options.value)
+        except TypeError as e:
+            print('  ERROR: Input is not valid JSON:')
+            print(e)
+            return False
 
         core = LookupTables.get_instance(config=config)
 

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -41,7 +41,7 @@ Available Sub-Commands:
 Examples:
 
     manage.py lookup-tables [describe-tables|get|set]
-                '''.format('\n'.join([
+'''.format('\n'.join([
                     '\t{command: <{pad}}{description}'.format(
                         command=command,
                         pad=30,
@@ -55,7 +55,7 @@ Examples:
 
         lookup_tables_subparsers = subparser.add_subparsers()
 
-        for _, subcommand in subcommands.items():
+        for subcommand in subcommands.values():
             subcommand.setup_subparser(lookup_tables_subparsers)
 
     @classmethod
@@ -105,24 +105,21 @@ class LookupTablesListAddSubCommand(CLICommand):
             '-t',
             '--table',
             help='Name of the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
         set_parser.add_argument(
             '-k',
             '--key',
             help='Key to modify on the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
         set_parser.add_argument(
             '-v',
             '--value',
             help='Value to add to the key',
-            required=True,
-            default=None
+            required=True
         )
 
     # pylint: disable=protected-access
@@ -191,7 +188,7 @@ class LookupTablesDescribeTablesSubCommand(CLICommand):
         lookup_tables = LookupTables.get_instance(config=config)
 
         print('{} Tables:\n'.format(len(lookup_tables._tables)))
-        for _, table in lookup_tables._tables.items():
+        for table in lookup_tables._tables.values():
             print(' Table Name: {}'.format(table.table_name))
             print(' Driver Id: {}'.format(table.driver_id))
             print(' Driver Type: {}\n'.format(table.driver_type))
@@ -224,16 +221,14 @@ class LookupTablesGetKeySubCommand(CLICommand):
             '-t',
             '--table',
             help='Name of the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
         get_parser.add_argument(
             '-k',
             '--key',
             help='Key to fetch on the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
     @classmethod
@@ -283,24 +278,21 @@ class LookupTablesSetSubCommand(CLICommand):
             '-t',
             '--table',
             help='Name of the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
         set_parser.add_argument(
             '-k',
             '--key',
             help='Key to set on the LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
         set_parser.add_argument(
             '-v',
             '--value',
             help='Value to save into LookupTable',
-            required=True,
-            default=None
+            required=True
         )
 
     # pylint: disable=protected-access

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -45,6 +45,10 @@ Examples:
                     '\t{command: <{pad}}{description}'.format(
                         command=command,
                         pad=30,
+
+                        # FIXME (Derek.wang)
+                        #   Ryan suggested that we could implement a __str__ or __repr__ function
+                        #   for each of the CLICommand classes
                         description=subcommand.description
                     )
                     for command, subcommand

--- a/stream_alert_cli/lookup_tables/handler.py
+++ b/stream_alert_cli/lookup_tables/handler.py
@@ -13,44 +13,160 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import copy
 import json
 
 from stream_alert.shared.logger import get_logger
 from stream_alert.shared.lookup_tables.core import LookupTables
-from stream_alert.shared.lookup_tables.drivers import PersistenceDriver
 from stream_alert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
 
 LOGGER = get_logger(__name__)
 
 
 class LookupTablesCommand(CLICommand):
-
     description = 'Describe and manage your LookupTables'
 
     @classmethod
     def setup_subparser(cls, subparser):
-        """Add subparser for LookupTables"""
+        # FIXME (derek.wang) Refactor this into a more robust command-nesting framework
+        subcommands = cls._subcommands()
         set_parser_epilog(
             subparser,
             epilog=(
                 '''\
-                Examples:
+Available Sub-Commands:
 
-                    manage.py lookup-tables [describe-tables|get|set]
-                '''
+{}
+
+Examples:
+
+    manage.py lookup-tables [describe-tables|get|set]
+                '''.format('\n'.join([
+                    '\t{command: <{pad}}{description}'.format(
+                        command=command,
+                        pad=30,
+                        description=subcommand.description
+                    )
+                    for command, subcommand
+                    in subcommands.items()
+                ]))
             )
         )
 
         lookup_tables_subparsers = subparser.add_subparsers()
 
-        cls._setup_describe_tables_subparser(lookup_tables_subparsers)
-        cls._setup_get_subparser(lookup_tables_subparsers)
-        cls._setup_set_subparser(lookup_tables_subparsers)
+        for _, subcommand in subcommands.items():
+            subcommand.setup_subparser(lookup_tables_subparsers)
 
     @classmethod
-    def _setup_describe_tables_subparser(cls, subparsers):
+    def handler(cls, options, config):
+        subcommands = cls._subcommands()
+        if options.subcommand in subcommands:
+            return subcommands[options.subcommand].handler(options, config)
+
+        LOGGER.error('Unhandled lookup-tables subcommand %s', options.subcommand)
+
+    @classmethod
+    def _subcommands(cls):
+        return {
+            # FIXME (derek.wang) Put the command strings into the commands themselves, so the
+            #   subparsers can be registered easily
+            'describe-tables': LookupTablesDescribeTablesSubCommand,
+            'get': LookupTablesGetKeySubCommand,
+            'set': LookupTablesSetSubCommand,
+            'list-add': LookupTablesListAddSubCommand,
+        }
+
+
+class LookupTablesListAddSubCommand(CLICommand):
+    description = 'Add a value to a list-typed LookupTables key'
+
+    @classmethod
+    def setup_subparser(cls, subparser):
+        set_parser = generate_subparser(
+            subparser,
+            'list-add',
+            description='Sets a key on the requested LookupTable',
+            subcommand=True
+        )
+
+        set_parser_epilog(
+            set_parser,
+            epilog=(
+                '''\
+                Examples:
+
+                    manage.py lookup-tables list-add -t [table] -k [key] -v [value]
+                '''
+            )
+        )
+
+        set_parser.add_argument(
+            '-t',
+            '--table',
+            help='Name of the LookupTable',
+            required=True,
+            default=None
+        )
+
+        set_parser.add_argument(
+            '-k',
+            '--key',
+            help='Key to modify on the LookupTable',
+            required=True,
+            default=None
+        )
+
+        set_parser.add_argument(
+            '-v',
+            '--value',
+            help='Value to add to the key',
+            required=True,
+            default=None
+        )
+
+    # pylint: disable=protected-access
+    @classmethod
+    def handler(cls, options, config):
+        print('==== LookupTables; List Add Key ====')
+
+        table_name = options.table
+        key = options.key
+
+        core = LookupTables.get_instance(config=config)
+
+        print('  Table: {}'.format(table_name))
+        print('  Key:   {}'.format(key))
+
+        table = core.table(table_name)
+        old_value = table.get(key)
+
+        if old_value is None:
+            old_value = []
+
+        if not isinstance(old_value, list):
+            print('  ERROR: The current value is not a list: {}'.format(old_value))
+            return False
+
+        new_value = copy.copy(old_value)
+        new_value.append(options.value)
+        sorted(new_value)
+
+        print('  Value: {} --> {}'.format(old_value, new_value))
+
+        table._driver.set(key, new_value)
+        table._driver.commit()
+
+        return True
+
+
+class LookupTablesDescribeTablesSubCommand(CLICommand):
+    description = 'Show information about all currently configured LookupTables'
+
+    @classmethod
+    def setup_subparser(cls, subparser):
         describe_tables_parser = generate_subparser(
-            subparsers,
+            subparser,
             'describe-tables',
             description='Shows metadata about all currently configured LookupTables',
             subcommand=True
@@ -67,10 +183,27 @@ class LookupTablesCommand(CLICommand):
             )
         )
 
+    # pylint: disable=protected-access
     @classmethod
-    def _setup_get_subparser(cls, subparsers):
+    def handler(cls, options, config):
+        print('==== LookupTables; Describe Tables ====\n')
+
+        lookup_tables = LookupTables.get_instance(config=config)
+
+        print('{} Tables:\n'.format(len(lookup_tables._tables)))
+        for _, table in lookup_tables._tables.items():
+            print(' Table Name: {}'.format(table.table_name))
+            print(' Driver Id: {}'.format(table.driver_id))
+            print(' Driver Type: {}\n'.format(table.driver_type))
+
+
+class LookupTablesGetKeySubCommand(CLICommand):
+    description = 'Retrieve a key from an existing LookupTable'
+
+    @classmethod
+    def setup_subparser(cls, subparser):
         get_parser = generate_subparser(
-            subparsers,
+            subparser,
             'get',
             description='Retrieves a key from the requested LookupTable',
             subcommand=True
@@ -104,9 +237,32 @@ class LookupTablesCommand(CLICommand):
         )
 
     @classmethod
-    def _setup_set_subparser(cls, subparsers):
+    def handler(cls, options, config):
+        table_name = options.table
+        key = options.key
+
+        print('==== LookupTables; Get Key ====')
+
+        LookupTables.get_instance(config=config)
+
+        print('  Table: {}'.format(table_name))
+        print('  Key:   {}'.format(key))
+
+        value = LookupTables.get(table_name, key)
+
+        print('  Value: {}'.format(value))
+        print('  Type:  {}'.format(type(value)))
+
+        return True
+
+
+class LookupTablesSetSubCommand(CLICommand):
+    description = 'Update the key of an existing LookupTable'
+
+    @classmethod
+    def setup_subparser(cls, subparser):
         set_parser = generate_subparser(
-            subparsers,
+            subparser,
             'set',
             description='Sets a key on the requested LookupTable',
             subcommand=True
@@ -118,7 +274,7 @@ class LookupTablesCommand(CLICommand):
                 '''\
                 Examples:
 
-                    manage.py lookup-tables set -t [table] -k [key] -v [value] -j
+                    manage.py lookup-tables set -t [table] -k [key] -v [value]
                 '''
             )
         )
@@ -147,76 +303,20 @@ class LookupTablesCommand(CLICommand):
             default=None
         )
 
-        set_parser.add_argument(
-            '-j',
-            '--json',
-            help='Parse the given value as JSON instead of as a string',
-            required=False,
-            action='store_true'
-        )
-
+    # pylint: disable=protected-access
     @classmethod
     def handler(cls, options, config):
-        subcommand = options.subcommand
-        if subcommand == 'describe-tables':
-            return cls._describe_tables_handler(config)
-
-        if subcommand == 'get':
-            return cls._get_handler(options, config)
-
-        if subcommand == 'set':
-            return cls._set_handler(options, config)
-
-        LOGGER.error('Unhandled lookup-tables subcommand %s', subcommand)
-
-    # pylint: disable=protected-access
-    @staticmethod
-    def _describe_tables_handler(config):
-        print('==== LookupTables; Describe Tables ====\n')
-
-        lookup_tables = LookupTables.get_instance(config=config)
-
-        print('{} Tables:\n'.format(len(lookup_tables._tables)))
-        for _, table in lookup_tables._tables.items():
-            print(' Table Name: {}'.format(table.table_name))
-            print(' Driver Id: {}'.format(table.driver_id))
-            print(' Driver Type: {}\n'.format(table.driver_type))
-
-    @staticmethod
-    def _get_handler(options, config):
-        table_name = options.table
-        key = options.key
-
-        print('==== LookupTables; Get Key ====')
-
-        LookupTables.get_instance(config=config)
-
-        print('  Table: {}'.format(table_name))
-        print('  Key:   {}'.format(key))
-
-        value = LookupTables.get(table_name, key)
-
-        print('  Value: {}'.format(value))
-        print('  Type:  {}'.format(type(value)))
-
-        return True
-
-    @staticmethod
-    def _set_handler(options, config):
         print('==== LookupTables; Set Key ====')
 
         table_name = options.table
         key = options.key
 
-        if options.json:
-            try:
-                new_value = json.loads(options.value)
-            except json.decoder.JSONDecodeError as e:
-                print('  ERROR: Input is not valid JSON:')
-                print(e)
-                return False
-        else:
-            new_value = options.value
+        try:
+            new_value = json.loads(options.value)
+        except json.decoder.JSONDecodeError as e:
+            print('  ERROR: Input is not valid JSON:')
+            print(e)
+            return False
 
         core = LookupTables.get_instance(config=config)
 
@@ -224,11 +324,6 @@ class LookupTablesCommand(CLICommand):
         print('  Key:   {}'.format(key))
 
         table = core.table(table_name)
-
-        if table.driver_type == PersistenceDriver.TYPE_NULL:
-            print('  ERROR: Nonexistent table referenced!')
-            return False
-
         old_value = table.get(key)
 
         print('  Value: {} --> {}'.format(old_value, new_value))


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers

## Background

I designed LookupTables' drivers to be able to store any complex JSON-serializable type...

Sadly the CLI command as-is could not do anything other than string. Whooops!

## Changes

* Now there's a new option: `--json`. It accepts the input `--value` as a JSON encoded string.
* I added a new subcommand, `list-add`. 
* I restructured some of the subcommand code