### PR TITLE
[rules] Added AWS Config Compliance and Remediation Rules

### DIFF
--- a/rules/community/cloudtrail/cloudtrail_aws_config.py
+++ b/rules/community/cloudtrail/cloudtrail_aws_config.py
@@ -1,0 +1,47 @@
+"""Alert on AWS Config"""
+from rules.matchers.matchers import AwsConfigMatcher
+from streamalert.shared.rule import rule
+
+
+# Populate this list to alert on specific Config Rules, otherwise all rules will be in-scope
+# Also consider the use of Lookup-Tables
+RULES_TO_ALERT_ON = []
+
+
+@rule(logs=["cloudtrail:events"], matchers=[AwsConfigMatcher.is_config_compliance])
+def config_compliance(record):
+    """
+    author:         jack (jack1902)
+    description:    Alert on AWS Config Complaince Change events of NON_COMPLIANT
+    testing:        From the Config page (https://console.aws.amazon.com/config/home)
+                    ensure recording is turned on. And you have a basic rule you can
+                    trigger as compliant or non-compliant.
+    """
+
+    non_compliance_present = any(
+        evaluation["complianceType"] == "NON_COMPLIANT"
+        for evaluation in record["requestParameters"]["evaluations"]
+    )
+
+    if RULES_TO_ALERT_ON:
+        # Alert on specific rule names. Useful when some Config Rules are just TOO noisy.
+        rule_name = record["additionalEventData"]["configRuleName"]
+        result = rule_name in RULES_TO_ALERT_ON and non_compliance_present
+    else:
+        # Alert on ALL config rules regardless of their name
+        result = non_compliance_present
+
+    return result
+
+
+@rule(logs=["cloudtrail:events"], matchers=[AwsConfigMatcher.is_auto_remediation])
+def config_auto_remediation(_):
+    """
+    author:         jack (jack1902)
+    description:    Alert on AWS Config Auto Remediation
+    testing:        From the Config page (https://console.aws.amazon.com/config/home)
+                    ensure recording is turned on. And you have a basic rule you can
+                    trigger as compliant or non-compliant. Then trigger the remediation
+                    either manually or have it done automatically.
+    """
+    return True

--- a/rules/community/guardduty/guard_duty_all.py
+++ b/rules/community/guardduty/guard_duty_all.py
@@ -1,9 +1,9 @@
 """Alert on GuardDuty"""
-from rules.matchers.matchers import GuardDutyMatcher
+from rules.matchers.matchers import AwsGuardDutyMatcher
 from streamalert.shared.rule import rule
 
 
-@rule(logs=['cloudwatch:events'], matchers=[GuardDutyMatcher.guard_duty])
+@rule(logs=['cloudwatch:events'], matchers=[AwsGuardDutyMatcher.guard_duty])
 def guard_duty_all(*_):
     """
     author:         spiper

--- a/rules/matchers/matchers.py
+++ b/rules/matchers/matchers.py
@@ -14,7 +14,7 @@ You can also supply multiple matchers for many common scenarios:
 @rule('root_logins', logs=['osquery:differential'],
       matchers=[matchers.prod, matchers.pci], outputs=['pagerduty:sample-integration'])
 """
-class GuardDutyMatcher:
+class AwsGuardDutyMatcher:
     """A class contains matchers for AWS GuardDuty service"""
 
     @classmethod
@@ -50,4 +50,39 @@ class OsqueryMatcher:
             rec['name'] == 'pack_incident-response_last' and
             int(rec['columns']['type']) == cls._EVENT_TYPE_LOGIN and
             (rec['columns']['username'] not in cls._RUNLEVELS)
+        )
+
+
+class AwsConfigMatcher:
+    """Contains Matchers relevant to AWS Config"""
+
+    @staticmethod
+    def is_config_compliance(rec):
+        """Check if the record event is from config compliance
+
+        Args:
+            rec (dict): Parsed log to check key/value pairs
+
+        Returns:
+            bool: True if from config and not in testMode else False
+        """
+        return (
+            rec['eventSource'] == 'config.amazonaws.com'
+            and rec['eventName'] == 'PutEvaluations'
+            and not rec['requestParameters']['testMode']
+        )
+
+    @staticmethod
+    def is_auto_remediation(rec):
+        """Check if the record is an auto-remediation event
+
+        Args:
+            rec (dict): Parsed log to check key/value pairs
+        Returns:
+            bool: True if auto_remediation event else False
+        """
+        return (
+            rec['eventName'] == 'StartAutomationExecution'
+            and rec['eventSource'] == 'ssm.amazonaws.com'
+            and rec['sourceIPAddress'] == 'config.amazonaws.com'
         )

--- a/tests/integration/rules/cloudtrail/cloudtrail_aws_config.json
+++ b/tests/integration/rules/cloudtrail/cloudtrail_aws_config.json
@@ -1,0 +1,199 @@
+[
+  {
+    "data": {
+      "Records": [
+        {
+          "additionalEventData": {
+            "configRuleArn": "...",
+            "configRuleInputParameters": "{}",
+            "configRuleName": "s3-bucket-logging-enabled",
+            "notificationJobType": "SCHEDULED_NOTIFICATION"
+          },
+          "awsRegion": "...",
+          "eventID": "...",
+          "eventName": "PutEvaluations",
+          "eventSource": "config.amazonaws.com",
+          "eventTime": "...",
+          "eventType": "AwsApiCall",
+          "eventVersion": "1.05",
+          "recipientAccountId": "...",
+          "requestID": "...",
+          "requestParameters": {
+            "evaluations": [
+              {
+                "complianceResourceId": "BUCKET_ONE",
+                "complianceResourceType": "AWS::S3::Bucket",
+                "complianceType": "NON_COMPLIANT",
+                "orderingTimestamp": "..."
+              },
+              {
+                "complianceResourceId": "BUCKET_TWO",
+                "complianceResourceType": "AWS::S3::Bucket",
+                "complianceType": "COMPLIANT",
+                "orderingTimestamp": "..."
+              }
+            ],
+            "resultToken": "...",
+            "testMode": false
+          },
+          "responseElements": null,
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "...",
+            "arn": "...",
+            "principalId": "...",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "..."
+              },
+              "sessionIssuer": {
+                "accountId": "...",
+                "arn": "...",
+                "principalId": "...",
+                "type": "Role",
+                "userName": "..."
+              },
+              "webIdFederationData": {}
+            },
+            "type": "AssumedRole"
+          }
+        }
+      ]
+    },
+    "description": "Triggers an alert caused by a config compliance change of NON_COMPLIANT",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "config_compliance"
+    ]
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "additionalEventData": {
+            "configRuleArn": "...",
+            "configRuleInputParameters": "{}",
+            "configRuleName": "s3-bucket-logging-enabled",
+            "notificationJobType": "SCHEDULED_NOTIFICATION"
+          },
+          "awsRegion": "...",
+          "eventID": "...",
+          "eventName": "PutEvaluations",
+          "eventSource": "config.amazonaws.com",
+          "eventTime": "...",
+          "eventType": "AwsApiCall",
+          "eventVersion": "1.05",
+          "recipientAccountId": "...",
+          "requestID": "...",
+          "requestParameters": {
+            "evaluations": [
+              {
+                "complianceResourceId": "BUCKET_ONE",
+                "complianceResourceType": "AWS::S3::Bucket",
+                "complianceType": "COMPLIANT",
+                "orderingTimestamp": "..."
+              },
+              {
+                "complianceResourceId": "BUCKET_TWO",
+                "complianceResourceType": "AWS::S3::Bucket",
+                "complianceType": "COMPLIANT",
+                "orderingTimestamp": "..."
+              }
+            ],
+            "resultToken": "...",
+            "testMode": false
+          },
+          "responseElements": null,
+          "sourceIPAddress": "...",
+          "userAgent": "...",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "...",
+            "arn": "...",
+            "principalId": "...",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "..."
+              },
+              "sessionIssuer": {
+                "accountId": "...",
+                "arn": "...",
+                "principalId": "...",
+                "type": "Role",
+                "userName": "..."
+              },
+              "webIdFederationData": {}
+            },
+            "type": "AssumedRole"
+          }
+        }
+      ]
+    },
+    "description": "Will not trigger an alert caused by a config compliance change of COMPLIANT",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": []
+  },
+  {
+    "data": {
+      "Records": [
+        {
+          "awsRegion": "eu-west-1",
+          "eventID": "...",
+          "eventName": "StartAutomationExecution",
+          "eventSource": "ssm.amazonaws.com",
+          "eventTime": "...",
+          "eventType": "...",
+          "eventVersion": "1.05",
+          "recipientAccountId": "...",
+          "requestID": "...",
+          "requestParameters": {
+            "domain": "vpc"
+          },
+          "responseElements": {
+            "allocationId": "..",
+            "domain": "vpc",
+            "networkBorderGroup": "...",
+            "publicIp": "...",
+            "publicIpv4Pool": "amazon",
+            "requestId": "..."
+          },
+          "sourceIPAddress": "config.amazonaws.com",
+          "userAgent": "...",
+          "userIdentity": {
+            "accessKeyId": "...",
+            "accountId": "...",
+            "arn": "...",
+            "principalId": "...",
+            "sessionContext": {
+              "attributes": {
+                "creationDate": "..."
+              },
+              "sessionIssuer": {
+                "accountId": "...",
+                "arn": "...",
+                "principalId": "...",
+                "type": "Role",
+                "userName": "..."
+              },
+              "webIdFederationData": {}
+            },
+            "type": "AssumedRole"
+          }
+        }
+      ]
+    },
+    "description": "Triggers an alert when auto-remediation of Config NON_COMPLIANT takes place",
+    "log": "cloudtrail:events",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "trigger_rules": [
+      "config_auto_remediation"
+    ]
+  }
+]


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

Added Rules to trigger alerts on AWS Config NON_COMPLIANT and when Config Remediation takes place

## Changes

* Added rule to Alert on AWS Config `NON_COMPLIANT`
* Added rule to Alert on AWS Config Remediation (this is extremely useful to notify people they got auto-remediated so they don't go crazy when things just suddenly change on them)

## Testing

* Added the `.json` file to run `./manage test rules` Rules engine passes :)
* Ran `./tests/scripts/pylint.sh` Fixed errors
* Ran `./tests/scripts/unit_tests.sh`
