### PR TITLE
[outputs] add Microsoft Teams as an alerting output

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -44,6 +44,9 @@
         "threshold": 0
       }
     },
+    "third_party_libraries": [
+      "pymsteams"
+    ],
     "timeout": 60,
     "vpc_config": {
       "security_group_ids": [],

--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -44,9 +44,6 @@
         "threshold": 0
       }
     },
-    "third_party_libraries": [
-      "pymsteams"
-    ],
     "timeout": 60,
     "vpc_config": {
       "security_group_ids": [],

--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -25,5 +25,8 @@
   ],
   "slack": [
     "sample-channel"
+  ],
+  "teams": [
+    "sample-webhook"
   ]
 }

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -42,7 +42,7 @@ Adding a new configuration for a currently supported service is handled using ``
     - ``<SERVICE_NAME>`` above should be one of the following supported service identifiers:
       ``aws-cloudwatch-log``, ``aws-firehose``, ``aws-lambda``, ``aws-s3``, ``aws-sns``, ``aws-sqs``,
       ``carbonblack``, ``github``, ``jira``, ``komand``, ``pagerduty``, ``pagerduty-incident``,
-      ``pagerduty-v2``, ``phantom``, ``slack``
+      ``pagerduty-v2``, ``phantom``, ``slack``, ``teams``
 
 For example:
  - ``python manage.py output slack``

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -22,6 +22,7 @@ Out of the box, StreamAlert supports:
 * **PagerDuty**
 * **Phantom**
 * **Slack**
+* **Microsoft Teams**
 
 StreamAlert can be extended to support any API. Creating a new output to send alerts to is easily accomplished through inheritance from the ``StreamOutputBase`` class. More on that in the `Adding Support for New Services`_ section below.
 

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -21,6 +21,7 @@ pathlib2
 policyuniverse
 pyfakefs
 pylint==2.3.1
+pymsteams
 requests
 Sphinx
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,7 @@ pycparser==2.19
 pyflakes==2.1.1
 Pygments==2.4.2
 PyJWT==1.7.1
+pymsteams==0.1.12
 pyparsing==2.4.2
 pyrsistent==0.15.5
 pytest==5.0.0

--- a/streamalert/alert_processor/outputs/teams.py
+++ b/streamalert/alert_processor/outputs/teams.py
@@ -1,0 +1,217 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from collections import OrderedDict
+
+import pymsteams
+from pymsteams import TeamsWebhookException
+
+from streamalert.alert_processor.helpers import compose_alert
+from streamalert.alert_processor.outputs.output_base import (
+    OutputDispatcher,
+    OutputProperty,
+    StreamAlertOutput,
+)
+from streamalert.shared.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@StreamAlertOutput
+class TeamsOutput(OutputDispatcher):
+    """TeamsOutput handles all alert dispatching for Microsoft Teams"""
+
+    __service__ = "teams"
+
+    @classmethod
+    def get_user_defined_properties(cls):
+        """Get properties that must be assigned by the user when configuring a new Microsoft Teams
+        output.  This should be sensitive or unique information for this use-case that needs
+        to come from the user.
+
+        Every output should return a dict that contains a 'descriptor' with a description of the
+        integration being configured.
+
+        Microsoft Teams also requires a user provided 'webhook' url that is comprised of the Teams
+        api url and the unique integration key for this output. This value should be should be
+        masked during input and is a credential requirement.
+
+        Returns:
+            OrderedDict: Contains various OutputProperty items
+        """
+        return OrderedDict(
+            [
+                (
+                    "descriptor",
+                    OutputProperty(
+                        description="a short and unique descriptor for this service configuration "
+                        "(ie: name of Team the webhook relates too)"
+                    ),
+                ),
+                (
+                    "url",
+                    OutputProperty(
+                        description="the full teams webhook url, including the secret",
+                        mask_input=True,
+                        cred_requirement=True,
+                    ),
+                ),
+            ]
+        )
+
+    @classmethod
+    def _format_message(cls, alert, publication, webhook_url):
+        """Format the message to be sent to Teams
+
+        Args:
+            alert (Alert): The alert
+            publication (dict): Alert relevant to the triggered rule
+
+        Returns:
+            pymsteams.connectorcard: The message to be sent to Teams
+                The card will look like (by Default):
+                    StreamAlert Rule Triggered: rule_name
+                    Rule Description:
+                    This will be the docstring from the rule, sent as the rule_description
+
+                    Record:
+                      key   value
+                      key   value
+                      ...
+        """
+        # Presentation defaults
+        default_title = "StreamAlert Rule Triggered: {}".format(alert.rule_name)
+        default_description = alert.rule_description
+        default_color = "E81123"  # Red in Hexstring format
+
+        # Special field that Publishers can use to customize the message
+        title = publication.get("@teams.title", default_title)
+        description = publication.get("@teams.description", default_description)
+        card_color = publication.get("@teams.card_color", default_color)
+        with_record = publication.get("@teams.with_record", True)
+
+        # Instantiate the card with the url
+        teams_card = pymsteams.connectorcard(webhook_url)
+
+        # Set the cards title, text and color
+        teams_card.title(title)
+        teams_card.text(description)
+        teams_card.color(card_color)
+
+        if with_record:
+            # Instantiate the card section
+            record_section = pymsteams.cardsection()
+
+            # Set the title
+            record_section.activityTitle("StreamAlert Alert Record")
+
+            # Add the raw alert as key/value pairs
+            for key, value in alert.record.items():
+                record_section.addFact(key, str(value))
+
+            teams_card.addSection(record_section)
+
+        if "@teams.additional_card_sections" in publication:
+            teams_card = cls._add_additional_sections(
+                teams_card, publication["@teams.additional_card_sections"]
+            )
+
+        return teams_card
+
+    @staticmethod
+    def _add_additional_sections(teams_card, additional_sections):
+        """Add additional card sections to the teams card
+
+        Args:
+            teams_card (pymsteams.connectorcard): Teams connector card
+            additional_sections (list[pymsteams.cardsection]):
+                Additional sections to be added to the card. Each section should be of
+                type: pymsteams.cardsection and have their relevant fields filled out.
+                Please review the pymsteams documentation for additional information.
+
+        Returns:
+            teams_card (pymsteams.connectorcard): teams_card with additional sections added
+        """
+        if not isinstance(additional_sections, list):
+            LOGGER.debug("additional_sections is not a list, converting")
+
+            additional_sections = list(additional_sections)
+
+        for additional_section in additional_sections:
+            if not isinstance(additional_section, pymsteams.cardsection):
+                LOGGER.error(
+                    "additional_section: %s is not an instance of %s",
+                    additional_section,
+                    pymsteams.cardsection,
+                )
+                continue
+
+            teams_card.addSection(additional_section)
+
+        return teams_card
+
+    def _dispatch(self, alert, descriptor):
+        """Sends the Teams Card to Teams
+
+        Publishing:
+            By default the teams output sends a teams card comprising some default intro text
+            and a section containing:
+            * title with rule name
+            * alert description
+            * alert record (as a section of key/value pairs)
+
+            To override this behavior use the following fields:
+
+            - @teams.title (str):
+                Replaces the title of the teams connector card.
+
+            - @teams.description (str):
+                Replaces the text of the team connector card
+
+            - @teams.card_color (str):
+                Replaces the default color of the connector card (red)
+                Note: colors are represented by hex string
+
+            - @teams.with_record (bool):
+                Set to False, to remove the alert record section. Useful if you want to have a
+                more targeted approach for the alert
+
+            - @teams.additional_card_sections (list[pymsteams.cardsection]):
+                Pass in additional sections you want to send on the message.
+
+                @see cls._add_additional_sections() for more info
+
+        Args:
+            alert (Alert): Alert instance which triggered a rule
+            descriptor (str): Output descriptor
+
+        Returns:
+            bool: True if alert was sent successfully, False otherwise
+        """
+        creds = self._load_creds(descriptor)
+        if not creds:
+            return False
+
+        publication = compose_alert(alert, self, descriptor)
+
+        teams_card = self._format_message(alert, publication, creds["url"])
+
+        try:
+            teams_card.send()
+        except TeamsWebhookException as err:
+            LOGGER.error("Error Sending Alert to Teams: %s", err)
+            return False
+
+        return True

--- a/streamalert/alert_processor/outputs/teams.py
+++ b/streamalert/alert_processor/outputs/teams.py
@@ -147,7 +147,7 @@ class TeamsOutput(OutputDispatcher):
         if not isinstance(additional_sections, list):
             LOGGER.debug("additional_sections is not a list, converting")
 
-            additional_sections = list(additional_sections)
+            additional_sections = [additional_sections]
 
         for additional_section in additional_sections:
             if not isinstance(additional_section, pymsteams.cardsection):

--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -54,6 +54,7 @@ class LambdaPackage:
         'netaddr': 'netaddr==0.7.19',
         'policyuniverse': 'policyuniverse==1.3.2.1',
         'requests': 'requests==2.22.0',
+        'pymsteams': 'pymsteams==0.1.12'
     }
 
     def __init__(self, config):
@@ -226,7 +227,7 @@ class AlertProcessorPackage(LambdaPackage):
         'streamalert/shared'
     }
     package_name = 'alert_processor'
-    package_libs = {'cbapi', 'netaddr', 'requests'}
+    package_libs = {'cbapi', 'netaddr', 'pymsteams', 'requests'}
 
 
 class AlertMergerPackage(LambdaPackage):

--- a/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
@@ -106,7 +106,8 @@ def test_output_loading():
         'pagerduty-v2',
         'pagerduty-incident',
         'phantom',
-        'slack'
+        'slack',
+        'teams'
     }
     assert_count_equal(loaded_outputs, expected_outputs)
 

--- a/tests/unit/streamalert/alert_processor/outputs/test_teams.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_teams.py
@@ -1,0 +1,318 @@
+"""
+Copyright 2017-present, Airbnb Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=protected-access,attribute-defined-outside-init,no-self-use
+import pymsteams
+from mock import MagicMock, Mock, patch
+from nose.tools import assert_equal, assert_false, assert_set_equal, assert_true
+
+from streamalert.alert_processor.helpers import compose_alert
+from streamalert.alert_processor.outputs.teams import TeamsOutput
+from tests.unit.streamalert.alert_processor.helpers import get_alert, get_random_alert
+
+
+@patch(
+    "streamalert.alert_processor.outputs.output_base.OutputDispatcher.MAX_RETRY_ATTEMPTS",
+    1,
+)
+class TestTeamsOutput:
+    """Test class for Teams"""
+
+    DESCRIPTOR = "unit_test_channel"
+    SERVICE = "teams"
+    OUTPUT = ":".join([SERVICE, DESCRIPTOR])
+    CREDS = {
+        "url": "https://outlook.office.com/webhook/GUID@GUID/IncomingWebhook/WEBHOOK-ID/KEY"
+    }
+
+    @patch("streamalert.alert_processor.outputs.output_base.OutputCredentialsProvider")
+    def setup(self, provider_constructor):
+        """Setup before each method"""
+        provider = MagicMock()
+        provider_constructor.return_value = provider
+        provider.load_credentials = Mock(
+            side_effect=lambda x: self.CREDS if x == self.DESCRIPTOR else None
+        )
+
+        self._provider = provider
+        self._dispatcher = TeamsOutput(None)
+
+    def test_format_message_default(self):
+        """TeamsOutput - Format Default Message - Teams"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(payload["title"], "StreamAlert Rule Triggered: test_rule_default")
+        assert_equal(len(payload["sections"]), 1)
+
+    def test_format_message_custom_title(self):
+        """TeamsOutput - Format Message - Custom Title"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.title"] = "This is a test"
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(payload["title"], "This is a test")
+        assert_equal(len(payload["sections"]), 1)
+
+    def test_format_message_custom_description(self):
+        """TeamsOutput - Format Message - Custom description"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.description"] = "This is a test"
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(payload["text"], "This is a test")
+        assert_equal(len(payload["sections"]), 1)
+
+    def test_format_message_custom_color(self):
+        """TeamsOutput - Format Message - Custom color"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.card_color"] = "46eb34"
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(payload["themeColor"], "46eb34")
+        assert_equal(len(payload["sections"]), 1)
+
+    def test_format_message_no_record(self):
+        """TeamsOutput - Format Message - No Record"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.with_record"] = False
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(set(payload.keys()), {"title", "text", "themeColor"})
+        assert_false(payload.get("sections"))
+
+    def test_format_message_additional_sections_with_record(self):
+        """TeamsOutput - Format Message - Additional card sections with record"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.with_record"] = True
+
+        # Setup test_card_section
+        test_card_section = pymsteams.cardsection()
+        test_card_section.title("test_section")
+        test_card_section.activityText("this is test section")
+        test_card_section.addFact("test", True)
+
+        # Pass card section in via Publisher
+        alert_publication["@teams.additional_card_sections"] = [test_card_section]
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        card_payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(card_payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(len(card_payload["sections"]), 2)
+
+        # Verify first section is the record
+        assert_equal(
+            card_payload["sections"][0]["activityTitle"], "StreamAlert Alert Record"
+        )
+
+        # Verify the second section is the passed in test_card_section
+        assert_equal(card_payload["sections"][1], test_card_section.payload)
+
+    @patch("logging.Logger.debug")
+    def test_format_message_single_section_no_record(self, log_mock):
+        """TeamsOutput - Format Message - single card section with no record"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.with_record"] = False
+
+        # Setup test_card_section
+        test_card_section = pymsteams.cardsection()
+        test_card_section.title("test_section")
+        test_card_section.activityText("this is test section")
+        test_card_section.addFact("test", True)
+
+        # Pass card section in via Publisher
+        alert_publication["@teams.additional_card_sections"] = test_card_section
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        card_payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(card_payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(len(card_payload["sections"]), 1)
+
+        # Verify the section is the passed in test_card_section
+        assert_equal(card_payload["sections"][0], test_card_section.payload)
+        log_mock.assert_called_with("additional_sections is not a list, converting")
+
+    def test_format_message_multiple_sections_no_record(self):
+        """TeamsOutput - Format Message - Multiple card sections with no record"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.with_record"] = False
+
+        # Setup test_card_section
+        test_card_section = pymsteams.cardsection()
+        test_card_section.title("test_section")
+        test_card_section.activityText("this is test section")
+        test_card_section.addFact("test", True)
+
+        # Pass card section in via Publisher
+        alert_publication["@teams.additional_card_sections"] = [
+            test_card_section,
+            test_card_section,
+        ]
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        card_payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(
+            set(card_payload.keys()), {"title", "text", "themeColor", "sections"}
+        )
+        assert_equal(len(card_payload["sections"]), 2)
+
+        # Verify the first and second section is the passed in test_card_section
+        assert_equal(card_payload["sections"][0], test_card_section.payload)
+        assert_equal(card_payload["sections"][1], test_card_section.payload)
+
+    @patch("logging.Logger.error")
+    def test_format_message_invalid_section(self, log_mock):
+        """TeamsOutput - Format Message - invalid section passed"""
+        rule_name = "test_rule_default"
+        alert = get_random_alert(25, rule_name)
+        output = MagicMock(spec=TeamsOutput)
+        alert_publication = compose_alert(alert, output, "asdf")
+        alert_publication["@teams.with_record"] = False
+
+        # Setup test_card_section
+        test_card_section = "invalid section"
+
+        # Pass card section in via Publisher
+        alert_publication["@teams.additional_card_sections"] = test_card_section
+
+        loaded_message = TeamsOutput._format_message(
+            alert, alert_publication, self.CREDS["url"]
+        )
+        card_payload = loaded_message.payload
+
+        # tests
+        assert_set_equal(set(card_payload.keys()), {"title", "text", "themeColor"})
+        log_mock.assert_called_with(
+            "additional_section: %s is not an instance of %s",
+            test_card_section,
+            pymsteams.cardsection,
+        )
+
+    @patch("logging.Logger.info")
+    @patch("requests.post")
+    def test_dispatch_success(self, url_mock, log_mock):
+        """TeamsOutput - Dispatch Success"""
+        url_mock.return_value.status_code = 200
+        url_mock.return_value.json.return_value = dict()
+
+        assert_true(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
+
+        log_mock.assert_called_with(
+            "Successfully sent alert to %s:%s", self.SERVICE, self.DESCRIPTOR
+        )
+
+    @patch("logging.Logger.error")
+    @patch("requests.post")
+    def test_dispatch_failure(self, url_mock, log_mock):
+        """TeamsOutput - Dispatch Failure, Bad Request"""
+        json_error = {"message": "error message", "errors": ["error1"]}
+        url_mock.return_value.json.return_value = json_error
+        url_mock.return_value.status_code = 400
+
+        assert_false(self._dispatcher.dispatch(get_alert(), self.OUTPUT))
+
+        log_mock.assert_called_with(
+            "Failed to send alert to %s:%s", self.SERVICE, self.DESCRIPTOR
+        )
+
+    @patch("logging.Logger.error")
+    def test_dispatch_bad_descriptor(self, log_mock):
+        """TeamsOutput - Dispatch Failure, Bad Descriptor"""
+        assert_false(
+            self._dispatcher.dispatch(
+                get_alert(), ":".join([self.SERVICE, "bad_descriptor"])
+            )
+        )
+
+        log_mock.assert_called_with(
+            "Failed to send alert to %s:%s", self.SERVICE, "bad_descriptor"
+        )


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #1078
resolves: #1078

## Background

We use Microsoft Teams instead of Slack, so I wanted to have the ability to use SA and Teams together 😄

## Changes

* Implemented `TeamsOutput` (very very similar to the `SlackOutput`)
* Added Tests
* Updated documentation for outputs.rst

## Testing

### Code
* I implemented the output and tested it against an Incoming Webhook on our Teams Instance
* wrote tests in a style similar to the `SlackOutput` tests
* Ran tests and now have 100% Code Coverage for this new addition
* Ran `pylint` against files

### Documentation
* ran `make html` and visually checked addition in browser
