### PR TITLE
[core] Updated cloudtrail:events optional_key

### DIFF
--- a/conf/schemas/cloudtrail.json
+++ b/conf/schemas/cloudtrail.json
@@ -60,6 +60,8 @@
         "resources",
         "serviceEventDetails",
         "sharedEventID",
+        "sourceIPAddress",
+        "userAgent",
         "vpcEndpointId"
       ]
     }

--- a/tests/integration/rules/cloudtrail/cloudtrail_quicksight.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_quicksight.json
@@ -1,0 +1,41 @@
+[
+    {
+        "data": {
+            "Records": [
+                {
+                    "eventVersion": "1.05",
+                    "userIdentity": {
+                        "arn": "arn",
+                        "accountId": "accountId",
+                        "userName": "userName",
+                        "type": "type"
+                    },
+                    "eventTime": "eventTime",
+                    "eventSource": "quicksight.amazonaws.com",
+                    "eventName": "QueryDatabase",
+                    "awsRegion": "awsRegion",
+                    "requestParameters": null,
+                    "responseElements": null,
+                    "eventID": "eventID",
+                    "readOnly": true,
+                    "eventType": "AwsServiceEvent",
+                    "recipientAccountId": "recipientAccountId",
+                    "serviceEventDetails": {
+                        "eventRequestDetails": {
+                            "dataSourceId": "dataSourceId",
+                            "queryId": "queryId",
+                            "resourceId": "resourceId",
+                            "dataSetId": "dataSetId",
+                            "dataSetMode": "dataSetMode"
+                        }
+                    }
+                }
+            ]
+        },
+        "description": "quicksight event via cloudtrail",
+        "log": "cloudtrail:events",
+        "service": "s3",
+        "source": "prefix.cluster.sample.bucket",
+        "validate_schema_only": true
+    }
+]


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #1100 

## Background

Having setup an org cloudtrail, i had errors on events coming in. These keys were added and it resolved the errors

## Changes

* Added `sourceIPAddress` and `userAgent` to `cloudtrail:events` schema

## Testing

* Ran `tests/scripts/rule_test.sh`
* Ran `tests/scripts/unit_tests.sh`
* Added an additional test schema only event to `tests/integration/rules/cloudtrail/`