### PR TITLE
[testing] Setting other AWS variables during testing

### DIFF
--- a/tests/scripts/unit_tests.sh
+++ b/tests/scripts/unit_tests.sh
@@ -3,6 +3,8 @@
 # Export fake creds to keep moto from complaining
 export AWS_ACCESS_KEY_ID=foobar_key
 export AWS_SECRET_ACCESS_KEY=foobar_secret
+export AWS_SESSION_TOKEN=foobar_session_token
+export AWS_DEFAULT_REGION=us-east-1
 
 nosetests tests/unit \
 --with-coverage \


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

`./tests/scripts/unit_tests.sh` fails on my machine as `AWS_SESSION_TOKEN` is configured and `AWS_DEFAULT_REGION` is different to what the tests are expecting.

## Changes

* configured `AWS_DEFAULT_REGION` to ensure tests pass which include `moto` resources
* configured `AWS_SESSION_TOKEN` to ensure `boto` isn't picking up my actual token

## Testing

- Ran `./tests/scripts/unit_tests.sh`
