### PR TITLE
Sanitize log names

### DIFF
--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -218,8 +218,36 @@ def load_config(conf_dir='conf/', exclude=None, include=None, validate=True):
     if validate:
         _validate_config(config)
 
+    if config.get('logs'):
+        config['logs'] = _sanitize_logs_name(config['logs'])
+
+    if (config.get('global')
+            and config['global'].get('infrastructure')
+            and config['global']['infrastructure'].get('firehose')
+            and config['global']['infrastructure']['firehose'].get('enabled_logs')):
+        config['global']['infrastructure']['firehose']['enabled_logs'] = _sanitize_logs_name(
+            config['global']['infrastructure']['firehose']['enabled_logs']
+        )
+
     return config
 
+
+def _sanitize_logs_name(config):
+    """Sanitize the name of logs and replace the dots with underscores. For some reason,
+    we have log name with dots in it in the conf/schemas/carbonblack.json or conf/logs.json.
+
+    Args:
+        config (dict): loaded config from conf/ directory
+
+    Returns:
+        new_config (dict): new config with sanitized keys
+    """
+    new_config = dict()
+    for key, _ in config.items():
+        sanitized_key = key.replace('.', '_')
+        new_config[sanitized_key] = config[key]
+
+    return new_config
 
 def _load_schemas(schemas_dir, schema_files):
     """Helper to load all schemas from the schemas directory into one ordered dictionary.

--- a/streamalert_cli/test/results.py
+++ b/streamalert_cli/test/results.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 import textwrap
 
 from streamalert.shared import rule
+from streamalert.shared.config import sanitize_key
 from streamalert.shared.logger import get_logger
 from streamalert_cli.test.event import TestEvent
 from streamalert_cli.test.format import format_green, format_red, format_underline
@@ -107,7 +108,7 @@ class TestResult(TestEvent):
         fmt['classification_status'] = (
             self._PASS_STRING if self.classification_tests_passed else self._FAIL_STRING
         )
-        fmt['expected_type'] = self.log
+        fmt['expected_type'] = sanitize_key(self.log)
         fmt['classified_type'] = (
             self._classified_result.log_schema_type
             if self._classified else format_red(
@@ -201,7 +202,7 @@ class TestResult(TestEvent):
 
     @property
     def _classified(self):
-        return self and self._classified_result.log_schema_type == self.log
+        return self and self._classified_result.log_schema_type == sanitize_key(self.log)
 
     def _format_rules(self, items, compare_set):
         if not items:

--- a/tests/unit/conf/lambda.json
+++ b/tests/unit/conf/lambda.json
@@ -31,7 +31,10 @@
   "athena_partition_refresh_config": {
     "memory": "128",
     "timeout": "60",
-    "file_format": "parquet"
+    "file_format": "parquet",
+    "buckets": {
+      "bucket": "data"
+    }
   },
   "classifier_config": {},
   "rule_promotion_config": {

--- a/tests/unit/conf/logs.json
+++ b/tests/unit/conf/logs.json
@@ -360,5 +360,14 @@
       "Field4": {}
     },
     "parser": "json"
+  },
+  "test:log.name.with.dots": {
+    "schema": {
+      "Field1": {},
+      "Field2": {},
+      "Field3": {},
+      "Field4": {}
+    },
+    "parser": "json"
   }
 }

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -87,6 +87,12 @@ def basic_streamalert_config():
                 },
                 'parser': 'json'
             },
+            'json:log_with_dots': {
+                'schema': {
+                    'name': 'string'
+                },
+                'parser': 'json'
+            },
             'csv_log': {
                 'schema': {
                     'data': 'string',

--- a/tests/unit/streamalert/shared/test_config.py
+++ b/tests/unit/streamalert/shared/test_config.py
@@ -87,6 +87,10 @@ class TestConfigLoading(fake_filesystem_unittest.TestCase):
             'conf_schemas/schemas/json.json',
             contents='{"json_log": {"schema": {"name": "string"},"parser": "json"}}'
         )
+        self.fs.create_file(
+            'conf_schemas/schemas/json_log_with_dots.json',
+            contents='{"json:log.with.dots": {"schema": {"name": "string"},"parser": "json"}}'
+        )
 
     def test_load_invalid_file(self):
         """Shared - Config Loading - Bad JSON"""

--- a/tests/unit/streamalert/shared/test_config.py
+++ b/tests/unit/streamalert/shared/test_config.py
@@ -16,7 +16,13 @@ limitations under the License.
 import json
 
 from mock import Mock
-from nose.tools import assert_equal, assert_count_equal, assert_raises
+from nose.tools import (
+    assert_equal,
+    assert_count_equal,
+    assert_false,
+    assert_raises,
+    assert_true
+)
 from pyfakefs import fake_filesystem_unittest
 
 from streamalert.shared.config import (
@@ -24,6 +30,8 @@ from streamalert.shared.config import (
     load_config,
     parse_lambda_arn,
     ConfigError,
+    _requires_sanitized_log_names,
+    _sanitize_log_names,
 )
 
 from tests.unit.helpers.config import basic_streamalert_config
@@ -288,3 +296,76 @@ class TestConfigValidation:
         config = basic_streamalert_config()
         config['clusters']['dev'] = config['clusters']['prod']
         assert_raises(ConfigError, _validate_config, config)
+
+
+class TestConfigLogName:
+    """Test sanitizing log name in the Config"""
+    # pylint: disable=no-self-use
+
+    def test_sanitize_log_names_in_logs(self):
+        """Shared - Sanitize log names in logs(schemas) config"""
+        config = {
+            'test:unit_test_1': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit_test_2': {'key1': 'val1', 'key2': 'val2'},
+            'testunittest3': {'key1': 'val1', 'key2': 'val2'},
+            'test:unit.test.4': {'key1': 'val1', 'key2': 'val2'},
+            'test:unit.test-5': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit:test_6': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit:test.7': {'key1': 'val1', 'key2': 'val2'}
+        }
+
+        expected_config = {
+            'test:unit_test_1': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit_test_2': {'key1': 'val1', 'key2': 'val2'},
+            'testunittest3': {'key1': 'val1', 'key2': 'val2'},
+            'test:unit_test_4': {'key1': 'val1', 'key2': 'val2'},
+            'test:unit_test_5': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit:test_6': {'key1': 'val1', 'key2': 'val2'},
+            'test_unit:test_7': {'key1': 'val1', 'key2': 'val2'}
+        }
+
+        result = _sanitize_log_names(config)
+        assert_equal(result, expected_config)
+
+    def test_sanitize_log_names_in_firehose_config(self):
+        """Shared - Sanitize log names in firehose config"""
+        config = {
+            'osquery': {},
+            'osquery:differential': {},
+            'carbonblack:alert.status.updated': {},
+            'test:unit-test.crazy.dots': {},
+            'test:unit_test_underscores': {}
+        }
+
+        expected_config = {
+            'osquery': {},
+            'osquery:differential': {},
+            'carbonblack:alert_status_updated': {},
+            'test:unit_test_crazy_dots': {},
+            'test:unit_test_underscores': {}
+        }
+
+        result = _sanitize_log_names(config)
+        assert_equal(result, expected_config)
+
+    def test_sanitize_log_names_config_error(self):
+        """Shared - Raise ConfigError when sanitize log names"""
+        config = {
+            'test:unit:more_colons': {'key1': 'val1', 'key2': 'val2'}
+        }
+
+        assert_raises(ConfigError, _sanitize_log_names, config)
+
+    def test_requires_sanitized_log_names(self):
+        """Shared - Validate if a config requires to sanitize the log names"""
+        config = {}
+        assert_false(_requires_sanitized_log_names(config))
+        config = {'global': {}}
+        assert_false(_requires_sanitized_log_names(config))
+        config = {'global': {'infrastructure': {}}}
+        assert_false(_requires_sanitized_log_names(config))
+        config = {'global': {'infrastructure': {'firehose': {'enabled_logs': {}}}}}
+        assert_false(_requires_sanitized_log_names(config))
+
+        config = {'global': {'infrastructure': {'firehose': {'enabled_logs': {'bala': {}}}}}}
+        assert_true(_requires_sanitized_log_names(config))

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from mock import patch
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 
 from streamalert_cli.athena import helpers
 from streamalert_cli.config import CLIConfig
+from streamalert.classifier.clients import FirehoseClient
 
 
 CONFIG = CLIConfig(config_path='tests/unit/conf')
@@ -127,3 +128,14 @@ def test_add_partition_statements_exceed_length():
                          "LOCATION 's3://bucket/test/2018/12/01/05'")
     assert_equal(results_copy[0], expected_result_0)
     assert_equal(results_copy[1], expected_result_1)
+
+# pylint: disable=protected-access
+def test_generate_data_table_schema():
+    """CLI - Athena generate_data_table_schema helper"""
+    config = CLIConfig(config_path='tests/unit/conf')
+    config['global']['infrastructure']['firehose']['enabled_logs'] = {
+        'test:log_name_with_dots': {}
+    }
+
+    assert_true(helpers.generate_data_table_schema(config, 'test_log_name_with_dots'))
+    FirehoseClient._ENABLED_LOGS.clear()


### PR DESCRIPTION
to: @ryandeivert @Ryxias @blakemotl 
cc: @airbnb/streamalert-maintainers
related to:
resolves: #1186 

## Background
See the issue #1186 for more details.

## Changes

* Replace all `.` (dot) in the log names in `conf/schemas/*.json` or `conf/logs.json` with `_` (underscore). The change is made to `Config` class where all the conf files are loaded.
* Also update rule test method to replace `.` with `_` when inspect `log` source in the testing events. Eventually there are two carbonblack testing events with `log` set to `carbonblack:ingress.event.procstart` and `carbonblack:ingress_event_procstart`.

## Testing
* Add unit tests to reproduce the issue and test the code change.
* `python manage.py athena create-table  --bucket nobody2020030420-streamalert-data  --table-name carbonblack_alert_status_updated` works in staging environment with the fix.
