### PR TITLE
[terraform] support remote state file locking

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -47,7 +47,7 @@
   },
   "terraform": {
     "create_bucket": true,
-    "lock_state_file": true,
+    "lock_state_file": false,
     "tfstate_bucket": "PREFIX_GOES_HERE.streamalert.terraform.state",
     "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   }

--- a/conf/global.json
+++ b/conf/global.json
@@ -47,6 +47,7 @@
   },
   "terraform": {
     "create_bucket": true,
+    "lock_state_file": true,
     "tfstate_bucket": "PREFIX_GOES_HERE.streamalert.terraform.state",
     "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   }

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -95,7 +95,17 @@ Deploy
   ./manage.py configure aws_account_id 111111111111  # Replace with your 12-digit AWS account ID
   ./manage.py configure prefix NAME                  # Choose a unique name prefix (alphanumeric characters only)
 
-2. Build the StreamAlert infrastructure for the first time:
+2. Configure terraform state locking (optional):
+
+  Streamalert supports terraforms native ability to lock the remote s3 state file whenever a user is planning and applying terraform configuration.
+  This is to prevent multiple users from deploying Streamalert at the same time potentially resulting in a broken state.
+  To enable this feature this you must first create a DynamoDB table named ``<prefix>_streamalert_terraform_state_lock`` with a primary key named ``LockID``.
+  Streamalert will automatically create the proper IAM permissions so that terraform can read and write to this table.
+  See `terraform's documentation <https://www.terraform.io/docs/backends/types/s3.html>`_ for more information.
+  
+  Once you have created this table, open ``conf/global.json``, find the ``terraform`` key and change ``lock_state_file`` to ``true``.
+
+3. Build the StreamAlert infrastructure for the first time:
 
 .. code-block:: bash
 
@@ -106,7 +116,7 @@ There will be multiple Terraform prompts, type "yes" at each one to continue.
 .. note:: You only need to ``./manage.py init`` once for any given StreamAlert deployment,
    although it is safe to run again if necessary.
 
-3. At this point, StreamAlert is up and running! You can, for example, see the S3 buckets
+4. At this point, StreamAlert is up and running! You can, for example, see the S3 buckets
 that were automatically created:
 
 .. code-block:: bash

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -87,6 +87,10 @@ with permissions for at least the following services:
 
 Deploy
 ------
+.. note:: Streamalert supports Terraform's native ability to lock the remote s3 state file whenever a user is planning and applying Terraform configuration.
+    This is to prevent multiple users from deploying StreamAlert at the same time potentially resulting in a broken state.
+    StreamAlert will automatically create and destroy this table via the command line interface.
+    See `Terraform's documentation <https://www.terraform.io/docs/backends/types/s3.html>`_ for more information.
 
 1. Set basic StreamAlert configuration options:
 
@@ -95,15 +99,7 @@ Deploy
   ./manage.py configure aws_account_id 111111111111  # Replace with your 12-digit AWS account ID
   ./manage.py configure prefix NAME                  # Choose a unique name prefix (alphanumeric characters only)
 
-2. Configure terraform state locking:
-
-  Streamalert supports terraforms native ability to lock the remote s3 state file whenever a user is planning and applying terraform configuration.
-  This is to prevent multiple users from deploying Streamalert at the same time potentially resulting in a broken state.
-  Streamalert will automatically create and destroy this table via the command line interface;
-  however, you may need to add the appropriate permissions (GetItem, PutItem and DeleteItem) to an IAM role to allow other users to deploy.
-  See `terraform's documentation <https://www.terraform.io/docs/backends/types/s3.html>`_ for more information.
-
-3. Build the StreamAlert infrastructure for the first time:
+2. Build the StreamAlert infrastructure for the first time:
 
 .. code-block:: bash
 
@@ -114,7 +110,7 @@ There will be multiple Terraform prompts, type "yes" at each one to continue.
 .. note:: You only need to ``./manage.py init`` once for any given StreamAlert deployment,
    although it is safe to run again if necessary.
 
-4. At this point, StreamAlert is up and running! You can, for example, see the S3 buckets
+3. At this point, StreamAlert is up and running! You can, for example, see the S3 buckets
 that were automatically created:
 
 .. code-block:: bash

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -95,15 +95,13 @@ Deploy
   ./manage.py configure aws_account_id 111111111111  # Replace with your 12-digit AWS account ID
   ./manage.py configure prefix NAME                  # Choose a unique name prefix (alphanumeric characters only)
 
-2. Configure terraform state locking (optional):
+2. Configure terraform state locking:
 
   Streamalert supports terraforms native ability to lock the remote s3 state file whenever a user is planning and applying terraform configuration.
   This is to prevent multiple users from deploying Streamalert at the same time potentially resulting in a broken state.
-  To enable this feature this you must first create a DynamoDB table named ``<prefix>_streamalert_terraform_state_lock`` with a primary key named ``LockID``.
-  Streamalert will automatically create the proper IAM permissions so that terraform can read and write to this table.
+  Streamalert will automatically create and destroy this table via the command line interface;
+  however, you may need to add the appropriate permissions (GetItem, PutItem and DeleteItem) to an IAM role to allow other users to deploy.
   See `terraform's documentation <https://www.terraform.io/docs/backends/types/s3.html>`_ for more information.
-  
-  Once you have created this table, open ``conf/global.json``, find the ``terraform`` key and change ``lock_state_file`` to ``true``.
 
 3. Build the StreamAlert infrastructure for the first time:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -87,7 +87,7 @@ with permissions for at least the following services:
 
 Deploy
 ------
-.. note:: Streamalert supports Terraform's native ability to lock the remote s3 state file whenever a user is planning and applying Terraform configuration.
+.. note:: StreamAlert supports Terraform's native ability to lock the remote s3 state file whenever a user is planning and applying Terraform configuration.
     This is to prevent multiple users from deploying StreamAlert at the same time potentially resulting in a broken state.
     StreamAlert will automatically create and destroy this table via the command line interface.
     See `Terraform's documentation <https://www.terraform.io/docs/backends/types/s3.html>`_ for more information.

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -167,7 +167,7 @@ def generate_main(config, init=False):
             'key': config['global']['terraform']['tfstate_s3_key'],
             'region': config['global']['account']['region'],
             'encrypt': True,
-            'dynamodb_table': "{}_streamalert_terraform_state_lock".format(
+            'dynamodb_table': '{}_streamalert_terraform_state_lock'.format(
                 config['global']['account']['prefix']
             ),
             'acl': 'private',

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -170,6 +170,10 @@ def generate_main(config, init=False):
             'acl': 'private',
             'kms_key_id': 'alias/{}'.format(config['global']['account']['kms_key_alias']),
         }
+        if config['global']['terraform']['lock_state_file']:
+            main_dict['terraform']['backend']['s3']['dynamodb_table'] = (
+                "{}_streamalert_terraform_state_lock".format(config['global']['account']['prefix'])
+            )
 
     # Configure initial S3 buckets
     main_dict['resource']['aws_s3_bucket'] = {

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -167,13 +167,12 @@ def generate_main(config, init=False):
             'key': config['global']['terraform']['tfstate_s3_key'],
             'region': config['global']['account']['region'],
             'encrypt': True,
+            'dynamodb_table': "{}_streamalert_terraform_state_lock".format(
+                config['global']['account']['prefix']
+            ),
             'acl': 'private',
             'kms_key_id': 'alias/{}'.format(config['global']['account']['kms_key_alias']),
         }
-        if config['global']['terraform']['lock_state_file']:
-            main_dict['terraform']['backend']['s3']['dynamodb_table'] = (
-                "{}_streamalert_terraform_state_lock".format(config['global']['account']['prefix'])
-            )
 
     # Configure initial S3 buckets
     main_dict['resource']['aws_s3_bucket'] = {

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -23,7 +23,11 @@ from streamalert_cli.athena.handler import create_table
 from streamalert_cli.helpers import check_credentials, continue_prompt, run_command, tf_runner
 from streamalert_cli.manage_lambda.deploy import deploy
 from streamalert_cli.terraform.generate import terraform_generate_handler
-from streamalert_cli.terraform.helpers import terraform_check, terraform_state_lock
+from streamalert_cli.terraform.helpers import (
+    terraform_check,
+    create_tf_state_lock_ddb_table,
+    destroy_tf_state_lock_ddb_table
+)
 from streamalert_cli.utils import (
     add_clusters_arg,
     CLICommand,
@@ -61,8 +65,7 @@ class TerraformInitCommand(CLICommand):
             bool: False if errors occurred, True otherwise
         """
         # Create the DynamoDB table for tf state locking before any terraform commands.
-        terraform_state_lock(
-            'create',
+        create_tf_state_lock_ddb_table(
             config['global']['account']['region'],
             '{}_streamalert_terraform_state_lock'.format(config['global']['account']['prefix'])
         )
@@ -242,8 +245,7 @@ class TerraformDestroyCommand(CLICommand):
             return False
 
         # Destroy DynamoDB state lock table
-        terraform_state_lock(
-            'destroy',
+        destroy_tf_state_lock_ddb_table(
             config['global']['account']['region'],
             '{}_streamalert_terraform_state_lock'.format(config['global']['account']['prefix'])
         )

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -241,6 +241,12 @@ class TerraformDestroyCommand(CLICommand):
         if not tf_runner(action='destroy', auto_approve=True):
             return False
 
+        # Destroy DynamoDB state lock table
+        terraform_state_lock(
+            'destroy',
+            config['global']['account']['region'],
+            '{}_streamalert_terraform_state_lock'.format(config['global']['account']['prefix'])
+        )
         # Remove old Terraform files
         return TerraformCleanCommand.handler(options, config)
 

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -23,7 +23,7 @@ from streamalert_cli.athena.handler import create_table
 from streamalert_cli.helpers import check_credentials, continue_prompt, run_command, tf_runner
 from streamalert_cli.manage_lambda.deploy import deploy
 from streamalert_cli.terraform.generate import terraform_generate_handler
-from streamalert_cli.terraform.helpers import terraform_check
+from streamalert_cli.terraform.helpers import terraform_check, terraform_state_lock
 from streamalert_cli.utils import (
     add_clusters_arg,
     CLICommand,
@@ -60,6 +60,12 @@ class TerraformInitCommand(CLICommand):
         Returns:
             bool: False if errors occurred, True otherwise
         """
+        # Create the DynamoDB table for tf state locking before any terraform commands.
+        terraform_state_lock(
+            'create',
+            config['global']['account']['region'],
+            '{}_streamalert_terraform_state_lock'.format(config['global']['account']['prefix'])
+        )
         # Stop here if only initializing the backend
         if options.backend:
             return cls._terraform_init_backend()

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -24,9 +24,9 @@ from streamalert_cli.helpers import check_credentials, continue_prompt, run_comm
 from streamalert_cli.manage_lambda.deploy import deploy
 from streamalert_cli.terraform.generate import terraform_generate_handler
 from streamalert_cli.terraform.helpers import (
-    terraform_check,
     create_tf_state_lock_ddb_table,
-    destroy_tf_state_lock_ddb_table
+    destroy_tf_state_lock_ddb_table,
+    terraform_check
 )
 from streamalert_cli.utils import (
     add_clusters_arg,

--- a/streamalert_cli/terraform/helpers.py
+++ b/streamalert_cli/terraform/helpers.py
@@ -12,8 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import boto3
+import time
 from streamalert_cli.helpers import run_command
+from streamalert.shared.logger import get_logger
 
+LOGGER = get_logger(__name__)
 
 def terraform_check():
     """Verify that Terraform is configured correctly
@@ -24,3 +28,33 @@ def terraform_check():
                        'your $PATH:\n'
                        '\t$ export PATH=$PATH:/usr/local/terraform/bin')
     return run_command(['terraform', 'version'], error_message=prereqs_message, quiet=True)
+
+def terraform_state_lock(action, region, table):
+    ddb_client = boto3.client('dynamodb', region_name=region)
+    ddb_tables = ddb_client.list_tables()
+    if action == 'create':
+        if table not in ddb_tables['TableNames']:
+            LOGGER.info('Creating terraform state locking DynamoDB table')
+            ddb_client.create_table(
+                AttributeDefinitions=[{
+                    'AttributeName': 'LockID',
+                    'AttributeType': 'S'
+                }],
+                TableName=table,
+                KeySchema=[{
+                    'AttributeName': 'LockID',
+                    'KeyType': 'HASH'
+                }],
+                BillingMode='PAY_PER_REQUEST'
+            )
+            wait = True
+            while wait:
+                desc_resp = ddb_client.describe_table(TableName=table)
+                if desc_resp['Table']['TableStatus'] == 'ACTIVE':
+                    wait = False
+                else:
+                    time.sleep(1)
+    elif action == 'destroy':
+        if table in ddb_tables['TableNames']:
+            LOGGER.info('Destroying terraform state locking DynamoDB table')
+            ddb_client.delete_table(TableName=table)

--- a/streamalert_cli/terraform/helpers.py
+++ b/streamalert_cli/terraform/helpers.py
@@ -12,8 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import boto3
 import time
+import boto3
+
 from streamalert_cli.helpers import run_command
 from streamalert.shared.logger import get_logger
 

--- a/streamalert_cli/terraform/helpers.py
+++ b/streamalert_cli/terraform/helpers.py
@@ -12,12 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import time
 import boto3
 
 from streamalert.shared.helpers.boto import default_config
-from streamalert_cli.helpers import run_command
 from streamalert.shared.logger import get_logger
+from streamalert_cli.helpers import run_command
 
 LOGGER = get_logger(__name__)
 

--- a/streamalert_cli/terraform/helpers.py
+++ b/streamalert_cli/terraform/helpers.py
@@ -34,8 +34,8 @@ def create_tf_state_lock_ddb_table(region, table):
     """Create the DynamoDB table for terraform remote state locking
 
     Args:
-        region: The AWS region to create the table in
-        table: The name of the DynamoDB table to create
+        region (str): The AWS region to create the table in
+        table (str): The name of the DynamoDB table to create
     """
     ddb_client = boto3.client('dynamodb', config=default_config(region=region))
     ddb_tables = ddb_client.list_tables()
@@ -61,8 +61,8 @@ def destroy_tf_state_lock_ddb_table(region, table):
     """Destroy the DynamoDB table for terraform remote state locking
 
     Args:
-        region: The AWS region to destroy the table in
-        table: The name of the DynamoDB table to destroy
+        region (str): The AWS region to destroy the table in
+        table (str): The name of the DynamoDB table to destroy
     """
     ddb_client = boto3.client('dynamodb', config=default_config(region=region))
     ddb_tables = ddb_client.list_tables()

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -42,7 +42,6 @@
   },
   "terraform": {
     "create_bucket": true,
-    "lock_state_file": true,
     "tfstate_bucket": "unit-test.streamalert.terraform.state",
     "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   },

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -42,6 +42,7 @@
   },
   "terraform": {
     "create_bucket": true,
+    "lock_state_file": true,
     "tfstate_bucket": "unit-test.streamalert.terraform.state",
     "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
   },

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -96,6 +96,7 @@ class TestTerraformGenerate:
                         'bucket': 'unit-test.streamalert.terraform.state',
                         'key': 'stream_alert_state/terraform.tfstate',
                         'region': 'us-west-1',
+                        'dynamodb_table': 'unit-test_streamalert_terraform_state_lock',
                         'encrypt': True,
                         'acl': 'private',
                         'kms_key_id': 'alias/unit-test'

--- a/tests/unit/streamalert_cli/terraform/test_helpers.py
+++ b/tests/unit/streamalert_cli/terraform/test_helpers.py
@@ -17,7 +17,10 @@ import boto3
 from mock import Mock, patch
 from nose.tools import assert_false, assert_true
 from moto import mock_dynamodb2
-from streamalert_cli.terraform.helpers import terraform_state_lock
+from streamalert_cli.terraform.helpers import (
+    create_tf_state_lock_ddb_table, 
+    destroy_tf_state_lock_ddb_table
+)
 
 from streamalert_cli.config import CLIConfig
 
@@ -28,7 +31,7 @@ REGION = CONFIG['global']['account']['region']
 @mock_dynamodb2()
 @patch('time.sleep', Mock())
 def test_terraform_state_lock_create():
-    terraform_state_lock('create', REGION, LOCK_TABLE)
+    create_tf_state_lock_ddb_table(REGION, LOCK_TABLE)
     client = boto3.client('dynamodb', REGION)
     # Verify table creation logic
     assert_true(LOCK_TABLE in client.list_tables()['TableNames'])
@@ -42,6 +45,6 @@ def test_terraform_state_lock_create():
 @mock_dynamodb2()
 def test_terraform_state_lock_destroy():
     # Verify destroy logic
-    terraform_state_lock('destroy', REGION, LOCK_TABLE)
+    destroy_tf_state_lock_ddb_table(REGION, LOCK_TABLE)
     client = boto3.client('dynamodb', REGION)
     assert_false(LOCK_TABLE in client.list_tables()['TableNames'])

--- a/tests/unit/streamalert_cli/terraform/test_helpers.py
+++ b/tests/unit/streamalert_cli/terraform/test_helpers.py
@@ -1,0 +1,47 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import boto3
+from mock import Mock, patch
+from nose.tools import assert_false, assert_true
+from moto import mock_dynamodb2
+from streamalert_cli.terraform.helpers import terraform_state_lock
+
+from streamalert_cli.config import CLIConfig
+
+CONFIG = CLIConfig(config_path='tests/unit/conf')
+LOCK_TABLE = '{}_streamalert_terraform_state_lock'.format(CONFIG['global']['account']['prefix'])
+REGION = CONFIG['global']['account']['region']
+
+@mock_dynamodb2()
+@patch('time.sleep', Mock())
+def test_terraform_state_lock_create():
+    terraform_state_lock('create', REGION, LOCK_TABLE)
+    client = boto3.client('dynamodb', REGION)
+    # Verify table creation logic
+    assert_true(LOCK_TABLE in client.list_tables()['TableNames'])
+    desc_resp = client.describe_table(TableName=LOCK_TABLE)
+    # Verify table is configured according to terraform docs
+    assert_true({'AttributeName': 'LockID', 'KeyType': 'HASH'} in desc_resp['Table']['KeySchema'])
+
+    expected_attr = {'AttributeName': 'LockID', 'AttributeType': 'S'}
+    assert_true(expected_attr in desc_resp['Table']['AttributeDefinitions'])
+
+@mock_dynamodb2()
+def test_terraform_state_lock_destroy():
+    # Verify destroy logic
+    terraform_state_lock('destroy', REGION, LOCK_TABLE)
+    client = boto3.client('dynamodb', REGION)
+    assert_false(LOCK_TABLE in client.list_tables()['TableNames'])

--- a/tests/unit/streamalert_cli/terraform/test_helpers.py
+++ b/tests/unit/streamalert_cli/terraform/test_helpers.py
@@ -18,7 +18,7 @@ from mock import Mock, patch
 from nose.tools import assert_false, assert_true
 from moto import mock_dynamodb2
 from streamalert_cli.terraform.helpers import (
-    create_tf_state_lock_ddb_table, 
+    create_tf_state_lock_ddb_table,
     destroy_tf_state_lock_ddb_table
 )
 


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @Ryxias 
cc: @airbnb/streamalert-maintainers
resolves: [#1054](https://github.com/airbnb/streamalert/issues/1054)

## Background
Currently if multiple people attempt to deploy to the same Streamalert deployment, there is nothing stopping them. This can result in a broken state file since two users are reading/writing from it at the same time. Terraform has native support for remote state locking. In the case of the s3 backend this involves using a DynamoDB table.

This implementation attempts to create and destroy the table automatically as part of the cli process. It bypasses terraform because once locking is enabled the table needs to be created and instead uses boto3. I tested to see if terraform was smart enough to recognize there was a module to create the locking table and execute that before attempting to lock the state, but it does not.

## Changes

* Added a new helper function to manage creation and destruction of the DynamoDB table used for s3 state locking as per terraform's [docs](https://www.terraform.io/docs/backends/types/s3.html) 
* Setup the CLI to automatically create the table on init and destroy the table on destroy.
* Updated docs to cover this new feature.
* Added tests for table creation/destruction.

## Testing
Unit and integration tests passing locally.
Functionally tested in a staging environment.
