### PR TITLE
fixing bug related to athena data bucket not existing

### DIFF
--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -82,6 +82,9 @@ def firehose_data_bucket(config):
     if not firehose_config:
         return False
 
+    if not firehose_config.get('enabled'):
+        return False
+
     return firehose_config.get(
         'bucket_name',
         '{}-streamalert-data'.format(config['global']['account']['prefix'])

--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -369,6 +369,9 @@ def create_table(table, bucket, config, schema_override=None):
     athena_client = get_athena_client(config)
 
     config_data_bucket = firehose_data_bucket(config)
+    if not config_data_bucket:
+        LOGGER.error('The \'firehose\' module is not enabled in global.json')
+        return False
 
     # Check if the table exists
     if athena_client.check_table_exists(sanitized_table_name):

--- a/streamalert_cli/terraform/rule_promotion.py
+++ b/streamalert_cli/terraform/rule_promotion.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from streamalert.rule_promotion.publisher import StatsPublisher
 from streamalert.shared import RULE_PROMOTION_NAME
-from streamalert.shared.config import firehose_alerts_bucket, firehose_data_bucket
+from streamalert.shared.config import firehose_alerts_bucket
 from streamalert_cli.manage_lambda.package import RulePromotionPackage
 from streamalert_cli.terraform.common import infinitedict
 from streamalert_cli.terraform.lambda_module import generate_lambda
@@ -37,12 +37,7 @@ def generate_rule_promotion(config):
 
     result = infinitedict()
 
-    athena_config = config['lambda']['athena_partition_refresh_config']
-    data_buckets = set(athena_config.get('buckets', []))
-    data_buckets.add(firehose_alerts_bucket(config))
-    data_bucket = firehose_data_bucket(config)  # Data retention is optional, so check for this
-    if data_bucket:
-        data_buckets.add(data_bucket)
+    alerts_bucket = firehose_alerts_bucket(config)
 
     # Set variables for the IAM permissions, etc module
     result['module']['rule_promotion_iam'] = {
@@ -55,7 +50,7 @@ def generate_rule_promotion(config):
         'function_alias_arn': '${module.rule_promotion_lambda.function_alias_arn}',
         'function_name': '${module.rule_promotion_lambda.function_name}',
         'athena_results_bucket_arn': '${module.streamalert_athena.results_bucket_arn}',
-        'athena_data_buckets': sorted(data_buckets),
+        'alerts_bucket': alerts_bucket,
         's3_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
     }
 

--- a/terraform/modules/tf_rule_promotion_iam/main.tf
+++ b/terraform/modules/tf_rule_promotion_iam/main.tf
@@ -119,6 +119,9 @@ data "aws_iam_policy_document" "rule_promotion_actions" {
       "s3:ListBucket",
     ]
 
-    resources = formatlist("arn:aws:s3:::%s*", var.athena_data_buckets)
+    resources = [
+      "arn:aws:s3:::${var.alerts_bucket}",
+      "arn:aws:s3:::${var.alerts_bucket}/*"
+    ]
   }
 }

--- a/terraform/modules/tf_rule_promotion_iam/variables.tf
+++ b/terraform/modules/tf_rule_promotion_iam/variables.tf
@@ -26,8 +26,8 @@ variable "athena_results_bucket_arn" {
   description = "S3 bucket arn to use for Athena search results"
 }
 
-variable "athena_data_buckets" {
-  description = "List of S3 buckets where Athena data is stored"
+variable "alerts_bucket" {
+  description = "Name of S3 bucket where alerts are stored and queryable by Athena"
   type        = list(string)
 }
 

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -266,6 +266,7 @@ def athena_cli_basic_config():
             },
             'infrastructure': {
                 'firehose': {
+                    'enabled': True,
                     'enabled_logs': {
                         'unit': {}
                     },

--- a/tests/unit/streamalert_cli/terraform/test_rule_promotion.py
+++ b/tests/unit/streamalert_cli/terraform/test_rule_promotion.py
@@ -43,10 +43,7 @@ class TestRulePromotion:
                     'send_digest_schedule_expression': 'cron(30 13 * * ? *)',
                     'digest_sns_topic': 'unit-test_streamalert_rule_staging_stats',
                     'athena_results_bucket_arn': '${module.streamalert_athena.results_bucket_arn}',
-                    'athena_data_buckets': [
-                        'unit-test-streamalert-data',
-                        'unit-test-streamalerts'
-                    ],
+                    'alerts_bucket': 'unit-test-streamalerts',
                     's3_kms_key_arn': '${aws_kms_key.server_side_encryption.arn}'
                 },
                 'rule_promotion_lambda': {


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/streamalert-maintainers
cc: @jack1902
resolves: #1158 

## Background

See #1158 

## Changes

* Adding fix to check if `enabled` is true in the firehose config.
* Removing unnecessary perms for data bucket access by rule promotion function. This function only queries alerts, so this is not needed.

