### PR TITLE
Added isotimestamp to duo auth schema

### DIFF
--- a/conf/schemas/duo.json
+++ b/conf/schemas/duo.json
@@ -17,6 +17,7 @@
       "factor": "string",
       "integration": "string",
       "ip": "string",
+      "isotimestamp": "string",
       "location": {},
       "new_enrollment": "boolean",
       "reason": "string",

--- a/tests/integration/rules/duo/duo_anonymous_ip_failure.json
+++ b/tests/integration/rules/duo/duo_anonymous_ip_failure.json
@@ -15,6 +15,7 @@
       "factor": "Duo Push",
       "integration": "Test Integration",
       "ip": "12.123.123.12",
+      "isotimestamp": "2017-09-13T15:28:19.000Z",
       "location": {
         "city": "Place",
         "country": "US",

--- a/tests/integration/rules/duo/duo_fraud.json
+++ b/tests/integration/rules/duo/duo_fraud.json
@@ -15,6 +15,7 @@
       "factor": "Duo Push",
       "integration": "Test Integration",
       "ip": "12.123.123.12",
+      "isotimestamp": "2017-09-13T15:28:19.000Z",
       "location": {
         "city": "Place",
         "country": "US",
@@ -50,6 +51,7 @@
       "factor": "Duo Push",
       "integration": "Test Integration",
       "ip": "12.123.123.12",
+      "isotimestamp": "2017-09-13T15:28:19.000Z",
       "location": {
         "city": "Place",
         "country": "US",


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Duo auth logs schema has changed.

## Changes

* Add isotimestamp field to duo auth schema
* Updated tests

## Testing
Tests passing locally
