### PR TITLE
Fix a parser bug when processing raw event encapsulated in a string

### DIFF
--- a/streamalert/classifier/parsers.py
+++ b/streamalert/classifier/parsers.py
@@ -241,6 +241,10 @@ class ParserBase(metaclass=ABCMeta):
         if not schema:
             return True
 
+        # Expect the record is a dict. Return False (schema doesn't match) if it is not.
+        if not isinstance(record, dict):
+            return False
+
         schema_keys = set(schema)
 
         keys = set(record) if not optionals else set(record).union(optionals)

--- a/tests/unit/streamalert/classifier/test_parsers_json.py
+++ b/tests/unit/streamalert/classifier/test_parsers_json.py
@@ -1091,3 +1091,35 @@ class TestJSONParser:
         parser = JSONParser(options)
         result = parser._extract_via_json_regex_key(record_data)
         assert_equal(result, False)
+
+    def test_parse_record_not_dict_mismatch(self):
+        """JSONParser - Parse record not in dict type and doesn't match schema"""
+        options = {
+            'schema': {
+                'key': 'string'
+            },
+            'parser': 'json'
+        }
+        record_data = "[{\"key\": \"value\"}]"
+
+        parser = JSONParser(options)
+        assert_equal(parser.parse(record_data), False)
+
+    def test_parse_record_not_dict_matched(self):
+        """JSONParser - Parse record not in dict type but match the schema"""
+        options = {
+            'schema': {
+                'key': 'string'
+            },
+            'parser': 'json',
+            'configuration': {
+                'json_path': "[*]"
+            }
+        }
+        record_data = "[{\"key\": \"value\"}]"
+
+        parser = JSONParser(options)
+        assert_equal(parser.parse(record_data), True)
+
+        expected_result = [{"key": "value"}]
+        assert_equal(parser.parsed_records, expected_result)


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: 
resolves: #1084

## Background

Please see #1084 

## Testing

* ran unit_test and pylint