### PR TITLE
raise exception when config sources are misconfigured

### DIFF
--- a/streamalert/classifier/classifier.py
+++ b/streamalert/classifier/classifier.py
@@ -21,6 +21,7 @@ from streamalert.classifier.clients import FirehoseClient, SQSClient
 from streamalert.classifier.parsers import get_parser
 from streamalert.classifier.payload.payload_base import StreamPayload
 from streamalert.shared import config, CLASSIFIER_FUNCTION_NAME as FUNCTION_NAME
+from streamalert.shared.exceptions import ConfigError
 from streamalert.shared.logger import get_logger
 from streamalert.shared.metrics import MetricLogger
 from streamalert.shared.normalize import Normalizer
@@ -87,19 +88,21 @@ class Classifier:
             bool: True if the resource's log sources loaded properly
         """
         # Get all logs for the configured service/entity (s3, kinesis, or sns)
-
         resources = self._config['clusters'][self._cluster]['data_sources'].get(service)
         if not resources:
-            LOGGER.error('Service [%s] not declared in sources configuration', service)
-            return False
+            error = 'Service [{}] not declared in sources configuration for resource [{}]'.format(
+                service,
+                resource
+            )
+            raise ConfigError(error)
 
         source_config = resources.get(resource)
         if not source_config:
-            LOGGER.error(
-                'Resource [%s] not declared in sources configuration for service [%s]',
+            error = 'Resource [{}] not declared in sources configuration for service [{}]'.format(
                 resource,
-                service)
-            return False
+                service
+            )
+            raise ConfigError(error)
 
         # Get the log schemas for source(s)
         return OrderedDict(

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -17,6 +17,7 @@ from collections import defaultdict, OrderedDict
 import json
 import os
 
+from streamalert.shared.exceptions import ConfigError
 from streamalert.shared.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -36,9 +37,6 @@ class TopLevelConfigKeys:
     THREAT_INTEL = 'threat_intel'
     LOOKUP_TABLES = 'lookup_tables'
 
-
-class ConfigError(Exception):
-    """Exception class for config file errors"""
 
 class SchemaSorter:
     """Statefully sort schema by priority where 0 is the highest priority
@@ -140,7 +138,6 @@ def load_config(conf_dir='conf/', exclude=None, include=None, validate=True):
     exclusions = exclude or set()
     conf_files = conf_files.difference(exclusions)
 
-
     schemas_dir = os.path.join(conf_dir, TopLevelConfigKeys.SCHEMAS)
     schema_files = []
 
@@ -181,6 +178,7 @@ def load_config(conf_dir='conf/', exclude=None, include=None, validate=True):
 
     return config
 
+
 def _load_schemas(schemas_dir, schema_files):
     """Helper to load all schemas from the schemas directory into one ordered dictionary.
 
@@ -200,6 +198,7 @@ def _load_schemas(schemas_dir, schema_files):
                            ', '.join(dup_schema))
         schemas.update(schemas_from_file)
     return OrderedDict(sorted(schemas.items(), key=SchemaSorter().sort_key))
+
 
 def _load_json_file(path, ordered=False):
     """Helper to return the loaded json from a given path
@@ -274,6 +273,7 @@ def _validate_config(config):
                         "IOC key '{}' within IOC type '{}' must be defined for at least "
                         "one log type in normalized types".format(normalized_key, ioc_type)
                     )
+
 
 def _validate_sources(cluster_name, data_sources, existing_sources):
     """Validates the sources for a cluster

--- a/streamalert/shared/exceptions.py
+++ b/streamalert/shared/exceptions.py
@@ -1,0 +1,23 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class StreamAlertError(Exception):
+    """Base streamalert exception for inheritance"""
+
+
+class ConfigError(StreamAlertError):
+    """Exception to be used for config related errors"""

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -26,10 +26,6 @@ from streamalert_cli.apps.helpers import save_app_auth_info
 LOGGER = get_logger(__name__)
 
 
-class CLIConfigError(Exception):
-    pass
-
-
 class CLIConfig:
     """A class to load, modify, and display the StreamAlertCLI Config"""
     DEFAULT_CONFIG_PATH = 'conf/'

--- a/tests/unit/streamalert/classifier/test_classifier.py
+++ b/tests/unit/streamalert/classifier/test_classifier.py
@@ -167,8 +167,7 @@ class TestClassifier:
             self._resource_name
         )
 
-    @patch('logging.Logger.error')
-    def test_load_logs_for_resource_invalid_resource(self, log_mock):
+    def test_load_logs_for_resource_invalid_resource(self):
         """Classifier - Load Logs for Resource, Invalid Resource"""
         assert_raises(
             ConfigError,

--- a/tests/unit/streamalert/classifier/test_classifier.py
+++ b/tests/unit/streamalert/classifier/test_classifier.py
@@ -17,10 +17,11 @@ from collections import OrderedDict
 import os
 
 from mock import Mock, patch
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_raises
 
 import streamalert.classifier.classifier as classifier_module
 from streamalert.classifier.classifier import Classifier
+from streamalert.shared.exceptions import ConfigError
 
 
 class TestClassifier:
@@ -157,24 +158,23 @@ class TestClassifier:
         result = self._classifier._load_logs_for_resource(self._service_name, self._resource_name)
         assert_equal(result, expected_result)
 
-    @patch('logging.Logger.error')
-    def test_load_logs_for_resource_invalid_service(self, log_mock):
+    def test_load_logs_for_resource_invalid_service(self):
         """Classifier - Load Logs for Resource, Invalid Service"""
-        service = 'invalid_service'
-        result = self._classifier._load_logs_for_resource(service, self._resource_name)
-        assert_equal(result, False)
-        log_mock.assert_called_with('Service [%s] not declared in sources configuration', service)
+        assert_raises(
+            ConfigError,
+            self._classifier._load_logs_for_resource,
+            'invalid_service',
+            self._resource_name
+        )
 
     @patch('logging.Logger.error')
     def test_load_logs_for_resource_invalid_resource(self, log_mock):
         """Classifier - Load Logs for Resource, Invalid Resource"""
-        resource = 'invalid_resource'
-        result = self._classifier._load_logs_for_resource(self._service_name, resource)
-        assert_equal(result, False)
-        log_mock.assert_called_with(
-            'Resource [%s] not declared in sources configuration for service [%s]',
-            resource,
-            self._service_name
+        assert_raises(
+            ConfigError,
+            self._classifier._load_logs_for_resource,
+            self._service_name,
+            'invalid_resource'
         )
 
     @patch.object(classifier_module, 'get_parser')


### PR DESCRIPTION
to: @chunyong-lin / @blakemotl 
cc: @airbnb/streamalert-maintainers

## Background

A misconfigured source configuration will cause the classifiers to fail to process data. Currently, an error is logged and the function just exits. This should fail more verbosely so the user knows something is wrong.

## Changes

* Adding a new `ConfigError` class (that inherits from a new `StreamAlertError` class)
* Raising `ConfigError` exceptions if there is a sources misconfiguration.

## Testing

Updating unit tests to check that exceptions are now raised.
