### PR TITLE
[schema] Add two new keys to osquery.json file

### DIFF
--- a/conf/schemas/osquery.json
+++ b/conf/schemas/osquery.json
@@ -33,7 +33,9 @@
       "hostIdentifier": "string",
       "log_type": "string",
       "name": "string",
-      "unixTime": "integer"
+      "unixTime": "integer",
+      "logNumericsAsNumbers": "string",
+      "numerics": "string"
     },
     "parser": "json",
     "configuration": {
@@ -41,7 +43,9 @@
         "counter",
         "decorations",
         "epoch",
-        "log_type"
+        "log_type",
+        "logNumericsAsNumbers",
+        "numerics"
       ]
     }
   },
@@ -56,14 +60,18 @@
       "log_type": "string",
       "name": "string",
       "snapshot": [],
-      "unixTime": "string"
+      "unixTime": "string",
+      "logNumericsAsNumbers": "string",
+      "numerics": "string"
     },
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
         "decorations",
         "epoch",
-        "counter"
+        "counter",
+        "logNumericsAsNumbers",
+        "numerics"
       ]
     }
   },


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
If you have mixed osquery versions running in your environment, you may want to update the osquery schemas. In a recent PR, osquery team [Change logNumericsAsNumbers to numerics](https://github.com/osquery/osquery/pull/6002) from osquery v4.1.0. Key `logNumericsAsNumbers` exists in osquery for a while.

## Changes

* Added two new keys to `conf/schemas/osquery.json` as optional top level keys.

