### PR TITLE
[cli] fix backend initialization

### DIFF
--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -64,7 +64,7 @@ class TerraformInitCommand(CLICommand):
 
         # Stop here if only initializing the backend
         if options.backend:
-            return cls._terraform_init_backend()
+            return cls._terraform_init_backend(config)
 
         LOGGER.info('Initializing StreamAlert')
 
@@ -113,7 +113,7 @@ class TerraformInitCommand(CLICommand):
         return tf_runner(refresh=False)
 
     @staticmethod
-    def _terraform_init_backend():
+    def _terraform_init_backend(config):
         """Initialize the infrastructure backend (S3) using Terraform
 
         Returns:
@@ -125,6 +125,10 @@ class TerraformInitCommand(CLICommand):
 
         # Verify terraform is installed
         if not terraform_check():
+            return False
+
+        # See generate_main() for how it uses the `init` kwarg for the local/remote backend
+        if not terraform_generate_handler(config=config, init=False):
             return False
 
         LOGGER.info('Initializing StreamAlert backend')


### PR DESCRIPTION
to: @ryandeivert @Ryxias 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #1159

## Background

Previously, the init command had a '-b' flag. This only initialized a local backend but the description on the flag stated 'useful for refreshing a pre-existing deployment'. This flag now actually reflects
this

## Changes

* added additional function calls to '-b' flag to initialize the remote backend

This generates the `main.tf.json` file containing the `remote` backend instead of the previously `local` backend and downloads the relevant provider plugin versions

## Testing

Ran the following in order to verify success (pre-existing deployment):

- `./manage.py clean` - Remove ALL terraform configuration files
- `./manage.py init -b` - Initialize the `remote` backend and download the relevant provider plugins and their versions
- `./manage.py build` - Perform a build (shouldn't contain ANY infrastructure changes, as no new infra has been added) 

These commands work as expected and in my view have fixed the issue better than i had originally proposed in a comment on the original issue

Also ran the `unit_tests` and `pylint`