### PR TITLE
Docs/GitHub previous link gave 404

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -127,7 +127,7 @@ If you are adding features to existing classes with tests, you must add test cas
 Integration Testing
 ~~~~~~~~~~~~~~~~~~~
 
-To verify StreamAlert works from end-to-end, locally, follow the testing instructions `here <https://streamalert.io/rules.html>`_.
+To verify StreamAlert works from end-to-end, locally, follow the testing instructions `here <https://streamalert.io/en/stable/testing.html#running-tests>`_.
 
 Pull Request
 ------------


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The previous link gave a 404, as the page did not exist. I believe the url i have set is the one it was describing? 

## Changes

* Changed the link provided

## Testing

- `make html` - Opened produced documentation in my browser
