### PR TITLE
adding role_count var to lookuptables terraform due to tf bug

### DIFF
--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -522,6 +522,7 @@ def _generate_lookup_tables_settings(config):
             'source': 'modules/tf_lookup_tables_dynamodb',
             'dynamodb_tables': sorted(dynamodb_tables),
             'roles': sorted(roles),
+            'role_count': len(roles),
             'account_id': config['global']['account']['aws_account_id'],
             'region': config['global']['account']['region'],
             'prefix': config['global']['account']['prefix'],
@@ -532,6 +533,7 @@ def _generate_lookup_tables_settings(config):
             'source': 'modules/tf_lookup_tables_s3',
             's3_buckets': sorted(s3_buckets),
             'roles': sorted(roles),
+            'role_count': len(roles),
             'prefix': config['global']['account']['prefix'],
         }
 

--- a/terraform/modules/tf_lookup_tables_dynamodb/main.tf
+++ b/terraform/modules/tf_lookup_tables_dynamodb/main.tf
@@ -14,6 +14,7 @@ module "aws_iam_policy_module" {
 
   policy_json = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables_dynamodb.json}"
   roles       = "${var.roles}"
+  role_count  = "${var.role_count}"
   type        = "dynamodb"
   prefix      = "${var.prefix}"
 }

--- a/terraform/modules/tf_lookup_tables_dynamodb/variables.tf
+++ b/terraform/modules/tf_lookup_tables_dynamodb/variables.tf
@@ -22,3 +22,10 @@ variable "roles" {
   description = "List of role ids to grant LookupTable access to"
   type        = "list"
 }
+
+// The below is only necessary becuase of:
+//  https://github.com/hashicorp/terraform/issues/10857
+// Fixed here: https://github.com/hashicorp/terraform/issues/12570#issuecomment-512621787
+variable "role_count" {
+  description = "Count of role ids to grant LookupTable access to. Note: this is a workaround until terraform v0.12.0 is supported"
+}

--- a/terraform/modules/tf_lookup_tables_policy/main.tf
+++ b/terraform/modules/tf_lookup_tables_policy/main.tf
@@ -4,7 +4,7 @@ resource "aws_iam_policy" "streamalert_read_from_lookup_tables" {
 }
 
 resource "aws_iam_role_policy_attachment" "streamalert_read_from_lookup_tables_s3" {
-  count      = "${length(var.roles)}"
+  count      = "${var.role_count}"
   role       = "${element(var.roles, count.index)}"
   policy_arn = "${aws_iam_policy.streamalert_read_from_lookup_tables.arn}"
 }

--- a/terraform/modules/tf_lookup_tables_policy/variables.tf
+++ b/terraform/modules/tf_lookup_tables_policy/variables.tf
@@ -17,3 +17,10 @@ variable "type" {
   description = "Type of access (e.g. s3 or dynamodb); used to suffix the policy name"
   type        = "string"
 }
+
+// The below is only necessary becuase of:
+//  https://github.com/hashicorp/terraform/issues/10857
+// Fixed here: https://github.com/hashicorp/terraform/issues/12570#issuecomment-512621787
+variable "role_count" {
+  description = "Count of role ids to grant LookupTable access to. Note: this is a workaround until terraform v0.12.0 is supported"
+}

--- a/terraform/modules/tf_lookup_tables_s3/main.tf
+++ b/terraform/modules/tf_lookup_tables_s3/main.tf
@@ -14,6 +14,7 @@ module "aws_iam_policy_module" {
   source      = "../tf_lookup_tables_policy"
   policy_json = "${data.aws_iam_policy_document.streamalert_read_items_from_lookup_tables_s3.json}"
   roles       = "${var.roles}"
+  role_count  = "${var.role_count}"
   type        = "s3"
   prefix      = "${var.prefix}"
 }

--- a/terraform/modules/tf_lookup_tables_s3/variables.tf
+++ b/terraform/modules/tf_lookup_tables_s3/variables.tf
@@ -12,3 +12,10 @@ variable "roles" {
   description = "List of role ids to grant LookupTable access to"
   type        = "list"
 }
+
+// The below is only necessary becuase of:
+//  https://github.com/hashicorp/terraform/issues/10857
+// Fixed here: https://github.com/hashicorp/terraform/issues/12570#issuecomment-512621787
+variable "role_count" {
+  description = "Count of role ids to grant LookupTable access to. Note: this is a workaround until terraform v0.12.0 is supported"
+}


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/streamalert-maintainers

## Background

There is a bug in terraform that prevents it from being able to get the count for lists that have computed properties.
See: https://github.com/hashicorp/terraform/issues/10857
Fixed here: https://github.com/hashicorp/terraform/issues/12570#issuecomment-512621787

## Changes

* Adding hard-coded `role_count` as a variable, instead of computing the role list length dynamically.

## Testing

Terraform apply
