### PR TITLE
Make scheduled_queries/ directory configurable from global.json

### DIFF
--- a/conf/global.json
+++ b/conf/global.json
@@ -10,6 +10,9 @@
     ],
     "rule_locations": [
       "rules"
+    ],
+    "scheduled_query_locations": [
+      "scheduled_queries"
     ]
   },
   "infrastructure": {

--- a/docs/source/config-global.rst
+++ b/docs/source/config-global.rst
@@ -66,6 +66,9 @@ Configuration
       ],
       "rule_locations": [
         "rules"
+      ],
+      "scheduled_query_locations": [
+        "scheduled_queries"
       ]
     }
   }
@@ -73,12 +76,13 @@ Configuration
 
 Options
 -------
-======================  ============  =================  ===============
-**Key**                 **Required**  **Default**        **Description**
-----------------------  ------------  -----------------  ---------------
-``matcher_locations``   Yes           ``["matchers"]``   List of local paths where ``matchers`` are defined
-``rule_locations``      Yes           ``["rules"]``      List of local paths where ``rules`` are defined
-======================  ============  =================  ===============
+=============================  =============  =========================  ===============
+**Key**                        **Required**   **Default**                **Description**
+-----------------------------  -------------  -------------------------  ---------------
+``matcher_locations``          Yes            ``["matchers"]``           List of local paths where ``matchers`` are defined
+``rule_locations``             Yes            ``["rules"]``              List of local paths where ``rules`` are defined
+``scheduled_query_locations``  Yes            ``["scheduled_queries"]``  List of local paths where ``scheduled_queries`` are defined
+=============================  =============  =========================  ===============
 
 
 **************

--- a/streamalert/scheduled_queries/query_packs/configuration.py
+++ b/streamalert/scheduled_queries/query_packs/configuration.py
@@ -15,8 +15,6 @@ limitations under the License.
 """
 from streamalert.shared.importer import import_folders
 
-PACKS_DIRECTORY = 'scheduled_queries/'
-
 
 class QueryPackConfiguration:
 
@@ -112,5 +110,6 @@ class QueryPackRepository:
         cls.QUERY_PACKS[name] = config
 
     @classmethod
-    def load_packs(cls):
-        import_folders(PACKS_DIRECTORY)
+    def load_packs(cls, directories):
+        for dir in directories:
+            import_folders(dir)

--- a/streamalert/scheduled_queries/query_packs/configuration.py
+++ b/streamalert/scheduled_queries/query_packs/configuration.py
@@ -111,5 +111,4 @@ class QueryPackRepository:
 
     @classmethod
     def load_packs(cls, directories):
-        for dir in directories:
-            import_folders(dir)
+        import_folders(*directories)

--- a/tests/unit/conf/global.json
+++ b/tests/unit/conf/global.json
@@ -7,7 +7,8 @@
   },
   "general": {
     "matcher_locations": [],
-    "rule_locations": []
+    "rule_locations": [],
+    "scheduled_query_locations": []
   },
   "infrastructure": {
     "alerts_table": {

--- a/tests/unit/streamalert/scheduled_queries/query_packs/test_configuration.py
+++ b/tests/unit/streamalert/scheduled_queries/query_packs/test_configuration.py
@@ -59,6 +59,6 @@ class TestQueryPackRepository:
     @staticmethod
     def test_load_and_get_packs():
         """StreamQuery - QueryPackRepository - get_packs"""
-        QueryPackRepository.load_packs()
+        QueryPackRepository.load_packs(['scheduled_queries/'])
 
         assert_true(len(QueryPackRepository.get_packs()) >= 1)


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/streamalert-maintainers

### Changes

It's now configurable under the node `scheduled_query_locations` in the `global.json` file
