### PR TITLE
[core] Added dynamic_outputs to Rule

### DIFF
--- a/docs/source/dynamic-outputs.rst
+++ b/docs/source/dynamic-outputs.rst
@@ -1,0 +1,129 @@
+Dynamic Outputs
+===============
+
+Prerequisites
+-------------
+
+* Any output assigned must be added with ``python manage.py output``
+* ``functions`` must return ``None``, ``str`` or ``List[str]`` which maps to an output configured with the above.
+* Only pass ``context`` if the ``rule`` sets context.
+
+Overview
+--------
+
+Adds the ability to have custom logic run to define an ``output`` or ``outputs`` based on information within the ``record``.
+For information on supported outputs and how to add support for additional outputs, see `outputs <outputs.html>`_
+
+As can be seen by the examples below, they are easy to configure, but add a very useful feature to StreamAlert. 
+
+- StreamAlert sends to all outputs defined within a rules ``outputs=[]`` and ``dynamic_outputs=[]`` when sending ``Alerts``.
+- It is also possible to pass ``context`` to the ``dynamic_function`` if the ``rule`` sets it.
+
+.. note::
+  Any ``output`` passed must be configured with ``./manage.py output -h``
+
+
+Dynamic Outputs, Simple
+-----------------------
+
+The below code block is considered a simple ``dynamic_output`` function, because the outputs are dynamically configured, but the information used still lives within the code. It also:
+
+ - allows you to maintain a static list of information inside your code
+ - will return the outputs relevant to the team who "own" the account
+ - ``Alerts`` are sent to the ``aws-sns:security`` output aswell as those returned by the function
+
+.. code-block:: python
+
+  from streamalert.shared.rule import rule
+
+  def map_account_to_team(record):
+      teams = {
+        "team_a": {"accounts": ["123", "456", ...], "outputs": ["aws-sns:team_a"]},
+        "team_b": {"accounts": ["789", ...], "outputs": ["aws-sns:team_b", "slack:team_b"]},
+      }
+
+      account_id = record.get('recipientaccountid')
+
+      for team in teams:
+          if account_id in team["accounts"]:
+              return team["outputs"]
+      # None is guarded against by StreamAlert
+
+  @rule(
+    logs=['cloudwatch:events'],
+    req_subkeys={
+      'detail': ['userIdentity', 'eventType']
+    },
+    outputs=["aws-sns:security"],
+    dynamic_outputs=[map_account_to_team]
+  )
+  def cloudtrail_root_account_usage(rec):
+    # Rule logic
+
+
+Dynamic Outputs, With LookupTables
+----------------------------------
+
+With the simple addition of a `lookup-table <lookup-tables.html>`_ you can take a rule like ``cloudtrail_root_account_usage`` and configure it as such:
+
+.. code-block:: python
+
+  from streamalert.shared.rule import rule
+  from streamalert.shared.lookup_tables.core import LookupTables
+
+  def dynamic_output_with_context(record, context): # pass context only if the rule added context
+      account_id = context["account_id"]
+ 
+      return LookupTables.get(
+        'my_lookup_table',
+        'aws-account-owner:{}'.format(account_id), 
+        None
+      ) # potentially returns [aws-sns:team_a]
+
+  @rule(
+    logs=['cloudwatch:events'],
+    outputs=["aws-sns:security],
+    dynamic_outputs=[dynamic_output_with_context],
+    context={"account_id": "valid_account_id"},
+  )
+  def cloudtrail_root_account_usage(rec):
+      context["account_id"] = record.get('recipientaccountid')
+      # Rule logic
+
+The above has the benefit of using information that lives outside of StreamAlert, which means teams can acquire new accounts and get ``Alerts``
+without having to alter StreamAlert code.
+
+
+Dynamic Outputs, With Other Data Source
+---------------------------------------
+
+.. code-block:: python
+
+  from streamalert.shared.rule import rule
+  import requests
+
+  def dynamic_output(record):
+      account_id = record.get('recipientaccountid')
+
+      # invoke an external API to get data back
+      response = requests.get("API/team_map")
+
+      for team in response.json():
+          if account_id in team["accounts"]:
+              return team["outputs"] # potentially "aws-lambda:team_a"
+
+  @rule(
+    logs=['cloudwatch:events'],
+    outputs=["aws-sns:security],
+    dynamic_outputs=[dynamic_output],
+  )
+  def cloudtrail_root_account_usage(rec):
+      # Rule logic
+
+
+The above example uses an external API to get the output map, which is to be queried with the ``account_id`` on the record.
+This is just an example, but hopefully highlights many ways in which ``dynamic_outputs`` can be used.
+
+.. warning:: 
+  The above example could result in many queries to the API in use and could potentially slow down StreamAlert
+  Lambdas when processing ``Alerts``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ Table of Contents
    rules
    testing
    outputs
+   dynamic-outputs
    publishers
    lookup-tables
    metrics

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -133,6 +133,7 @@ The following table provides an overview of each rule option, with more details 
 ``merge_by_keys``      ``List[str]``             List of key names that must match in value before merging alerts
 ``merge_window_mins``  ``int``                   Merge related alerts at this interval rather than sending immediately
 ``outputs``            ``List[str]``             List of alert outputs
+``dynamic_outputs``    ``List[function]``        List of functions which return valid outputs
 ``req_subkeys``        ``Dict[str, List[str]]``  Subkeys which must be present in the record
 =====================  ========================  ===============
 
@@ -252,9 +253,15 @@ but those keys can be nested anywhere in the record structure.
 outputs
 ~~~~~~~
 
-Defines the alert destination if the return value of a rule is ``True``.
+The ``outputs`` keyword argument defines the alert destination if the return value of a rule is ``True``.
 Alerts are always sent to an :ref:`Athena table <athena_user_guide>` which is easy to query.
 Any number of additional `outputs <outputs.html>`_ can be specified.
+
+dynamic_outputs
+~~~~~~~~~~~~~~~
+
+The ``dynamic_outputs`` keyword argument defines additional `outputs <outputs.html>`_ to an Alert which are dynamically generated.
+See `dynamic_outputs <dynamic_outputs.html>`_ for more info
 
 req_subkeys
 ~~~~~~~~~~~

--- a/streamalert/shared/rule.py
+++ b/streamalert/shared/rule.py
@@ -59,6 +59,7 @@ class Rule:
         self.merge_by_keys = kwargs.get('merge_by_keys')
         self.merge_window_mins = kwargs.get('merge_window_mins') or 0
         self.outputs = kwargs.get('outputs')
+        self.dynamic_outputs = kwargs.get('dynamic_outputs')
         self.publishers = kwargs.get('publishers')
         self.req_subkeys = kwargs.get('req_subkeys')
         self.initial_context = kwargs.get('context')
@@ -198,6 +199,11 @@ class Rule:
     @property
     def outputs_set(self):
         return set(self.outputs or [])
+
+
+    @property
+    def dynamic_outputs_set(self):
+        return set(self.dynamic_outputs or [])
 
     @classmethod
     def disabled_rules(cls):

--- a/tests/unit/streamalert/rules_engine/test_rules_engine.py
+++ b/tests/unit/streamalert/rules_engine/test_rules_engine.py
@@ -18,7 +18,7 @@ limitations under the License.
 from datetime import datetime, timedelta
 
 from mock import Mock, patch, PropertyMock
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_false, assert_true
 
 from publishers.community.generic import remove_internal_fields
 from streamalert.shared.publisher import AlertPublisher, Register, DefaultPublisher
@@ -56,6 +56,7 @@ class ThisPublisher(AlertPublisher):
 # Without this time.sleep patch, backoff performs sleep
 # operations and drastically slows down testing
 # @patch('time.sleep', Mock())
+# pylint: disable=R0904
 class TestRulesEngine:
     """Tests for RulesEngine"""
     # pylint: disable=attribute-defined-outside-init,protected-access,no-self-use
@@ -200,6 +201,7 @@ class TestRulesEngine:
             process=Mock(return_value=True),
             is_staged=Mock(return_value=False),
             outputs_set={'slack:test'},
+            dynamic_outputs=None,
             description='rule description',
             publishers=None,
             context=None,
@@ -296,6 +298,7 @@ class TestRulesEngine:
             process=Mock(return_value=True),
             is_staged=Mock(return_value=False),
             outputs_set={'slack:test', 'demisto:test'},
+            dynamic_outputs=None,
             description='rule description',
             publishers={
                 'demisto': 'streamalert.shared.publisher.DefaultPublisher',
@@ -345,6 +348,290 @@ class TestRulesEngine:
             )
 
             assert_equal(result is not None, True)
+
+    # --- Tests for _configure_outputs()
+
+    def test_check_valid_output_list(self):
+        """RulesEngine - _check_valid_output, list"""
+
+        output = list()
+        result = self._rules_engine._check_valid_output(output)
+
+        assert_false(result)
+
+    def test_check_valid_output_int(self):
+        """RulesEngine - _check_valid_output, int"""
+
+        output = 1
+        result = self._rules_engine._check_valid_output(output)
+
+        assert_false(result)
+
+    def test_check_valid_output_invalid_string(self):
+        """RulesEngine - _check_valid_output, invalid string"""
+
+        output = "aws-sns"  # missing :
+        result = self._rules_engine._check_valid_output(output)
+
+        assert_false(result)
+
+    def test_check_valid_output_valid_string(self):
+        """RulesEngine - _check_valid_output, valid string"""
+
+        output = "aws-sns:test"
+        result = self._rules_engine._check_valid_output(output)
+
+        assert_true(result)
+
+    @patch('logging.Logger.error')
+    def test_call_dynamic_output_function_raise_error(self, log_error):
+        """RulesEngine - _call_dynamic_output_function, raise error"""
+        dynamic_output_function = Mock(__name__='test', side_effect=Exception('BOOM!'))
+
+        rule_name = "test"
+
+        dynamic_outputs = self._rules_engine._call_dynamic_output_function(
+            dynamic_output_function, rule_name, []
+        )
+
+        assert_equal(dynamic_outputs, [])
+        log_error.assert_called_with(
+            'Exception when calling dynamic_output %s for rule %s', 'test', rule_name
+        )
+
+    def test_call_dynamic_output_function_string(self):
+        """RulesEngine - _call_dynamic_output_function, output returns string"""
+        dynamic_output_function = Mock(__name__='test', return_value="test")
+
+        record = {'foo': 'bar'}
+        dynamic_outputs = self._rules_engine._call_dynamic_output_function(
+            dynamic_output_function, "test", [record]
+        )
+
+        assert_equal(dynamic_outputs, ["test"])
+        dynamic_output_function.assert_called()
+        dynamic_output_function.assert_called_with(record)
+
+    def test_call_dynamic_output_function_list(self):
+        """RulesEngine - _call_dynamic_output_function, output returns list"""
+        dynamic_output_function = Mock(__name__='test', return_value=["test"])
+
+        record = {'foo': 'bar'}
+        dynamic_outputs = self._rules_engine._call_dynamic_output_function(
+            dynamic_output_function, "test", [record]
+        )
+
+        assert_equal(dynamic_outputs, ["test"])
+        dynamic_output_function.assert_called()
+        dynamic_output_function.assert_called_with(record)
+
+    def test_call_dynamic_output_function_none(self):
+        """RulesEngine - _call_dynamic_output_function, output returns None"""
+        dynamic_output_function = Mock(__name__='test', return_value=None)
+
+        record = {'foo': 'bar'}
+        dynamic_outputs = self._rules_engine._call_dynamic_output_function(
+            dynamic_output_function, "test", [record]
+        )
+
+        assert_equal(dynamic_outputs, [])
+        dynamic_output_function.assert_called()
+        dynamic_output_function.assert_called_with(record)
+
+    def test_configure_dynamic_outputs_no_context(self):
+        """RulesEngine - _configure_dynamic_outputs, no context"""
+        dynamic_output = Mock(return_value="aws-sns:test")
+        rule = Mock(
+            name="test",
+            outputs_set=set(),
+            dynamic_outputs_set={dynamic_output},
+            publishers=None,
+            context=None,
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_call_dynamic_output_function") as call_dynamic:
+            call_dynamic.return_value = ["aws-sns:test"]
+
+            dynamic_outputs = self._rules_engine._configure_dynamic_outputs(record, rule)
+
+            # Tests
+            assert_equal(dynamic_outputs, ["aws-sns:test"])
+            call_dynamic.assert_called()
+            call_dynamic.assert_called_with(dynamic_output, rule.name, [record])
+
+    def test_configure_dynamic_outputs_with_context(self):
+        """RulesEngine - _configure_dynamic_outputs, with context"""
+        dynamic_output = Mock(return_value="aws-sns:test")
+        rule = Mock(
+            name="test",
+            outputs_set=set(),
+            dynamic_outputs_set={dynamic_output},
+            publishers=None,
+            context={"test": True},
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_call_dynamic_output_function") as call_dynamic:
+            call_dynamic.return_value = ["aws-sns:test"]
+
+            dynamic_outputs = self._rules_engine._configure_dynamic_outputs(record, rule)
+
+            # Tests
+            assert_equal(dynamic_outputs, ["aws-sns:test"])
+            call_dynamic.assert_called()
+            call_dynamic.assert_called_with(dynamic_output, rule.name, [record, rule.context])
+
+    def test_configure_dynamic_outputs_empty_list(self):
+        """RulesEngine - _configure_dynamic_outputs, empty list"""
+        dynamic_output = Mock(return_value=None)
+        rule = Mock(
+            name="test",
+            outputs_set=set(),
+            dynamic_outputs_set={dynamic_output},
+            publishers=None,
+            context=None,
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_call_dynamic_output_function") as call_dynamic:
+            call_dynamic.return_value = []
+
+            dynamic_outputs = self._rules_engine._configure_dynamic_outputs(record, rule)
+
+            # Tests
+            assert_equal(dynamic_outputs, [])
+            call_dynamic.assert_called()
+            call_dynamic.assert_called_with(dynamic_output, rule.name, [record])
+
+    def test_configure_outputs_staged(self):
+        """RulesEngine - _configure_outputs, staged rule"""
+        rule = Mock(
+            outputs_set=set(),
+            is_staged=Mock(return_value=True),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_check_valid_output") as check_valid:
+            check_valid.return_value = True
+
+            outputs = self._rules_engine._configure_outputs(record, rule)
+
+            # Tests
+            rule.is_staged.assert_called()
+            check_valid.assert_called()
+            assert_equal(outputs, self._rules_engine._required_outputs_set)
+
+    def test_configure_outputs_unstaged_with_static_outputs(self):
+        """RulesEngine - _configure_outputs, unstaged with static outputs"""
+        rule = Mock(
+            outputs_set={"aws-sns:static"},
+            dynamic_outputs=None,
+            is_staged=Mock(return_value=False),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_check_valid_output") as check_valid:
+            check_valid.return_value = True
+
+            outputs = self._rules_engine._configure_outputs(record, rule)
+
+            # Tests
+            rule.is_staged.assert_called()
+            check_valid.assert_called()
+            expected = self._rules_engine._required_outputs_set.union({"aws-sns:static"})
+            assert_equal(outputs, expected)
+
+    def test_configure_outputs_unstaged_with_no_outputs(self):
+        """RulesEngine - _configure_outputs, unstaged with no additional outputs"""
+        rule = Mock(
+            outputs_set=set(),
+            dynamic_outputs=None,
+            is_staged=Mock(return_value=False),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_check_valid_output") as check_valid:
+            check_valid.return_value = True
+
+            outputs = self._rules_engine._configure_outputs(record, rule)
+
+            # Tests
+            rule.is_staged.assert_called()
+            assert_equal(outputs, self._rules_engine._required_outputs_set)
+
+    def test_configure_outputs_unstaged_with_dynamic_outputs(self):
+        """RulesEngine - _configure_outputs, unstaged with dynamic outputs"""
+        rule = Mock(
+            outputs_set=set(),
+            dynamic_outputs=[Mock(return_value="aws-sns:dynamic")],
+            is_staged=Mock(return_value=False),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_configure_dynamic_outputs") as configure_dynamic:
+            configure_dynamic.return_value = ["aws-sns:dynamic"]
+
+            with patch.object(RulesEngine, "_check_valid_output") as check_valid:
+                check_valid.return_value = True
+
+                outputs = self._rules_engine._configure_outputs(record, rule)
+
+                # Tests
+                rule.is_staged.assert_called()
+                configure_dynamic.assert_called()
+                configure_dynamic.assert_called_with(record, rule)
+                check_valid.assert_called()
+                expected = self._rules_engine._required_outputs_set.union({"aws-sns:dynamic"})
+                assert_equal(outputs, expected)
+
+    def test_configure_outputs_unstaged_with_all_outputs(self):
+        """RulesEngine - _configure_outputs, unstaged with all output sources"""
+        rule = Mock(
+            outputs_set={"aws-sns:static"},
+            dynamic_outputs=[Mock(return_value="aws-sns:dynamic")],
+            is_staged=Mock(return_value=False),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_configure_dynamic_outputs") as configure_dynamic:
+            configure_dynamic.return_value = ["aws-sns:dynamic"]
+
+            with patch.object(RulesEngine, "_check_valid_output") as check_valid:
+                check_valid.return_value = True
+
+                outputs = self._rules_engine._configure_outputs(record, rule)
+
+                # Tests
+                rule.is_staged.assert_called()
+                configure_dynamic.assert_called()
+                configure_dynamic.assert_called_with(record, rule)
+                check_valid.assert_called()
+                expected = self._rules_engine._required_outputs_set.union(
+                    {"aws-sns:static", "aws-sns:dynamic"}
+                )
+                assert_equal(outputs, expected)
+
+    def test_configure_outputs_invalid_output(self):
+        """RulesEngine - _configure_outputs, unstaged with all outputs and one invalid output"""
+        rule = Mock(
+            outputs_set={"aws-sns:static"},
+            dynamic_outputs=[Mock(return_value="invalid_output_will_not_be_in_final_outputs")],
+            is_staged=Mock(return_value=False),
+        )
+        record = {'foo': 'bar'}
+
+        with patch.object(RulesEngine, "_configure_dynamic_outputs") as configure_dynamic:
+            configure_dynamic.return_value = ["invalid_output_will_not_be_in_final_outputs"]
+
+            outputs = self._rules_engine._configure_outputs(record, rule)
+
+            # Tests
+            rule.is_staged.assert_called()
+            configure_dynamic.assert_called()
+            configure_dynamic.assert_called_with(record, rule)
+            expected = self._rules_engine._required_outputs_set.union({"aws-sns:static"})
+            assert_equal(outputs, expected)
 
     # --- Tests for _configure_publishers()
 

--- a/tests/unit/streamalert/shared/test_rule.py
+++ b/tests/unit/streamalert/shared/test_rule.py
@@ -17,7 +17,7 @@ limitations under the License.
 import hashlib
 
 from mock import patch
-from nose.tools import assert_equal, raises
+from nose.tools import assert_equal, assert_true, raises
 
 from streamalert.shared import rule, rule_table
 
@@ -290,3 +290,63 @@ def {}(_):
         result = rule.Rule.rules_for_log_type('log_type_03')
         assert_equal(len(result), 1)
         assert_equal(result[0].name, 'rule_04')
+
+    def test_rule_outputs(self):
+        """Rule - outputs is configured"""
+        self._create_rule_helper(
+            'test_rule', options={'logs': ['log_type_01'], 'outputs': ['aws-sns:test']}
+        )
+
+        result = rule.Rule._rules["test_rule"]
+
+        # Verify outputs is configured
+        assert_equal(result.outputs, ['aws-sns:test'])
+
+    def test_rule_outputs_set(self):
+        """Rule - outputs, check outputs_set"""
+        self._create_rule_helper(
+            'test_rule',
+            options={
+                'logs': ['log_type_01'],
+                'outputs': ['aws-sns:test', 'aws-sns:test'],
+            },
+        )
+
+        result = rule.Rule._rules["test_rule"]
+
+        # Verify outputs is configured
+        assert_equal(result.outputs, ['aws-sns:test', 'aws-sns:test'])
+        assert_true(isinstance(result.outputs_set, set))
+        assert_equal(result.outputs_set, {'aws-sns:test'})
+
+    def test_rule_dynamic_outputs(self):
+        """Rule - dynamic_outputs is configured"""
+
+        def dynamic_function():
+            return "aws-sns:test"
+
+        self._create_rule_helper(
+            'test_rule',
+            options={'logs': ['log_type_01'], 'dynamic_outputs': [dynamic_function]},
+        )
+        result = rule.Rule._rules["test_rule"]
+
+        # Verify dynamic_outputs is configured
+        assert_equal(result.dynamic_outputs, [dynamic_function])
+
+    def test_rule_dynamic_outputs_set(self):
+        """Rule - dynamic_outputs, check dynamic_outputs_set"""
+
+        def dynamic_function():
+            return "aws-sns:test"
+
+        self._create_rule_helper(
+            'test_rule',
+            options={'logs': ['log_type_01'], 'dynamic_outputs': [dynamic_function]},
+        )
+        result = rule.Rule._rules["test_rule"]
+
+        # Verify outputs is configured
+        assert_equal(result.dynamic_outputs, [dynamic_function])
+        assert_true(isinstance(result.dynamic_outputs_set, set))
+        assert_equal(result.dynamic_outputs_set, {dynamic_function})


### PR DESCRIPTION
to: @ryandeivert @Ryxias 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #1075 

## Background

Wanted the ability to dynamically configure outputs based on information in the record

## Changes

* Now possible to pass dynamic_outputs to the @rule decorator and have
outputs be dynamically configured based on information in the record.
* Added documentation

## Testing

- Ran `tests/scripts/pylint.sh`
- Ran `tests/scripts/unit_tests.sh`
- Added additional tests to cover the new code
- Ran `tests/scripts/test_the_docs.sh` and verified visually the new documentation changes
