### PR TITLE
Vagrant AWS cli and env vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,9 +33,6 @@ def configure_python(machine, version)
 end
 
 STREAMALERT_SHELL_ENV = %{
-export AWS_DEFAULT_REGION='#{ENV.fetch('SA_AWS_DEFAULT_REGION', 'Your region here!')}'
-export AWS_ACCESS_KEY_ID='#{ENV.fetch('SA_AWS_ACCESS_KEY_ID', 'Your access key ID here!')}'
-export AWS_SECRET_ACCESS_KEY='#{ENV.fetch('SA_AWS_SECRET_ACCESS_KEY', 'Your secret access key here!')}'
 export SA_EMAIL='#{ENV.fetch('SA_EMAIL', 'example@example.com')}'
 }
 
@@ -114,4 +111,11 @@ Vagrant.configure(2) do |config|
     configure_streamalert(py3)
     final_message(py3)
   end
+
+  config.ssh.forward_env = [
+    'AWS_DEFAULT_REGION',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN'
+  ]
 end

--- a/vagrant/cli/streamalert/install.sh
+++ b/vagrant/cli/streamalert/install.sh
@@ -1,2 +1,7 @@
 # Install git so we can clone the streamalert repository
 apt-get install git awscli -y
+
+# Configure ssh to allow env variables AWS_* to be passed through
+cp /vagrant/vagrant/cli/streamalert/sshd_config /etc/ssh/sshd_config && \
+  /etc/init.d/ssh restart
+

--- a/vagrant/cli/streamalert/install.sh
+++ b/vagrant/cli/streamalert/install.sh
@@ -1,2 +1,2 @@
 # Install git so we can clone the streamalert repository
-apt-get install git -y
+apt-get install git awscli -y

--- a/vagrant/cli/streamalert/sshd_config
+++ b/vagrant/cli/streamalert/sshd_config
@@ -1,0 +1,122 @@
+#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_* AWS_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

Using vagrant on a windows machine, i have AWS creds setup through assumed_roles so have to pass `AWS_*` variables through as they only last for a short period of time

## Changes

* Added `awscli` to `apt-get install` - This fixes the missing `awscli` when connecting to the machine
* Updated the Vagrant file to pass variables through when runninng `vagrant ssh` this includes all the `AWS_*` variables. This required an update of the `sshd_config`

## Testing

- `vagrant provision && vagrant up && vagrant ssh` then on the box i ran `aws s3 ls | grep streamalert` to see a list of s3 buckets on the machine