### PR TITLE
Redesigns Publisher Testing

### DIFF
--- a/docs/source/publishers.rst
+++ b/docs/source/publishers.rst
@@ -266,7 +266,7 @@ integration, leaving the Slack integration the same. Registering the publisher c
 
   @rule(
     logs=['ssh'],
-    output=['slack:engineering', 'pagerduty:engineering'],
+    outputs=['slack:engineering', 'pagerduty:engineering'],
     publishers={
       'pagerduty:engineering': simplify_pagerduty_output,
     }

--- a/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
+++ b/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
@@ -846,6 +846,24 @@
     "source": "prefix.cluster.sample.bucket",
     "trigger_rules": [
       "cloudtrail_critical_api_calls"
-    ]
+    ],
+    "publisher_tests": {
+      "slack:sample-channel": [
+        [
+          "keys(@)",
+          "is",
+          [
+            "@slack.text",
+            "@slack.attachments",
+            "@slack._previous_publication"
+          ]
+        ],
+        [
+          "\"@slack.text\"",
+          "is",
+          "Rule triggeredsss"
+        ]
+      ]
+    }
   }
 ]

--- a/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
+++ b/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
@@ -861,7 +861,7 @@
         [
           "\"@slack.text\"",
           "is",
-          "Rule triggeredsss"
+          "Rule triggered"
         ]
       ]
     }

--- a/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
+++ b/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.json
@@ -849,15 +849,15 @@
     ],
     "publisher_tests": {
       "slack:sample-channel": [
-        [
-          "keys(@)",
-          "is",
-          [
+        {
+          "jmespath_expression": "keys(@)",
+          "condition": "is",
+          "value": [
             "@slack.text",
             "@slack.attachments",
             "@slack._previous_publication"
           ]
-        ],
+        },
         [
           "\"@slack.text\"",
           "is",

--- a/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.py
+++ b/rules/community/cloudwatch_events/cloudtrail_critical_api_calls.py
@@ -1,4 +1,5 @@
 """Alert on destructive AWS API calls."""
+from publishers.community.slack.slack_layout import Summary, AttachRuleInfo, AttachFullRecord
 from streamalert.shared.rule import rule
 
 _CRITICAL_EVENTS = {
@@ -53,7 +54,13 @@ AWS_ORG_EVENTS = {
 }
 
 
-@rule(logs=['cloudtrail:events'])
+@rule(
+    logs=['cloudtrail:events'],
+    outputs=['slack:sample-channel'],
+    publishers={
+        'slack': [Summary, AttachRuleInfo, AttachFullRecord]
+    }
+)
 def cloudtrail_critical_api_calls(rec):
     """
     author:           airbnb_csirt

--- a/streamalert_cli/test/event.py
+++ b/streamalert_cli/test/event.py
@@ -31,7 +31,9 @@ class TestEvent:
 
     ACCEPTABLE_DATA_KEYS = {'data', 'override_record'}
     REQUIRED_KEYS = {'description', 'log', 'service', 'source'}
-    OPTIONAL_KEYS = {'compress', 'trigger_rules', 'classify_only', 'skip_publishers'}
+    OPTIONAL_KEYS = {
+        'compress', 'trigger_rules', 'classify_only', 'skip_publishers', 'publisher_tests'
+    }
 
     def __init__(self, test_data):
         self._event = test_data
@@ -80,6 +82,10 @@ class TestEvent:
     @property
     def skip_publishers(self):
         return self._event.get('skip_publishers', False)
+
+    @property
+    def publisher_tests(self):
+        return [] if self.skip_publishers else self._event.get('publisher_tests', [])
 
     @property
     def is_valid(self):

--- a/streamalert_cli/test/event_file.py
+++ b/streamalert_cli/test/event_file.py
@@ -27,7 +27,7 @@ class TestEventFile:
 
     def __init__(self, full_path):
         self._full_path = full_path
-        self._results = []  # type: streamalert_cli.test.results.TestResult
+        self._results = []  # type: list[streamalert_cli.test.results.TestResult]
         self.error = None
 
     def __bool__(self):

--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -374,76 +374,8 @@ class TestRunner:
                 )
 
                 if event.publisher_tests:
-                    for alert in event.alerts:
-                        publication_results = self._run_publishers(alert)
-
-                        publisher_test_results = []
-                        for output, individual_tests in event.publisher_tests.items():
-                            for publisher_test in individual_tests:
-                                if not isinstance(publisher_test, list) or len(publisher_test) != 3:
-                                    publisher_test_results.append({
-                                        'success': False,
-                                        'error': (
-                                            'Invalid publisher test specified: {}'
-                                            'Publisher test must be a triple with elements: '
-                                            '(jsonpath, condition, condition_value)'
-                                        ).format(publisher_test),
-                                        'output_descriptor': output,
-                                    })
-                                    continue
-
-                                jsonpath, condition, condition_value = publisher_test
-
-                                if output not in publication_results:
-                                    publisher_test_results.append({
-                                        'success': False,
-                                        'error': (
-                                            'No such output {} was configured for this alert'
-                                        ).format(output),
-                                        'output_descriptor': output,
-                                    })
-                                    continue
-
-                                publication = publication_results[output]['publication']
-
-                                subject_value = jmespath.search(jsonpath, publication)
-
-                                if condition == 'is':
-                                    res = subject_value == condition_value
-                                elif condition == 'in':
-                                    if isinstance(condition_value, list):
-                                        res = subject_value in condition_value
-                                    else:
-                                        res = condition_value.contains(subject_value)
-                                else:
-                                    publisher_test_results.append({
-                                        'success': False,
-                                        'error': (
-                                            'Invalid condition specified: {}\n'
-                                            'Valid conditions are: {}'
-                                        ).format(condition, ['is', 'in']),
-                                        'output_descriptor': output,
-                                    })
-                                    continue
-
-                                publisher_test_results.append({
-                                    'success': res,
-                                    'failure': None if res else (
-                                        'Item at path "{}" {} "{}",\nActual value: "{}"'.format(
-                                            jsonpath,
-                                            (
-                                                "should have been" if condition == 'is'
-                                                else "should have contained"
-                                            ),
-                                            condition_value,
-                                            subject_value
-                                        )
-                                    ),
-                                    'output_descriptor': output
-                                })
-
-                        event.set_publication_results(publisher_test_results)
-
+                    runner = PublisherTestRunner()
+                    runner.run_publisher_tests(event)
 
                 if self._type == self.Types.LIVE:
                     for alert in event.alerts:
@@ -472,37 +404,6 @@ class TestRunner:
 
         return self._failed == 0
 
-    @staticmethod
-    def _run_publishers(alert):
-        """Runs publishers for all currently configured outputs on the given alert
-
-        Args:
-            - alert (Alert): The alert
-
-        Returns:
-            dict: A dict keyed by output:descriptor strings, mapped to nested dicts.
-                self._rules_engine._lookup_tables  The nested dicts have 2 keys:
-                  - publication (dict): The dict publication
-                  - success (bool): True if the publishing finished, False if it errored.
-        """
-        configured_outputs = alert.outputs
-
-        results = {}
-        for configured_output in configured_outputs:
-            [output_name, descriptor] = configured_output.split(':')
-
-            try:
-                output = MagicMock(spec=OutputDispatcher, __service__=output_name)
-                results[configured_output] = {
-                    'publication': compose_alert(alert, output, descriptor),
-                    'success': True,
-                }
-            except (RuntimeError, TypeError, NameError) as err:
-                results[configured_output] = {
-                    'success': False,
-                    'error': err,
-                }
-        return results
 
     def _handle_fixtures(self, rule_dir, setup=True):
         path = os.path.join(rule_dir, 'test_fixtures')
@@ -589,3 +490,119 @@ class TestRunner:
             yield root, files
 
         self._teardown_all_fixtures(cached_fixtures)
+
+
+class PublisherTestRunner:
+    PUBLISHER_CONDITIONALS = {
+        'is': {
+            'comparator': lambda subject, predicate: subject == predicate,
+            'clause': 'should have been',
+        },
+        'in': {
+            'comparator': lambda s, p: s in p if isinstance(p, list) else p.contains(s),
+            'clause': 'should have contained'
+        }
+    }
+
+    def run_publisher_tests(self, event):
+        """
+        Runs all publishers and compares their results to the suite of configured publisher tests.
+
+        Args:
+            - event (TestEvent): The integration test
+        """
+        for alert in event.alerts:
+            publication_results = self._run_publishers(alert)
+
+            publisher_test_results = []
+            for output, individual_tests in event.publisher_tests.items():
+                for publisher_test in individual_tests:
+                    if not isinstance(publisher_test, list) or len(publisher_test) != 3:
+                        publisher_test_results.append({
+                            'success': False,
+                            'error': (
+                                'Invalid publisher test specified: {}'
+                                'Publisher test must be a triple with elements: '
+                                '(jsonpath, condition, condition_value)'
+                            ).format(publisher_test),
+                            'output_descriptor': output,
+                        })
+                        continue
+
+                    jsonpath, condition, condition_value = publisher_test
+
+                    if output not in publication_results:
+                        publisher_test_results.append({
+                            'success': False,
+                            'error': (
+                                'No such output {} was configured for this alert'
+                            ).format(output),
+                            'output_descriptor': output,
+                        })
+                        continue
+
+                    publication = publication_results[output]['publication']
+
+                    subject_value = jmespath.search(jsonpath, publication)
+
+                    conditional = self.PUBLISHER_CONDITIONALS.get(condition, None)
+
+                    if not conditional:
+                        publisher_test_results.append({
+                            'success': False,
+                            'error': (
+                                'Invalid condition specified: {}\n'
+                                'Valid conditions are: {}'
+                            ).format(condition, list(self.PUBLISHER_CONDITIONALS.keys())),
+                            'output_descriptor': output,
+                        })
+                        continue
+
+                    res = conditional['comparator'](subject_value, condition_value)
+
+                    publisher_test_results.append({
+                        'success': res,
+                        'failure': None if res else (
+                            'Item at path "{}" {} "{}",\nActual value: "{}"'.format(
+                                jsonpath,
+                                conditional['clause'],
+                                condition_value,
+                                subject_value
+                            )
+                        ),
+                        'output_descriptor': output
+                    })
+
+            event.set_publication_results(publisher_test_results)
+
+    @staticmethod
+    def _run_publishers(alert):
+        """Runs publishers for all currently configured outputs on the given alert
+
+        Args:
+            - alert (Alert): The alert
+
+        Returns:
+            dict: A dict keyed by output:descriptor strings, mapped to nested dicts.
+                self._rules_engine._lookup_tables  The nested dicts have 2 keys:
+                  - publication (dict): The dict publication
+                  - success (bool): True if the publishing finished, False if it errored.
+        """
+        configured_outputs = alert.outputs
+
+        results = {}
+        for configured_output in configured_outputs:
+            [output_name, descriptor] = configured_output.split(':')
+
+            try:
+                output = MagicMock(spec=OutputDispatcher, __service__=output_name)
+                results[configured_output] = {
+                    'publication': compose_alert(alert, output, descriptor),
+                    'success': True,
+                }
+            except (RuntimeError, TypeError, NameError) as err:
+                results[configured_output] = {
+                    'success': False,
+                    'error': err,
+                }
+        return results


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers
resolves: #1149 

**NOTE: I'm merging this into `origin/ryandeivert-refactor-integration-tests`**

## Background

The first time I did Alert Publishers I didn't really think through how to do testing well. Taking another pass at this, allowing individuals to write jsonpath-based conditionals.

## Changes

There is now a new field in integration test JSON files: `publisher_tests`. It takes the following format:

```
"publisher_tests": {
    "[OUTPUT_DESCRIPTOR]": [
      [
        "[PATH]",
        "[CONDITIONAL]",
        [VALUE]
      ],
      ...
  },
  "[OUTPUT_DESCRIPTOR_2]": [ ... ]
}
```

* `OUTPUT_DESCRIPTOR`: Should be an output that the alert publishes to, e.g. `slack:sample-channel`
* `PATH`: A jmespath-compatible search path.
* `CONDITIONAL`: Currently supports `is` for equality matching, or `in` for substring/list contains
* `VALUE`: The value that the jsonpath value should match 

### Other Change: No more unit tests for community content

I didn't see the value of continuing to have unit tests for Publishers. I think in general, we should use unit tests for canonical StreamAlert code, and liberally use **integration tests** for other code.


## Testing

Currently on @ryandeivert's branch the Integration tests are broken so I can't test this right now
