### PR TITLE
[Schema] OSquery optional TLK

### DIFF
--- a/conf/schemas/osquery.json
+++ b/conf/schemas/osquery.json
@@ -18,6 +18,7 @@
       "optional_top_level_keys": [
         "decorations",
         "epoch",
+        "log_type",
         "counter"
       ]
     }
@@ -70,6 +71,7 @@
         "decorations",
         "epoch",
         "counter",
+        "log_type",
         "logNumericsAsNumbers",
         "numerics"
       ]
@@ -91,7 +93,8 @@
     "parser": "json",
     "configuration": {
       "optional_top_level_keys": [
-        "decorations"
+        "decorations",
+        "log_type"
       ]
     }
   }

--- a/conf/schemas/osquery.json
+++ b/conf/schemas/osquery.json
@@ -4,6 +4,7 @@
       "calendarTime": "string",
       "counter": "integer",
       "decorations": {},
+      "log_type": "string",
       "diffResults": {
         "added": [],
         "removed": []

--- a/tests/integration/rules/osquery/osquery_snapshot.json
+++ b/tests/integration/rules/osquery/osquery_snapshot.json
@@ -1,0 +1,26 @@
+[
+  {
+    "data": {
+      "numerics": false,
+      "name": "pack/windows-hardening/Disallowed",
+      "calendarTime": "Thu Feb 27 14:34:21 2020 UTC",
+      "counter": 0,
+      "epoch": 0,
+      "snapshot": [],
+      "decorations": {
+        "hostname": "foo-hostname",
+        "hardware_serial": "8Q394Y2",
+        "uuid": "4C4C4544-0051-XXXX-YYYY-ZZZZZZZZZZZZ"
+      },
+      "unixTime": 1582814061,
+      "action": "snapshot",
+      "hostIdentifier": "4C4C4544-0051-XXXX-YYYY-ZZZZZZZZZZZZ"
+    },
+    "log": "osquery:snapshot",
+    "description": "OSQuery event.",
+    "validate_schema_only": true,
+    "trigger_rules": [],
+    "source": "prefix_cluster1_streamalert",
+    "service": "kinesis"
+  }
+]


### PR DESCRIPTION
to:
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The following makes `log_type` an optional top-level key as this is only added by the [TLS logger](https://github.com/osquery/osquery/blob/d373d042606acda3cb46d6424cfe09be6939b554/plugins/logger/tls_logger.cpp#L100) This fixes classification for Filebeat and other non-TLS sources such as Kolide Fleet.  



## Changes

Add `log_type` an optional top-level key to the OSquery Schema.

## Testing

Steps for how this change was tested and verified
