### PR TITLE
Fix config.py to respect firehose being disabled

### DIFF
--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -78,8 +78,8 @@ def firehose_data_bucket(config):
             False if firehose is not configured
     """
     # The default name is <prefix>-streamalert-data but can be overridden
-    firehose_config = config['global']['infrastructure'].get('firehose')
-    if not firehose_config:
+    firehose_config = config['global']['infrastructure'].get('firehose', {})
+    if not firehose_config.get('enabled', False):
         return False
 
     return firehose_config.get(


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers
related to: #1158 
resolves: #1158 

## Background

Having just pulled down `release-3-0-0` for a fresh deployment, the firehose s3 notification was being passed through even though `enabled` was set to `False`

## Changes

* config.py now respects `enabled` on the firehose config

## Testing

* Was able to deploy the infrastructure :)
* ran `./tests/scripts/unit_tests.sh`
* ran `./tests/scripts/pylint.sh`
