### PR TITLE
Removes a default option that is breaking deploys

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -34,7 +34,6 @@
         "write_capacity": 5
       }
     },
-    "s3_access_logging": {},
     "classifier_sqs": {
       "use_prefix": true
     }

--- a/conf/global.json
+++ b/conf/global.json
@@ -34,9 +34,7 @@
         "write_capacity": 5
       }
     },
-    "s3_access_logging": {
-      "bucket_name": "specify bucket name here"
-    },
+    "s3_access_logging": {},
     "classifier_sqs": {
       "use_prefix": true
     }


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @blakemotl 
cc: @airbnb/streamalert-maintainers


## Background

This default option actually breaks deploys because it provides the name of an existing logging bucket that is invalid.

Notably, this is already documented here: https://www.streamalert.io/en/release-3-0-0/config-global.html#s3-access-logging