### PR TITLE
[testing] enable trend tests, previously only schema

### DIFF
--- a/tests/integration/rules/trendmicro/trendmicro_schema.json
+++ b/tests/integration/rules/trendmicro/trendmicro_schema.json
@@ -5,7 +5,7 @@
         "log": "trendmicro:malwareevent",
         "service": "sns",
         "source": "prefix_cluster_sample_topic",
-        "validate_schema_only": true,
+        "validate_schema_only": false,
         "trigger_rules": [
             "trendmicro_malware_event"
         ]
@@ -16,7 +16,7 @@
         "log": "trendmicro:malwareevent",
         "service": "sns",
         "source": "prefix_cluster_sample_topic",
-        "validate_schema_only": true,
+        "validate_schema_only": false,
         "trigger_rules": [
             "trendmicro_malware_event"
         ]
@@ -27,7 +27,7 @@
         "log": "trendmicro:malwareevent",
         "service": "sns",
         "source": "prefix_cluster_sample_topic",
-        "validate_schema_only": true,
+        "validate_schema_only": false,
         "trigger_rules": [
             "trendmicro_malware_event"
         ]
@@ -38,7 +38,7 @@
         "log": "trendmicro:malwareevent",
         "service": "sns",
         "source": "prefix_cluster_sample_topic",
-        "validate_schema_only": true,
+        "validate_schema_only": false,
         "trigger_rules": [
             "trendmicro_malware_event"
         ]
@@ -49,7 +49,7 @@
         "log": "trendmicro:malwareevent",
         "service": "sns",
         "source": "prefix_cluster_sample_topic",
-        "validate_schema_only": true,
+        "validate_schema_only": false,
         "trigger_rules": [
             "trendmicro_malware_event"
         ]


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

Forgot to enable the tests on previous branch

## Changes

* validate_schema_only `true` -> `false`

## Testing

- `./manage.py test rules`