### PR TITLE
[WIP - do not merge] fixing bugs found during resource migration

### DIFF
--- a/streamalert_cli/terraform/classifier.py
+++ b/streamalert_cli/terraform/classifier.py
@@ -58,6 +58,9 @@ def generate_classifier(cluster_name, cluster_dict, config):
         config['clusters'][cluster_name]['modules']['stream_alert']['classifier_config']
     )
 
+    firehose_config = config['global']['infrastructure'].get('firehose', {})
+    use_firehose_prefix = firehose_config.get('use_prefix', True)
+
     tf_module_prefix = 'classifier_{}'.format(cluster_name)
     iam_module = '{}_iam'.format(tf_module_prefix)
 
@@ -67,6 +70,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         'account_id': config['global']['account']['aws_account_id'],
         'region': config['global']['account']['region'],
         'prefix': config['global']['account']['prefix'],
+        'firehose_use_prefix': use_firehose_prefix,
         'function_role_id': '${{module.{}_lambda.role_id}}'.format(tf_module_prefix),
         'function_alias_arn': '${{module.{}_lambda.function_alias_arn}}'.format(tf_module_prefix),
         'function_name': '${{module.{}_lambda.function_name}}'.format(tf_module_prefix),

--- a/streamalert_cli/terraform/metrics.py
+++ b/streamalert_cli/terraform/metrics.py
@@ -101,7 +101,7 @@ def generate_aggregate_cloudwatch_metric_alarms(config):
 
         func = func.replace('_config', '')
 
-        for idx, name in enumerate(metric_alarms):
+        for idx, name in enumerate(sorted(metric_alarms)):
             alarm_settings = metric_alarms[name]
             alarm_settings['source'] = 'modules/tf_metric_alarms'
             alarm_settings['sns_topic_arn'] = sns_topic_arn

--- a/streamalert_cli/terraform/metrics.py
+++ b/streamalert_cli/terraform/metrics.py
@@ -184,7 +184,7 @@ def generate_cluster_cloudwatch_metric_alarms(cluster_name, cluster_dict, config
         )
     ]
 
-    for idx, metric_alarm in enumerate(metric_alarms):
+    for idx, metric_alarm in enumerate(sorted(metric_alarms)):
         metric_alarm['source'] = 'modules/tf_metric_alarms'
         metric_alarm['sns_topic_arn'] = sns_topic_arn
         cluster_dict['module']['metric_alarm_{}_{}'.format(cluster_name, idx)] = metric_alarm

--- a/terraform/modules/tf_alert_processor_iam/main.tf
+++ b/terraform/modules/tf_alert_processor_iam/main.tf
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "output_secrets" {
 
 // Allow the Alert Processor to send to default firehose and S3 outputs
 resource "aws_iam_role_policy" "default_outputs" {
-  name   = "SinkToDefaultOutputs"
+  name   = "DefaultOutputs"
   role   = "${var.role_id}"
   policy = "${data.aws_iam_policy_document.default_outputs.json}"
 }

--- a/terraform/modules/tf_classifier/firehose.tf
+++ b/terraform/modules/tf_classifier/firehose.tf
@@ -5,6 +5,10 @@ resource "aws_iam_role_policy" "classifier_firehose" {
   policy = "${data.aws_iam_policy_document.classifier_firehose.json}"
 }
 
+locals {
+  stream_prefix = "${var.firehose_use_prefix ? "${var.prefix}_" : ""}streamalert_data_"
+}
+
 // IAM Policy Doc: Allow the Classifier to PutRecord* on any StreamAlert Data Firehose
 data "aws_iam_policy_document" "classifier_firehose" {
   statement {
@@ -17,7 +21,7 @@ data "aws_iam_policy_document" "classifier_firehose" {
     ]
 
     resources = [
-      "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/${var.prefix}_streamalert_data_*",
+      "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/${local.stream_prefix}*",
     ]
   }
 }

--- a/terraform/modules/tf_classifier/variables.tf
+++ b/terraform/modules/tf_classifier/variables.tf
@@ -35,3 +35,7 @@ variable "classifier_sqs_queue_arn" {
 variable "classifier_sqs_sse_kms_key_arn" {
   description = "ARN of the KMS key that handles server-side-encryption of classifier SQS frames"
 }
+
+variable "firehose_use_prefix" {
+  description = "When true, prepends the StreamAlert prefix to the AWS Firehose permissions"
+}

--- a/terraform/modules/tf_cloudtrail/main.tf
+++ b/terraform/modules/tf_cloudtrail/main.tf
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "cloudtrail_to_cloudwatch_create_logs" {
 //   for suppression of logs that originated in this region.
 resource "aws_cloudwatch_log_subscription_filter" "cloudtrail_via_cloudwatch" {
   count           = "${var.send_to_cloudwatch ? 1 : 0}"
-  name            = "cloudtrail_delivery"
+  name            = "${var.prefix}_${var.cluster}_cloudtrail_delivery"
   log_group_name  = "${aws_cloudwatch_log_group.cloudtrail_logging.name}"
   filter_pattern  = "${var.exclude_home_region_events ? local.apply_filter_string : ""}"
   destination_arn = "${var.cloudwatch_destination_arn}"

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -92,6 +92,7 @@ class TestTerraformGenerateClassifier:
                     'account_id': '123456789012',
                     'region': 'us-east-1',
                     'prefix': 'unit-test',
+                    'firehose_use_prefix': True,
                     'function_role_id': '${module.classifier_test_lambda.role_id}',
                     'function_alias_arn': '${module.classifier_test_lambda.function_alias_arn}',
                     'function_name': '${module.classifier_test_lambda.function_name}',


### PR DESCRIPTION
to: @Ryxias 
cc: @airbnb/streamalert-maintainers

## Changes

* Ensuring order of metric alarms remains unchanged by sorting them by name
* Fixing firehose permission with classifier. This was introduced with firehose prefixing
* fixing inconsistent order of metric alarms
* fixing missed resource name prefix + cluster

## Testing

Updates to unit tests
