### PR TITLE
[core] Moved the secret_store from S3 to SSM

### DIFF
--- a/scripts/migrate_from_s3_to_ssm.py
+++ b/scripts/migrate_from_s3_to_ssm.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+import sys
+import json
+from io import BytesIO
+import boto3
+from botocore.exceptions import ClientError
+
+FILE_NAME = 'ssm_ready_secrets.json'
+
+
+def decrypt_secrets(ciphertext, region):
+    """Decrypts the given ciphertext using AWS KMS
+
+    Args:
+        ciphertext (str): The raw, encrypted data to be decrypted
+        region (str): AWS region
+
+    Returns:
+        string: The decrypted plaintext
+
+    Raises:
+        ClientError
+    """
+    client = boto3.client('kms', region_name=region)
+    try:
+        response = client.decrypt(CiphertextBlob=ciphertext)
+    except ClientError:
+        print('An error occurred during KMS decryption')
+        raise
+    else:
+        return response['Plaintext']
+
+
+def pull_from_s3(bucket, key):
+    """Pull file contents from S3 into memory
+
+    Args:
+        bucket (boto3.resources.factory.s3.Bucket): The S3 Bucket resource
+        key (str): The key to pull
+
+    Returns:
+        None: An error occured
+        ciphertext: The encrypted contents of the file
+
+    Raises:
+        ClientError
+    """
+    io = BytesIO()
+
+    try:
+        bucket.download_fileobj(key, io)
+    except ClientError:
+        print(f"Error fetching {key} from s3")
+        raise
+    else:
+        return io.getvalue()
+
+
+def get_output_secrets(bucket, key, region):
+    """Pull the secrets from s3
+
+    Args:
+        bucket (boto3.resources.factory.s3.Bucket): The S3 Bucket resource
+        key (str): The key to download and decrypt
+    Returns:
+        None: An error occured
+        dict: The secrets from s3
+    """
+    try:
+        encrypted_secrets = pull_from_s3(bucket, key)
+        secrets = decrypt_secrets(encrypted_secrets, region)
+    except ClientError:
+        pass
+    else:
+        return json.loads(secrets)
+
+
+def save_to_fs(secrets):
+    """Save the secrets to the local FileSystem
+
+    Args:
+        secrets (dict): Secrets ready to be taken by set-from-file subcommand
+    """
+
+    saved = False
+
+    try:
+        with open(FILE_NAME, "w") as _fp:
+            json.dump(secrets, _fp)
+    except Exception:
+        print("Error saving secrets to FileSystem")
+    else:
+        print(f"Secrets saved to {FILE_NAME}")
+        saved = True
+
+    return saved
+
+
+if __name__ == "__main__":
+    import os
+    sys.path.append(os.path.realpath('.'))
+
+    from streamalert.alert_processor.outputs.output_base import (
+        StreamAlertOutput
+    )
+    from streamalert_cli.config import CLIConfig
+
+    config = CLIConfig()
+    output_config = config.get("outputs")
+    if not output_config:
+        print("No Outputs configured")
+        sys.exit(1)
+
+    region = config["global"]["account"]["region"]
+    prefix = config["global"]["account"]["prefix"]
+
+    bucket_name = f"{prefix}.streamalert.secrets"
+    s3 = boto3.resource('s3', region_name=region)
+    bucket = s3.Bucket(bucket_name)
+
+    secrets = {}
+    for service, descriptors in output_config.items():
+        dispatcher = StreamAlertOutput.get_dispatcher(service)
+        required_properties = dispatcher.get_user_defined_properties()
+
+        if not any(prop.cred_requirement for prop in required_properties.values()):
+            # The service has no 'cred_requirement' so it will not contain anything in s3
+            continue
+
+        service_outputs = []
+
+        for descriptor in descriptors:
+            if 'sample' in descriptor:
+                # Skip sample outputs
+                continue
+
+            key = f"{service}/{descriptor}"
+            output_secrets = get_output_secrets(bucket, key, region)
+            if not output_secrets:
+                print(f"No Secrets Found for {service}:{descriptor}")
+                continue
+
+            output_secrets["descriptor"] = descriptor
+            service_outputs.append(output_secrets)
+
+        if service_outputs:
+            # Add the service secrets into the secrets dict
+            secrets[service] = service_outputs
+
+    if not save_to_fs(secrets):
+        # An error occured so exit with code 1
+        sys.exit(1)
+
+    print(
+        "\nPlease Upgrade to the release containing SSM as the secret_store and then run"
+        f"\n\n $ python manage.py output set-from-file --file --update {FILE_NAME}\n\nto push",
+        "the secrets to SSM"
+    )

--- a/streamalert/shared/helpers/aws_api_client.py
+++ b/streamalert/shared/helpers/aws_api_client.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import json
 import boto3
 
 from botocore.exceptions import ClientError
@@ -182,3 +183,71 @@ class AwsS3:
         except ClientError:
             LOGGER.error('An error occurred during S3 DownloadFileobj')
             raise
+
+
+class AwsSsm:
+    """Class containing helper functions for aws ssm"""
+
+    @staticmethod
+    def get_parameter(parameter_name, region, with_decryption=True):
+        """gets the parameter_name from SSM Parameter store
+
+        Args:
+            parameter_name (str): The name of the parameter to fetch
+            region (str): AWS region
+            with_decryption (bool): Should decryption be attempted via this call
+
+        Returns:
+            str: The parameter either encrypted or not
+
+        Raises:
+            ClientError
+        """
+        client = boto3.client('ssm', config=default_config(region=region))
+
+        try:
+            response = client.get_parameter(Name=parameter_name, WithDecryption=with_decryption)
+        except ClientError:
+            LOGGER.error('Error getting parameter %s', parameter_name)
+            raise
+        else:
+            return response["Parameter"]["Value"]
+
+    @staticmethod
+    def put_parameter(name, value, region, kms_key_alias):
+        """puts a parameter into SSM Parameter store
+
+        Args:
+            name (str): The name of the parameter to save
+            value (str or dict): The value of the parameter to save
+            region (str): AWS region
+            kms_key_alias (str): The kms key alias in use for secrets
+
+        Returns:
+            bool: True if successful else False
+        """
+        client = boto3.client('ssm', config=default_config(region=region))
+        result = False
+
+        key_id = 'alias/{}'.format(kms_key_alias)
+        parameter_value = json.dumps(value) if isinstance(value, dict) else str(value)
+        try:
+            client.put_parameter(
+                Name=name,
+                Description='StreamAlert Secret',
+                Value=parameter_value,
+                Type='SecureString',
+                KeyId=key_id,
+                Overwrite=True,
+                Tier='Standard'
+            )
+        except ClientError as err:
+            LOGGER.exception(
+                'Error saving parameter %s to SSM Param Store\n%s',
+                name, err
+            )
+            result = False
+        else:
+            result = True
+
+        return result

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -179,11 +179,6 @@ def generate_main(config, init=False):
 
     # Configure initial S3 buckets
     main_dict['resource']['aws_s3_bucket'] = {
-        'streamalert_secrets': generate_s3_bucket(
-            # FIXME (derek.wang) DRY out by using OutputCredentialsProvider?
-            bucket='{}.streamalert.secrets'.format(config['global']['account']['prefix']),
-            logging=_config_get_logging_bucket(config)
-        ),
         'streamalerts': generate_s3_bucket(
             bucket='{}.streamalerts'.format(config['global']['account']['prefix']),
             logging=_config_get_logging_bucket(config)

--- a/terraform/modules/tf_alert_processor_iam/main.tf
+++ b/terraform/modules/tf_alert_processor_iam/main.tf
@@ -62,10 +62,11 @@ data "aws_iam_policy_document" "output_secrets" {
   // Allow retrieving encrypted output secrets
   statement {
     effect    = "Allow"
-    actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${var.prefix}.streamalert.secrets/*"]
+    actions   = ["ssm:GetParameter"]
+    resources = ["arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.prefix}_streamalert_secrets/*"]
   }
 }
+
 
 // Allow the Alert Processor to send to default firehose and S3 outputs
 resource "aws_iam_role_policy" "default_outputs" {

--- a/tests/unit/helpers/aws_mocks.py
+++ b/tests/unit/helpers/aws_mocks.py
@@ -23,6 +23,7 @@ from botocore.exceptions import ClientError
 
 from streamalert.shared.helpers.aws_api_client import AwsS3
 
+
 class MockLambdaClient:
     """http://boto3.readthedocs.io/en/latest/reference/services/lambda.html"""
 

--- a/tests/unit/streamalert/alert_processor/helpers.py
+++ b/tests/unit/streamalert/alert_processor/helpers.py
@@ -13,13 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import json
 import random
 
 from streamalert.alert_processor.outputs.credentials.provider import LocalFileDriver
 from streamalert.shared.alert import Alert
 from streamalert.shared.helpers.aws_api_client import AwsKms, AwsSsm
-from tests.unit.helpers.aws_mocks import put_mock_s3_object
 
 
 def get_random_alert(key_count, rule_name, omit_rule_desc=False):
@@ -86,15 +84,6 @@ def remove_temp_secrets():
 def encrypt_with_kms(data, region, alias):
     """Encrypt the given data with KMS."""
     return AwsKms.encrypt(data, region=region, key_alias=alias)
-
-
-def put_mock_creds(output_name, creds, bucket, region, alias):
-    """Helper function to mock encrypt creds and put on s3"""
-    creds_string = json.dumps(creds)
-
-    enc_creds = encrypt_with_kms(creds_string, region, alias)
-
-    put_mock_s3_object(bucket, output_name, enc_creds, region)
 
 
 def put_mock_ssm_parameters(parameter_name, parameter_value, kms_key_alias, region='us-east-1'):

--- a/tests/unit/streamalert/alert_processor/helpers.py
+++ b/tests/unit/streamalert/alert_processor/helpers.py
@@ -18,7 +18,7 @@ import random
 
 from streamalert.alert_processor.outputs.credentials.provider import LocalFileDriver
 from streamalert.shared.alert import Alert
-from streamalert.shared.helpers.aws_api_client import AwsKms
+from streamalert.shared.helpers.aws_api_client import AwsKms, AwsSsm
 from tests.unit.helpers.aws_mocks import put_mock_s3_object
 
 
@@ -95,3 +95,7 @@ def put_mock_creds(output_name, creds, bucket, region, alias):
     enc_creds = encrypt_with_kms(creds_string, region, alias)
 
     put_mock_s3_object(bucket, output_name, enc_creds, region)
+
+
+def put_mock_ssm_parameters(parameter_name, parameter_value, kms_key_alias, region='us-east-1'):
+    AwsSsm.put_parameter(parameter_name, parameter_value, region, kms_key_alias)

--- a/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,attribute-defined-outside-init
 from mock import Mock, patch, MagicMock
-from moto import mock_kms, mock_s3, mock_ssm
+from moto import mock_kms, mock_ssm
 from nose.tools import (
     assert_equal,
     assert_is_instance,
@@ -42,8 +42,6 @@ from tests.unit.streamalert.alert_processor import (
     PREFIX
 )
 from tests.unit.streamalert.alert_processor.helpers import (
-    put_mock_creds,
-    remove_temp_secrets,
     put_mock_ssm_parameters
 )
 

--- a/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_output_base.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 # pylint: disable=abstract-class-instantiated,protected-access,attribute-defined-outside-init
 from mock import Mock, patch, MagicMock
-from moto import mock_kms, mock_s3
+from moto import mock_kms, mock_s3, mock_ssm
 from nose.tools import (
     assert_equal,
     assert_is_instance,
@@ -38,11 +38,13 @@ from tests.unit.streamalert.alert_processor import (
     CONFIG,
     KMS_ALIAS,
     MOCK_ENV,
-    REGION
+    REGION,
+    PREFIX
 )
 from tests.unit.streamalert.alert_processor.helpers import (
     put_mock_creds,
-    remove_temp_secrets
+    remove_temp_secrets,
+    put_mock_ssm_parameters
 )
 
 
@@ -166,29 +168,27 @@ class TestOutputDispatcher:
         result = self._dispatcher._check_http_response(mock_response)
         assert_equal(result, False)
 
-    @mock_s3
+    @mock_ssm
     @mock_kms
     def test_load_creds(self):
         """OutputDispatcher - Load Credentials"""
-        remove_temp_secrets()
-        key = get_formatted_output_credentials_name(
-            'test_service',
-            self._descriptor
+        param_name = '/{}_streamalert_secrets/{}'.format(
+            PREFIX, get_formatted_output_credentials_name('test_service', self._descriptor)
         )
 
-        creds = {'url': 'http://www.foo.bar/test',
-                 'token': 'token_to_encrypt'}
+        creds = {
+            'url': 'http://www.foo.bar/test',
+            'token': 'token_to_encrypt'
+        }
 
-        put_mock_creds(key, creds,
-                       self._dispatcher._credentials_provider._core_driver._bucket,
-                       REGION, KMS_ALIAS)
+        put_mock_ssm_parameters(param_name, creds, KMS_ALIAS, region=REGION)
 
         loaded_creds = self._dispatcher._load_creds(self._descriptor)
 
         assert_is_not_none(loaded_creds)
         assert_equal(len(loaded_creds), 2)
-        assert_equal(loaded_creds['url'], 'http://www.foo.bar/test')
-        assert_equal(loaded_creds['token'], 'token_to_encrypt')
+        assert_equal(loaded_creds['url'], creds['url'])
+        assert_equal(loaded_creds['token'], creds['token'])
 
     def test_format_output_config(self):
         """OutputDispatcher - Format Output Config"""

--- a/tests/unit/streamalert/shared/test_aws_api_client.py
+++ b/tests/unit/streamalert/shared/test_aws_api_client.py
@@ -13,15 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import tempfile
-
 from botocore.exceptions import ClientError
 from mock import patch
-from moto import mock_kms, mock_s3
+from moto import mock_kms
 from nose.tools import assert_equal, raises
 
-from streamalert.shared.helpers.aws_api_client import AwsS3, AwsKms
-from tests.unit.helpers.aws_mocks import put_mock_s3_object
+from streamalert.shared.helpers.aws_api_client import AwsKms
 from tests.unit.streamalert.alert_processor import KMS_ALIAS, REGION
 
 
@@ -51,34 +48,3 @@ class TestAwsKms:
         }
         boto_mock.side_effect = ClientError(response, 'operation')
         AwsKms.encrypt('secret', region=REGION, key_alias=KMS_ALIAS)
-
-
-class TestAwsS3:
-
-    @staticmethod
-    @mock_s3
-    def test_put_download():
-        """AwsApiClient - AwsS3 - PutObject/Download - Upload then download object"""
-        payload = 'zzzzz'.encode()
-        bucket = 'bucket'
-        key = 'key'
-
-        # Annoyingly, moto needs us to create the bucket first
-        # We put a random unrelated object into the bucket and this will set up the bucket for us
-        put_mock_s3_object(bucket, 'aaa', 'bbb', REGION)
-
-        AwsS3.put_object(payload, bucket=bucket, key=key, region=REGION)
-
-        with tempfile.SpooledTemporaryFile(0, 'a+b') as file_handle:
-            result = AwsS3.download_fileobj(file_handle, bucket=bucket, key=key, region=REGION)
-
-        assert_equal(result, payload)
-
-    @staticmethod
-    @raises(ClientError)
-    @mock_s3
-    def test_put_object_s3_failure():
-        """AwsApiClient - AwsS3 - PutObject - S3 Failure"""
-
-        # S3 will automatically fail because the bucket has not been created yet.
-        AwsS3.put_object('zzzpayload', bucket='aaa', key='zzz', region=REGION)

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -127,28 +127,6 @@ class TestTerraformGenerate:
                     }
                 },
                 'aws_s3_bucket': {
-                    'streamalert_secrets': {
-                        'bucket': 'unit-test.streamalert.secrets',
-                        'acl': 'private',
-                        'force_destroy': True,
-                        'versioning': {
-                            'enabled': True
-                        },
-                        'logging': {
-                            'target_bucket': 'unit-test.streamalert.s3-logging',
-                            'target_prefix': 'unit-test.streamalert.secrets/'
-                        },
-                        'server_side_encryption_configuration': {
-                            'rule': {
-                                'apply_server_side_encryption_by_default': {
-                                    'sse_algorithm': 'aws:kms',
-                                    'kms_master_key_id': (
-                                        '${aws_kms_key.server_side_encryption.key_id}')
-                                }
-                            }
-                        },
-                        'policy': ANY
-                    },
                     'terraform_remote_state': {
                         'bucket': 'unit-test.streamalert.terraform.state',
                         'acl': 'private',


### PR DESCRIPTION
to: @ryandeivert @Ryxias 
cc: @airbnb/streamalert-maintainers
related to: #240
resolves: #240

## Background

Using S3 as a `secret_store` is no longer desirable. Using SSM Parameter store makes visibility into what secrets are set much easier and requires less setup by StreamAlert

## Changes

* Implemented SSMDriver (a bit of `copy&pasta` from the S3Driver)
* Updated unit_tests so they pass when using this new driver
* Removed secrets bucket creation
* Added `ssm:GetParameter` permissions to the `alert_processor`

## Testing

* ran `./tests/scripts/pylint.sh` - currently there are warnings (i aim to clean this code up but want to ensure this initial commit is good)
* ran `./tests/scripts/unit_tests.sh` - All created tests now pass, i need to add some for SSMDriver