### PR TITLE
Refactors StreamQuery a little to "hide" the ServiceContainer

### DIFF
--- a/streamalert/scheduled_queries/config/lambda_conf.py
+++ b/streamalert/scheduled_queries/config/lambda_conf.py
@@ -15,11 +15,14 @@ limitations under the License.
 """
 import os
 
-parameters = {
-    'command_name': 'StreamQuery',
-    'aws_region': os.environ['REGION'],
-    'log_level': os.environ['LOGGER_LEVEL'],
-    'athena_database': os.environ['ATHENA_DATABASE'],
-    'athena_results_bucket': os.environ['ATHENA_RESULTS_BUCKET'],
-    'kinesis_stream': os.environ['KINESIS_STREAM'],
-}
+
+def get_streamquery_env_vars():
+    """Returns environment variables pertinent to StreamQuery"""
+    return {
+        'command_name': 'StreamQuery',
+        'aws_region': os.environ['REGION'],
+        'log_level': os.environ['LOGGER_LEVEL'],
+        'athena_database': os.environ['ATHENA_DATABASE'],
+        'athena_results_bucket': os.environ['ATHENA_RESULTS_BUCKET'],
+        'kinesis_stream': os.environ['KINESIS_STREAM'],
+    }

--- a/streamalert/scheduled_queries/config/services.py
+++ b/streamalert/scheduled_queries/config/services.py
@@ -88,51 +88,51 @@ def configure_container(container):
     container.register(ServiceDefinition('boto3_kinesis_client', _make_boto3_kinesis_client))
 
 
-def _make_command_processor(_container):
+def _make_command_processor(container):
     return CommandProcessor(
-        logger=_container.get('logger'),
-        kinesis=_container.get('streamalert_forwarder'),
-        state_manager=_container.get('state_manager'),
-        manager_factory=_container.get('query_pack_manager_factory')
+        logger=container.get('logger'),
+        kinesis=container.get('streamalert_forwarder'),
+        state_manager=container.get('state_manager'),
+        manager_factory=container.get('query_pack_manager_factory')
     )
 
 
-def _make_logger(_container):
-    logger = logging.getLogger(_container.get_parameter('command_name'))
-    logger.setLevel(_container.get_parameter('log_level').upper())
+def _make_logger(container):
+    logger = logging.getLogger(container.get_parameter('command_name'))
+    logger.setLevel(container.get_parameter('log_level').upper())
     logging.basicConfig(
         format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s'
     )
     return logger
 
 
-def _make_kinesis(_container):
+def _make_kinesis(container):
     return KinesisClient(
-        logger=_container.get('logger'),
-        client=_container.get('boto3_kinesis_client'),
-        kinesis_stream=_container.get_parameter('kinesis_stream')
+        logger=container.get('logger'),
+        client=container.get('boto3_kinesis_client'),
+        kinesis_stream=container.get_parameter('kinesis_stream')
     )
 
 
-def _make_cache(_container):
+def _make_cache(container):
     cache = StateManager(
-        logger=_container.get('logger')
+        logger=container.get('logger')
     )
 
     return cache
 
 
-def _make_athena(_container):
+def _make_athena(container):
     return AthenaClient(
-        logger=_container.get('logger'),
-        client=_container.get('boto3_athena_client'),
-        database=_container.get_parameter('athena_database'),
-        results_bucket=_container.get_parameter('athena_results_bucket')
+        logger=container.get('logger'),
+        client=container.get('boto3_athena_client'),
+        database=container.get_parameter('athena_database'),
+        results_bucket=container.get_parameter('athena_results_bucket')
     )
 
 
-def _make_param_generator(_container):
-    return QueryParameterGenerator(_container.get('logger'), _container.get('clock'))
+def _make_param_generator(container):
+    return QueryParameterGenerator(container.get('logger'), container.get('clock'))
 
 
 def _make_query_pack_repo(_):
@@ -141,20 +141,20 @@ def _make_query_pack_repo(_):
     return repo
 
 
-def _make_query_pack_factory(_container):
+def _make_query_pack_factory(container):
     return QueryPacksManagerFactory(
-        _container.get('query_pack_execution_context')
+        container.get('query_pack_execution_context')
     )
 
 
-def _make_execution_context(_container):
+def _make_execution_context(container):
     return QueryPackExecutionContext(
-        cache=_container.get('state_manager'),
-        athena=_container.get('athena'),
-        logger=_container.get('logger'),
-        params=_container.get('query_parameter_generator'),
-        repository=_container.get('query_pack_repository'),
-        clock=_container.get('clock')
+        cache=container.get('state_manager'),
+        athena=container.get('athena'),
+        logger=container.get('logger'),
+        params=container.get('query_parameter_generator'),
+        repository=container.get('query_pack_repository'),
+        clock=container.get('clock')
     )
 
 
@@ -162,9 +162,9 @@ def _make_clock(_):
     return Clock()
 
 
-def _make_boto3_athena_client(_container):
-    region = _container.get_parameter('aws_region')
-    logger = _container.get('logger')
+def _make_boto3_athena_client(container):
+    region = container.get_parameter('aws_region')
+    logger = container.get('logger')
 
     config = botocore_client.Config(
         connect_timeout=5,
@@ -183,9 +183,9 @@ def _make_boto3_athena_client(_container):
         logger.error('AWS Athena Connection via Profile Failed')
 
 
-def _make_boto3_kinesis_client(_container):
-    region = _container.get_parameter('aws_region')
-    logger = _container.get('logger')
+def _make_boto3_kinesis_client(container):
+    region = container.get_parameter('aws_region')
+    logger = container.get('logger')
 
     config = botocore_client.Config(
         connect_timeout=5,

--- a/streamalert/scheduled_queries/config/services.py
+++ b/streamalert/scheduled_queries/config/services.py
@@ -20,7 +20,8 @@ from botocore import client as botocore_client
 from botocore.exceptions import ProfileNotFound
 
 from streamalert.scheduled_queries.command.processor import CommandProcessor
-from streamalert.scheduled_queries.container.container import ServiceDefinition
+from streamalert.scheduled_queries.config.lambda_conf import get_streamquery_env_vars
+from streamalert.scheduled_queries.container.container import ServiceDefinition, ServiceContainer
 from streamalert.scheduled_queries.handlers.athena import AthenaClient
 from streamalert.scheduled_queries.query_packs.configuration import QueryPackRepository
 from streamalert.scheduled_queries.query_packs.manager import (
@@ -28,9 +29,42 @@ from streamalert.scheduled_queries.query_packs.manager import (
     QueryPacksManagerFactory,
     QueryParameterGenerator,
 )
-from streamalert.scheduled_queries.state.state_manager import StateManager
+from streamalert.scheduled_queries.state.state_manager import StateManager, StepFunctionStateManager
 from streamalert.scheduled_queries.streamalert.kinesis import KinesisClient
 from streamalert.scheduled_queries.support.clock import Clock
+
+
+# FIXME (Ryxias)
+#   Eventually we should get rid of the ServiceContainer. This pattern isn't really in the spirit
+#   of StreamAlert and is a relic from when StreamQuery was a separately maintained project.
+class ApplicationServices:
+    def __init__(self):
+        # Boot the service container
+        self._service_container = ServiceContainer(get_streamquery_env_vars())
+        configure_container(self._service_container)
+
+    @property
+    def logger(self):
+        return self._service_container.get('logger')
+
+    @property
+    def command_processor(self):
+        return self._service_container.get('command_processor')
+
+    @property
+    def state_manager(self):
+        return self._service_container.get('state_manager')
+
+    @property
+    def clock(self):
+        return self._service_container.get('clock')
+
+    def create_step_function_state_manager(self):
+        return StepFunctionStateManager(
+            self.state_manager,
+            self.logger,
+            self.clock
+        )
 
 
 # pylint: disable=too-many-statements
@@ -40,117 +74,128 @@ def configure_container(container):
     Params:
         container (ServiceContainer)
     """
+    container.register(ServiceDefinition('command_processor', _make_command_processor))
+    container.register(ServiceDefinition('logger', _make_logger))
+    container.register(ServiceDefinition('streamalert_forwarder', _make_kinesis))
+    container.register(ServiceDefinition('state_manager', _make_cache))
+    container.register(ServiceDefinition('athena', _make_athena))
+    container.register(ServiceDefinition('query_parameter_generator', _make_param_generator))
+    container.register(ServiceDefinition('query_pack_repository', _make_query_pack_repo))
+    container.register(ServiceDefinition('query_pack_manager_factory', _make_query_pack_factory))
+    container.register(ServiceDefinition('query_pack_execution_context', _make_execution_context))
+    container.register(ServiceDefinition('clock', _make_clock))
+    container.register(ServiceDefinition('boto3_athena_client', _make_boto3_athena_client))
+    container.register(ServiceDefinition('boto3_kinesis_client', _make_boto3_kinesis_client))
 
-    def make_command_processor(_container):
-        return CommandProcessor(
-            logger=_container.get('logger'),
-            kinesis=_container.get('streamalert_forwarder'),
-            state_manager=_container.get('state_manager'),
-            manager_factory=_container.get('query_pack_manager_factory')
+
+def _make_command_processor(_container):
+    return CommandProcessor(
+        logger=_container.get('logger'),
+        kinesis=_container.get('streamalert_forwarder'),
+        state_manager=_container.get('state_manager'),
+        manager_factory=_container.get('query_pack_manager_factory')
+    )
+
+
+def _make_logger(_container):
+    logger = logging.getLogger(_container.get_parameter('command_name'))
+    logger.setLevel(_container.get_parameter('log_level').upper())
+    logging.basicConfig(
+        format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s'
+    )
+    return logger
+
+
+def _make_kinesis(_container):
+    return KinesisClient(
+        logger=_container.get('logger'),
+        client=_container.get('boto3_kinesis_client'),
+        kinesis_stream=_container.get_parameter('kinesis_stream')
+    )
+
+
+def _make_cache(_container):
+    cache = StateManager(
+        logger=_container.get('logger')
+    )
+
+    return cache
+
+
+def _make_athena(_container):
+    return AthenaClient(
+        logger=_container.get('logger'),
+        client=_container.get('boto3_athena_client'),
+        database=_container.get_parameter('athena_database'),
+        results_bucket=_container.get_parameter('athena_results_bucket')
+    )
+
+
+def _make_param_generator(_container):
+    return QueryParameterGenerator(_container.get('logger'), _container.get('clock'))
+
+
+def _make_query_pack_repo(_):
+    repo = QueryPackRepository
+    repo.load_packs()
+    return repo
+
+
+def _make_query_pack_factory(_container):
+    return QueryPacksManagerFactory(
+        _container.get('query_pack_execution_context')
+    )
+
+
+def _make_execution_context(_container):
+    return QueryPackExecutionContext(
+        cache=_container.get('state_manager'),
+        athena=_container.get('athena'),
+        logger=_container.get('logger'),
+        params=_container.get('query_parameter_generator'),
+        repository=_container.get('query_pack_repository'),
+        clock=_container.get('clock')
+    )
+
+
+def _make_clock(_):
+    return Clock()
+
+
+def _make_boto3_athena_client(_container):
+    region = _container.get_parameter('aws_region')
+    logger = _container.get('logger')
+
+    config = botocore_client.Config(
+        connect_timeout=5,
+        read_timeout=5,
+        region_name=region
+    )
+
+    session_kwargs = {}
+    try:
+        session = boto3.Session(**session_kwargs)
+        return session.client(
+            'athena',
+            config=config,
         )
+    except ProfileNotFound:
+        logger.error('AWS Athena Connection via Profile Failed')
 
-    def make_logger(_container):
-        logger = logging.getLogger(_container.get_parameter('command_name'))
-        logger.setLevel(_container.get_parameter('log_level').upper())
-        logging.basicConfig(
-            format='%(name)s [%(levelname)s]: [%(module)s.%(funcName)s] %(message)s'
-        )
-        return logger
 
-    def make_kinesis(_container):
-        return KinesisClient(
-            logger=_container.get('logger'),
-            client=_container.get('boto3_kinesis_client'),
-            kinesis_stream=_container.get_parameter('kinesis_stream')
-        )
+def _make_boto3_kinesis_client(_container):
+    region = _container.get_parameter('aws_region')
+    logger = _container.get('logger')
 
-    def make_cache(_container):
-        cache = StateManager(
-            logger=_container.get('logger')
-        )
+    config = botocore_client.Config(
+        connect_timeout=5,
+        read_timeout=5,
+        region_name=region
+    )
 
-        return cache
-
-    def make_athena(_container):
-        return AthenaClient(
-            logger=_container.get('logger'),
-            client=_container.get('boto3_athena_client'),
-            database=_container.get_parameter('athena_database'),
-            results_bucket=_container.get_parameter('athena_results_bucket')
-        )
-
-    def make_param_generator(_container):
-        return QueryParameterGenerator(_container.get('logger'), _container.get('clock'))
-
-    def make_query_pack_repo(_):
-        repo = QueryPackRepository
-        repo.load_packs()
-        return repo
-
-    def make_query_pack_factory(_container):
-        return QueryPacksManagerFactory(
-            _container.get('query_pack_execution_context')
-        )
-
-    def make_execution_context(_container):
-        return QueryPackExecutionContext(
-            cache=_container.get('state_manager'),
-            athena=_container.get('athena'),
-            logger=_container.get('logger'),
-            params=_container.get('query_parameter_generator'),
-            repository=_container.get('query_pack_repository'),
-            clock=_container.get('clock')
-        )
-
-    def make_clock(_):
-        return Clock()
-
-    def make_boto3_athena_client(_container):
-        region = _container.get_parameter('aws_region')
-        logger = _container.get('logger')
-
-        config = botocore_client.Config(
-            connect_timeout=5,
-            read_timeout=5,
-            region_name=region
-        )
-
-        session_kwargs = {}
-        try:
-            session = boto3.Session(**session_kwargs)
-            return session.client(
-                'athena',
-                config=config,
-            )
-        except ProfileNotFound:
-            logger.error('AWS Athena Connection via Profile Failed')
-
-    def make_boto3_kinesis_client(_container):
-        region = _container.get_parameter('aws_region')
-        logger = _container.get('logger')
-
-        config = botocore_client.Config(
-            connect_timeout=5,
-            read_timeout=5,
-            region_name=region
-        )
-
-        session_kwargs = {}
-        try:
-            session = boto3.Session(**session_kwargs)
-            return session.client('kinesis', config=config)
-        except ProfileNotFound:
-            logger.error('AWS Kinesis Connection via Profile Failed')
-
-    container.register(ServiceDefinition('command_processor', make_command_processor))
-    container.register(ServiceDefinition('logger', make_logger))
-    container.register(ServiceDefinition('streamalert_forwarder', make_kinesis))
-    container.register(ServiceDefinition('state_manager', make_cache))
-    container.register(ServiceDefinition('athena', make_athena))
-    container.register(ServiceDefinition('query_parameter_generator', make_param_generator))
-    container.register(ServiceDefinition('query_pack_repository', make_query_pack_repo))
-    container.register(ServiceDefinition('query_pack_manager_factory', make_query_pack_factory))
-    container.register(ServiceDefinition('query_pack_execution_context', make_execution_context))
-    container.register(ServiceDefinition('clock', make_clock))
-    container.register(ServiceDefinition('boto3_athena_client', make_boto3_athena_client))
-    container.register(ServiceDefinition('boto3_kinesis_client', make_boto3_kinesis_client))
+    session_kwargs = {}
+    try:
+        session = boto3.Session(**session_kwargs)
+        return session.client('kinesis', config=config)
+    except ProfileNotFound:
+        logger.error('AWS Kinesis Connection via Profile Failed')

--- a/streamalert/scheduled_queries/handlers/athena.py
+++ b/streamalert/scheduled_queries/handlers/athena.py
@@ -23,6 +23,9 @@ class AthenaQueryExecutionError(Exception):
     """Exception to be raised when an Athena query fails"""
 
 
+# FIXME (ryxias)
+#   At some point we should DRY out the implementation of this API client with the one in
+#   streamalert/shared/athena.py
 class AthenaClient:
     """A StreamAlert Athena Client for creating tables, databases, and executing queries"""
 

--- a/streamalert/scheduled_queries/query_packs/manager.py
+++ b/streamalert/scheduled_queries/query_packs/manager.py
@@ -80,7 +80,7 @@ class QueryPack:
             param: self._execution_context.parameter_generator.generate(param)
             for param in self._configuration.query_parameters
         }
-        self._query_string = self.generate_query_string()
+        self._query_string = None
 
     @property
     def unique_id(self):
@@ -185,7 +185,8 @@ class QueryPack:
         self._execution_context.logger.debug(
             'Generated Parameters: {}'.format(json.dumps(params, indent=2))
         )
-        return self._configuration.generate_query(**params)
+        self._query_string = self._configuration.generate_query(**params)
+        return self._query_string
 
 
 class QueryPacksManagerFactory:

--- a/streamalert/scheduled_queries/state/state_manager.py
+++ b/streamalert/scheduled_queries/state/state_manager.py
@@ -13,11 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import json
+from datetime import datetime
 
 
 class StateManager:
-    """Encapsulation of a caching system that is currently backed by the filesystem"""
+    """Encapsulation of a caching system that is currently backed by the filesystem
+
+    The "state" of a StreamQuery execution is encapsulated by
+    """
 
     def __init__(self, logger=None):
         self._logger = logger
@@ -53,50 +56,105 @@ class StateManager:
         return self._data
 
 
-class FileWritingStateManager:
-    def __init__(self, state_manager, cache_file, logger):
-        self._state_manager = state_manager
-        self._cache_file = cache_file
-        self._logger = logger
-
-    def write_to_file(self):
-        with open(self._cache_file, 'w+') as output:
-            # pylint: disable=protected-access
-            data = self._state_manager._dangerously_get_all_data()
-            schema_string = json.dumps(data, indent=2, separators=(',', ': '))
-            output.write(schema_string + '\n')  # Ensure a newline at the EOF
-            self._logger.info('Successfully wrote to target file: %s', self._cache_file)
-
-    def load_from_file(self):
-        try:
-            with open(self._cache_file, 'r+') as file:
-                # pylint: disable=protected-access
-                self._state_manager._dangerously_set_all_data(json.load(file))
-        except FileNotFoundError:
-            # Assume this is benign and that we simply haven't created a cache file yet
-            return
-        except json.decoder.JSONDecodeError:
-            # The cache is corrupted
-            self._logger.error('Cache corrupted. Rebuilding cache...')
-
-
 class StepFunctionStateManager:
-    def __init__(self, state_manager, logger):
+    """State management when using AWS Step Functions
+
+    The State of a step function is stored in a JSON blob that is passed from one State Machine
+    state to the next. In states that execute Lambda functions, the state is passed in via the
+    JSON event trigger.
+    """
+
+    def __init__(self, state_manager, logger, clock):
         self._state_manager = state_manager
         self._logger = logger
+        self._clock = clock
 
     def load_from_step_function_event(self, event):
+        """Given a lambda input event, loads the execution state of this StreamQuery iteration.
+
+        When using Step Functions, lambda receives the state machine's state as the input event.
+
+        ON FIRST execution, the expected event looks like this:
+
+        {
+          "name": "streamquery_cloudwatch_trigger",
+          "event_id": "abcdabcd-1234-5678-1234-000001200000",
+          "source_arn": "arn:aws:events:us-east-1:123456789012:rule/myprefix_schedule_thing",
+          "streamquery_configuration": {
+            "clock": "2020-02-18T23:55:16Z",
+            "tags": [
+              "hourly",
+              "production"
+            ]
+          }
+        }
+
+        This represents the state of the Step Function state machine when it is first triggered
+        by CloudWatch. In the above event, the event is generated via CloudWatch. The
+        "streamquery_configuration" node is used to configure the lambda execution.
+
+            @see terraform/modules/tf_scheduled_queries/cloudwatch_schedule.tf
+
+
+        Henceforth, the "state" is always stored under a single key, "step_function_state".
+        In these subsequent executions, the expected input event looks like this:
+
+        {
+          "done": 0,
+          "continue": 1,
+          "step_function_state": {
+            "streamquery_configuration": {
+              "clock": "2020-02-18T23:55:16Z",
+              "tags": [
+                "hourly",
+                "production"
+              ]
+            },
+            "my_query": {
+              "query_execution_id": "70e509ed-c992-4096-8882-6bb070578347"
+            },
+            "my_other_query": {
+              "query_execution_id": "b56cf6f3-d760-4abe-9345-fccd9cfa05e8"
+            },
+            "my_done_query": {
+              "query_execution_id": "beeffc15-7608-48b4-89a4-a8e7ea81c5e6",
+              "sent_to_streamalert": true
+            }
+            ...
+          }
+        }
+
+        This "step_function_state" stores both the configuration (tags & clock), as well as the
+        execution states of the scheduled queries.
+
+        The "done" and "continue" flags at the stop of the event are
+        """
         # pylint: disable=protected-access
         self._state_manager._dangerously_set_all_data(event.get('step_function_state', {}))
         self._logger.info('Successfully loaded from Step Function Event')
 
-        # Special; if the event contains this key we load the configuration:
+        # Special; The first time we execute the function, our "step_function_state" is empty, so
+        # we will not have the streamquery_configuration set up. This code loads it from the
+        # input event. Henceforth, this "streamquery_configuration" will be saved to and loaded
+        # from "step_function_state".
         if 'streamquery_configuration' in event:
             # We expect 2 keys to exist, passed in from the CloudWatch rule input transformer:
             #   - clock: ISO timestamp in UTC
             #   - tags:  Array of strings
             self._logger.info('Loading configuration from first-run...')
             self._state_manager.set('streamquery_configuration', event['streamquery_configuration'])
+
+        # Now, wind the clock to the correct time, based upon the configuration
+        isotime = self._state_manager.get('streamquery_configuration', {}).get('clock', False)
+        if isotime:
+            clock_datetime = datetime.strptime(isotime, "%Y-%m-%dT%H:%M:%SZ")
+            self._clock.time_machine(clock_datetime)
+            self._logger.info('Winding clock to %s...', self._clock.now)
+        else:
+            self._logger.warning(
+                'No clock configuration provided. Defaulting to %s',
+                self._clock.now
+            )
 
     def write_to_step_function_response(self, response):
         response.update({

--- a/tests/unit/streamalert/scheduled_queries/query_packs/test_manager.py
+++ b/tests/unit/streamalert/scheduled_queries/query_packs/test_manager.py
@@ -262,18 +262,15 @@ class TestQueryParameterGenerator:
         )
 
 
-class TestQueryPacksManagerFactory:
-    """This is just here for coverage..."""
+@patch('streamalert.scheduled_queries.query_packs.manager.QueryPacksManager')
+def test_new_manager(constructor_spy):
+    """StreamQuery - QueryPacksManagerFactory - new_manager"""
+    context = MagicMock(name='MockedExecutionContext')
+    factory = QueryPacksManagerFactory(context)
 
-    @patch('streamalert.scheduled_queries.query_packs.manager.QueryPacksManager')
-    def test_new_manager(self, constructor_spy):
-        """StreamQuery - QueryPacksManagerFactory - new_manager"""
-        context = MagicMock(name='MockedExecutionContext')
-        factory = QueryPacksManagerFactory(context)
+    instance = MagicMock(name='MockedManager')
+    constructor_spy.return_value = instance
 
-        instance = MagicMock(name='MockedManager')
-        constructor_spy.return_value = instance
+    assert_equals(factory.new_manager(), instance)
 
-        assert_equals(factory.new_manager(), instance)
-
-        constructor_spy.assert_called_with(context)
+    constructor_spy.assert_called_with(context)


### PR DESCRIPTION
to: @ryandeivert @blakemotl @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Was following up PR #1128 with some refactoring

## Changes

* The `ServiceContainer` is a controversial point which is rather hard to refactor out of StreamQuery at this time. I decided to "hide it" with a layer of [David Wheeler's dreaded *indirection*](https://en.wikipedia.org/wiki/Indirection). Guess his aphorism holds true. This new layer is the [`ApplicationServices` class](https://github.com/airbnb/streamalert/pull/1130/files#diff-c7c50c03b935b677633e8db443006aaeR40-R67), which is intended to hide the Service Container and its usage through the services.py file
* I greatly expanded the doc blocks available in the Lambda function handler. I think this was important to make it easier to figure out "how" StreamQuery works
* Removed `FileWritingStateManager` as we no longer use that
* Improved test coverage

## Why is the ServiceContainer hard to refactor?

The ServiceContainer implements a classical [Inversion of Control container](https://www.martinfowler.com/articles/injection.html), and one of the extremely key elements to it is singleton services, particularly the `StateManager`.

Since it's not really Pythonic to do IoC, the **_right_** way to refactor this is to extract the `StateManager` into an object, not a service, and to pass it around as the application state.

This isn't a _huge_ refactor but it's probably a bit too risky for now. I'll do it later

## Testing

Deployed it to staging and observed that it's working properly
