### PR TITLE
[terraform] fixed #1048 issue by reverting #1060 and fixed #1047

### DIFF
--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -362,17 +362,13 @@ def generate_cluster(config, cluster_name):
     return cluster_dict
 
 
-def cleanup_old_tf_files(config):
-    """Cleanup old .tf files, these are now .tf.json files per Hashicorp best practices"""
-    files_for_removal = set(config.clusters()).union({'athena', 'main'})
+def cleanup_old_tf_files():
+    """
+    Cleanup old *.tf.json files
+    """
     for terraform_file in os.listdir('terraform'):
-        if terraform_file == 'variables.tf':
-            continue
-
         if fnmatch(terraform_file, '*.tf.json'):
-            # Allow to retain misc files in the terraform/ directory
-            if terraform_file.split('.')[0] in files_for_removal:
-                os.remove(os.path.join('terraform', terraform_file))
+            os.remove(os.path.join('terraform', terraform_file))
 
 
 class TerraformGenerateCommand(CLICommand):
@@ -405,7 +401,7 @@ def terraform_generate_handler(config, init=False, check_tf=True, check_creds=Tr
     if check_tf and not terraform_check():
         return False
 
-    cleanup_old_tf_files(config)
+    cleanup_old_tf_files()
 
     # Setup the main.tf.json file
     LOGGER.debug('Generating cluster file: main.tf.json')

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -233,7 +233,7 @@ class TerraformDestroyCommand(CLICommand):
         # Migrate back to local state so Terraform can successfully
         # destroy the S3 bucket used by the backend.
         # Do not check for terraform or aws creds again since these were checked above
-        if not terraform_generate_handler(config=config, init=False, check_tf=False,
+        if not terraform_generate_handler(config=config, init=True, check_tf=False,
                                           check_creds=False):
             return False
 


### PR DESCRIPTION
TL;DR fixing #1047 and #1048 

to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #1060 #1047 #1048 
resolves: #1048 #1047

## Background

The fix introduced in #1060 to fix #1047 caused #1048 . Having deployed numerous times recently, this is how i have managed to remove both issues at the same time.

## Changes

* changing back to `init=True` so that the backend on destroy is configured as local resolves: #1048 
* Changing which files are removed by the `terraform_cli` to include the metric_filters resolves #1047 (this is because the `metric_filters.tf.json`

### Issues this introduces

Whilst this fixes two issues, it does introduce a new one: 

```Error: Error deleting CloudWatch Log Metric Filter: ResourceNotFoundException: The specified log group does not exist.```

Above is a snippet from: [error.txt](https://github.com/airbnb/streamalert/files/4071882/terraform.txt)



This one feels much more related to Terraform itself, rather than anything StreamAlert does though

## Testing

- `tests/scripts/unit_tests.sh`
- `tests/scripts/pylint.sh`
- `tests/scripts/test_the_docs.sh`
- Deployed numerous times, required #1089 to be able to deploy consistently and then ran `./manage.py destroy` which produced the issue above
