### PR TITLE
fixing the tf_s3_events module to properly handle multiple lambda_function blocks

### DIFF
--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -613,16 +613,18 @@ Example: S3 Events Cluster
     {
       "id": "s3-events-example",
       "modules": {
-        "s3_events": [
-          {
-            "bucket_id": "bucket-1",
-            "enable_events": true
-          },
-          {
-            "bucket_id": "bucket-2",
-            "enable_events": true
-          }
-        ],
+        "s3_events": {
+          "bucket_name_01": [
+            {
+              "filter_prefix": "AWSLogs/1234",
+              "filter_suffix": ".log"
+            },
+            {
+              "filter_prefix": "AWSLogs/5678"
+            }
+          ],
+          "bucket_name_02": []
+        },
         "stream_alert": {
           "classifier_config": {
             "enable_custom_metrics": true,
@@ -636,17 +638,19 @@ Example: S3 Events Cluster
       "region": "us-east-1"
     }
 
-This configures the two buckets to notify the classifier function in this cluster when new objects
-arrive in the bucket, and authorizes the classifier to download objects from either bucket.
+This configures the two buckets (``bucket_name_01`` and ``bucket_name_02``) to notify the classifier
+function in this cluster when new objects arrive in the bucket at the specified (optional) prefix(es),
+provided the objects have the specified (optional) suffix(es). Additionally, this will authorize the
+classifier to download objects from each bucket.
 
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
-Unlike the other modules, ``s3_events`` expects a *list* of dictionaries. Each element represents a
-single bucket source and has the following options:
+The ``s3_events`` module expects a *dictionary/map* of bucket names, where the value for each key
+(bucket name) is a list of maps. Each map in the list can include optional prefixes (``filter_prefix``)
+and suffixes (``filter_suffix``) to which the notification should be applied. The mere existence of a
+bucket name in this map within this module implicitly enables event notifications for said bucket.
+Note that the value specified for the map of prefixes and suffixes can be an empty list (``[]``).
+An empty list will enable event notifications for **all** objects created in the bucket by default.
 
-==================  ===========  ===============
-**Key**             **Default**  **Description**
-------------------  -----------  ---------------
-``bucket_id``       ---          The name of the S3 bucket
-``enable_events``   ``true``     Toggle the S3 event notification
-==================  ===========  ===============
+See the above example for how prefixes/suffixes can be (optionally) specified (as in "bucket_name_01")
+and how to use the empty list to enable bucket-wide notifications (as in "bucket_name_02").

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -531,7 +531,7 @@ class CLIConfig:
         return True
 
     @staticmethod
-    def _config_writer(path, data, sort=True):
+    def _config_writer(path, data, sort=False):
         with open(path, 'r+') as conf_file:
             json.dump(data, conf_file, indent=2, separators=(',', ': '), sort_keys=sort)
             conf_file.truncate()
@@ -550,4 +550,4 @@ class CLIConfig:
                     parts = path_parts + [cluster_key]
                     self._config_writer(format_path(parts), self.config['clusters'][cluster_key])
             elif config_key != 'logs':
-                self._config_writer(format_path(path_parts), self.config[config_key], True)
+                self._config_writer(format_path(path_parts), self.config[config_key])

--- a/streamalert_cli/terraform/s3_events.py
+++ b/streamalert_cli/terraform/s3_events.py
@@ -33,14 +33,6 @@ def generate_s3_events(cluster_name, cluster_dict, config):
     prefix = config['global']['account']['prefix']
     s3_event_buckets = modules['s3_events']
 
-    # Detect legacy and convert
-    if isinstance(s3_event_buckets, dict) and 's3_bucket_id' in s3_event_buckets:
-        del config['clusters'][cluster_name]['modules']['s3_events']
-        s3_event_buckets = [{'bucket_id': s3_event_buckets['s3_bucket_id']}]
-        config['clusters'][cluster_name]['modules']['s3_events'] = s3_event_buckets
-        LOGGER.info('Converting legacy S3 Events config')
-        config.write()
-
     # Add each configured S3 bucket module
     for index, bucket_info in enumerate(s3_event_buckets):
         if 'bucket_id' not in bucket_info:

--- a/streamalert_cli/terraform/s3_events.py
+++ b/streamalert_cli/terraform/s3_events.py
@@ -32,30 +32,18 @@ def generate_s3_events(cluster_name, cluster_dict, config):
     modules = config['clusters'][cluster_name]['modules']
     prefix = config['global']['account']['prefix']
     s3_event_buckets = modules['s3_events']
+    lambda_module_path = 'module.classifier_{}_lambda'.format(cluster_name)
 
     # Add each configured S3 bucket module
-    for index, bucket_info in enumerate(s3_event_buckets):
-        if 'bucket_id' not in bucket_info:
-            LOGGER.error('Config Error: Missing bucket_id key from s3_event configuration')
-            return False
-
-        cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, index)] = {
+    for bucket_name, info in s3_event_buckets.items():
+        cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, bucket_name)] = {
             'source': './modules/tf_s3_events',
-            'lambda_role_id': '${{module.classifier_{}_lambda.role_id}}'.format(cluster_name),
-            'lambda_function_alias': (
-                '${{module.classifier_{}_lambda.function_alias}}'.format(cluster_name)
-            ),
-            'lambda_function_alias_arn': (
-                '${{module.classifier_{}_lambda.function_alias_arn}}'.format(cluster_name)
-            ),
-            'lambda_function_name': (
-                '${{module.classifier_{}_lambda.function_name}}'.format(cluster_name)
-            ),
-            'bucket_id': bucket_info['bucket_id'],
-            'notification_id': '{}_{}'.format(cluster_name, index),
-            'enable_events': bucket_info.get('enable_events', True),
-            'filter_prefix': bucket_info.get('filter_prefix', ''),
-            'filter_suffix': bucket_info.get('filter_suffix', '')
+            'lambda_role_id': '${{{}.role_id}}'.format(lambda_module_path),
+            'lambda_function_alias': '${{{}.function_alias}}'.format(lambda_module_path),
+            'lambda_function_alias_arn': '${{{}.function_alias_arn}}'.format(lambda_module_path),
+            'lambda_function_name': '${{{}.function_name}}'.format(lambda_module_path),
+            'bucket_name': bucket_name,
+            'filters': info
         }
 
     return True

--- a/terraform/modules/tf_lambda/variables.tf
+++ b/terraform/modules/tf_lambda/variables.tf
@@ -72,7 +72,7 @@ variable "default_tags" {
 variable "tags" {
   type        = map(string)
   default     = {}
-  description = "Any dditional tags to be associated with all applicable components"
+  description = "Any additional tags to be associated with all applicable components"
 }
 
 variable "auto_publish_versions" {

--- a/terraform/modules/tf_s3_events/main.tf
+++ b/terraform/modules/tf_s3_events/main.tf
@@ -1,30 +1,32 @@
 // Lambda Permission: Allow S3 Event Notifications to invoke Lambda
 resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "InvokeFromS3Bucket_${var.notification_id}"
+  statement_id  = "${var.prefix}_${var.cluster}_InvokeFromS3Bucket_${var.bucket_name}"
   action        = "lambda:InvokeFunction"
   function_name = var.lambda_function_name
   principal     = "s3.amazonaws.com"
-  source_arn    = "arn:aws:s3:::${var.bucket_id}"
+  source_arn    = "arn:aws:s3:::${var.bucket_name}"
   qualifier     = var.lambda_function_alias
 }
 
 // S3 Bucket Notification: Invoke the StreamAlert Classifier
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  count  = var.enable_events ? 1 : 0
-  bucket = var.bucket_id
+  bucket = var.bucket_name
 
-  lambda_function {
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = var.filter_prefix
-    filter_suffix       = var.filter_suffix
-    id                  = "notify_${var.notification_id}"
-    lambda_function_arn = var.lambda_function_alias_arn
+  dynamic "lambda_function" {
+    for_each = var.filters
+
+    content {
+      events              = ["s3:ObjectCreated:*"]
+      filter_prefix       = lookup(lambda_function.value, "filter_prefix", "") // use lookup since this is optional
+      filter_suffix       = lookup(lambda_function.value, "filter_suffix", "") // use lookup since this is optional
+      lambda_function_arn = var.lambda_function_alias_arn
+    }
   }
 }
 
 // IAM Policy: Allow Lambda to GetObjects from S3
 resource "aws_iam_role_policy" "lambda_s3_permission" {
-  name   = "S3GetObjects_${var.notification_id}"
+  name   = "${var.prefix}_${var.cluster}_S3GetObjects_${var.bucket_name}"
   role   = var.lambda_role_id
   policy = data.aws_iam_policy_document.s3_read_only.json
 }
@@ -39,7 +41,7 @@ data "aws_iam_policy_document" "s3_read_only" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.bucket_id}",
+      "arn:aws:s3:::${var.bucket_name}",
     ]
   }
 
@@ -51,7 +53,7 @@ data "aws_iam_policy_document" "s3_read_only" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.bucket_id}/*",
+      "arn:aws:s3:::${var.bucket_name}/*",
     ]
   }
 }

--- a/terraform/modules/tf_s3_events/variables.tf
+++ b/terraform/modules/tf_s3_events/variables.tf
@@ -1,22 +1,26 @@
-variable "bucket_id" {
+variable "prefix" {
+  type = string
 }
 
-variable "enable_events" {
-  default = true
+variable "cluster" {
+  type = string
 }
 
-variable "filter_prefix" {
-  default = ""
+variable "bucket_name" {
+  type = string
 }
 
-variable "filter_suffix" {
-  default = ""
+// Map of prefixes and suffixes
+variable "filters" {
+  type = list(map(string))
 }
 
 variable "lambda_function_alias_arn" {
+  type = string
 }
 
 variable "lambda_function_name" {
+  type = string
 }
 
 variable "lambda_function_alias" {
@@ -24,7 +28,5 @@ variable "lambda_function_alias" {
 }
 
 variable "lambda_role_id" {
-}
-
-variable "notification_id" {
+  type = string
 }

--- a/tests/unit/conf/clusters/advanced.json
+++ b/tests/unit/conf/clusters/advanced.json
@@ -42,17 +42,15 @@
     "kinesis_events": {
       "enabled": true
     },
-    "s3_events": [
-      {
-        "bucket_id": "unit-test-bucket.data",
-        "filter_prefix": "AWSLogs/123456789/CloudTrail/us-east-1/",
-        "filter_suffix": ".log"
-      },
-      {
-        "bucket_id": "unit-test.cloudtrail.data",
-        "enable_events": false
-      }
-    ],
+    "s3_events": {
+      "unit-test-bucket.data": [
+        {
+          "filter_prefix": "AWSLogs/123456789/CloudTrail/us-east-1/",
+          "filter_suffix": ".log"
+        }
+      ],
+      "unit-test.cloudtrail.data": []
+    },
     "stream_alert": {
       "classifier_config": {
         "inputs": {

--- a/tests/unit/conf/clusters/test.json
+++ b/tests/unit/conf/clusters/test.json
@@ -47,11 +47,9 @@
     "kinesis_events": {
       "enabled": true
     },
-    "s3_events": [
-      {
-        "bucket_id": "unit-test-bucket.legacy.data"
-      }
-    ],
+    "s3_events": {
+      "unit-test-bucket.legacy.data": []
+    },
     "stream_alert": {
       "classifier_config": {
         "inputs": {

--- a/tests/unit/conf/clusters/test.json
+++ b/tests/unit/conf/clusters/test.json
@@ -48,7 +48,7 @@
       "enabled": true
     },
     "s3_events": {
-      "unit-test-bucket.legacy.data": []
+      "unit-test-bucket": []
     },
     "stream_alert": {
       "classifier_config": {

--- a/tests/unit/conf/clusters/trusted.json
+++ b/tests/unit/conf/clusters/trusted.json
@@ -21,11 +21,9 @@
     "kinesis_events": {
       "enabled": true
     },
-    "s3_events": [
-      {
-        "bucket_id": "unit-test-bucket.legacy.data"
-      }
-    ],
+    "s3_events": {
+      "unit-test-bucket.legacy.data": []
+    },
     "stream_alert": {
       "classifier_config": {
         "inputs": {

--- a/tests/unit/conf/clusters/trusted.json
+++ b/tests/unit/conf/clusters/trusted.json
@@ -22,7 +22,7 @@
       "enabled": true
     },
     "s3_events": {
-      "unit-test-bucket.legacy.data": []
+      "unit-test-bucket": []
     },
     "stream_alert": {
       "classifier_config": {

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -455,7 +455,7 @@ class TestTerraformGenerate:
             'cloudwatch_monitoring_test',
             'kinesis_test',
             'kinesis_events_test',
-            's3_events_unit-test_test_0'
+            's3_events_unit-test_test_unit-test-bucket',
         }
 
         assert_equal(set(tf_cluster['module']), test_modules)
@@ -489,8 +489,8 @@ class TestTerraformGenerate:
             'kinesis_events_advanced',
             'flow_logs_advanced',
             'cloudtrail_advanced',
-            's3_events_unit-test_advanced_1',
-            's3_events_unit-test_advanced_0'
+            's3_events_unit-test_advanced_unit-test-bucket.data',
+            's3_events_unit-test_advanced_unit-test.cloudtrail.data',
         }
 
         assert_equal(set(tf_cluster['module'].keys()), advanced_modules)

--- a/tests/unit/streamalert_cli/terraform/test_s3_events.py
+++ b/tests/unit/streamalert_cli/terraform/test_s3_events.py
@@ -22,21 +22,6 @@ from streamalert_cli.terraform import common, s3_events
 CONFIG = CLIConfig(config_path='tests/unit/conf')
 
 
-def test_generate_s3_events_legacy():
-    """CLI - Terraform - S3 Events - Legacy"""
-    cluster_dict = common.infinitedict()
-    CONFIG['clusters']['test']['modules']['s3_events'] = {
-        's3_bucket_id': 'unit-test-bucket.legacy.data'
-    }
-    result = s3_events.generate_s3_events('test', cluster_dict, CONFIG)
-
-    assert_true(result)
-    assert_equal(CONFIG['clusters']['test']['modules']['s3_events'],
-                 [{
-                     'bucket_id': 'unit-test-bucket.legacy.data'
-                 }])
-
-
 def test_generate_s3_events():
     """CLI - Terraform - S3 Events with Valid Buckets"""
     cluster_dict = common.infinitedict()

--- a/tests/unit/streamalert_cli/terraform/test_s3_events.py
+++ b/tests/unit/streamalert_cli/terraform/test_s3_events.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from mock import patch
 from nose.tools import assert_equal
 
 from streamalert_cli.config import CLIConfig


### PR DESCRIPTION
to: @chunyong-lin / @Ryxias 
cc: @airbnb/streamalert-maintainers
resolves: #1026 

## Background

See #1026

## Changes

* not sorting keys in config, since it is not necessary
* fixing typo in tf description
* removing s3 events legacy garbage for config
* updating tf_s3_events module for proper handling of more than one filter per bucket
* updating tf_s3_events module generation code and tests
* updating documentation to reflect changes to tf_s3_events module

## Testing

Updates to unit tests. I also init'd this module by itself with tf vars to ensure it was working as expected.
