### PR TITLE
[tf] Change alerts_bucket type to string in tf_rule_promotion_iam module

### DIFF
--- a/terraform/modules/tf_rule_promotion_iam/variables.tf
+++ b/terraform/modules/tf_rule_promotion_iam/variables.tf
@@ -28,7 +28,7 @@ variable "athena_results_bucket_arn" {
 
 variable "alerts_bucket" {
   description = "Name of S3 bucket where alerts are stored and queryable by Athena"
-  type        = list(string)
+  type        = string
 }
 
 variable "s3_kms_key_arn" {


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
Minor fix that the type of `alerts_bucket` in `tf_rule_promotion_iam` module should be a `string`.

## Testing
Ran `terraform validate` internally and it was passed.
