### PR TITLE
fixing small bugs with terraform 12 code

### DIFF
--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -114,11 +114,9 @@ Example: CloudTrail via S3 Events
         "enable_kinesis": false,
         "enable_logging": true
       },
-      "s3_events": [
-        {
-          "bucket_id": "PREFIX.CLUSTER.streamalert.cloudtrail"
-        }
-      ],
+      "s3_events": {
+        "PREFIX.CLUSTER.streamalert.cloudtrail": []
+      },
       "stream_alert": {
         "classifier_config": {
           "enable_custom_metrics": true,

--- a/streamalert_cli/terraform/s3_events.py
+++ b/streamalert_cli/terraform/s3_events.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import re
+
 from streamalert.shared.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -36,8 +38,12 @@ def generate_s3_events(cluster_name, cluster_dict, config):
 
     # Add each configured S3 bucket module
     for bucket_name, info in s3_event_buckets.items():
-        cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, bucket_name)] = {
+        # Replace all invalid module characters with underscores
+        mod_suffix = re.sub('[^a-zA-Z0-9_-]', '_', bucket_name)
+        cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, mod_suffix)] = {
             'source': './modules/tf_s3_events',
+            'prefix': prefix,
+            'cluster': cluster_name,
             'lambda_role_id': '${{{}.role_id}}'.format(lambda_module_path),
             'lambda_function_alias': '${{{}.function_alias}}'.format(lambda_module_path),
             'lambda_function_alias_arn': '${{{}.function_alias_arn}}'.format(lambda_module_path),

--- a/streamalert_cli/terraform/s3_events.py
+++ b/streamalert_cli/terraform/s3_events.py
@@ -42,8 +42,6 @@ def generate_s3_events(cluster_name, cluster_dict, config):
         mod_suffix = re.sub('[^a-zA-Z0-9_-]', '_', bucket_name)
         cluster_dict['module']['s3_events_{}_{}_{}'.format(prefix, cluster_name, mod_suffix)] = {
             'source': './modules/tf_s3_events',
-            'prefix': prefix,
-            'cluster': cluster_name,
             'lambda_role_id': '${{{}.role_id}}'.format(lambda_module_path),
             'lambda_function_alias': '${{{}.function_alias}}'.format(lambda_module_path),
             'lambda_function_alias_arn': '${{{}.function_alias_arn}}'.format(lambda_module_path),

--- a/terraform/modules/tf_kinesis_events/variables.tf
+++ b/terraform/modules/tf_kinesis_events/variables.tf
@@ -16,5 +16,3 @@ variable "lambda_production_enabled" {
 variable "lambda_function_alias_arn" {
   type = string
 }
-
-variable "lambda_function_alias_arn" {}

--- a/terraform/modules/tf_lookup_tables_dynamodb/main.tf
+++ b/terraform/modules/tf_lookup_tables_dynamodb/main.tf
@@ -5,15 +5,7 @@ data "aws_iam_policy_document" "streamalert_read_items_from_lookup_tables_dynamo
       "dynamodb:DescribeTable",
     ]
 
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibility in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
-    resources = [local.dynamodb_table_arns]
+    resources = local.dynamodb_table_arns
   }
 }
 

--- a/terraform/modules/tf_s3_events/main.tf
+++ b/terraform/modules/tf_s3_events/main.tf
@@ -1,6 +1,10 @@
+locals {
+  sanitized_bucket_name = replace(var.bucket_name, "/[^a-zA-Z0-9_-]/", "_")
+}
+
 // Lambda Permission: Allow S3 Event Notifications to invoke Lambda
 resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "${var.prefix}_${var.cluster}_InvokeFromS3Bucket_${var.bucket_name}"
+  statement_id  = "${var.prefix}_${var.cluster}_InvokeFromS3Bucket_${local.sanitized_bucket_name}"
   action        = "lambda:InvokeFunction"
   function_name = var.lambda_function_name
   principal     = "s3.amazonaws.com"
@@ -8,12 +12,18 @@ resource "aws_lambda_permission" "allow_bucket" {
   qualifier     = var.lambda_function_alias
 }
 
+// This hack ensures that the lambda_function block is still created
+// even if no filters are provided
+locals {
+  filters = coalescelist(var.filters, [{ filter_prefix = "" }])
+}
+
 // S3 Bucket Notification: Invoke the StreamAlert Classifier
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = var.bucket_name
 
   dynamic "lambda_function" {
-    for_each = var.filters
+    for_each = local.filters
 
     content {
       events              = ["s3:ObjectCreated:*"]

--- a/terraform/modules/tf_s3_events/main.tf
+++ b/terraform/modules/tf_s3_events/main.tf
@@ -4,7 +4,7 @@ locals {
 
 // Lambda Permission: Allow S3 Event Notifications to invoke Lambda
 resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "${var.prefix}_${var.cluster}_InvokeFromS3Bucket_${local.sanitized_bucket_name}"
+  statement_id  = "InvokeFromS3Bucket_${local.sanitized_bucket_name}"
   action        = "lambda:InvokeFunction"
   function_name = var.lambda_function_name
   principal     = "s3.amazonaws.com"
@@ -15,7 +15,7 @@ resource "aws_lambda_permission" "allow_bucket" {
 // This hack ensures that the lambda_function block is still created
 // even if no filters are provided
 locals {
-  filters = coalescelist(var.filters, [{ filter_prefix = "" }])
+  filters = coalescelist(var.filters, [{}])
 }
 
 // S3 Bucket Notification: Invoke the StreamAlert Classifier
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
 // IAM Policy: Allow Lambda to GetObjects from S3
 resource "aws_iam_role_policy" "lambda_s3_permission" {
-  name   = "${var.prefix}_${var.cluster}_S3GetObjects_${var.bucket_name}"
+  name   = "S3GetObjects_${var.bucket_name}"
   role   = var.lambda_role_id
   policy = data.aws_iam_policy_document.s3_read_only.json
 }

--- a/terraform/modules/tf_s3_events/variables.tf
+++ b/terraform/modules/tf_s3_events/variables.tf
@@ -1,11 +1,3 @@
-variable "prefix" {
-  type = string
-}
-
-variable "cluster" {
-  type = string
-}
-
 variable "bucket_name" {
   type = string
 }

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -489,8 +489,8 @@ class TestTerraformGenerate:
             'kinesis_events_advanced',
             'flow_logs_advanced',
             'cloudtrail_advanced',
-            's3_events_unit-test_advanced_unit-test-bucket.data',
-            's3_events_unit-test_advanced_unit-test.cloudtrail.data'
+            's3_events_unit-test_advanced_unit-test-bucket_data',
+            's3_events_unit-test_advanced_unit-test_cloudtrail_data'
         }
 
         assert_equal(set(tf_cluster['module'].keys()), advanced_modules)

--- a/tests/unit/streamalert_cli/terraform/test_s3_events.py
+++ b/tests/unit/streamalert_cli/terraform/test_s3_events.py
@@ -30,17 +30,11 @@ def test_generate_s3_events():
         'module': {
             's3_events_unit-test_advanced_unit-test-bucket_data': {
                 'source': './modules/tf_s3_events',
-                'prefix': 'unit-test',
-                'cluster': 'advanced',
-                'lambda_function_alias': (
-                    '${module.classifier_advanced_lambda.function_alias}'
-                ),
+                'lambda_function_alias': '${module.classifier_advanced_lambda.function_alias}',
                 'lambda_function_alias_arn': (
                     '${module.classifier_advanced_lambda.function_alias_arn}'
                 ),
-                'lambda_function_name': (
-                    '${module.classifier_advanced_lambda.function_name}'
-                ),
+                'lambda_function_name': '${module.classifier_advanced_lambda.function_name}',
                 'bucket_name': 'unit-test-bucket.data',
                 'lambda_role_id': '${module.classifier_advanced_lambda.role_id}',
                 'filters': [
@@ -52,17 +46,11 @@ def test_generate_s3_events():
             },
             's3_events_unit-test_advanced_unit-test_cloudtrail_data': {
                 'source': './modules/tf_s3_events',
-                'prefix': 'unit-test',
-                'cluster': 'advanced',
-                'lambda_function_alias': (
-                    '${module.classifier_advanced_lambda.function_alias}'
-                ),
+                'lambda_function_alias': '${module.classifier_advanced_lambda.function_alias}',
                 'lambda_function_alias_arn': (
                     '${module.classifier_advanced_lambda.function_alias_arn}'
                 ),
-                'lambda_function_name': (
-                    '${module.classifier_advanced_lambda.function_name}'
-                ),
+                'lambda_function_name': '${module.classifier_advanced_lambda.function_name}',
                 'bucket_name': 'unit-test.cloudtrail.data',
                 'lambda_role_id': '${module.classifier_advanced_lambda.role_id}',
                 'filters': []

--- a/tests/unit/streamalert_cli/terraform/test_s3_events.py
+++ b/tests/unit/streamalert_cli/terraform/test_s3_events.py
@@ -28,8 +28,10 @@ def test_generate_s3_events():
 
     expected_config = {
         'module': {
-            's3_events_unit-test_advanced_unit-test-bucket.data': {
+            's3_events_unit-test_advanced_unit-test-bucket_data': {
                 'source': './modules/tf_s3_events',
+                'prefix': 'unit-test',
+                'cluster': 'advanced',
                 'lambda_function_alias': (
                     '${module.classifier_advanced_lambda.function_alias}'
                 ),
@@ -48,8 +50,10 @@ def test_generate_s3_events():
                     }
                 ]
             },
-            's3_events_unit-test_advanced_unit-test.cloudtrail.data': {
+            's3_events_unit-test_advanced_unit-test_cloudtrail_data': {
                 'source': './modules/tf_s3_events',
+                'prefix': 'unit-test',
+                'cluster': 'advanced',
                 'lambda_function_alias': (
                     '${module.classifier_advanced_lambda.function_alias}'
                 ),


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #1035 , #1052 

## Changes

* Fixing documentation update that was missed.
* Adding fix for potential invalid terraform module name (eg - a bucket name contains a `.`)
* Fixing issue where no `lambda_function` block would be defined for s3 events where no `filter_prefix` or `filter_suffix` parameters were set.
* Removing unnecessary prefixing from role policy/lambda permission resources in `tf_s3_events` module.
* Removing duplicative variable declaration in `tf_kinesis_events` module.
* Updating `# TF-UPGRADE-TODO` block to use local arn list directly as list.

## Testing

Updating unit tests.
