### PR TITLE
[docs] fixing venv module usage typo

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -45,7 +45,7 @@ Download StreamAlert
 .. code-block:: bash
 
   cd streamalert
-  python3.7 -m virtualenv venv
+  python3.7 -m venv venv
   source venv/bin/activate
 
 3. Install the StreamAlert requirements:

--- a/streamalert/apps/_apps/README.rst
+++ b/streamalert/apps/_apps/README.rst
@@ -61,7 +61,7 @@ on ec2 instance
   $ rm -rf $HOME/.cache/pip/
 
   # Create and source venv
-  $ python3.7 -m virtualenv $HOME/venv
+  $ python3.7 -m venv $HOME/venv
   $ source $HOME/venv/bin/activate
 
   # Upgrade pip and setuptools (they are super old)
@@ -126,7 +126,7 @@ SSH and Build Dependencies
   $ which python3.7
 
   # Create and source venv
-  $ python3.7 -m virtualenv venv && source venv/bin/activate
+  $ python3.7 -m venv venv && source venv/bin/activate
 
   # upgrade pip and setuptools if neccessary
   $ pip install --upgrade pip setuptools


### PR DESCRIPTION
to: @chunyong-lin 

## Background

I noticed the usage of the `venv` module for python3 was incorrectly using the `virtualenv` name.

## Changes

* Changing `virtualenv` --> `venv`

