### PR TITLE
Docs/general update

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -8,14 +8,14 @@ Install Dependencies
 --------------------
 
 1. Install Python 3.7 and `pip <https://pip.pypa.io/en/stable/installing/>`_
-2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ v0.11.X:
+2. Install `Terraform <https://www.terraform.io/intro/getting-started/install.html>`_ >= v0.12.9:
 
 .. code-block:: bash
 
   brew install terraform  # MacOS Homebrew
-  terraform --version     # Must be v0.11.X
+  terraform --version     # Must be >= v0.12.9
 
-.. note:: Terraform versions >= 0.12.X are not currently supported.
+.. note:: Terraform versions <= 0.12.8 are not supported.
 
 3. Install `virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_:
 
@@ -38,7 +38,7 @@ Download StreamAlert
 
 .. code-block:: bash
 
-  git clone --branch stable https://github.com/airbnb/streamalert.git
+  git clone --branch release-3-0-0 https://github.com/airbnb/streamalert.git
 
 2. Create and activate a virtual environment:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -15,7 +15,7 @@ Install Dependencies
   brew install terraform  # MacOS Homebrew
   terraform --version     # Must be >= v0.12.9
 
-.. note:: Terraform versions <= 0.12.8 are not supported.
+.. note:: Terraform versions lower than 0.12 are not supported. Recommend to install terraform version 0.12.9 or up.
 
 3. Install `virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_:
 
@@ -38,7 +38,7 @@ Download StreamAlert
 
 .. code-block:: bash
 
-  git clone --branch release-3-0-0 https://github.com/airbnb/streamalert.git
+  git clone --branch stable https://github.com/airbnb/streamalert.git
 
 2. Create and activate a virtual environment:
 

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -144,11 +144,7 @@ Adding support for a new service involves five steps:
 
 4. Add the ``@StreamAlertOutput`` class decorator to the new subclass so it registered when the `outputs` module is loaded.
 
-5. To allow the cli to configure a new integration for this service, add the value used above for the ``__service__`` property to the ``manage.py`` file.
-
-   - The ``output_parser`` contains a ``choices`` list for ``--service`` that must include this new service.
-
-6. Extend the ``AlertProcessorTester.setup_outputs`` method in ``streamalert_cli/test.py`` module to provide mock credentials for your new output.
+5. Extend the ``AlertProcessorTester.setup_outputs`` method in ``streamalert_cli/test.py`` module to provide mock credentials for your new output.
 
 Strategy
 --------


### PR DESCRIPTION
to: @chunyong-lin
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
Reason for the change

- Documentation was slightly out of sync with what steps are required to deploy StreamAlert
- Outputs no longer required the step of altering the cli, as the choices are dynamically set when invoked

## Changes

* Bumped Terraform version to 12.9 as discussed on slack
* changed git clone command to point to release-3-0-0 
* removed step no longer required when configuring outputs (i noticed this when i started work on a separate branch to implement Microsoft Teams)

## Testing

1. Ran `make html`
2. Opened the documentation in my browser and verified visually that the changes took affect
