### PR TITLE
Cylin fix create table via athena tf

### DIFF
--- a/streamalert/classifier/clients/firehose.py
+++ b/streamalert/classifier/clients/firehose.py
@@ -328,11 +328,8 @@ class FirehoseClient:
                 base_name[:-1]
             ) if base_name[-2] != '_' else '{}_'.format(base_name[:-2])
 
-        # combine the first part and first 8 chars of hash result together as new
+        # combine the base_name and first 8 chars of hash result together as new
         # stream name.
-        # e.g. if use prefix
-        # 'very_very_very_long_log_stream_name_abcd_59_characters_long' may hash to
-        # 'very_very_very_long_log_stream_name_abcd_59_06ceefaa'
         return '{}{}'.format(
             base_name, hashlib.md5(base_name.encode()).hexdigest()  # nosec
         )[:cls.AWS_FIREHOSE_NAME_MAX_LEN]

--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -402,7 +402,7 @@ def create_table(table, bucket, config, schema_override=None):
         # Use the bucket if supplied, otherwise use the default data bucket
         bucket = bucket or config_data_bucket
 
-        log_info = config['logs'][table.replace('_', ':', 1)]
+        log_info = config['logs'][enabled_logs.get(sanitized_table_name)]
 
         schema = dict(log_info['schema'])
         sanitized_schema = FirehoseClient.sanitize_keys(schema)

--- a/streamalert_cli/athena/helpers.py
+++ b/streamalert_cli/athena/helpers.py
@@ -212,7 +212,7 @@ def generate_data_table_schema(config, table, schema_override=None):
                      'is not enabled.', sanitized_table_name)
         return None
 
-    log_info = config['logs'][table.replace('_', ':', 1)]
+    log_info = config['logs'][enabled_logs.get(sanitized_table_name)]
 
     schema = dict(log_info['schema'])
     sanitized_schema = FirehoseClient.sanitize_keys(schema)

--- a/streamalert_cli/terraform/firehose.py
+++ b/streamalert_cli/terraform/firehose.py
@@ -78,7 +78,7 @@ def generate_firehose(logging_bucket, main_dict, config):
             'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
             'glue_catalog_db_name': db_name,
             'glue_catalog_table_name': log_stream_name,
-            'schema': generate_data_table_schema(config, log_stream_name)
+            'schema': generate_data_table_schema(config, log_type_name)
         }
 
         # Try to get alarm info for this specific log type

--- a/tests/unit/streamalert/classifier/clients/test_firehose.py
+++ b/tests/unit/streamalert/classifier/clients/test_firehose.py
@@ -488,17 +488,6 @@ class TestFirehoseClient:
             'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
         ]
 
-        # the hex value can be calculated via python intepreter based on the
-        # generate_firehose_suffix function. Copy and paste the tips here
-        # and make it easier if we change the test cases in the future.
-        #
-        # >>> import hashlib
-        # >>> s = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
-        # >>> hashlib.md5(s[44:].encode()).hexdigest()[:8]
-        # 'e80fecd8'
-        # >>> ''.join([s[:44], h[:8]])
-        # 'very_very_very_long_log_stream_name_abcdefg_e80fecd8'
-        #
         expected_results = [
             'streamalert_logstreamname',
             'streamalert_log_stream_name',
@@ -521,17 +510,6 @@ class TestFirehoseClient:
             'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
         ]
 
-        # >>> import hashlib
-        # >>> s3 = 'very_very_long_log_stream_name_ab_52_characters_long'
-        # >>> s4 = 'very_very_very_long_log_stream_name_abcdefg_abcdefg_70_characters_long'
-        # >>> h3 = hashlib.md5(s3[37:].encode()).hexdigest()
-        # >>> h4 = hashlib.md5(s4[37:].encode()).hexdigest()
-        # >>> ''.join([s3[:37], h3[:8]])
-        # >>> ''.join([s3[:37], h3[:8]])
-        # 'very_very_long_log_stream_name_ab_52_06ceefaa'
-        # >>> ''.join([s4[:37], h4[:8]])
-        # 'very_very_very_long_log_stream_name_a759cd21f'
-        #
         expected_results = [
             'prefix_streamalert_logstreamname',
             'prefix_streamalert_log_stream_name',

--- a/tests/unit/streamalert_cli/athena/test_handler.py
+++ b/tests/unit/streamalert_cli/athena/test_handler.py
@@ -83,8 +83,8 @@ class TestAthenaCli:
     @staticmethod
     @patch('streamalert.shared.athena.AthenaClient.check_table_exists', Mock(return_value=False))
     @patch('streamalert.shared.athena.AthenaClient.run_query', Mock(return_value=True))
-    def test_create_table():
-        """CLI - Athena create table helper"""
+    def test_create_table_with_dots():
+        """CLI - Athena create table helper when log name contains dots"""
         config = CLIConfig(config_path='tests/unit/conf')
         config['global']['infrastructure']['firehose']['enabled_logs'] = {
             'test:log.name.with.dots': {}
@@ -93,6 +93,24 @@ class TestAthenaCli:
         assert_true(
             handler.create_table(
                 'test:log.name.with.dots',
+                'bucket',
+                config
+            )
+        )
+
+    @staticmethod
+    @patch('streamalert.shared.athena.AthenaClient.check_table_exists', Mock(return_value=False))
+    @patch('streamalert.shared.athena.AthenaClient.run_query', Mock(return_value=True))
+    def test_create_table_with_underscores():
+        """CLI - Athena create table helper when log name contains underscores"""
+        config = CLIConfig(config_path='tests/unit/conf')
+        config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'cloudwatch:test_match_types': {}
+        }
+
+        assert_true(
+            handler.create_table(
+                'cloudwatch:test_match_types',
                 'bucket',
                 config
             )

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from mock import patch
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 
 from streamalert_cli.athena import helpers
 from streamalert_cli.config import CLIConfig
+from streamalert.classifier.clients import FirehoseClient
 
 
 CONFIG = CLIConfig(config_path='tests/unit/conf')
@@ -127,3 +128,25 @@ def test_add_partition_statements_exceed_length():
                          "LOCATION 's3://bucket/test/2018/12/01/05'")
     assert_equal(results_copy[0], expected_result_0)
     assert_equal(results_copy[1], expected_result_1)
+
+# pylint: disable=protected-access
+def test_generate_data_table_schema():
+    """CLI - Athena generate_data_table_schema helper"""
+    config = CLIConfig(config_path='tests/unit/conf')
+    config['global']['infrastructure']['firehose']['enabled_logs'] = {
+        'test:log.name.with.dots': {}
+    }
+
+    assert_true(helpers.generate_data_table_schema(config, 'test:log.name.with.dots'))
+    FirehoseClient._ENABLED_LOGS.clear()
+
+# pylint: disable=protected-access
+def test_generate_data_table_schema_2():
+    """CLI - Athena generate_data_table_schema helper"""
+    config = CLIConfig(config_path='tests/unit/conf')
+    config['global']['infrastructure']['firehose']['enabled_logs'] = {
+        'cloudwatch:test_match_types': {}
+    }
+
+    assert_true(helpers.generate_data_table_schema(config, 'cloudwatch:test_match_types'))
+    FirehoseClient._ENABLED_LOGS.clear()


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: 
resolves: #1186

## Background
Hope this is the last bug I need to fix for this month 🤞 

`create_table` (used to create table via athena api calls) and `generate_data_table_schema ` (used to create table via terraform) methods will throw error when the log name contains underscore, e.g. `cloudwatch:test_match_types`, although it doesn't error out when the log name contains dots, e.g. `test:log.name.with.dots`, thanks for recent fix #1197 

I realize that `FirehoseClient.load_enabled_log_sources()` returns a dictionary about enabled logs where the key is sanitized log name and the value is the original log name defined either in `conf/schemas/*.json` or `conf/logs.json`. So we can use original log name and we don't need to do `table.replace('_', ':', 1)` anymore.

An example of the return value of `FirehoseClient.load_enabled_log_sources()` is
```
{
  'osquery_batch': 'osquery:batch', 
  'osquery_differential': 'osquery:differential', 
  'osquery_snapshot': 'osquery:snapshot',
  'osquery_status': 'osquery:status', 
  'carbonblack_alert_status_updated': 'carbonblack:alert.status.updated', 
  'carbonblack_alert_watchlist_hit_feedsearch_bin': 'carbonblack:alert.watchlist.hit.feedsearch.bin', 
  'cloudwatch_events_dots_test_crazy_long_name_yay_hahahahaha': 'cloudwatch:events.dots-test.crazy.long_name_yay_hahahahaha', 
  'cloudwatch_flow_logs': 'cloudwatch:flow_logs', 
  'cloudwatch_rds_aurora': 'cloudwatch:rds_aurora'
}
```

## Changes

* Pass original log name to `create_table` and `generate_data_table_schema` methods
* Add unit test cases

## Testing
* Unit test cases are passed
* `python manage.py build` works correctly with `cloudwatch`, `osquery` and `carbonblack` logs enabled.
