### PR TITLE
[Schema] Log type

### DIFF
--- a/conf/schemas/osquery.json
+++ b/conf/schemas/osquery.json
@@ -18,6 +18,7 @@
       "optional_top_level_keys": [
         "decorations",
         "epoch",
+        "log_type",
         "counter"
       ]
     }
@@ -70,6 +71,7 @@
         "decorations",
         "epoch",
         "counter",
+        "log_type",
         "logNumericsAsNumbers",
         "numerics"
       ]
@@ -91,7 +93,8 @@
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
-        "decorations"
+        "decorations",
+        "log_type"
       ]
     }
   }


### PR DESCRIPTION
to:
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The following makes `log_type` an optional top-level key as this is only added by the [TLS logger](https://github.com/osquery/osquery/blob/d373d042606acda3cb46d6424cfe09be6939b554/plugins/logger/tls_logger.cpp#L100) This fixes classification for Filebeat and other non-TLS sources such as Kolide Fleet.  



## Changes

Add `log_type` an optional top-level key to the OSquery Schema.

## Testing

Steps for how this change was tested and verified
