### PR TITLE
[core] Hash firehose stream name if it is too long

### DIFF
--- a/docs/source/config-global.rst
+++ b/docs/source/config-global.rst
@@ -353,9 +353,9 @@ For instance, suppose the following schemas are defined across one or more files
 Supposing also that the above ``enabled_logs`` :ref:`example <firehose_example_02>` is used, the
 following Firehose resources will be created:
 
-* ``<prefix>_streamalert_data_cloudwatch_cloudtrail``
-* ``<prefix>_streamalert_data_osquery_differential``
-* ``<prefix>_streamalert_data_osquery_status``
+* ``<prefix>_data_cloudwatch_cloudtrail``
+* ``<prefix>_data_osquery_differential``
+* ``<prefix>_data_osquery_status``
 
 .. note::
 

--- a/docs/source/config-global.rst
+++ b/docs/source/config-global.rst
@@ -353,9 +353,9 @@ For instance, suppose the following schemas are defined across one or more files
 Supposing also that the above ``enabled_logs`` :ref:`example <firehose_example_02>` is used, the
 following Firehose resources will be created:
 
-* ``<prefix>_data_cloudwatch_cloudtrail``
-* ``<prefix>_data_osquery_differential``
-* ``<prefix>_data_osquery_status``
+* ``<prefix>_streamalert_cloudwatch_cloudtrail``
+* ``<prefix>_streamalert_osquery_differential``
+* ``<prefix>_streamalert_osquery_status``
 
 .. note::
 

--- a/streamalert/classifier/clients/firehose.py
+++ b/streamalert/classifier/clients/firehose.py
@@ -342,7 +342,7 @@ class FirehoseClient:
         # chars.
         pos = reserved_len - cls.FIREHOSE_NAME_HASH_LEN
         hash_part = log_stream_name[pos:]
-        hash_result = hashlib.md5(hash_part.encode()).hexdigest()
+        hash_result = hashlib.md5(hash_part.encode()).hexdigest() # nosec
 
         # combine the first part and first 8 chars of hash result together as new
         # stream name.

--- a/streamalert/classifier/clients/firehose.py
+++ b/streamalert/classifier/clients/firehose.py
@@ -53,7 +53,7 @@ class FirehoseClient:
     MAX_RECORD_SIZE = 1000 * 1000 - 2
 
     # Default firehose name format, should be formatted with deployment prefix
-    DEFAULT_FIREHOSE_FMT = '{}data_{}'
+    DEFAULT_FIREHOSE_FMT = '{}streamalert_{}'
 
     # Exception for which backoff operations should be performed
     EXCEPTIONS_TO_BACKOFF = (ClientError, BotocoreConnectionError, HTTPClientError)
@@ -62,9 +62,9 @@ class FirehoseClient:
     _ENABLED_LOGS = dict()
 
     # The max length of the firehose stream name is 64. For streamalert data firehose,
-    # we reserve 5 chars to have `data_` as part of prefix. Please refer to
+    # we reserve 12 chars to have `streamalert_` as part of prefix. Please refer to
     # terraform/modules/tf_kinesis_firehose_delivery_stream/main.tf
-    FIREHOSE_NAME_MAX_LEN = 59
+    FIREHOSE_NAME_MAX_LEN = 52
 
     FIREHOSE_NAME_HASH_LEN = 8
 
@@ -318,8 +318,9 @@ class FirehoseClient:
         longer than 64 characters
 
         Args:
-            prefix (str): TODO
-            log_stream_name (str): TODO
+            use_prefix (bool): Does apply prefix defined in conf/global.json to firehose stream name
+            prefix (str): The prefix defined in conf/global.json to firehose stream name
+            log_stream_name (str): The name of the log from conf/logs.json or conf/schemas/*.json
 
         Returns:
             str: compliant stream name

--- a/streamalert/classifier/clients/firehose.py
+++ b/streamalert/classifier/clients/firehose.py
@@ -313,8 +313,8 @@ class FirehoseClient:
         return re.sub(cls.SPECIAL_CHAR_REGEX, cls.SPECIAL_CHAR_SUB, log_name)
 
     @classmethod
-    def generate_firehose_stream_name(cls, use_prefix, prefix, log_stream_name):
-        """Generate stream name complaint to firehose naming restriction, no
+    def generate_firehose_suffix(cls, use_prefix, prefix, log_stream_name):
+        """Generate suffix of stream name complaint to firehose naming restriction, no
         longer than 64 characters
 
         Args:
@@ -323,7 +323,7 @@ class FirehoseClient:
             log_stream_name (str): The name of the log from conf/logs.json or conf/schemas/*.json
 
         Returns:
-            str: compliant stream name
+            str: suffix of stream name
         """
 
         reserved_len = cls.FIREHOSE_NAME_MAX_LEN
@@ -448,7 +448,7 @@ class FirehoseClient:
             formatted_log_type = self.firehose_log_name(log_type)
 
             # firehose stream name has the length limit, no longer than 64 characters
-            formatted_stream_name = self.generate_firehose_stream_name(
+            formatted_stream_name = self.generate_firehose_suffix(
                 self._use_prefix, self._original_prefix, formatted_log_type
             )
             stream_name = self.DEFAULT_FIREHOSE_FMT.format(self._prefix, formatted_stream_name)

--- a/streamalert_cli/terraform/firehose.py
+++ b/streamalert_cli/terraform/firehose.py
@@ -72,7 +72,9 @@ def generate_firehose(logging_bucket, main_dict, config):
             'file_format': get_data_file_format(config),
             'use_prefix': firehose_conf.get('use_prefix', True),
             'prefix': prefix,
-            'log_name': log_stream_name,
+            'log_name': FirehoseClient.generate_firehose_stream_name(
+                firehose_conf.get('use_prefix', True), prefix, log_stream_name
+            ),
             'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',
             's3_bucket_name': firehose_s3_bucket_name,
             'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',

--- a/streamalert_cli/terraform/firehose.py
+++ b/streamalert_cli/terraform/firehose.py
@@ -72,7 +72,7 @@ def generate_firehose(logging_bucket, main_dict, config):
             'file_format': get_data_file_format(config),
             'use_prefix': firehose_conf.get('use_prefix', True),
             'prefix': prefix,
-            'log_name': FirehoseClient.generate_firehose_stream_name(
+            'log_name': FirehoseClient.generate_firehose_suffix(
                 firehose_conf.get('use_prefix', True), prefix, log_stream_name
             ),
             'role_arn': '${module.kinesis_firehose_setup.firehose_role_arn}',

--- a/terraform/modules/tf_classifier/firehose.tf
+++ b/terraform/modules/tf_classifier/firehose.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role_policy" "classifier_firehose" {
 }
 
 locals {
-  stream_prefix = "${var.firehose_use_prefix ? "${var.prefix}_" : ""}streamalert_data_"
+  stream_prefix = "${var.firehose_use_prefix ? "${var.prefix}_" : ""}data_"
 }
 
 // IAM Policy Doc: Allow the Classifier to PutRecord* on any StreamAlert Data Firehose

--- a/terraform/modules/tf_classifier/firehose.tf
+++ b/terraform/modules/tf_classifier/firehose.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role_policy" "classifier_firehose" {
 }
 
 locals {
-  stream_prefix = "${var.firehose_use_prefix ? "${var.prefix}_" : ""}data_"
+  stream_prefix = "${var.firehose_use_prefix ? "${var.prefix}_" : ""}streamalert_"
 }
 
 // IAM Policy Doc: Allow the Classifier to PutRecord* on any StreamAlert Data Firehose

--- a/terraform/modules/tf_kinesis_firehose_delivery_stream/main.tf
+++ b/terraform/modules/tf_kinesis_firehose_delivery_stream/main.tf
@@ -11,7 +11,8 @@ locals {
   # https://docs.aws.amazon.com/athena/latest/ug/tables-location-format.html
   # So all data in parquet format will be saved s3 bucket with prefix
   # "s3://bucketname/parquet/[data-type]".
-  s3_path_prefix = "parquet/${var.log_name}"
+  # glue_catalog_table_name maps to data-type if the length of data-type is not to long.
+  s3_path_prefix = "parquet/${var.glue_catalog_table_name}"
 }
 
 locals {
@@ -26,7 +27,7 @@ locals {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "streamalert_data" {
-  name        = "${var.use_prefix ? "${var.prefix}_" : ""}streamalert_data_${var.log_name}"
+  name        = "${var.use_prefix ? "${var.prefix}_" : ""}data_${var.log_name}"
   destination = var.file_format == "parquet" ? "extended_s3" : "s3"
 
   // AWS Firehose Stream for data to S3 and saved in JSON format
@@ -35,7 +36,7 @@ resource "aws_kinesis_firehose_delivery_stream" "streamalert_data" {
     content {
       role_arn           = var.role_arn
       bucket_arn         = "arn:aws:s3:::${var.s3_bucket_name}"
-      prefix             = "${var.log_name}/"
+      prefix             = "${var.glue_catalog_table_name}/"
       buffer_size        = var.buffer_size
       buffer_interval    = var.buffer_interval
       compression_format = "GZIP"
@@ -113,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "firehose_records_alarm" {
 // data athena table
 resource "aws_glue_catalog_table" "data" {
   count         = var.file_format == "parquet" ? 1 : 0
-  name          = var.log_name
+  name          = var.glue_catalog_table_name
   database_name = var.glue_catalog_db_name
 
   table_type = "EXTERNAL_TABLE"

--- a/terraform/modules/tf_kinesis_firehose_delivery_stream/main.tf
+++ b/terraform/modules/tf_kinesis_firehose_delivery_stream/main.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "streamalert_data" {
-  name        = "${var.use_prefix ? "${var.prefix}_" : ""}data_${var.log_name}"
+  name        = "${var.use_prefix ? "${var.prefix}_" : ""}streamalert_${var.log_name}"
   destination = var.file_format == "parquet" ? "extended_s3" : "s3"
 
   // AWS Firehose Stream for data to S3 and saved in JSON format

--- a/tests/unit/streamalert/classifier/clients/test_firehose.py
+++ b/tests/unit/streamalert/classifier/clients/test_firehose.py
@@ -412,7 +412,7 @@ class TestFirehoseClient:
         ]
         self._client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'unit-test_data_log_type_01_sub_type_01', expected_batch
+            'unit-test_streamalert_log_type_01_sub_type_01', expected_batch
         )
 
     @patch.object(FirehoseClient, '_send_batch')
@@ -434,7 +434,7 @@ class TestFirehoseClient:
 
         client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'data_log_type_01_sub_type_01', expected_batch
+            'streamalert_log_type_01_sub_type_01', expected_batch
         )
 
     @property
@@ -477,7 +477,7 @@ class TestFirehoseClient:
 
         client.send(self._sample_payloads_long_log_name)
         send_batch_mock.assert_called_with(
-            'data_very_very_very_long_log_stream_name_abcdefg_abcdefgbe9581ad', expected_batch
+            'streamalert_very_very_very_long_log_stream_name_abcdefg_e80fecd8', expected_batch
         )
 
     def test_generate_firehose_stream_name(self):
@@ -485,7 +485,7 @@ class TestFirehoseClient:
         stream_names = [
             'logstreamname',
             'log_stream_name',
-            'very_very_very_long_log_stream_name_abcd_59_characters_long',
+            'very_very_long_log_stream_name_ab_52_characters_long',
             'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
         ]
 
@@ -495,14 +495,16 @@ class TestFirehoseClient:
         #
         # >>> import hashlib
         # >>> s = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
-        # >>> hashlib.md5(s[51:].encode()).hexdigest()[:8]
-        # >>> be9581ad
+        # >>> hashlib.md5(s[44:].encode()).hexdigest()[:8]
+        # 'e80fecd8'
+        # >>> ''.join([s[:44], h[:8]])
+        # 'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
         #
         expected_results = [
             'logstreamname',
             'log_stream_name',
-            'very_very_very_long_log_stream_name_abcd_59_characters_long',
-            'very_very_very_long_log_stream_name_abcdefg_abcdefgbe9581ad'
+            'very_very_long_log_stream_name_ab_52_characters_long',
+            'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
         ]
         results = [
             self._client.generate_firehose_stream_name(False, 'prefix', stream_name)
@@ -516,25 +518,26 @@ class TestFirehoseClient:
         stream_names = [
             'logstreamname',
             'log_stream_name',
-            'very_very_very_long_log_stream_name_abcd_59_characters_long',
+            'very_very_long_log_stream_name_ab_52_characters_long',
             'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
         ]
 
         # >>> import hashlib
-        # >>> s3 = 'very_very_very_long_log_stream_name_abcd_59_characters_long'
+        # >>> s3 = 'very_very_long_log_stream_name_ab_52_characters_long'
         # >>> s4 = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
-        # >>> h3 = hashlib.md5(s3[44:].encode()).hexdigest()
-        # >>> h4 = hashlib.md5(s4[44:].encode()).hexdigest()
-        # >>> ''.join([s3[:44], h3[:8]])
-        # 'very_very_very_long_log_stream_name_abcd_59_06ceefaa'
-        # >>> ''.join([s4[:44], h4[:8]])
-        # 'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
+        # >>> h3 = hashlib.md5(s3[37:].encode()).hexdigest()
+        # >>> h4 = hashlib.md5(s4[37:].encode()).hexdigest()
+        # >>> ''.join([s3[:37], h3[:8]])
+        # >>> ''.join([s3[:37], h3[:8]])
+        # 'very_very_long_log_stream_name_ab_52_06ceefaa'
+        # >>> ''.join([s4[:37], h4[:8]])
+        # 'very_very_very_long_log_stream_name_a759cd21f'
         #
         expected_results = [
             'logstreamname',
             'log_stream_name',
-            'very_very_very_long_log_stream_name_abcd_59_06ceefaa',
-            'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
+            'very_very_long_log_stream_name_ab_52_06ceefaa',
+            'very_very_very_long_log_stream_name_a759cd21f'
         ]
         results = [
             self._client.generate_firehose_stream_name(True, 'prefix', stream_name)

--- a/tests/unit/streamalert/classifier/clients/test_firehose.py
+++ b/tests/unit/streamalert/classifier/clients/test_firehose.py
@@ -480,7 +480,7 @@ class TestFirehoseClient:
             'streamalert_very_very_very_long_log_stream_name_abcdefg_e80fecd8', expected_batch
         )
 
-    def test_generate_firehose_stream_name(self):
+    def test_generate_firehose_suffix(self):
         """FirehoseClient - Test helper to generate firehose stream name when prefix disabled"""
         stream_names = [
             'logstreamname',
@@ -490,7 +490,7 @@ class TestFirehoseClient:
         ]
 
         # the hex value can be calculated via python intepreter based on the
-        # generate_firehose_stream_name function. Copy and paste the tips here
+        # generate_firehose_suffix function. Copy and paste the tips here
         # and make it easier if we change the test cases in the future.
         #
         # >>> import hashlib
@@ -507,13 +507,13 @@ class TestFirehoseClient:
             'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
         ]
         results = [
-            self._client.generate_firehose_stream_name(False, 'prefix', stream_name)
+            self._client.generate_firehose_suffix(False, 'prefix', stream_name)
             for stream_name in stream_names
         ]
 
         assert_equal(expected_results, results)
 
-    def test_generate_firehose_stream_name_prefix(self):
+    def test_generate_firehose_suffix_prefix(self):
         """FirehoseClient - Test helper to generate firehose stream name with prefix"""
         stream_names = [
             'logstreamname',
@@ -540,7 +540,7 @@ class TestFirehoseClient:
             'very_very_very_long_log_stream_name_a759cd21f'
         ]
         results = [
-            self._client.generate_firehose_stream_name(True, 'prefix', stream_name)
+            self._client.generate_firehose_suffix(True, 'prefix', stream_name)
             for stream_name in stream_names
         ]
 

--- a/tests/unit/streamalert/classifier/clients/test_firehose.py
+++ b/tests/unit/streamalert/classifier/clients/test_firehose.py
@@ -412,7 +412,7 @@ class TestFirehoseClient:
         ]
         self._client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'unit-test_streamalert_data_log_type_01_sub_type_01', expected_batch
+            'unit-test_data_log_type_01_sub_type_01', expected_batch
         )
 
     @patch.object(FirehoseClient, '_send_batch')
@@ -434,5 +434,111 @@ class TestFirehoseClient:
 
         client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'streamalert_data_log_type_01_sub_type_01', expected_batch
+            'data_log_type_01_sub_type_01', expected_batch
         )
+
+    @property
+    def _sample_payloads_long_log_name(self):
+        return [
+            Mock(
+                log_schema_type=(
+                    'very_very_very_long_log_stream_name_abcdefg_'
+                    'abcdefg_70_characters_long'
+                ),
+                parsed_records=[
+                    {
+                        'unit_key_01': 1,
+                        'unit_key_02': 'test'
+                    },
+                    {
+                        'unit_key_01': 2,
+                        'unit_key_02': 'test'
+                    }
+                ]
+            )
+        ]
+
+    @patch.object(FirehoseClient, '_send_batch')
+    def test_send_long_log_name(self, send_batch_mock):
+        """FirehoseClient - Send data when the log name is very long"""
+        FirehoseClient._ENABLED_LOGS = {
+            'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long': {}
+        }
+        expected_batch = [
+            '{"unit_key_01":1,"unit_key_02":"test"}\n',
+            '{"unit_key_01":2,"unit_key_02":"test"}\n'
+        ]
+
+        client = FirehoseClient.load_from_config(
+            prefix='unit-test',
+            firehose_config={'enabled': True, 'use_prefix': False},
+            log_sources=None
+        )
+
+        client.send(self._sample_payloads_long_log_name)
+        send_batch_mock.assert_called_with(
+            'data_very_very_very_long_log_stream_name_abcdefg_abcdefgbe9581ad', expected_batch
+        )
+
+    def test_generate_firehose_stream_name(self):
+        """FirehoseClient - Test helper to generate firehose stream name when prefix disabled"""
+        stream_names = [
+            'logstreamname',
+            'log_stream_name',
+            'very_very_very_long_log_stream_name_abcd_59_characters_long',
+            'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
+        ]
+
+        # the hex value can be calculated via python intepreter based on the
+        # generate_firehose_stream_name function. Copy and paste the tips here
+        # and make it easier if we change the test cases in the future.
+        #
+        # >>> import hashlib
+        # >>> s = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
+        # >>> hashlib.md5(s[51:].encode()).hexdigest()[:8]
+        # >>> be9581ad
+        #
+        expected_results = [
+            'logstreamname',
+            'log_stream_name',
+            'very_very_very_long_log_stream_name_abcd_59_characters_long',
+            'very_very_very_long_log_stream_name_abcdefg_abcdefgbe9581ad'
+        ]
+        results = [
+            self._client.generate_firehose_stream_name(False, 'prefix', stream_name)
+            for stream_name in stream_names
+        ]
+
+        assert_equal(expected_results, results)
+
+    def test_generate_firehose_stream_name_prefix(self):
+        """FirehoseClient - Test helper to generate firehose stream name with prefix"""
+        stream_names = [
+            'logstreamname',
+            'log_stream_name',
+            'very_very_very_long_log_stream_name_abcd_59_characters_long',
+            'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
+        ]
+
+        # >>> import hashlib
+        # >>> s3 = 'very_very_very_long_log_stream_name_abcd_59_characters_long'
+        # >>> s4 = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
+        # >>> h3 = hashlib.md5(s3[44:].encode()).hexdigest()
+        # >>> h4 = hashlib.md5(s4[44:].encode()).hexdigest()
+        # >>> ''.join([s3[:44], h3[:8]])
+        # 'very_very_very_long_log_stream_name_abcd_59_06ceefaa'
+        # >>> ''.join([s4[:44], h4[:8]])
+        # 'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
+        #
+        expected_results = [
+            'logstreamname',
+            'log_stream_name',
+            'very_very_very_long_log_stream_name_abcd_59_06ceefaa',
+            'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
+        ]
+        results = [
+            self._client.generate_firehose_stream_name(True, 'prefix', stream_name)
+            for stream_name in stream_names
+        ]
+
+        assert_equal(expected_results, results)


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #1115 #1188 
resolves: #1190 

## Background
See issue #1190 

## Changes
* Update firehose stream name in `classifier` and pass the new stream name to `tf_kinesis_firehose_delivery_stream` module during terraform generate time. The firehose stream name is based on schema name.
  * This change will generate a new stream name if it's longer than 64 characters. In another words, most of the firehose stream name will remain the same.
  * For the stream name longer than 64 characters, the first 58 characters remains unchanged and the rest characters will hash to 8 characters by `hashlib.md5()`. `hashlib.md5()` returns 32 characters (128-bit) and we will only take the first 8 characters. There is low chance is too reach the stream name limit, so I don't worry the hash conflict.
* Remove `_streamalert_` (13 chars) from firehose stream name. Firehose stream name is restrict to the name length is no longer than 64 characters. We want the schema names more descriptive and it will be easily hit the limit especially when we add prefix.
* Use `var.glue_catalog_table_name` in the s3 file prefix instead of `var.log_name`, then latter may be changed if it is too long.

## Testing
* Add unit test cases to cover the code change.
* Tested in staging environment with the data matched to schemas both with short and extremely long schema name, e.g. `osquery_differential` and `cloudwatch:events.dots-test.crazy.long_name_yay_hahahahaha`
  * classifier can process data and send data to both firehose
  * rule's engine can trigger alerts from both types of data.
  * alert process can send alerts to firehose correctly
  * athena partition can partition both types of data
  * both types of data and alerts can be searchable in the Athena in parquet format.