### PR TITLE
[cli] Added ability to edit existing outputs

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -64,6 +64,13 @@ After a ``descriptor`` is provided, the user is then prompted for the Slack webh
 
 .. note:: The user input for the Slack webhook URL will be masked. This 'masking' approach currently applies to any potentially sensitive information the user may have to enter on the cli and can be enforced through any new services that are implemented.
 
+Edit existing outputs
+---------------------
+
+To edit ``outputs`` which have already been configured using ``python manage.py output`` you can pass the flag ``--edit``. This will allow you to update the configuration for any of the supported output services.
+
+.. note:: This will follow the same prompts as the above configuration section.
+
 Adding Support for New Services
 -------------------------------
 


### PR DESCRIPTION
to: @0xdabbad00 @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #940 
resolves: #940 

## Background

Wanted the ability to re-configure existing `outputs`

## Changes

* [cli] Added ability to edit existing outputs
* [docs] Updated outputs.rst with a description for the --edit command

## Testing

* ran `./tests/scripts/unit_tests.sh`
* ran `./tests/scripts/pylint.sh`
* ran `./tests/scripts/test_the_docs.sh` and verified the additions to the documentation


I also ran carried out the following commands in this order with this `descriptor: test_new, to_email: test, from_email: test`:
- `./manage.py output aws-ses` - Saved `output` successfully
- `./manage.py output aws-ses` - Asked me for a new `descriptor`
- `./manage.py output aws-ses --edit` - updated `output` successfully

Caveats of `--edit` it is possible to pass this flag even for non-existing `output` and it will still update the configuration. This is because i don't see the point in having the user error out to have to remove the flag in order to add a brand new `output`