### PR TITLE
[unit test] Use single quote around strings

### DIFF
--- a/tests/unit/streamalert/classifier/test_parsers_json.py
+++ b/tests/unit/streamalert/classifier/test_parsers_json.py
@@ -1121,5 +1121,5 @@ class TestJSONParser:
         parser = JSONParser(options)
         assert_equal(parser.parse(record_data), True)
 
-        expected_result = [{"key": "value"}]
+        expected_result = [{'key': 'value'}]
         assert_equal(parser.parsed_records, expected_result)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
We use single quote around strings rather than double quotes. Call me crazy...

## Testing
```
./tests/scripts/unit_tests.sh
```
