### PR TITLE
fix setting of rules engine environment variable

### DIFF
--- a/streamalert_cli/terraform/rules_engine.py
+++ b/streamalert_cli/terraform/rules_engine.py
@@ -52,7 +52,7 @@ def generate_rules_engine(config):
         'STREAMALERT_PREFIX': prefix,
     }
 
-    if 'log_rule_statistics' in config['lambda']['rules_engine_config']:
+    if config['lambda']['rules_engine_config'].get('log_rule_statistics'):
         environment['STREAMALERT_TRACK_RULE_STATS'] = '1'
 
     # Set variables for the Lambda module


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

The `STREAMALERT_TRACK_RULE_STATS` is currently getting set even if the rules engine config contains something like:

`"log_rule_statistics": false`

which is bad.

## Changes

* Updating the environment variable inclusion to look for a truthy setting.

## Testing

N/A
