### PR TITLE
[LookupTables] Adds new JSON file import CLI command

### DIFF
--- a/streamalert/shared/lookup_tables/utils.py
+++ b/streamalert/shared/lookup_tables/utils.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from streamalert.shared.lookup_tables.drivers import PersistenceDriver
+
+
+# pylint: disable=protected-access
+class LookupTablesMagic:
+    """Namespace full of magic methods that dig around the public interface of LookupTables.
+
+    These methods are not on the public interface by design to prevent these access patterns from
+    being utilized in "normal" Lambda code.
+    """
+
+    @staticmethod
+    def get_all_table_data(table):
+        """
+        Return all of the data in the given lookup table as a dict. Only works with S3, and you
+        should DEFINITELY AVOID USING THIS.
+
+        Params:
+            - table (LookupTable)
+
+        Returns:
+            dict
+        """
+        if table.driver_type != PersistenceDriver.TYPE_S3:
+            raise RuntimeError("Cannot use lookup_table helper on non-S3 table.")
+
+        # Make a single dummy call to force the table to initialize
+        table.get('dummy', None)
+
+        # Do some black magic tomfoolery
+        return table._driver._cache._data
+
+    @staticmethod
+    def set_table_value(table, key, new_value):
+        """Set a value into a LookupTable and then immediately commit it.
+
+        Params:
+            - table (LookupTable)
+            - key (str)
+            - new_value (str|int|list|dict|mixed)
+        """
+        table._driver.set(key, new_value)
+        table._driver.commit()
+
+    @staticmethod
+    def get_all_tables(lookup_tables_core):
+        """Returns all lookup tables, keyed by their names
+
+        Params:
+        - lookup_tables_core (LookupTablesCore)
+
+        Returns:
+             dict[str, LookupTable]
+        """
+        return lookup_tables_core._tables

--- a/streamalert/shared/lookup_tables/utils.py
+++ b/streamalert/shared/lookup_tables/utils.py
@@ -30,7 +30,7 @@ class LookupTablesMagic:
         Return all of the data in the given lookup table as a dict. Only works with S3, and you
         should DEFINITELY AVOID USING THIS.
 
-        Params:
+        Args:
             - table (LookupTable)
 
         Returns:
@@ -49,7 +49,7 @@ class LookupTablesMagic:
     def set_table_value(table, key, new_value):
         """Set a value into a LookupTable and then immediately commit it.
 
-        Params:
+        Args:
             - table (LookupTable)
             - key (str)
             - new_value (str|int|list|dict|mixed)
@@ -61,7 +61,7 @@ class LookupTablesMagic:
     def get_all_tables(lookup_tables_core):
         """Returns all lookup tables, keyed by their names
 
-        Params:
+        Args:
         - lookup_tables_core (LookupTablesCore)
 
         Returns:

--- a/streamalert_cli/lookup_tables/handler.py
+++ b/streamalert_cli/lookup_tables/handler.py
@@ -16,9 +16,9 @@ limitations under the License.
 import copy
 import json
 
-from stream_alert.shared.logger import get_logger
-from stream_alert.shared.lookup_tables.core import LookupTables
-from stream_alert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
+from streamalert.shared.logger import get_logger
+from streamalert.shared.lookup_tables.core import LookupTables
+from streamalert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
 
 LOGGER = get_logger(__name__)
 

--- a/streamalert_cli/lookup_tables/handler.py
+++ b/streamalert_cli/lookup_tables/handler.py
@@ -18,6 +18,7 @@ import json
 
 from streamalert.shared.logger import get_logger
 from streamalert.shared.lookup_tables.core import LookupTables
+from streamalert.shared.lookup_tables.utils import LookupTablesMagic
 from streamalert_cli.utils import CLICommand, generate_subparser, set_parser_epilog
 
 LOGGER = get_logger(__name__)
@@ -101,7 +102,8 @@ class LookupTablesSetFromFile(CLICommand):
                 '''\
                 Examples:
 
-                    manage.py lookup-tables set-from-json-file -t [table] -k [key] -f [path/to/file.json]
+                    manage.py lookup-tables set-from-json-file -t [table] -k [key] -f \
+[path/to/file.json]
                 '''
             )
         )
@@ -153,8 +155,7 @@ class LookupTablesSetFromFile(CLICommand):
             json.dumps(new_value, indent=2)
         ))
 
-        table._driver.set(key, new_value)
-        table._driver.commit()
+        LookupTablesMagic.set_table_value(table, key, new_value)
 
         return True
 
@@ -217,7 +218,6 @@ class LookupTablesListAddSubCommand(CLICommand):
             action='store_true'
         )
 
-    # pylint: disable=protected-access
     @classmethod
     def handler(cls, options, config):
         print('==== LookupTables; List Add Key ====')
@@ -251,8 +251,7 @@ class LookupTablesListAddSubCommand(CLICommand):
 
         print('  Value: {} --> {}'.format(old_value, new_value))
 
-        table._driver.set(key, new_value)
-        table._driver.commit()
+        LookupTablesMagic.set_table_value(table, key, new_value)
 
         return True
 
@@ -280,15 +279,14 @@ class LookupTablesDescribeTablesSubCommand(CLICommand):
             )
         )
 
-    # pylint: disable=protected-access
     @classmethod
     def handler(cls, options, config):
         print('==== LookupTables; Describe Tables ====\n')
 
-        lookup_tables = LookupTables.get_instance(config=config)
+        lookup_tables = LookupTablesMagic.get_all_tables(LookupTables.get_instance(config=config))
 
-        print('{} Tables:\n'.format(len(lookup_tables._tables)))
-        for table in lookup_tables._tables.values():
+        print('{} Tables:\n'.format(len(lookup_tables)))
+        for table in lookup_tables.values():
             print(' Table Name: {}'.format(table.table_name))
             print(' Driver Id: {}'.format(table.driver_id))
             print(' Driver Type: {}\n'.format(table.driver_type))
@@ -411,7 +409,6 @@ class LookupTablesSetSubCommand(CLICommand):
             action='store_true'
         )
 
-    # pylint: disable=protected-access
     @classmethod
     def handler(cls, options, config):
         print('==== LookupTables; Set Key ====')
@@ -439,7 +436,6 @@ class LookupTablesSetSubCommand(CLICommand):
 
         print('  Value: {} --> {}'.format(old_value, new_value))
 
-        table._driver.set(key, new_value)
-        table._driver.commit()
+        LookupTablesMagic.set_table_value(table, key, new_value)
 
         return True

--- a/streamalert_cli/lookup_tables/handler.py
+++ b/streamalert_cli/lookup_tables/handler.py
@@ -346,7 +346,7 @@ class LookupTablesGetKeySubCommand(CLICommand):
         print()
         print('  Type:  {}'.format(type(value)))
 
-        if isinstance(value, dict) or isinstance(value, list):
+        if isinstance(value, (list, dict)):
             # Render lists and dicts a bit better to make them easier to read
             print('  Value:')
             print(json.dumps(value, indent=2))

--- a/streamalert_cli/lookup_tables/handler.py
+++ b/streamalert_cli/lookup_tables/handler.py
@@ -86,6 +86,7 @@ Examples:
 
 
 class LookupTablesSetFromFile(CLICommand):
+    description = 'Set a LookupTable key from a JSON file'
 
     @classmethod
     def setup_subparser(cls, subparser):

--- a/streamalert_cli/lookup_tables/handler.py
+++ b/streamalert_cli/lookup_tables/handler.py
@@ -133,29 +133,25 @@ class LookupTablesSetFromFile(CLICommand):
     def handler(cls, options, config):
         print('==== LookupTables; Set from JSON File ====')
 
-        table_name = options.table
-        key = options.key
-        file = options.file
-
         core = LookupTables.get_instance(config=config)
 
-        print('  Table: {}'.format(table_name))
-        print('  Key:   {}'.format(key))
-        print('  File:  {}'.format(file))
+        print('  Table: {}'.format(options.table))
+        print('  Key:   {}'.format(options.key))
+        print('  File:  {}'.format(options.file))
 
-        table = core.table(table_name)
+        table = core.table(options.table)
 
-        old_value = table.get(key)
+        old_value = table.get(options.key)
 
-        with open(file, "r") as json_file_fp:
+        with open(options.file, "r") as json_file_fp:
             new_value = json.load(json_file_fp)
 
         print('  Value: {} --> {}'.format(
-            json.dumps(old_value, indent=2),
-            json.dumps(new_value, indent=2)
+            json.dumps(old_value, indent=2, sort_keys=True),
+            json.dumps(new_value, indent=2, sort_keys=True)
         ))
 
-        LookupTablesMagic.set_table_value(table, key, new_value)
+        LookupTablesMagic.set_table_value(table, options.key, new_value)
 
         return True
 
@@ -244,7 +240,7 @@ class LookupTablesListAddSubCommand(CLICommand):
         new_value.append(options.value)
 
         if options.unique:
-            new_value = list(dict.fromkeys(new_value))
+            new_value = list(set(new_value))
 
         if options.sort:
             new_value = sorted(new_value)
@@ -349,7 +345,7 @@ class LookupTablesGetKeySubCommand(CLICommand):
         if isinstance(value, (list, dict)):
             # Render lists and dicts a bit better to make them easier to read
             print('  Value:')
-            print(json.dumps(value, indent=2))
+            print(json.dumps(value, indent=2, sort_keys=True))
         else:
             print('  Value: {}'.format(value))
 

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -276,7 +276,7 @@ class TestRunner:
 
         dummy_configuration = {}
         mock_data = self._lookup_tables_mock
-        for table_name, table in rules_engine_instance._lookup_tables._tables.items():
+        for table_name in rules_engine_instance._lookup_tables._tables.keys():
             driver = EphemeralDriver(dummy_configuration)
             driver._cache = mock_data.get(table_name, {})
             ephemeral_table = LookupTable(table_name, driver, dummy_configuration)

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -264,7 +264,6 @@ class TestRunner:
 
             return _rules_engine.run(records=record)
 
-    # pylint: disable=protected-access
     def _install_lookup_tables_mocks(self, rules_engine_instance):
         """
         Extremely gnarly, extremely questionable manner to install mocking data into our tables.
@@ -276,6 +275,8 @@ class TestRunner:
 
         dummy_configuration = {}
         mock_data = self._lookup_tables_mock
+
+        # pylint: disable=protected-access
         for table_name in rules_engine_instance._lookup_tables._tables.keys():
             driver = EphemeralDriver(dummy_configuration)
             driver._cache = mock_data.get(table_name, {})

--- a/tests/integration/fixtures/lookup_tables/dynamo-backed-table.json
+++ b/tests/integration/fixtures/lookup_tables/dynamo-backed-table.json
@@ -1,0 +1,3 @@
+{
+  "key": "Anonymous IP"
+}


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl @fusionrace 
cc: @airbnb/streamalert-maintainers

## Background

Per request from @fusionrace, LookupTables can now import data from a JSON file.

## Changes

* Adds a new lookup tables CLI command: `lookup-tables set-from-json-file`
* Adds two options to `list-add`: `--sort` and `--unique`
* Refactors some magic code into its own class with disclaimer

## How to use

There is now a subcommand under the `lookup-tables` command, called `set-from-json-file`

```
$ ./manage.py lookup-tables --help
usage: ./manage.py lookup-tables [-h]
                                 {describe-tables,get,set,list-add,set-from-json-file}
                                 ...

Describe and manage your LookupTables

positional arguments:
  {describe-tables,get,set,list-add,set-from-json-file}

optional arguments:
  -h, --help            show this help message and exit

Available Sub-Commands:

	describe-tables               Show information about all currently configured LookupTables
	get                           Retrieve a key from an existing LookupTable
	set                           Update the key of an existing LookupTable
	list-add                      Add a value to a list-typed LookupTables key
	set-from-json-file            NotImplemented

Examples:

    manage.py lookup-tables [describe-tables|get|set]
```

`set-from-json-file` takes 3 arguments: `--table`, `--key`, and `--file`.

```
usage: ./manage.py lookup-tables set-from-json-file [-h] -t TABLE -k KEY -f
                                                    FILE

Pushes the contents of a given json file into the LookupTable key

optional arguments:
  -h, --help            show this help message and exit
  -t TABLE, --table TABLE
                        Name of the LookupTable
  -k KEY, --key KEY     Key to modify on the LookupTable
  -f FILE, --file FILE  Path to the json file, relative to the current working
                        directory

Examples:

    manage.py lookup-tables set-from-json-file -t [table] -k [key] -f [path/to/file.json]
```

It takes the entire JSON blob in the given `.json` file and puts it into the LookupTable key as a dict/list.