### PR TITLE
Fix bug with default value for firehose use_prefix

### DIFF
--- a/streamalert/classifier/clients/firehose.py
+++ b/streamalert/classifier/clients/firehose.py
@@ -63,7 +63,8 @@ class FirehoseClient:
     def __init__(self, prefix, firehose_config=None, log_sources=None):
         self._prefix = (
             '{}_'.format(prefix)
-            if firehose_config and firehose_config.get('use_prefix')
+            # This default value must be consistent with the classifier Terraform config
+            if firehose_config and firehose_config.get('use_prefix', True)
             else ''
         )
         self._client = boto3.client('firehose', config=boto_helpers.default_config())

--- a/streamalert_cli/terraform/classifier.py
+++ b/streamalert_cli/terraform/classifier.py
@@ -59,6 +59,7 @@ def generate_classifier(cluster_name, cluster_dict, config):
     )
 
     firehose_config = config['global']['infrastructure'].get('firehose', {})
+    # The default value here must be consistent with the firehose client default
     use_firehose_prefix = firehose_config.get('use_prefix', True)
 
     tf_module_prefix = 'classifier_{}'.format(cluster_name)


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers


## Background

If you don't provide an explicit value for `use_prefix`, the default values do not match between the Classifier Terraform and the Python firehose client.

