### PR TITLE
[rule] Fix cloudtrail_public_resources

### DIFF
--- a/rules/community/cloudtrail/cloudtrail_public_resources.py
+++ b/rules/community/cloudtrail/cloudtrail_public_resources.py
@@ -51,7 +51,7 @@ def cloudtrail_public_resources(rec):
             policy_string = rec['requestParameters'].get('attributeValue', '')
     elif rec['eventName'] == 'CreateTopic':
         policy_string = (
-            rec.get('requestParameters', {}).get('attributes', '').get('Policy', '')
+            rec.get('requestParameters', {}).get('attributes', {}).get('Policy', '')
         )
 
     # Check ECR


### PR DESCRIPTION
to: @chunyong-lin @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to:
resolves: 

## Background

Lambda error when this rule was evaluated. There is a `.get()` on a `string`. Setting default as `{}` so that `.get()` works

## Changes

* default `''` -> `{}`

## Testing

* Ran `tests/scripts/rule_test.sh`
* Ran `tests/scripts/unit_tests.sh`
