### PR TITLE
[cli] Fix unknown module referenced bug

### DIFF
--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -233,7 +233,7 @@ class TerraformDestroyCommand(CLICommand):
         # Migrate back to local state so Terraform can successfully
         # destroy the S3 bucket used by the backend.
         # Do not check for terraform or aws creds again since these were checked above
-        if not terraform_generate_handler(config=config, init=True, check_tf=False,
+        if not terraform_generate_handler(config=config, init=False, check_tf=False,
                                           check_creds=False):
             return False
 


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves: #1047

## Background
During a new deployment of StreamAlert based on branch `release-3-0-0` to stage environment, re-run `python manage.py init` if first init was failed and it would be interrupted with error messages
```
Error: module 'metric_filters_Classifier_FailedParses_PROD_AGGREGATE': unknown module referenced: classifier_prod_lambda

Error: module 'metric_filters_Classifier_SQSFailedRecords_PROD_AGGREGATE': unknown module referenced: classifier_prod_lambda

Error: module 'metric_filters_Classifier_FirehoseRecordsSent_PROD_AGGREGATE': unknown module referenced: classifier_prod_lambda
(...)
```

My investigation is that terraform configuration file `terraform/prod.tf.json` for `prod` cluster (in my case) is deleted but it has been saved in terraform state file locally. So terraform complaint the reference is not found.

`terraform_generate_handler` is a shared helper. When the `init` option is set to `True`, it will delete old tf files for each cluster and return earlier before regenerate cluster tf files. 
https://github.com/airbnb/streamalert/blob/ee16de6e307d56373c7c7f3d595efdcc2cba51aa/streamalert_cli/terraform/generate.py#L400-L408

The proposed change is set the `init` option to `False` in the handler of `TerraformDestroyCommand` class, so that it will regenerate tf files for each cluster.

## Testing
It was tested in staging environment.
