### PR TITLE
[cli] Handle when AttributeError when test classifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - ./tests/scripts/unit_tests.sh
   - ./manage.py test rules
+  - ./manage.py test classifier
   - sphinx-build -W docs/source docs/build
   - ./tests/scripts/pylint.sh
   - bandit --ini setup.cfg -r .

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -234,13 +234,9 @@ class TestRunner:
             'AWS_ACCOUNT_ID': self._config['global']['account']['aws_account_id'],
             'ALERTS_TABLE': '{}_streamalert_alerts'.format(prefix),
         }
-        try:
-            if options.stats:
-                env['STREAMALERT_TRACK_RULE_STATS'] = '1'
-        except AttributeError:
-            # "stats" attribute only exists when doing integration test on rules.
-            # We do nothing for other test options, e.g. classifier
-            pass
+
+        if 'stats' in options and options.stats:
+            env['STREAMALERT_TRACK_RULE_STATS'] = '1'
 
         patch.dict(
             os.environ,

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -234,8 +234,13 @@ class TestRunner:
             'AWS_ACCOUNT_ID': self._config['global']['account']['aws_account_id'],
             'ALERTS_TABLE': '{}_streamalert_alerts'.format(prefix),
         }
-        if options.stats:
-            env['STREAMALERT_TRACK_RULE_STATS'] = '1'
+        try:
+            if options.stats:
+                env['STREAMALERT_TRACK_RULE_STATS'] = '1'
+        except AttributeError:
+            # "stats" attribute only exists when doing integration test on rules.
+            # We do nothing for other test options, e.g. classifier
+            pass
 
         patch.dict(
             os.environ,


### PR DESCRIPTION
to: @Ryxias or @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to: #1019 
resolves: #1044

## Background
PR #1019 introduced `stats` argument from cli command line, but is not always exist. It exists in rule test parser, but not classifier parser. When I run `python manage.py test classifier` it throws error `AttributeError: 'Namespace' object has no attribute 'stats'`. 
### Description
I did print out the value of options when it passed to test handler, it doesn't has `stats` attribute. 
```
Namespace(command='test', debug=False, files=set(), files_dir='tests/integration/rules/', quiet=False, rules=set(), subcommand='classifier', verbose=False, **{'test subcommand': 'classifier'})
```

The full traceback for future reference
```
python manage.py test classifier                 

Traceback (most recent call last):
  File "manage.py", line 116, in <module>
    main()
  File "manage.py", line 112, in main
    sys.exit(not cli_runner(options))
  File "/Users/xxxxx/xxx/streamalert/streamalert_cli/runner.py", line 70, in cli_runner
    result = cmds[args.command](args)
  File "/Users/xxxxx/xxx/streamalert/streamalert_cli/runner.py", line 126, in <lambda>
    command: lambda opts, cmd=cli_command: cmd.handler(opts, config)
  File "/Users/xxxxx/xxx/streamalert/streamalert_cli/test/handler.py", line 198, in handler
    result = result and TestRunner(options, config).run()
  File "/Users/xxxxx/xxx/streamalert/streamalert_cli/test/handler.py", line 237, in __init__
    if options.stats:
AttributeError: 'Namespace' object has no attribute 'stats'
```

## Changes

* Catch `AttributeError` and doing nothing if `stats` attribute doesn't exist.
* Add `classifier test` to CI to catch similar failure in the future.

## Testing
Manually ran
```
./manage.py test classifier
```
