### PR TITLE
Fix unhashable type dict bug

### DIFF
--- a/streamalert/shared/normalize.py
+++ b/streamalert/shared/normalize.py
@@ -74,7 +74,6 @@ class Normalizer:
 
         return result
 
-
     @classmethod
     def _extract_values(cls, record, keys_to_normalize):
         """Recursively extract lists of path parts from a dictionary
@@ -91,6 +90,7 @@ class Normalizer:
             if isinstance(value, dict):  # If this is a dict, look for nested
                 for nested_value in cls._extract_values(value, keys_to_normalize):
                     yield nested_value
+                continue
 
             if key not in keys_to_normalize:
                 continue
@@ -98,8 +98,9 @@ class Normalizer:
             if isinstance(value, list):  # If this is a list of values, return all of them
                 for item in value:
                     yield item
-            else:
-                yield value
+                continue
+
+            yield value
 
     @classmethod
     def normalize(cls, record, log_type):

--- a/tests/unit/streamalert/shared/test_normalizer.py
+++ b/tests/unit/streamalert/shared/test_normalizer.py
@@ -131,6 +131,41 @@ class TestNormalizer:
 
         assert_equal(record, expected_record)
 
+    def test_normalize_corner_case(self):
+        """Normalizer - Normalize - Corner Case"""
+        log_type = 'cloudtrail'
+        Normalizer._types_config = {
+            log_type: {
+                'normalized_key': {
+                    'normalized_key',
+                    'original_key'
+                },
+                'sourceAccount': {
+                    'account',
+                    'accountId'
+                }
+            }
+        }
+        record = {
+            'unrelated_key': 'foobar',
+            'original_key': {
+                'original_key': 'fizzbuzz',
+            }
+        }
+        Normalizer.normalize(record, log_type)
+
+        expected_record = {
+            'unrelated_key': 'foobar',
+            'original_key': {
+                'original_key': 'fizzbuzz',
+            },
+            'streamalert:normalization': {
+                'normalized_key': ['fizzbuzz']
+            }
+        }
+
+        assert_equal(record, expected_record)
+
     @patch('logging.Logger.debug')
     def test_normalize_none_defined(self, log_mock):
         """Normalizer - Normalize, No Types Defined"""


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
fixes: #893

## Background

```
[ERROR] TypeError: unhashable type: 'dict' Traceback (most recent call last): File "/var/task/streamalert/classifier/main.py", line 26, in handler Classifier().run(event.get('Records', [])) File "/var/task/streamalert/classifier/classifier.py", line 245, in run self._classify_payload(payload) File "/var/task/streamalert/classifier/classifier.py", line 185, in _classify_payload Normalizer.normalize(parsed_rec, record.log_type) File "/var/task/streamalert/shared/normalize.py", line 118, in normalize record.update({cls.NORMALIZATION_KEY: cls.match_types(record, log_normalized_types)}) File "/var/task/streamalert/shared/normalize.py", line 68, in match_types values.add(value)
```

A small change in the data coming into one of our clusters has triggered this error. It's due to a missing `continue`.  I fixed up the code