### PR TITLE
[terraform] Implemented a fix for the count error

### DIFF
--- a/streamalert_cli/terraform/rules_engine.py
+++ b/streamalert_cli/terraform/rules_engine.py
@@ -42,6 +42,9 @@ def generate_rules_engine(config):
         'threat_intel_enabled': config.get('threat_intel', {}).get('enabled'),
         'dynamodb_table_name': config.get('threat_intel', {}).get('dynamodb_table_name'),
         'rules_table_arn': '${module.globals.rules_table_arn}',
+        'enable_rule_staging': config['global']['infrastructure']['rule_staging'].get(
+            'enabled', False
+        ),
         'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
         'classifier_sqs_sse_kms_key_arn': '${module.globals.classifier_sqs_sse_kms_key_arn}',
         'sqs_record_batch_size': min(config.get('sqs_record_batch_size', 10), 10)

--- a/terraform/modules/tf_rules_engine/iam.tf
+++ b/terraform/modules/tf_rules_engine/iam.tf
@@ -24,14 +24,14 @@ data "aws_iam_policy_document" "read_threat_intel_table" {
 
 // Allow the Rules Engine to read the rules table
 resource "aws_iam_role_policy" "read_rules_table" {
-  count  = var.rules_table_arn == "" ? 0 : 1
+  count  = var.enable_rule_staging ? 1 : 0
   name   = "ReadRulesDynamoDB"
   role   = var.function_role_id
   policy = data.aws_iam_policy_document.read_rules_table[0].json
 }
 
 data "aws_iam_policy_document" "read_rules_table" {
-  count = var.rules_table_arn == "" ? 0 : 1
+  count = var.enable_rule_staging ? 1 : 0
 
   statement {
     effect = "Allow"

--- a/terraform/modules/tf_rules_engine/variables.tf
+++ b/terraform/modules/tf_rules_engine/variables.tf
@@ -30,6 +30,11 @@ variable "dynamodb_table_name" {
   default = "streamalert_threat_intel_ioc_table"
 }
 
+variable "enable_rule_staging" {
+  description = "Deploy rule staging resources if enabled"
+  default     = false
+}
+
 variable "rules_table_arn" {
   description = "ARN of the rules table for reading rule staging information"
 }

--- a/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate_rules_engine.py
@@ -34,6 +34,9 @@ class TestTerraformGenerateRuleEngine:
                 'infrastructure': {
                     'monitoring': {
                         'sns_topic_name': 'test_topic'
+                    },
+                    'rule_staging': {
+                        'enabled': False
                     }
                 }
             },
@@ -86,6 +89,7 @@ class TestTerraformGenerateRuleEngine:
                     'threat_intel_enabled': self.config['threat_intel']['enabled'],
                     'dynamodb_table_name': self.config['threat_intel']['dynamodb_table_name'],
                     'rules_table_arn': '${module.globals.rules_table_arn}',
+                    'enable_rule_staging': False,
                     'classifier_sqs_queue_arn': '${module.globals.classifier_sqs_queue_arn}',
                     'classifier_sqs_sse_kms_key_arn': (
                         '${module.globals.classifier_sqs_sse_kms_key_arn}'


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #1083 
# Description

Running `terraform init` failed on `terraform` count

## Changes

* Updated `streamalert_cli` to pass `bool` to `tf_rules_engine` instead of using the arn for the count (`bool` is known before apply)
* Updated test case to include new key

## Testing

* Ran `tests/scripts/unit_tests.sh`
* Ran `tests/scripts/pylint.sh`
* Changed to the `tf_rules_engine` directory and ran `terraform fmt`
* Did a full deploy from scratch and it works!