### PR TITLE
[schemas] adding alias field to duo auth logs schema

### DIFF
--- a/conf/schemas/duo.json
+++ b/conf/schemas/duo.json
@@ -12,6 +12,7 @@
   "duo:authentication": {
     "schema": {
       "access_device": {},
+      "alias": "string",
       "device": "string",
       "factor": "string",
       "integration": "string",

--- a/streamalert/apps/_apps/duo.py
+++ b/streamalert/apps/_apps/duo.py
@@ -99,19 +99,30 @@ class DuoApp(AppIntegration):
         Returns:
             [
                 {
-                    'timestamp': <int:unix timestamp>,
-                    'device': <str:device>,
-                    'username': <str:username>,
-                    'factor': <str:factor>,
-                    'result': <str:result>,
-                    'ip': <str:ip address>,
-                    'new_enrollment': <bool:if event corresponds to enrollment>,
-                    'integration': <str:integration>,
+                    'access_device': {
+                        'browser': 'Chrome',
+                        'browser_version': '1.2.3',
+                        'flash_version': 'uninstalled',
+                        'java_version': 'uninstalled',
+                        'os': 'Mac OS X',
+                        'os_version': '10.15.3',
+                        'trusted_endpoint_status': 'unknown'
+                    },
+                    'alias': '',
+                    'device': '123-456-7890',
+                    'factor': 'Duo Push',
+                    'integration': 'web.site.com',
+                    'ip': '1.1.1.1',
                     'location': {
-                        'state': '<str:state>',
-                        'city': '<str:city>',
-                        'country': '<str:country>'
-                    }
+                        'city': 'Portland',
+                        'country': 'US',
+                        'state': 'Oregon'
+                    },
+                    'new_enrollment': False,
+                    'reason': 'User approved',
+                    'result': 'SUCCESS',
+                    'timestamp': 1581705165,
+                    'username': 'user.name@site.com'
                 }
             ]
         """

--- a/tests/integration/rules/duo/duo_anonymous_ip_failure.json
+++ b/tests/integration/rules/duo/duo_anonymous_ip_failure.json
@@ -1,29 +1,30 @@
 [
   {
     "data": {
-      "username": "user.name@email.com",
       "access_device": {
+        "browser": "Chrome",
+        "browser_version": "60.0.0000.80",
         "flash_version": "27.0.0.0",
         "java_version": "uninstalled",
-        "os_version": "10.12.6",
-        "browser_version": "60.0.0000.80",
-        "trusted_endpoint_status": "not trusted",
         "os": "Mac OS X",
-        "browser": "Chrome"
+        "os_version": "10.12.6",
+        "trusted_endpoint_status": "not trusted"
       },
-      "timestamp": 1505316499,
-      "new_enrollment": false,
-      "ip": "12.123.123.12",
+      "alias": "",
+      "device": "555-123-4567",
+      "factor": "Duo Push",
       "integration": "Test Integration",
-      "reason": "Anonymous IP",
+      "ip": "12.123.123.12",
       "location": {
         "city": "Place",
-        "state": "State",
-        "country": "US"
+        "country": "US",
+        "state": "State"
       },
-      "factor": "Duo Push",
-      "device": "555-123-4567",
-      "result": "FAILURE"
+      "new_enrollment": false,
+      "reason": "Anonymous IP",
+      "result": "FAILURE",
+      "timestamp": 1505316499,
+      "username": "user.name@email.com"
     },
     "description": "Duo authentication log marked as failure as a result of 'Anonymous IP' that will create an alert",
     "log": "duo:authentication",

--- a/tests/integration/rules/duo/duo_fraud.json
+++ b/tests/integration/rules/duo/duo_fraud.json
@@ -10,6 +10,7 @@
         "os_version": "10.12.6",
         "trusted_endpoint_status": "not trusted"
       },
+      "alias": "",
       "device": "555-123-4567",
       "factor": "Duo Push",
       "integration": "Test Integration",
@@ -44,6 +45,7 @@
         "os_version": "10.12.6",
         "trusted_endpoint_status": "not trusted"
       },
+      "alias": "",
       "device": "555-123-5678",
       "factor": "Duo Push",
       "integration": "Test Integration",

--- a/tests/unit/streamalert/apps/test_apps/test_duo.py
+++ b/tests/unit/streamalert/apps/test_apps/test_duo.py
@@ -81,6 +81,7 @@ class TestDuoApp:
         """Helper function for returning sample duo (auth) logs"""
         return [{
             'access_device': {},
+            'alias': '',
             'device': '+1 123 456 1234',
             'factor': 'Duo Push',
             'integration': 'Test Access',


### PR DESCRIPTION
to: @chunyong-lin / @blakemotl 
cc: @airbnb/streamalert-maintainers

## Background

DUO added a new key to authentication logs that is breaking classification.

## Changes

* Adding `alias` field to schema

### Note
Please don't suggest adding this as an optional key. I am purposely not adding it as one because that isn't really a thing with APIs that are feeding us data. The intent of "optionals" lets different endpoints have different versions of sensors to allow for backwards/forwards compatibility.

## Testing

Updates to unit tests and rule tests.
