### PR TITLE
renaming all known references of "stream_alert" to "streamalert"

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -53,10 +53,10 @@ When writing commit messages, make sure to prefix with one of the following tags
   [docs]              # changes to StreamAlert documentation
   [cli]               # streamalert_cli changes
   [terraform]         # terraform changes
-  [core]              # changes with core stream_alert classes used across lambda functions
+  [core]              # changes with core streamalert classes used across lambda functions
   [testing]           # changes with testing infrastructure or processes
   [setup]             # StreamAlert development setup changes
-  [config]            # stream_alert config changes
+  [config]            # streamalert config changes
 
 The first line of your commit message should be short.  Use newlines to explain further::
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ def configure_python(machine, version)
                    }
 end
 
-STREAM_ALERT_SHELL_ENV = %{
+STREAMALERT_SHELL_ENV = %{
 export AWS_DEFAULT_REGION='#{ENV.fetch('SA_AWS_DEFAULT_REGION', 'Your region here!')}'
 export AWS_ACCESS_KEY_ID='#{ENV.fetch('SA_AWS_ACCESS_KEY_ID', 'Your access key ID here!')}'
 export AWS_SECRET_ACCESS_KEY='#{ENV.fetch('SA_AWS_SECRET_ACCESS_KEY', 'Your secret access key here!')}'
@@ -52,7 +52,7 @@ def configure_streamalert(machine)
   machine.vm.provision :shell,
                    # Append the environment variables to the .bashrc for
                    # the vagrant user (unprivileged default)
-                   inline: "echo \"#{STREAM_ALERT_SHELL_ENV}\" >> ~/.bashrc",
+                   inline: "echo \"#{STREAMALERT_SHELL_ENV}\" >> ~/.bashrc",
                    # Install this to the vagrant user (unprivileged default)
                    privileged: false
 
@@ -82,7 +82,7 @@ created correctly, run "aws s3 ls | grep streamalert".
 The following lines were appended to the vagrant (default) user's
 ~/.bashrc:
 
-#{STREAM_ALERT_SHELL_ENV}
+#{STREAMALERT_SHELL_ENV}
 
 }
 

--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -20,7 +20,7 @@
           "binaryalert"
       ]
     },
-    "stream_alert_app": {
+    "streamalert_app": {
       "prefix_cluster_box_admin_events_sm-app-name_app": [
         "box"
       ],

--- a/conf/clusters/prod.json
+++ b/conf/clusters/prod.json
@@ -53,7 +53,7 @@
       "kinesis_alarms_enabled": false,
       "lambda_alarms_enabled": true
     },
-    "stream_alert": {
+    "streamalert": {
       "classifier_config": {
         "enable_custom_metrics": true,
         "inputs": {

--- a/conf/global.json
+++ b/conf/global.json
@@ -49,6 +49,6 @@
     "create_bucket": true,
     "lock_state_file": false,
     "tfstate_bucket": "PREFIX_GOES_HERE.streamalert.terraform.state",
-    "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
+    "tfstate_s3_key": "streamalert_state/terraform.tfstate"
   }
 }

--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -32,7 +32,7 @@ Configuration options are divided into different modules, each of which is discu
 
 Classifier Function
 -------------------
-``stream_alert`` is the only required module because it configures the cluster's classifier.
+``streamalert`` is the only required module because it configures the cluster's classifier.
 
 Example: Minimal Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -253,7 +253,7 @@ Once you have applied this change to enable StreamAlert to subscribe to CloudWat
 in the *producer* account to actually deliver the logs, optionally with
 `Terraform <https://www.terraform.io/docs/providers/aws/r/cloudwatch_log_subscription_filter.html>`_.
 The CloudWatch logs destination ARN will be
-``arn:aws:logs:REGION:STREAMALERT_ACCOUNT:destination:stream_alert_CLUSTER_cloudwatch_to_kinesis``.
+``arn:aws:logs:REGION:STREAMALERT_ACCOUNT:destination:streamalert_CLUSTER_cloudwatch_to_kinesis``.
 
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/clusters.rst
+++ b/docs/source/clusters.rst
@@ -42,7 +42,7 @@ Example: Minimal Cluster
   {
     "id": "minimal-cluster",
     "modules": {
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "log_level": "info",
@@ -63,7 +63,7 @@ Example: Classifier with SNS Inputs
   {
     "id": "sns-inputs",
     "modules": {
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "inputs": {
@@ -117,7 +117,7 @@ Example: CloudTrail via S3 Events
       "s3_events": {
         "PREFIX.CLUSTER.streamalert.cloudtrail": []
       },
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "log_level": "info",
@@ -156,7 +156,7 @@ Example: CloudTrail via CloudWatch Logs
           "batch_size": 10,
           "enabled": true
         },
-        "stream_alert": {
+        "streamalert": {
           "classifier_config": {
             "enable_custom_metrics": true,
             "log_level": "info",
@@ -232,7 +232,7 @@ Example: CloudWatch Logs Cluster
         "batch_size": 100,
         "enabled": true
       },
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "log_level": "info",
@@ -295,7 +295,7 @@ Example: Enable CloudWatch Monitoring
           "kinesis_write_throughput_exceeded_threshold": 10
         }
       },
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "log_level": "info",
@@ -424,7 +424,7 @@ Example: Kinesis Cluster
         "batch_size": 100,
         "enabled": true
       },
-      "stream_alert": {
+      "streamalert": {
         "classifier_config": {
           "enable_custom_metrics": true,
           "log_level": "info",
@@ -558,7 +558,7 @@ Example: Flow Logs Cluster
           "batch_size": 2,
           "enabled": true
         },
-        "stream_alert": {
+        "streamalert": {
           "classifier_config": {
             "enable_custom_metrics": true,
             "log_level": "info",
@@ -623,7 +623,7 @@ Example: S3 Events Cluster
           ],
           "bucket_name_02": []
         },
-        "stream_alert": {
+        "streamalert": {
           "classifier_config": {
             "enable_custom_metrics": true,
             "log_level": "info",

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -14,7 +14,7 @@ Install Dependencies
 
   brew install terraform  # MacOS Homebrew
   terraform --version     # Must be v0.11.X
-  
+
 .. note:: Terraform versions >= 0.12.X are not currently supported.
 
 3. Install `virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_:
@@ -151,7 +151,7 @@ SNS for both sending the log data and receiving the alert, but StreamAlert also 
 .. note:: You will need to click the verification link in your email to activate the subscription.
 
 4. Add the ``streamalert-test-data`` SNS topic as an input to the (default) ``prod`` `cluster <clusters.html>`_.
-Open ``conf/clusters/prod.json`` and change the ``stream_alert`` module to look like this:
+Open ``conf/clusters/prod.json`` and change the ``streamalert`` module to look like this:
 
 .. code-block:: json
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -156,7 +156,7 @@ Open ``conf/clusters/prod.json`` and change the ``stream_alert`` module to look 
 .. code-block:: json
 
   {
-    "stream_alert": {
+    "streamalert": {
       "classifier_config": {
         "enable_custom_metrics": true,
         "inputs": {

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -19,8 +19,8 @@ This file should contain the following structure:
       "data": "Either a string, or JSON object",
       "description": "This test should trigger or not trigger an alert",
       "log": "The log name declared in a json file under the conf/schemas directory",
-      "service": "The service sending the log - kinesis, s3, sns, or stream_alert_app",
-      "source": "The exact resource which sent the log - kinesis stream name, s3 bucket ID, SNS topic name, or stream_alert_app_function name",
+      "service": "The service sending the log - kinesis, s3, sns, or streamalert_app",
+      "source": "The exact resource which sent the log - kinesis stream name, s3 bucket ID, SNS topic name, or streamalert_app function name",
       "trigger_rules": [
         "rule_name_that_should_trigger_for_this_event",
         "another_rule_name_that_should_trigger_for_this_event"
@@ -114,7 +114,7 @@ Key                        Type                    Required  Description
 ``log``                    ``string``              Yes       The log type this test record should parse as. The value of this
                                                              should be taken from the defined logs in one or more files in the ``conf/schemas`` directory
 ``service``                ``string``              Yes       The name of the service which sent the log.
-                                                             This should be one of: ``kinesis``, ``s3``, ``sns``, or ``stream_alert_app``.
+                                                             This should be one of: ``kinesis``, ``s3``, ``sns``, or ``streamalert_app``.
 ``source``                 ``string``              Yes       The name of the Kinesis Stream or S3 bucket, SNS topic or StreamAlert App
                                                              function where the data originated from. This value should match a source
                                                              provided in the ``data_sources`` field defined within a cluster in ``conf/clusters/<cluster>.json``

--- a/streamalert/alert_processor/outputs/credentials/provider.py
+++ b/streamalert/alert_processor/outputs/credentials/provider.py
@@ -533,9 +533,9 @@ class LocalFileDriver(CredentialsProvidingDriver, FileDescriptorProvider, Creden
         Will automatically create the new directory if it does not exist.
 
         Returns:
-            str: local path for stream_alert_secrets tmp directory
+            str: local path for streamalert_secrets tmp directory
         """
-        temp_dir = os.path.join(tempfile.gettempdir(), "stream_alert_secrets")
+        temp_dir = os.path.join(tempfile.gettempdir(), "streamalert_secrets")
 
         # Check if this item exists as a file, and remove it if it does
         if os.path.isfile(temp_dir):

--- a/streamalert/apps/batcher.py
+++ b/streamalert/apps/batcher.py
@@ -90,7 +90,7 @@ class Batcher:
         """
         # Create a payload to be sent to the classifier function that contains the
         # service these logs were collected from and the list of logs
-        payload = {'Records': [{'stream_alert_app': self._source_function, 'logs': logs}]}
+        payload = {'Records': [{'streamalert_app': self._source_function, 'logs': logs}]}
         payload_json = json.dumps(payload, separators=(',', ':'))
         if len(payload_json) > self.MAX_LAMBDA_PAYLOAD_SIZE:
             if len(logs) == 1:

--- a/streamalert/classifier/payload/apps.py
+++ b/streamalert/classifier/payload/apps.py
@@ -41,5 +41,5 @@ class AppPayload(StreamPayload):
         for data in self.raw_record['logs']:
             yield PayloadRecord(data)
 
-        MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.TOTAL_STREAM_ALERT_APP_RECORDS,
+        MetricLogger.log_metric(FUNCTION_NAME, MetricLogger.TOTAL_STREAMALERT_APP_RECORDS,
                                 len(self.raw_record['logs']))

--- a/streamalert/classifier/payload/apps.py
+++ b/streamalert/classifier/payload/apps.py
@@ -28,7 +28,7 @@ class AppPayload(StreamPayload):
 
     @classmethod
     def service(cls):
-        return 'stream_alert_app'
+        return 'streamalert_app'
 
     def _pre_parse(self):
         """Pre-parsing method for incoming app records

--- a/streamalert/classifier/payload/payload_base.py
+++ b/streamalert/classifier/payload/payload_base.py
@@ -249,7 +249,7 @@ class StreamPayload(metaclass=ABCMeta):
             'kinesis': lambda r: r['eventSourceARN'].split('/')[-1],
             's3': lambda r: r['s3']['bucket']['name'],
             'Sns': lambda r: r['Sns']['TopicArn'].split(':')[-1],
-            'stream_alert_app': lambda r: r['stream_alert_app']
+            'streamalert_app': lambda r: r['streamalert_app']
         }
 
         service, resource = None, None

--- a/streamalert/rules_engine/threat_intel.py
+++ b/streamalert/rules_engine/threat_intel.py
@@ -356,7 +356,7 @@ class ThreatIntel:
         # Threat Intel can be disabled for any given cluster
         enabled_clusters = {
             cluster for cluster, values in config['clusters'].items()
-            if values['modules']['stream_alert'].get('enable_threat_intel', False)
+            if values['modules']['streamalert'].get('enable_threat_intel', False)
         }
 
         if not enabled_clusters:

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -74,7 +74,7 @@ def parse_lambda_arn(function_arn):
     and the name of the function.
 
     Example:
-        arn:aws:lambda:aws-region:acct-id:function:stream_alert:production
+        arn:aws:lambda:aws-region:acct-id:function:streamalert:production
 
     Args:
         function_arn (str): The AWS Lambda function ARN

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -22,7 +22,7 @@ from streamalert.shared.logger import get_logger
 
 LOGGER = get_logger(__name__)
 
-SUPPORTED_SOURCES = {'kinesis', 's3', 'sns', 'stream_alert_app'}
+SUPPORTED_SOURCES = {'kinesis', 's3', 'sns', 'streamalert_app'}
 
 
 class TopLevelConfigKeys:
@@ -256,11 +256,11 @@ def _validate_config(config):
             _validate_sources(cluster_name, cluster_attrs['data_sources'], existing_sources)
 
             if not cluster_attrs.get('modules', {}).get('streamalert'):
-                error = '\'streamalert\' module is missing in the \'{}\' cluster'.format(
+                error = "'streamalert' module is missing in the '{}' cluster".format(
                     cluster_name
                 )
                 if cluster_attrs.get('modules', {}).get('stream_alert'):
-                    error += '. \'stream_alert\' should be renamed to \'streamalert\''
+                    error += ". 'stream_alert' should be renamed to 'streamalert'"
                 raise ConfigError(error)
 
     if TopLevelConfigKeys.THREAT_INTEL in config:

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -255,6 +255,14 @@ def _validate_config(config):
                 raise ConfigError("'data_sources' missing for cluster {}".format(cluster_name))
             _validate_sources(cluster_name, cluster_attrs['data_sources'], existing_sources)
 
+            if not cluster_attrs.get('modules', {}).get('streamalert'):
+                error = '\'streamalert\' module is missing in the \'{}\' cluster'.format(
+                    cluster_name
+                )
+                if cluster_attrs.get('modules', {}).get('stream_alert'):
+                    error += '. \'stream_alert\' should be renamed to \'streamalert\''
+                raise ConfigError(error)
+
     if TopLevelConfigKeys.THREAT_INTEL in config:
         if TopLevelConfigKeys.NORMALIZED_TYPES not in config:
             raise ConfigError('Normalized types must also be loaded with IOC types')

--- a/streamalert/shared/metrics.py
+++ b/streamalert/shared/metrics.py
@@ -61,7 +61,7 @@ class MetricLogger:
     TOTAL_PROCESSED_SIZE = 'TotalProcessedSize'
     TOTAL_RECORDS = 'TotalRecords'
     TOTAL_S3_RECORDS = 'TotalS3Records'
-    TOTAL_STREAM_ALERT_APP_RECORDS = 'TotalStreamAlertAppRecords'
+    TOTAL_STREAMALERT_APP_RECORDS = 'TotalStreamAlertAppRecords'
     FIREHOSE_RECORDS_SENT = 'FirehoseRecordsSent'
     FIREHOSE_FAILED_RECORDS = 'FirehoseFailedRecords'
     SQS_FAILED_RECORDS = 'SQSFailedRecords'
@@ -111,8 +111,8 @@ class MetricLogger:
                             _default_value_lookup),
             TOTAL_S3_RECORDS: (_default_filter.format(TOTAL_S3_RECORDS),
                                _default_value_lookup),
-            TOTAL_STREAM_ALERT_APP_RECORDS:
-                (_default_filter.format(TOTAL_STREAM_ALERT_APP_RECORDS), _default_value_lookup)
+            TOTAL_STREAMALERT_APP_RECORDS:
+                (_default_filter.format(TOTAL_STREAMALERT_APP_RECORDS), _default_value_lookup)
         },
         RULES_ENGINE_FUNCTION_NAME: {
             FAILED_DYNAMO_WRITES: (_default_filter.format(FAILED_DYNAMO_WRITES),

--- a/streamalert_cli/apps/handler.py
+++ b/streamalert_cli/apps/handler.py
@@ -177,7 +177,7 @@ class AppCommand(CLICommand):
         # List all of the available app integrations, broken down by cluster
         if options.subcommand == 'list':
             all_info = {
-                cluster: cluster_config['modules'].get('stream_alert_apps')
+                cluster: cluster_config['modules'].get('streamalert_apps')
                 for cluster, cluster_config in config['clusters'].items()
             }
 
@@ -220,7 +220,7 @@ class AppCommand(CLICommand):
         # Update the auth information for an existing app integration function
         if options.subcommand == 'update-auth':
             cluster_config = config['clusters'][app_info['cluster']]
-            apps = cluster_config['modules'].get('stream_alert_apps', {})
+            apps = cluster_config['modules'].get('streamalert_apps', {})
             if not apps:
                 LOGGER.error('No apps configured for cluster \'%s\'', app_info['cluster'])
                 return False
@@ -239,7 +239,7 @@ class AppCommand(CLICommand):
 
             # Get the type for this app integration from the current
             # config so we can update it properly
-            app_info['type'] = cluster_config['modules']['stream_alert_apps'][func_name]['type']
+            app_info['type'] = cluster_config['modules']['streamalert_apps'][func_name]['type']
 
             app = StreamAlertApp.get_app(app_info['type'])
 

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -155,7 +155,7 @@ class CLIConfig:
             else:
                 # Classifier - toggle for each cluster
                 for cluster in clusters:
-                    self.config['clusters'][cluster]['modules']['stream_alert'] \
+                    self.config['clusters'][cluster]['modules']['streamalert'] \
                         [function_config]['enable_custom_metrics'] = enabled
 
         self.write()
@@ -199,7 +199,7 @@ class CLIConfig:
         for func in funcs:
             func_config = '{}_config'.format(func)
             for cluster, cluster_config in self.config['clusters'].items():
-                func_alarms = cluster_config['modules']['stream_alert'][func_config].get(
+                func_alarms = cluster_config['modules']['streamalert'][func_config].get(
                     'custom_metric_alarms', {}
                 )
                 if alarm_name in func_alarms:
@@ -222,7 +222,7 @@ class CLIConfig:
         return {
             cluster
             for cluster, cluster_config in self.config['clusters'].items()
-            if (self.config['clusters'][cluster]['modules']['stream_alert']
+            if (self.config['clusters'][cluster]['modules']['streamalert']
                 [function_config].get('enable_custom_metrics'))
         }
 
@@ -240,7 +240,7 @@ class CLIConfig:
         config_name = '{}_config'.format(function_name)
         for cluster in alarm_info['clusters']:
             function_config = (
-                self.config['clusters'][cluster]['modules']['stream_alert'][config_name])
+                self.config['clusters'][cluster]['modules']['streamalert'][config_name])
 
             if not function_config.get('enable_custom_metrics'):
                 prompt = ('Metrics are not currently enabled for the \'{}\' function '

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -441,7 +441,7 @@ class CLIConfig:
         cluster_config['modules']['streamalert_apps'] = apps_config
 
         # Add this service to the sources for this app integration
-        # The `stream_alert_app` is purposely singular here
+        # The `streamalert_app` is purposely singular here
         app_sources = self.config['clusters'][cluster_name]['data_sources'].get(
             'streamalert_app', {}
         )

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -386,7 +386,7 @@ class CLIConfig:
         # Check to see if there is an existing configuration for this app integration
         cluster_config = self.config['clusters'][cluster_name]
 
-        if func_name in cluster_config['modules'].get('stream_alert_apps', {}):
+        if func_name in cluster_config['modules'].get('streamalert_apps', {}):
             prompt = ('An app with the name \'{}\' is already configured for cluster '
                       '\'{}\'. Would you like to update the existing app\'s configuration'
                       '?'.format(app_name, cluster_name))
@@ -406,7 +406,7 @@ class CLIConfig:
         if prompt_for_auth and not save_app_auth_info(app, app_info, func_name, overwrite):
             return False
 
-        apps_config = cluster_config['modules'].get('stream_alert_apps', {})
+        apps_config = cluster_config['modules'].get('streamalert_apps', {})
         if not exists:
             # Save a default app settings to the config for new apps
             new_app_config = {
@@ -438,15 +438,15 @@ class CLIConfig:
             }
             apps_config[func_name].update(updated_app_config)
 
-        cluster_config['modules']['stream_alert_apps'] = apps_config
+        cluster_config['modules']['streamalert_apps'] = apps_config
 
         # Add this service to the sources for this app integration
         # The `stream_alert_app` is purposely singular here
         app_sources = self.config['clusters'][cluster_name]['data_sources'].get(
-            'stream_alert_app', {}
+            'streamalert_app', {}
         )
         app_sources[func_name] = [app.service()]
-        self.config['clusters'][cluster_name]['data_sources']['stream_alert_app'] = app_sources
+        self.config['clusters'][cluster_name]['data_sources']['streamalert_app'] = app_sources
 
         LOGGER.info('Successfully added \'%s\' app integration to \'conf/clusters/%s.json\' '
                     'for service \'%s\'.', app_info['app_name'], app_info['cluster'],

--- a/streamalert_cli/manage_lambda/deploy.py
+++ b/streamalert_cli/manage_lambda/deploy.py
@@ -211,7 +211,7 @@ def _create(function_name, config, clusters=None):
         ),
         'athena': PackageMap(
             streamalert_packages.AthenaPackage,
-            {'module.stream_alert_athena'},
+            {'module.streamalert_athena'},
             True
         ),
         'classifier': PackageMap(

--- a/streamalert_cli/manage_lambda/deploy.py
+++ b/streamalert_cli/manage_lambda/deploy.py
@@ -203,10 +203,10 @@ def _create(function_name, config, clusters=None):
              for suffix in {'lambda', 'iam'}
              for cluster in clusters
              for app_info in config['clusters'][cluster]['modules'].get(
-                 'stream_alert_apps', {}
+                 'streamalert_apps', {}
              ).values()
              if 'app_name' in app_info},
-            any(info['modules'].get('stream_alert_apps')
+            any(info['modules'].get('streamalert_apps')
                 for info in config['clusters'].values())
         ),
         'athena': PackageMap(

--- a/streamalert_cli/manage_lambda/deploy.py
+++ b/streamalert_cli/manage_lambda/deploy.py
@@ -19,7 +19,7 @@ import sys
 from streamalert.shared import rule_table
 from streamalert.shared.logger import get_logger
 from streamalert_cli import helpers
-from streamalert_cli.manage_lambda import package as stream_alert_packages
+from streamalert_cli.manage_lambda import package as streamalert_packages
 from streamalert_cli.terraform.generate import terraform_generate_handler
 from streamalert_cli.utils import (
     add_default_lambda_args,
@@ -188,17 +188,17 @@ def _create(function_name, config, clusters=None):
 
     package_mapping = {
         'alert': PackageMap(
-            stream_alert_packages.AlertProcessorPackage,
+            streamalert_packages.AlertProcessorPackage,
             {'module.alert_processor_iam', 'module.alert_processor_lambda'},
             True
         ),
         'alert_merger': PackageMap(
-            stream_alert_packages.AlertMergerPackage,
+            streamalert_packages.AlertMergerPackage,
             {'module.alert_merger_iam', 'module.alert_merger_lambda'},
             True
         ),
         'apps': PackageMap(
-            stream_alert_packages.AppPackage,
+            streamalert_packages.AppPackage,
             {'module.app_{}_{}_{}'.format(app_info['app_name'], cluster, suffix)
              for suffix in {'lambda', 'iam'}
              for cluster in clusters
@@ -210,29 +210,29 @@ def _create(function_name, config, clusters=None):
                 for info in config['clusters'].values())
         ),
         'athena': PackageMap(
-            stream_alert_packages.AthenaPackage,
+            streamalert_packages.AthenaPackage,
             {'module.stream_alert_athena'},
             True
         ),
         'classifier': PackageMap(
-            stream_alert_packages.ClassifierPackage,
+            streamalert_packages.ClassifierPackage,
             {'module.classifier_{}_{}'.format(cluster, suffix)
              for suffix in {'lambda', 'iam'}
              for cluster in clusters},
             True
         ),
         'rule': PackageMap(
-            stream_alert_packages.RulesEnginePackage,
+            streamalert_packages.RulesEnginePackage,
             {'module.rules_engine_iam', 'module.rules_engine_lambda'},
             True
         ),
         'rule_promo': PackageMap(
-            stream_alert_packages.RulePromotionPackage,
+            streamalert_packages.RulePromotionPackage,
             {'module.rule_promotion_iam', 'module.rule_promotion_lambda'},
             config['lambda'].get('rule_promotion_config', {}).get('enabled', False)
         ),
         'threat_intel_downloader': PackageMap(
-            stream_alert_packages.ThreatIntelDownloaderPackage,
+            streamalert_packages.ThreatIntelDownloaderPackage,
             {'module.threat_intel_downloader'},
             config['lambda'].get('threat_intel_downloader_config', False)
         )

--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -244,7 +244,7 @@ class AlertMergerPackage(LambdaPackage):
 
 class AppPackage(LambdaPackage):
     """Deployment package class for App functions"""
-    config_key = 'stream_alert_apps_config'
+    config_key = 'streamalert_apps_config'
     lambda_handler = 'streamalert.apps.main.handler'
     package_files = {
         'streamalert/__init__.py',

--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -251,7 +251,7 @@ class AppPackage(LambdaPackage):
         'streamalert/apps',
         'streamalert/shared'
     }
-    package_name = 'stream_alert_app'
+    package_name = 'streamalert_app'
     precompiled_libs = {'boxsdk[jwt]', 'aliyun-python-sdk-actiontrail'}
     package_libs = {
         'aliyun-python-sdk-actiontrail',

--- a/streamalert_cli/manage_lambda/rollback.py
+++ b/streamalert_cli/manage_lambda/rollback.py
@@ -120,7 +120,7 @@ class RollbackCommand(CLICommand):
 
         if rollback_all or 'apps' in options.function:
             for cluster in clusters:
-                apps_config = config['clusters'][cluster]['modules'].get('stream_alert_apps', {})
+                apps_config = config['clusters'][cluster]['modules'].get('streamalert_apps', {})
                 for lambda_name in sorted(apps_config):
                     success = success and _rollback_production(client, lambda_name)
 

--- a/streamalert_cli/status/handler.py
+++ b/streamalert_cli/status/handler.py
@@ -72,7 +72,7 @@ class StatusCommand(CLICommand):
 
         cluster_non_func_keys = sorted(['enable_threat_intel'])
         for cluster in sorted(config['clusters']):
-            sa_config = config['clusters'][cluster]['modules']['stream_alert']
+            sa_config = config['clusters'][cluster]['modules']['streamalert']
 
             print(_format_header('Cluster: {}'.format(cluster), True))
             for key in cluster_non_func_keys:

--- a/streamalert_cli/terraform/alert_processor.py
+++ b/streamalert_cli/terraform/alert_processor.py
@@ -39,7 +39,7 @@ def generate_alert_processor(config):
         'region': config['global']['account']['region'],
         'prefix': prefix,
         'role_id': '${module.alert_processor_lambda.role_id}',
-        'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
+        'kms_key_arn': '${aws_kms_key.streamalert_secrets.arn}',
         'sse_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
         'output_lambda_functions': [
             # Strip qualifiers: only the function name is needed for the IAM permissions

--- a/streamalert_cli/terraform/apps.py
+++ b/streamalert_cli/terraform/apps.py
@@ -32,7 +32,7 @@ def generate_apps(cluster_name, cluster_dict, config):
     prefix = config['global']['account']['prefix']
 
     for function_name, app_info in config['clusters'][cluster_name]['modules'].get(
-            'stream_alert_apps', {}).items():
+            'streamalert_apps', {}).items():
 
         tf_module_prefix = 'app_{}_{}'.format(app_info['app_name'], cluster_name)
 
@@ -59,7 +59,7 @@ def generate_apps(cluster_name, cluster_dict, config):
             function_name,
             AppPackage.package_name + '.zip',
             AppPackage.lambda_handler,
-            config['clusters'][cluster_name]['modules']['stream_alert_apps'][function_name],
+            config['clusters'][cluster_name]['modules']['streamalert_apps'][function_name],
             config,
             input_event=app_config
         )

--- a/streamalert_cli/terraform/athena.py
+++ b/streamalert_cli/terraform/athena.py
@@ -45,7 +45,7 @@ def generate_athena(config):
         '{}_streamalert_athena_s3_notifications'.format(prefix)
     ).strip()
 
-    athena_dict['module']['stream_alert_athena'] = {
+    athena_dict['module']['streamalert_athena'] = {
         's3_logging_bucket': config['global']['s3_access_logging']['logging_bucket'],
         'source': './modules/tf_athena',
         'database_name': database,
@@ -96,6 +96,6 @@ def generate_athena(config):
                for metric, settings in
                current_metrics[metrics.ATHENA_PARTITION_REFRESH_NAME].items()]
 
-    athena_dict['module']['stream_alert_athena']['athena_metric_filters'] = filters
+    athena_dict['module']['streamalert_athena']['athena_metric_filters'] = filters
 
     return athena_dict

--- a/streamalert_cli/terraform/classifier.py
+++ b/streamalert_cli/terraform/classifier.py
@@ -27,7 +27,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
 
     JSON Input from the config:
 
-        "stream_alert": {
+        "streamalert": {
           "classifier_config": {
             "log_level": "info",
             "log_retention_days": 14,
@@ -55,7 +55,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
         }
     """
     classifier_config = (
-        config['clusters'][cluster_name]['modules']['stream_alert']['classifier_config']
+        config['clusters'][cluster_name]['modules']['streamalert']['classifier_config']
     )
 
     firehose_config = config['global']['infrastructure'].get('firehose', {})

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -176,7 +176,7 @@ def generate_main(config, init=False):
 
     # Configure initial S3 buckets
     main_dict['resource']['aws_s3_bucket'] = {
-        'stream_alert_secrets': generate_s3_bucket(
+        'streamalert_secrets': generate_s3_bucket(
             # FIXME (derek.wang) DRY out by using OutputCredentialsProvider?
             bucket='{}.streamalert.secrets'.format(config['global']['account']['prefix']),
             logging=_config_get_logging_bucket(config)
@@ -255,13 +255,13 @@ def generate_main(config, init=False):
         'target_key_id': '${aws_kms_key.server_side_encryption.key_id}'
     }
 
-    main_dict['resource']['aws_kms_key']['stream_alert_secrets'] = {
+    main_dict['resource']['aws_kms_key']['streamalert_secrets'] = {
         'enable_key_rotation': True,
         'description': 'StreamAlert secret management'
     }
-    main_dict['resource']['aws_kms_alias']['stream_alert_secrets'] = {
+    main_dict['resource']['aws_kms_alias']['streamalert_secrets'] = {
         'name': 'alias/{}'.format(config['global']['account']['kms_key_alias']),
-        'target_key_id': '${aws_kms_key.stream_alert_secrets.key_id}'
+        'target_key_id': '${aws_kms_key.streamalert_secrets.key_id}'
     }
 
     # Global infrastructure settings

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -87,10 +87,10 @@ class TerraformInitCommand(CLICommand):
         LOGGER.info('Building initial infrastructure')
         init_targets = [
             'aws_s3_bucket.lambda_source', 'aws_s3_bucket.logging_bucket',
-            'aws_s3_bucket.stream_alert_secrets', 'aws_s3_bucket.terraform_remote_state',
+            'aws_s3_bucket.streamalert_secrets', 'aws_s3_bucket.terraform_remote_state',
             'aws_s3_bucket.streamalerts',
             'aws_kms_key.server_side_encryption', 'aws_kms_alias.server_side_encryption',
-            'aws_kms_key.stream_alert_secrets', 'aws_kms_alias.stream_alert_secrets'
+            'aws_kms_key.streamalert_secrets', 'aws_kms_alias.streamalert_secrets'
         ]
         if not tf_runner(targets=init_targets):
             LOGGER.error('An error occurred while running StreamAlert init')

--- a/streamalert_cli/terraform/metrics.py
+++ b/streamalert_cli/terraform/metrics.py
@@ -119,7 +119,7 @@ def generate_cluster_cloudwatch_metric_filters(cluster_name, cluster_dict, confi
         cluster_dict (defaultdict): The dict containing all Terraform config for a given cluster.
         config (dict): The loaded config from the 'conf/' directory
     """
-    stream_alert_config = config['clusters'][cluster_name]['modules']['streamalert']
+    streamalert_config = config['clusters'][cluster_name]['modules']['streamalert']
 
     current_metrics = metrics.MetricLogger.get_available_metrics()
 
@@ -129,10 +129,10 @@ def generate_cluster_cloudwatch_metric_filters(cluster_name, cluster_dict, confi
             continue
 
         func_config_name = '{}_config'.format(func)
-        if func_config_name not in stream_alert_config:
+        if func_config_name not in streamalert_config:
             continue
 
-        if not stream_alert_config[func_config_name].get('enable_custom_metrics'):
+        if not streamalert_config[func_config_name].get('enable_custom_metrics'):
             continue
 
         metric_prefix = metrics.FUNC_PREFIXES[func]
@@ -173,13 +173,13 @@ def generate_cluster_cloudwatch_metric_alarms(cluster_name, cluster_dict, config
 
     sns_topic_arn = monitoring_topic_arn(config)
 
-    stream_alert_config = config['clusters'][cluster_name]['modules']['streamalert']
+    streamalert_config = config['clusters'][cluster_name]['modules']['streamalert']
 
     # Add cluster metric alarms for the clustered function(s). ie: classifier
     metric_alarms = [
         metric_alarm
         for func in CLUSTERED_FUNCTIONS
-        for metric_alarm in stream_alert_config['{}_config'.format(func)].get(
+        for metric_alarm in streamalert_config['{}_config'.format(func)].get(
             'custom_metric_alarms', []
         )
     ]

--- a/streamalert_cli/terraform/metrics.py
+++ b/streamalert_cli/terraform/metrics.py
@@ -31,7 +31,7 @@ def generate_aggregate_cloudwatch_metric_filters(config):
         cluster: [
             func.replace('_config', '')
             for func in CLUSTERED_FUNCTIONS
-            if cluster_config['modules']['stream_alert']['{}_config'.format(func)].get(
+            if cluster_config['modules']['streamalert']['{}_config'.format(func)].get(
                 'enable_custom_metrics'
             )
         ] for cluster, cluster_config in config['clusters'].items()

--- a/streamalert_cli/terraform/metrics.py
+++ b/streamalert_cli/terraform/metrics.py
@@ -119,7 +119,7 @@ def generate_cluster_cloudwatch_metric_filters(cluster_name, cluster_dict, confi
         cluster_dict (defaultdict): The dict containing all Terraform config for a given cluster.
         config (dict): The loaded config from the 'conf/' directory
     """
-    stream_alert_config = config['clusters'][cluster_name]['modules']['stream_alert']
+    stream_alert_config = config['clusters'][cluster_name]['modules']['streamalert']
 
     current_metrics = metrics.MetricLogger.get_available_metrics()
 
@@ -173,7 +173,7 @@ def generate_cluster_cloudwatch_metric_alarms(cluster_name, cluster_dict, config
 
     sns_topic_arn = monitoring_topic_arn(config)
 
-    stream_alert_config = config['clusters'][cluster_name]['modules']['stream_alert']
+    stream_alert_config = config['clusters'][cluster_name]['modules']['streamalert']
 
     # Add cluster metric alarms for the clustered function(s). ie: classifier
     metric_alarms = [

--- a/streamalert_cli/terraform/rule_promotion.py
+++ b/streamalert_cli/terraform/rule_promotion.py
@@ -49,7 +49,7 @@ def generate_rule_promotion(config):
         'rules_table_arn': '${module.globals.rules_table_arn}',
         'function_alias_arn': '${module.rule_promotion_lambda.function_alias_arn}',
         'function_name': '${module.rule_promotion_lambda.function_name}',
-        'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}',
+        'athena_results_bucket_arn': '${module.streamalert_athena.results_bucket_arn}',
         'athena_data_buckets': data_buckets,
         's3_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
     }

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -552,7 +552,7 @@ class TestRunner:
         elif not isinstance(data, str):
             return False, 'Invalid data type: {}'.format(type(data))
 
-        if test_event['service'] not in {'s3', 'kinesis', 'sns', 'stream_alert_app'}:
+        if test_event['service'] not in {'s3', 'kinesis', 'sns', 'streamalert_app'}:
             return False, 'Unsupported service: {}'.format(test_event['service'])
 
         # Get a formatted record for this particular service
@@ -662,8 +662,8 @@ class TestRunner:
                 }
             }
 
-        if service == 'stream_alert_app':
-            return {'stream_alert_app': source, 'logs': [data]}
+        if service == 'streamalert_app':
+            return {'streamalert_app': source, 'logs': [data]}
 
     @staticmethod
     def _validate_test_event(test_event):

--- a/tests/integration/rules/aliyun/aliyun_basic.json
+++ b/tests/integration/rules/aliyun/aliyun_basic.json
@@ -43,7 +43,7 @@
     },
     "description": "schema validation check for aliyun:actiontrail with ApiCall call event",
     "log": "aliyun:actiontrail",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_aliyun_actiontrail_sm-app-name_app",
     "trigger_rules": []
   },
@@ -79,7 +79,7 @@
     },
     "description": "schema validation check for aliyun:actiontrail with example ApiCall event data",
     "log": "aliyun:actiontrail",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_aliyun_actiontrail_sm-app-name_app",
     "trigger_rules": []
   },
@@ -116,7 +116,7 @@
     },
     "description": "schema validation check for aliyun:actiontrail with example StopInstance console event data",
     "log": "aliyun:actiontrail",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_aliyun_actiontrail_sm-app-name_app",
     "trigger_rules": []
   },
@@ -153,7 +153,7 @@
     },
     "description": "schema validation check for aliyun:actiontrail with example AssumeRole event data",
     "log": "aliyun:actiontrail",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_aliyun_actiontrail_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/box/box_admin_events.json
+++ b/tests/integration/rules/box/box_admin_events.json
@@ -23,7 +23,7 @@
     },
     "description": "Box admin event log example (validation only)",
     "log": "box:admin_events",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_box_admin_events_sm-app-name_app",
     "trigger_rules": [],
     "validate_schema_only": true

--- a/tests/integration/rules/duo/duo_anonymous_ip_failure.json
+++ b/tests/integration/rules/duo/duo_anonymous_ip_failure.json
@@ -27,7 +27,7 @@
     },
     "description": "Duo authentication log marked as failure as a result of 'Anonymous IP' that will create an alert",
     "log": "duo:authentication",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_auth_sm-app-name_app",
     "trigger_rules": [
       "duo_anonymous_ip_failure"
@@ -45,7 +45,7 @@
     },
     "description": "Duo authentication log marked as failure as a result of 'Location restricted' that will not create an alert",
     "log": "duo:authentication",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_auth_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_auto_generated.json
@@ -9,7 +9,7 @@
     },
     "description": "A DUO bypass code that was hand crafted should create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": [
       "duo_bypass_code_create_non_auto_generated"
@@ -25,7 +25,7 @@
     },
     "description": "A DUO bypass code that was auto generated should not create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_non_expiring.json
@@ -9,7 +9,7 @@
     },
     "description": "A DUO bypass code that has no expiration should create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": [
       "duo_bypass_code_create_non_expiring"
@@ -25,7 +25,7 @@
     },
     "description": "A DUO bypass code that has an expiration should not create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
+++ b/tests/integration/rules/duo/duo_bypass_code_create_unlimited_use.json
@@ -9,7 +9,7 @@
     },
     "description": "A DUO bypass code that has unlimited use should create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": [
       "duo_bypass_code_create_unlimited_use"
@@ -25,7 +25,7 @@
     },
     "description": "A DUO bypass code that has finite remaining uses should not create an alert.",
     "log": "duo:administrator",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_admin_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/duo/duo_fraud.json
+++ b/tests/integration/rules/duo/duo_fraud.json
@@ -27,7 +27,7 @@
     },
     "description": "Duo authentication log marked as fraud that will create an alert",
     "log": "duo:authentication",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_auth_sm-app-name_app",
     "trigger_rules": [
       "duo_fraud"
@@ -61,7 +61,7 @@
     },
     "description": "Duo authentication log marked as success that will not create an alert",
     "log": "duo:authentication",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_duo_auth_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/gsuite/gsuite_admin.json
+++ b/tests/integration/rules/gsuite/gsuite_admin.json
@@ -33,7 +33,7 @@
     },
     "description": "G Suite Admin Report Log example (validation only)",
     "log": "gsuite:reports",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_gsuite_admin_sm-app-name_app",
     "trigger_rules": [],
     "validate_schema_only": true

--- a/tests/integration/rules/onelogin/onelogin_events_assumed_role.json
+++ b/tests/integration/rules/onelogin/onelogin_events_assumed_role.json
@@ -35,7 +35,7 @@
     },
     "description": "OneLogin generated event when a user assumed a different role, it should alert",
     "log": "onelogin:events",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_onelogin-events-app-name_app",
     "trigger_rules": [
       "onelogin_events_assumed_role"
@@ -77,7 +77,7 @@
     },
     "description": "OneLogin generated event when a user do any other action, it should not alert",
     "log": "onelogin:events",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_onelogin-events-app-name_app",
     "trigger_rules": []
   }

--- a/tests/integration/rules/slack/slack_basic.json
+++ b/tests/integration/rules/slack/slack_basic.json
@@ -14,7 +14,7 @@
     },
     "description": "basic schema validation check for slack:access",
     "log": "slack:access",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_slack_access_sm-app-name_app",
     "trigger_rules": []
   },
@@ -31,7 +31,7 @@
     },
     "description": "schema validation check for slack:integration with service log type",
     "log": "slack:integration",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_slack_integration_sm-app-name_app",
     "trigger_rules": []
   },
@@ -47,7 +47,7 @@
     },
     "description": "schema validation check for slack:integration with app log type",
     "log": "slack:integration",
-    "service": "stream_alert_app",
+    "service": "streamalert_app",
     "source": "prefix_cluster_slack_integration_sm-app-name_app",
     "trigger_rules": []
   }

--- a/tests/unit/conf/clusters/advanced.json
+++ b/tests/unit/conf/clusters/advanced.json
@@ -51,7 +51,7 @@
       ],
       "unit-test.cloudtrail.data": []
     },
-    "stream_alert": {
+    "streamalert": {
       "classifier_config": {
         "inputs": {
           "aws-sns": []

--- a/tests/unit/conf/clusters/test.json
+++ b/tests/unit/conf/clusters/test.json
@@ -50,7 +50,7 @@
     "s3_events": {
       "unit-test-bucket": []
     },
-    "stream_alert": {
+    "streamalert": {
       "classifier_config": {
         "inputs": {
           "aws-sns": []

--- a/tests/unit/conf/clusters/trusted.json
+++ b/tests/unit/conf/clusters/trusted.json
@@ -24,7 +24,7 @@
     "s3_events": {
       "unit-test-bucket": []
     },
-    "stream_alert": {
+    "streamalert": {
       "classifier_config": {
         "inputs": {
           "aws-sns": []

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -43,7 +43,7 @@
   "terraform": {
     "create_bucket": true,
     "tfstate_bucket": "unit-test.streamalert.terraform.state",
-    "tfstate_s3_key": "stream_alert_state/terraform.tfstate"
+    "tfstate_s3_key": "streamalert_state/terraform.tfstate"
   },
   "threat_intel": {
     "dynamodb_table": "test_table_name",

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -186,7 +186,7 @@ def basic_streamalert_config():
                     'kinesis_events': {
                         'enabled': True
                     },
-                    'stream_alert': {
+                    'streamalert': {
                         'classifier_config': {
                             'enable_custom_metrics': True,
                             'log_level': 'info',
@@ -218,7 +218,7 @@ def basic_streamalert_config():
             'corp': {
                 'id': 'corp',
                 'modules': {
-                    'stream_alert': {
+                    'streamalert': {
                         'classifier_config': {
                             'enable_custom_metrics': True,
                             'log_level': 'info',

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -237,7 +237,7 @@ def basic_streamalert_config():
                             'timeout': 10
                         }
                     },
-                    'stream_alert_apps': {
+                    'streamalert_apps': {
                         'unit-test_corp_box_admin_events_box_collector_app': {
                             'app_name': 'box_collector',
                             'concurrency_limit': 2,

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -63,7 +63,7 @@ def basic_streamalert_config():
             'terraform': {
                 'create_bucket': True,
                 'tfstate_bucket': 'unit-test.streamalert.terraform.state',
-                'tfstate_s3_key': 'stream_alert_state/terraform.tfstate'
+                'tfstate_s3_key': 'streamalert_state/terraform.tfstate'
             },
         },
         'threat_intel': {

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -47,7 +47,7 @@ def basic_streamalert_config():
         'global': {
             'account': {
                 'aws_account_id': '123456789123',
-                'kms_key_alias': 'stream_alert_secrets',
+                'kms_key_alias': 'streamalert_secrets',
                 'prefix': 'unit-test',
                 'region': 'us-west-2'
             },

--- a/tests/unit/streamalert/alert_processor/__init__.py
+++ b/tests/unit/streamalert/alert_processor/__init__.py
@@ -24,7 +24,7 @@ base_config = load_config('tests/unit/conf/', include={'outputs.json'})['outputs
 CONFIG = resources.merge_required_outputs(base_config, PREFIX)
 
 ALERTS_TABLE = '{}_streamalert_alerts'.format(PREFIX)
-KMS_ALIAS = 'alias/stream_alert_secrets_test'
+KMS_ALIAS = 'alias/streamalert_secrets_test'
 
 MOCK_ENV = {
     'AWS_ACCOUNT_ID': ACCOUNT_ID,

--- a/tests/unit/streamalert/alert_processor/outputs/credentials/test_provider.py
+++ b/tests/unit/streamalert/alert_processor/outputs/credentials/test_provider.py
@@ -475,7 +475,7 @@ def test_get_formatted_output_credentials_name():
 def test_get_load_credentials_temp_dir():
     """LocalFileDriver - Get Load Credentials Temp Dir"""
     temp_dir = LocalFileDriver.get_local_credentials_temp_dir()
-    assert_equal(temp_dir.split('/')[-1], 'stream_alert_secrets')
+    assert_equal(temp_dir.split('/')[-1], 'streamalert_secrets')
 
 
 def test_get_formatted_output_credentials_name_no_descriptor(): #pylint: disable=invalid-name

--- a/tests/unit/streamalert/apps/test_batcher.py
+++ b/tests/unit/streamalert/apps/test_batcher.py
@@ -80,7 +80,7 @@ class TestAppBatcher:
 
         log_mock.assert_called_with('Log payload size for single log exceeds input '
                                     'limit and will be dropped (%d > %d max).',
-                                    128073, 128000)
+                                    128072, 128000)
 
     @patch('streamalert.apps.batcher.Batcher._send_logs_to_lambda')
     def test_segment_and_send(self, batcher_mock):

--- a/tests/unit/streamalert/classifier/payload/test_payload_base.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_base.py
@@ -125,11 +125,11 @@ class TestStreamPayload:
     def test_load_from_raw_record_app(self):
         """StreamPayload - Load from Raw Record, StreamAlertApp"""
         record = {
-            'stream_alert_app': 'test_app'
+            'streamalert_app': 'test_app'
         }
         with patch.object(RegisterInput, 'load_for_service') as load_mock:
             StreamPayload.load_from_raw_record(record)
-            load_mock.assert_called_with('stream_alert_app', 'test_app', record)
+            load_mock.assert_called_with('streamalert_app', 'test_app', record)
 
     def test_load_from_raw_record_sns_s3(self):
         """StreamPayload - Load from Raw Record, SNS S3 Event"""

--- a/tests/unit/streamalert/classifier/test_parsers_json.py
+++ b/tests/unit/streamalert/classifier/test_parsers_json.py
@@ -723,11 +723,11 @@ class TestJSONParser:
                     'awsRegion': 'us-west-1',
                     'eventName': 'DescribeStream',
                     'userIdentity': {
-                        'userName': 'stream_alert_user',
+                        'userName': 'streamalert_user',
                         'principalId': 'AAAAAAAAAAAAAAAA',
                         'accessKeyId': 'FFFFFFFFFFFFFFFFFF',
                         'type': 'IAMUser',
-                        'arn': 'arn:aws:iam::111111111111:user/stream_alert_user',
+                        'arn': 'arn:aws:iam::111111111111:user/streamalert_user',
                         'accountId': '111111111111'
                     },
                     'eventSource': 'kinesis.amazonaws.com',
@@ -741,18 +741,18 @@ class TestJSONParser:
                     'eventID': '1111111',
                     'eventTime': '2017-01-31T12:00:00Z',
                     'requestParameters': {
-                        'streamName': 'stream_alert_prod'
+                        'streamName': 'streamalert_prod'
                     },
                     'eventType': 'AwsApiCall',
                     'responseElements': None,
                     'awsRegion': 'us-east-1',
                     'eventName': 'DescribeStream',
                     'userIdentity': {
-                        'userName': 'stream_alert_prod_user',
+                        'userName': 'streamalert_prod_user',
                         'principalId': 'BBBBBBBBBBBBBBBB',
                         'accessKeyId': 'GGGGGGGGGGGGGGGG',
                         'type': 'IAMUser',
-                        'arn': 'arn:aws:iam::222222222222:user/stream_alert_prod_user',
+                        'arn': 'arn:aws:iam::222222222222:user/streamalert_prod_user',
                         'accountId': '222222222222'
                     },
                     'eventSource': 'kinesis.amazonaws.com',
@@ -850,12 +850,12 @@ class TestJSONParser:
                     'timestamp': 1488216331000
                 }
             ],
-            'logGroup': 'airdev_prod_stream_alert_flow_logs',
+            'logGroup': 'airdev_prod_streamalert_flow_logs',
             'logStream': 'eni-77ccbe24-all',
             'messageType': 'DATA_MESSAGE',
             'owner': '123456789012',
             'subscriptionFilters': [
-                'airdev_prod_stream_alert_flow_logs_to_lambda'
+                'airdev_prod_streamalert_flow_logs_to_lambda'
             ]
         })
 
@@ -880,7 +880,7 @@ class TestJSONParser:
                 'windowend': 1488216389,
                 'windowstart': 1488216331,
                 'streamalert:envelope_keys': {
-                    'logGroup': 'airdev_prod_stream_alert_flow_logs',
+                    'logGroup': 'airdev_prod_streamalert_flow_logs',
                     'logStream': 'eni-77ccbe24-all',
                     'owner': 123456789012
                 }
@@ -901,7 +901,7 @@ class TestJSONParser:
                 'windowend': 1488216389,
                 'windowstart': 1488216331,
                 'streamalert:envelope_keys': {
-                    'logGroup': 'airdev_prod_stream_alert_flow_logs',
+                    'logGroup': 'airdev_prod_streamalert_flow_logs',
                     'logStream': 'eni-77ccbe24-all',
                     'owner': 123456789012
                 }

--- a/tests/unit/streamalert/classifier/test_parsers_json.py
+++ b/tests/unit/streamalert/classifier/test_parsers_json.py
@@ -716,7 +716,7 @@ class TestJSONParser:
                     'eventID': '0000000',
                     'eventTime': '2016-12-31T12:00:00Z',
                     'requestParameters': {
-                        'streamName': 'stream_alert'
+                        'streamName': 'streamalert'
                     },
                     'eventType': 'AwsApiCall',
                     'responseElements': None,

--- a/tests/unit/streamalert/rules_engine/test_threat_intel.py
+++ b/tests/unit/streamalert/rules_engine/test_threat_intel.py
@@ -65,7 +65,7 @@ class TestThreatIntel:
             'clusters': {
                 'prod': {
                     'modules': {
-                        'stream_alert': {
+                        'streamalert': {
                             'enable_threat_intel': True
                         }
                     }
@@ -523,7 +523,7 @@ class TestThreatIntel:
             'clusters': {
                 'prod': {
                     'modules': {
-                        'stream_alert': {
+                        'streamalert': {
                             'enable_threat_intel': False
                         }
                     }

--- a/tests/unit/streamalert/shared/test_config.py
+++ b/tests/unit/streamalert/shared/test_config.py
@@ -51,9 +51,11 @@ class TestConfigLoading(fake_filesystem_unittest.TestCase):
 
         config_data = basic_streamalert_config()
 
+        mock_cluster_contents = '{"data_sources": {}, "modules": {"streamalert": {"foo": "bar"}}}'
+
         # Add config files which should be loaded
-        self.fs.create_file('conf/clusters/prod.json', contents='{"data_sources": {}}')
-        self.fs.create_file('conf/clusters/dev.json', contents='{"data_sources": {}}')
+        self.fs.create_file('conf/clusters/prod.json', contents=mock_cluster_contents)
+        self.fs.create_file('conf/clusters/dev.json', contents=mock_cluster_contents)
         self.fs.create_file('conf/global.json', contents='{}')
         self.fs.create_file('conf/lambda.json', contents='{}')
         self.fs.create_file('conf/logs.json', contents='{}')
@@ -72,8 +74,8 @@ class TestConfigLoading(fake_filesystem_unittest.TestCase):
         )
 
         # Create similar structure but with schemas folder instead of logs.json and 2 clusters.
-        self.fs.create_file('conf_schemas/clusters/prod.json', contents='{"data_sources": {}}')
-        self.fs.create_file('conf_schemas/clusters/dev.json', contents='{"data_sources": {}}')
+        self.fs.create_file('conf_schemas/clusters/prod.json', contents=mock_cluster_contents)
+        self.fs.create_file('conf_schemas/clusters/dev.json', contents=mock_cluster_contents)
         self.fs.create_file('conf_schemas/global.json', contents='{}')
         self.fs.create_file('conf_schemas/lambda.json', contents='{}')
         self.fs.create_file('conf_schemas/outputs.json', contents='{}')

--- a/tests/unit/streamalert/shared/test_config.py
+++ b/tests/unit/streamalert/shared/test_config.py
@@ -245,6 +245,12 @@ class TestConfigValidation:
         assert_equal(env['function_name'], func_name)
         assert_equal(env['qualifier'], 'development')
 
+    def test_missing_streamalert_module(self):
+        """Shared - Config Validator, Missing streamalert Module"""
+        config = basic_streamalert_config()
+        del config['clusters']['prod']['modules']['streamalert']
+        assert_raises(ConfigError, _validate_config, config)
+
     def test_config_invalid_ioc_types(self):
         """Shared - Config Validator - IOC Types, Invalid"""
         # Load a valid config

--- a/tests/unit/streamalert_cli/terraform/test_alert_processor.py
+++ b/tests/unit/streamalert_cli/terraform/test_alert_processor.py
@@ -36,7 +36,7 @@ class TestAlertProcessor(unittest.TestCase):
             'module': {
                 'alert_processor_iam': {
                     'account_id': '12345678910',
-                    'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
+                    'kms_key_arn': '${aws_kms_key.streamalert_secrets.arn}',
                     'output_lambda_functions': [
                         'unit_test_function',
                         'unit_test_qualified_function'
@@ -100,7 +100,7 @@ class TestAlertProcessor(unittest.TestCase):
             'module': {
                 'alert_processor_iam': {
                     'account_id': '12345678910',
-                    'kms_key_arn': '${aws_kms_key.stream_alert_secrets.arn}',
+                    'kms_key_arn': '${aws_kms_key.streamalert_secrets.arn}',
                     'output_lambda_functions': [],
                     'output_s3_buckets': [],
                     'output_sns_topics': [],

--- a/tests/unit/streamalert_cli/terraform/test_athena.py
+++ b/tests/unit/streamalert_cli/terraform/test_athena.py
@@ -37,7 +37,7 @@ def test_generate_athena():
 
     expected_athena_config = {
         'module': {
-            'stream_alert_athena': {
+            'streamalert_athena': {
                 's3_logging_bucket': '{}.streamalert.s3-logging'.format(prefix),
                 'source': './modules/tf_athena',
                 'database_name': '{}_streamalert'.format(prefix),
@@ -72,16 +72,16 @@ def test_generate_athena():
 
     # List order messes up the comparison between both dictionaries
     assert_equal(
-        set(athena_config['module']['stream_alert_athena']['athena_data_buckets']),
-        set(expected_athena_config['module']['stream_alert_athena']['athena_data_buckets'])
+        set(athena_config['module']['streamalert_athena']['athena_data_buckets']),
+        set(expected_athena_config['module']['streamalert_athena']['athena_data_buckets'])
     )
 
     # Delete the keys to compare the rest of the generated module
-    del athena_config['module']['stream_alert_athena']['athena_data_buckets']
-    del expected_athena_config['module']['stream_alert_athena']['athena_data_buckets']
+    del athena_config['module']['streamalert_athena']['athena_data_buckets']
+    del expected_athena_config['module']['streamalert_athena']['athena_data_buckets']
 
     # Compare each generated Athena module from the expected module
-    assert_equal(athena_config['module']['stream_alert_athena'],
-                 expected_athena_config['module']['stream_alert_athena'])
+    assert_equal(athena_config['module']['streamalert_athena'],
+                 expected_athena_config['module']['streamalert_athena'])
     assert_equal(athena_config['module']['athena_monitoring'],
                  expected_athena_config['module']['athena_monitoring'])

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -94,7 +94,7 @@ class TestTerraformGenerate:
                 'backend': {
                     's3': {
                         'bucket': 'unit-test.streamalert.terraform.state',
-                        'key': 'stream_alert_state/terraform.tfstate',
+                        'key': 'streamalert_state/terraform.tfstate',
                         'region': 'us-west-1',
                         'dynamodb_table': 'unit-test_streamalert_terraform_state_lock',
                         'encrypt': True,

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -110,7 +110,7 @@ class TestTerraformGenerate:
                         'description': 'StreamAlert S3 Server-Side Encryption',
                         'policy': ANY
                     },
-                    'stream_alert_secrets': {
+                    'streamalert_secrets': {
                         'enable_key_rotation': True,
                         'description': 'StreamAlert secret management'
                     }
@@ -120,13 +120,13 @@ class TestTerraformGenerate:
                         'name': 'alias/unit-test_server-side-encryption',
                         'target_key_id': '${aws_kms_key.server_side_encryption.key_id}'
                     },
-                    'stream_alert_secrets': {
+                    'streamalert_secrets': {
                         'name': 'alias/unit-test',
-                        'target_key_id': '${aws_kms_key.stream_alert_secrets.key_id}'
+                        'target_key_id': '${aws_kms_key.streamalert_secrets.key_id}'
                     }
                 },
                 'aws_s3_bucket': {
-                    'stream_alert_secrets': {
+                    'streamalert_secrets': {
                         'bucket': 'unit-test.streamalert.secrets',
                         'acl': 'private',
                         'force_destroy': True,

--- a/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_classifier.py
@@ -40,7 +40,7 @@ class TestTerraformGenerateClassifier:
             'clusters': {
                 'test': {
                     'modules': {
-                        'stream_alert': {
+                        'streamalert': {
                             'classifier_config': {
                                 'inputs': {
                                     'aws-sns': [

--- a/tests/unit/streamalert_cli/terraform/test_helpers.py
+++ b/tests/unit/streamalert_cli/terraform/test_helpers.py
@@ -31,6 +31,7 @@ REGION = CONFIG['global']['account']['region']
 @mock_dynamodb2()
 @patch('time.sleep', Mock())
 def test_terraform_state_lock_create():
+    """CLI - Terraform Create State Lock Table"""
     create_tf_state_lock_ddb_table(REGION, LOCK_TABLE)
     client = boto3.client('dynamodb', REGION)
     # Verify table creation logic
@@ -44,6 +45,7 @@ def test_terraform_state_lock_create():
 
 @mock_dynamodb2()
 def test_terraform_state_lock_destroy():
+    """CLI - Terraform Delete State Lock Table"""
     # Verify destroy logic
     destroy_tf_state_lock_ddb_table(REGION, LOCK_TABLE)
     client = boto3.client('dynamodb', REGION)

--- a/tests/unit/streamalert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/streamalert_cli/terraform/test_rule_promotion.py
@@ -42,7 +42,7 @@ class TestRulePromotion:
                     'source': './modules/tf_rule_promotion_iam',
                     'send_digest_schedule_expression': 'cron(30 13 * * ? *)',
                     'digest_sns_topic': 'unit-test_streamalert_rule_staging_stats',
-                    'athena_results_bucket_arn': '${module.stream_alert_athena.results_bucket_arn}',
+                    'athena_results_bucket_arn': '${module.streamalert_athena.results_bucket_arn}',
                     'athena_data_buckets': [
                         'unit-test.streamalert.data',
                         'unit-test.streamalerts'

--- a/tests/unit/streamalert_cli/test_cli_config.py
+++ b/tests/unit/streamalert_cli/test_cli_config.py
@@ -123,7 +123,7 @@ class TestCLIConfig:
 
         self.config.add_metric_alarm(alarm_info)
         result = (
-            self.config['clusters']['prod']['modules']['stream_alert']
+            self.config['clusters']['prod']['modules']['streamalert']
             ['classifier_config']['custom_metric_alarms']
         )
 


### PR DESCRIPTION
to: @chunyong-lin / @Ryxias 
cc: @airbnb/streamalert-maintainers

## Background

This PR is a bit beefy - but it essentially renames all usage of `stream_alert` to `streamalert`. This is in preparation for the v3 release, since it will be easier to do this now than later.

## Changes

- updating stream_alert_app references
- updating config reading for new "streamalert" module name
- mass rename of stream_alert_secrets -- streamalert_secrets
- vagrant env var naming update
- fixing unit tests that did not have a docstring

## Testing

Updating unit tests for config read logic and other config usage.
