### PR TITLE
[core] Adding ability to send initial alert in merge_group

### DIFF
--- a/streamalert/rules_engine/rules_engine.py
+++ b/streamalert/rules_engine/rules_engine.py
@@ -199,6 +199,7 @@ class RulesEngine:
             log_source=payload['log_schema_type'],
             log_type=payload['data_type'],
             merge_by_keys=rule.merge_by_keys,
+            merge_send_initial=rule.merge_send_initial,
             merge_window=timedelta(minutes=rule.merge_window_mins),
             publishers=self._configure_publishers(rule),
             rule_description=rule.description,

--- a/streamalert/shared/rule.py
+++ b/streamalert/shared/rule.py
@@ -57,6 +57,7 @@ class Rule:
         self.logs = kwargs.get('logs')
         self.matchers = kwargs.get('matchers')
         self.merge_by_keys = kwargs.get('merge_by_keys')
+        self.merge_send_initial = kwargs.get('merge_send_initial')
         self.merge_window_mins = kwargs.get('merge_window_mins') or 0
         self.outputs = kwargs.get('outputs')
         self.dynamic_outputs = kwargs.get('dynamic_outputs')

--- a/tests/unit/streamalert/rules_engine/test_rules_engine.py
+++ b/tests/unit/streamalert/rules_engine/test_rules_engine.py
@@ -206,6 +206,7 @@ class TestRulesEngine:
             publishers=None,
             context=None,
             merge_by_keys=None,
+            merge_send_initial=False,
             merge_window_mins=0
         )
 
@@ -230,6 +231,7 @@ class TestRulesEngine:
                 log_source='log_type',
                 log_type='json',
                 merge_by_keys=None,
+                merge_send_initial=False,
                 merge_window=timedelta(minutes=0),
                 publishers=None,
                 rule_description='rule description',
@@ -250,6 +252,7 @@ class TestRulesEngine:
             publishers=None,
             context=None,
             merge_by_keys=None,
+            merge_send_initial=False,
             merge_window_mins=0
         )
 
@@ -274,6 +277,7 @@ class TestRulesEngine:
                 log_source='log_type',
                 log_type='json',
                 merge_by_keys=None,
+                merge_send_initial=False,
                 merge_window=timedelta(minutes=0),
                 publishers=None,
                 rule_description='rule description',
@@ -307,6 +311,7 @@ class TestRulesEngine:
             },
             context=None,
             merge_by_keys=None,
+            merge_send_initial=False,
             merge_window_mins=0
         )
 
@@ -331,6 +336,7 @@ class TestRulesEngine:
                 log_source='log_type',
                 log_type='json',
                 merge_by_keys=None,
+                merge_send_initial=False,
                 merge_window=timedelta(minutes=0),
                 publishers={
                     'slack:test': [


### PR DESCRIPTION
TL;DR I will add more tests etc but this is just an initial attempt, what do you think?

to: @chunyong-lin @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to: #1104 
resolves: #1104 

## Background

Wanted the ability to send the first `Alert` when merging alerts. This allows the outputs to be informed immediately, but not flooded (hence merging) without waiting for the merging to take place before outputs are notified.

## Changes

* Added kwargs to `Rule`: 
    `merge_send_initial`: State if the first `Alert` in a `merge_group` should be sent immediately
* Added kwargs to `Alert`: 
    `merge_initial_sent` - track if the initial_alert has been sent
    `merge_send_initial` - Passed in from `Rule` but states if the first `Alert` in a group should be sent immediately
* `alert_merger` now creates a `merged_alert` from this `initial_alert` and updates the `initial_alert context` to state it `relates_to_alert: MERGED_ALERT_ID` This allows for the final merged alert to state it relates to the `alert` you received 30 mins ago (configured with `merge_window_mins`). This is picked up by the `alert_processor` as if its any other alert.

## Testing

- Updated unit_tests but want input on if we should be using mocks here. Since i am reliant on the `alerts_table` to track state i think i should place records into the table and then verify they exist as expected
- Ran `tests/scripts/pylint.sh`
