### PR TITLE
[cli] Allow to rebuild partitions when the statement length exceeds the limit

### DIFF
--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -252,7 +252,7 @@ def rebuild_partitions(table, bucket, config):
     if not create_table(table, bucket, config):
         return False
 
-    new_partitions_statements = helpers.add_partition_statement(
+    new_partitions_statements = helpers.add_partition_statements(
         partitions, bucket, sanitized_table_name)
 
     LOGGER.info('Creating total %d new partitions for %s', len(partitions), sanitized_table_name)

--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -35,9 +35,6 @@ CREATE_TABLE_STATEMENT = ('CREATE EXTERNAL TABLE {table_name} ({schema}) '
                           'WITH SERDEPROPERTIES (\'ignore.malformed.json\' = \'true\') '
                           'LOCATION \'s3://{bucket}/{table_name}/\'')
 
-MAX_QUERY_LENGTH = 262144
-
-
 class AthenaCommand(CLICommand):
     description = 'Perform actions related to Athena'
 
@@ -255,30 +252,31 @@ def rebuild_partitions(table, bucket, config):
     if not create_table(table, bucket, config):
         return False
 
-    new_partitions_statement = helpers.add_partition_statement(
+    new_partitions_statements = helpers.add_partition_statement(
         partitions, bucket, sanitized_table_name)
 
-    # Make sure our new alter table statement is within the query API limits
-    if len(new_partitions_statement) > MAX_QUERY_LENGTH:
-        file_name = 'partitions_{}.txt'.format(sanitized_table_name)
-        LOGGER.error(
-            'Partition statement too large, writing to local file with name %s',
-            file_name
-        )
-        with open(file_name, 'w') as partition_file:
-            partition_file.write(new_partitions_statement)
-        return False
+    LOGGER.info('Creating total %d new partitions for %s', len(partitions), sanitized_table_name)
 
-    LOGGER.info('Creating %d new partitions for %s', len(partitions), sanitized_table_name)
+    for idx, statement in enumerate(new_partitions_statements):
+        success = athena_client.run_query(query=statement)
+        LOGGER.info('Rebuilt partitions part %d', idx+1)
+        if not success:
+            LOGGER.error('Error re-creating new partitions for %s', sanitized_table_name)
+            write_partitions_statements(new_partitions_statements, sanitized_table_name)
+            return False
 
-    success = athena_client.run_query(query=new_partitions_statement)
-    if not success:
-        LOGGER.error('Error re-creating new partitions for %s', sanitized_table_name)
-        return False
-
-    LOGGER.info('Successfully rebuilt partitions for %s', sanitized_table_name)
+    LOGGER.info('Successfully rebuilt all partitions for %s', sanitized_table_name)
     return True
 
+def write_partitions_statements(statements, sanitized_table_name):
+    """Write partitions statements to a file if re-creating new partitions failed"""
+    file_name = 'partitions_{}.txt'.format(sanitized_table_name)
+    LOGGER.error(
+        'Rebuild partitions failed, writing to local file with name %s',
+        file_name
+    )
+    with open(file_name, 'w') as partition_file:
+        partition_file.write(statements)
 
 def drop_all_tables(config):
     """Drop all 'streamalert' Athena tables

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -278,3 +278,38 @@ def basic_streamalert_config():
             }
         }
     }
+
+def athena_cli_basic_config():
+    return {
+        'global': {
+            'account': {
+                'aws_account_id': '123456789123',
+                'kms_key_alias': 'stream_alert_secrets',
+                'prefix': 'unit-test',
+                'region': 'us-west-2'
+            },
+            'infrastructure': {
+                'firehose': {
+                    'enabled_logs': {
+                        'unit': {}
+                    },
+                }
+            }
+        },
+        'logs': {
+            'unit:my_test': {
+                'schema': {
+                    'name': 'string'
+                },
+                'parser': 'json'
+            }
+        },
+        'lambda': {
+            'athena_partition_refresh_config': {
+                'buckets': {
+                    'unit-test.streamalert.data': 'data',
+                    'unit-test.streamalerts': 'alerts'
+                },
+            }
+        }
+    }

--- a/tests/unit/streamalert_cli/athena/test_handler.py
+++ b/tests/unit/streamalert_cli/athena/test_handler.py
@@ -13,28 +13,68 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from nose.tools import assert_equal
+# pylint: disable=protected-access
+from mock import patch
+from nose.tools import assert_equal, assert_true
 
+from streamalert.classifier.clients import FirehoseClient
 from streamalert_cli.athena import handler
 
+from tests.unit.helpers.aws_mocks import MockAthenaClient
+from tests.unit.helpers.config import athena_cli_basic_config, MockCLIConfig
 
-def test_construct_create_table_statement():
-    """CLI - Athena Construct Create Table Statement"""
-    # pylint: disable=protected-access
-    schema = {
-        'value01': 'string',
-        'value02': 'integer',
-        'value03': {
-            'value04': 'boolean',
-            'value05': 'float'
+
+class TestAthenaCli:
+    """Class to test Athena CLI"""
+
+    @staticmethod
+    def teardown():
+        """Clean up after each test"""
+        FirehoseClient._ENABLED_LOGS.clear()
+
+    @staticmethod
+    def test_construct_create_table_statement():
+        """CLI - Athena Construct Create Table Statement"""
+        # pylint: disable=protected-access
+        schema = {
+            'value01': 'string',
+            'value02': 'integer',
+            'value03': {
+                'value04': 'boolean',
+                'value05': 'float'
+            }
         }
-    }
 
-    expected_result = ('CREATE EXTERNAL TABLE table-name (value01 string, value02 integer, '
-                       'value03 struct<value04:boolean, value05:float>) PARTITIONED BY '
-                       '(dt string) ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\' '
-                       'WITH SERDEPROPERTIES (\'ignore.malformed.json\' = \'true\') '
-                       'LOCATION \'s3://bucket-name/table-name/\'')
+        expected_result = ('CREATE EXTERNAL TABLE table-name (value01 string, value02 integer, '
+                           'value03 struct<value04:boolean, value05:float>) PARTITIONED BY '
+                           '(dt string) ROW FORMAT SERDE \'org.openx.data.jsonserde.JsonSerDe\' '
+                           'WITH SERDEPROPERTIES (\'ignore.malformed.json\' = \'true\') '
+                           'LOCATION \'s3://bucket-name/table-name/\'')
 
-    result = handler._construct_create_table_statement(schema, 'table-name', 'bucket-name')
-    assert_equal(result, expected_result)
+        result = handler._construct_create_table_statement(schema, 'table-name', 'bucket-name')
+        assert_equal(result, expected_result)
+
+    @staticmethod
+    def test_rebuild_partitions():
+        """CLI - Athena rebuild partitions helper"""
+
+        with patch('streamalert.shared.athena.boto3') as mock_athena:
+            mock_show_partitions_result = [
+                {'Data': [{'VarCharValue': 'dt=2019-12-04-05'}]},
+                {'Data': [{'VarCharValue': 'dt=2019-12-03-22'}]},
+                {'Data': [{'VarCharValue': 'dt=2019-12-03-23'}]},
+                {'Data': [{'VarCharValue': 'dt=2019-12-03-20'}]},
+                {'Data': [{'VarCharValue': 'dt=2019-12-04-01'}]}
+            ]
+
+            mock_show_table_result = []
+            mock_athena.client.side_effect = [
+                MockAthenaClient(results=mock_show_partitions_result),
+                MockAthenaClient(results=mock_show_table_result)
+            ]
+
+            config = MockCLIConfig(config=athena_cli_basic_config())
+
+            table = 'unit_my_test'
+            bucket = 'bucket'
+            assert_true(handler.rebuild_partitions(table, bucket, config))

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from mock import patch
 from nose.tools import assert_equal
 
 from streamalert_cli.athena import helpers
@@ -94,5 +95,33 @@ def test_add_partition_statement():
                        "PARTITION (dt = '2018-12-01-05') "
                        "LOCATION 's3://bucket/test/2018/12/01/05'")
 
-    result = helpers.add_partition_statement(partitions, 'bucket', 'test')
-    assert_equal(result, expected_result)
+    results = helpers.add_partition_statement(partitions, 'bucket', 'test')
+    assert_equal(len(results), 1)
+    assert_equal(results[0], expected_result)
+
+
+@patch.object(helpers, 'MAX_QUERY_LENGTH', 256)
+def test_add_partition_statement_exceed_length():
+    """CLI - Athena Add Partition Statement when statement exceed max query length"""
+    partitions = {
+        'dt=2017-12-01-01',
+        'dt=2016-12-01-02',
+        'dt=2018-12-01-05',
+        'dt=2013-12-01-04',
+    }
+
+    results = helpers.add_partition_statement(partitions, 'bucket', 'test')
+    assert_equal(len(results), 2)
+
+    expected_result_0 = ("ALTER TABLE test ADD IF NOT EXISTS "
+                         "PARTITION (dt = '2013-12-01-04') "
+                         "LOCATION 's3://bucket/test/2013/12/01/04' "
+                         "PARTITION (dt = '2016-12-01-02') "
+                         "LOCATION 's3://bucket/test/2016/12/01/02'")
+    expected_result_1 = ("ALTER TABLE test ADD IF NOT EXISTS "
+                         "PARTITION (dt = '2017-12-01-01') "
+                         "LOCATION 's3://bucket/test/2017/12/01/01' "
+                         "PARTITION (dt = '2018-12-01-05') "
+                         "LOCATION 's3://bucket/test/2018/12/01/05'")
+    assert_equal(results[0], expected_result_0)
+    assert_equal(results[1], expected_result_1)

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -76,7 +76,7 @@ def test_generate_athena_schema_nested():
 
     assert_equal(athena_schema, expected_athena_schema)
 
-def test_add_partition_statement():
+def test_add_partition_statements():
     """CLI - Athena Add Partition Statement"""
     partitions = {
         'dt=2017-12-01-01',
@@ -95,13 +95,14 @@ def test_add_partition_statement():
                        "PARTITION (dt = '2018-12-01-05') "
                        "LOCATION 's3://bucket/test/2018/12/01/05'")
 
-    results = helpers.add_partition_statement(partitions, 'bucket', 'test')
-    assert_equal(len(results), 1)
-    assert_equal(results[0], expected_result)
+    results = helpers.add_partition_statements(partitions, 'bucket', 'test')
+    results_copy = list(results)
+    assert_equal(len(results_copy), 1)
+    assert_equal(results_copy[0], expected_result)
 
 
 @patch.object(helpers, 'MAX_QUERY_LENGTH', 256)
-def test_add_partition_statement_exceed_length():
+def test_add_partition_statements_exceed_length():
     """CLI - Athena Add Partition Statement when statement exceed max query length"""
     partitions = {
         'dt=2017-12-01-01',
@@ -110,8 +111,9 @@ def test_add_partition_statement_exceed_length():
         'dt=2013-12-01-04',
     }
 
-    results = helpers.add_partition_statement(partitions, 'bucket', 'test')
-    assert_equal(len(results), 2)
+    results = helpers.add_partition_statements(partitions, 'bucket', 'test')
+    results_copy = list(results)
+    assert_equal(len(results_copy), 2)
 
     expected_result_0 = ("ALTER TABLE test ADD IF NOT EXISTS "
                          "PARTITION (dt = '2013-12-01-04') "
@@ -123,5 +125,5 @@ def test_add_partition_statement_exceed_length():
                          "LOCATION 's3://bucket/test/2017/12/01/01' "
                          "PARTITION (dt = '2018-12-01-05') "
                          "LOCATION 's3://bucket/test/2018/12/01/05'")
-    assert_equal(results[0], expected_result_0)
-    assert_equal(results[1], expected_result_1)
+    assert_equal(results_copy[0], expected_result_0)
+    assert_equal(results_copy[1], expected_result_1)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves: #963 

## Background
It is pretty common that there will have new keys added to an log schema over the time.  StreamAlert users will have to add these new keys as optional keys to the schema. If the users use Athena to search historical data, it is required to rebuild the table for the log schema which has new key added.

StreamAlert provides command line to alter the table based on the new schema by running following command.
```
manage.py athena rebuild-partitions  --bucket s3.bucket.name  --table-name my_athena_table
```

However, [the maximum allowed query string length in Athena API call is 262144 bytes](https://docs.aws.amazon.com/athena/latest/ug/service-limits.html). In current implementation, StreamAlert will save the whole query into a txt file if the length exceeds the limit. And the user has to run the query from Athena console manually. It is not ideal.
https://github.com/airbnb/streamalert/blob/7d198a3273781f66465420e90886a3ce53ec7559/stream_alert_cli/athena/handler.py#L137-L145

## Changes

* Break the `ALTER TABLE` statement for rebuilding partitions into a list of string under the Athena statement length limit.
* Add test cases for the code change.

## Testing
* Unit test cases added.
* Tested in staging environment.