### PR TITLE
[outputs] aws-ses

### DIFF
--- a/conf/outputs.json
+++ b/conf/outputs.json
@@ -5,6 +5,9 @@
   "aws-s3": {
     "bucket": "aws-s3-bucket"
   },
+  "aws-ses": [
+    "sample-integration"
+  ],
   "aws-sns": {
     "sample-topic": "sample-topic-name"
   },

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -12,6 +12,7 @@ Out of the box, StreamAlert supports:
 * **AWS Kinesis Firehose**
 * **AWS Lambda**
 * **AWS S3**
+* **AWS SES**
 * **AWS SNS**
 * **AWS SQS**
 * **CarbonBlack**

--- a/terraform/modules/tf_alert_processor_iam/main.tf
+++ b/terraform/modules/tf_alert_processor_iam/main.tf
@@ -196,3 +196,24 @@ data "aws_iam_policy_document" "send_to_sqs_queues" {
     resources = ["${local.sqs_arn_prefix}:${element(local.sqs_outputs, count.index)}"]
   }
 }
+
+// Allow the Alert Processor to use ses:SendRawEmail
+resource "aws_iam_role_policy" "send_raw_emails" {
+  name   = "SendRawEmails"
+  role   = var.role_id
+  policy = data.aws_iam_policy_document.send_raw_emails.json
+}
+
+data "aws_iam_policy_document" "send_raw_emails" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ses:SendRawEmail"
+    ]
+
+    // * because there isn't a way to state the emails or
+    // domains before the user puts them in as a secret
+    resources = ["*"]
+  }
+}

--- a/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
@@ -94,6 +94,7 @@ def test_output_loading():
         'aws-firehose',
         'aws-lambda',
         'aws-s3',
+        'aws-ses',
         'aws-sns',
         'aws-sqs',
         'aws-cloudwatch-log',


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #1080
resolves: #1080

## Background

Adding support for aws-ses, this is a desired output and one i think others would like.

## Changes

* Added aws-ses to docs
* Implemented the `SESOutput` Class
* Added tests
* Added additional permissions to the `alert_processor`

## Testing

* ran `tests/scripts/test_the_docs.sh` and verified additional info was ther
* ran `tests/scripts/pylint.sh` to verify code score and remediated any issues
* ran `tests/scripts/unit_tests.sh` to verify tests worked

* Tried to deploy the `terraform` for release 3-0-0 (this work is based off that branch) and ran into some issues which i am highlighting on `slack` and `github`