### PR TITLE
Make list targets work again

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -105,7 +105,7 @@ Deploy
 
 .. note::
 
-  * Update the ``file_format`` value in ``conf/lambda.json``, choose ``parquet`` or ``json``. We will set default value to ``parquet`` in the future release.
+  * Update the ``file_format`` value in ``conf/lambda.json``. Valid options are ``parquet`` or ``json``. The default value will be parquet in a future release, but this must be manually configured at this time.
 
   .. code-block:: bash
 
@@ -115,7 +115,7 @@ Deploy
       "log_level": "info"
     }
 
-  * For more information, please visit :ref:`historical_search` page for more information.
+  * More information can be found on the `historical search <historical-search.html>`_ page.
 
 2. Build the StreamAlert infrastructure for the first time:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -103,6 +103,20 @@ Deploy
   python manage.py configure aws_account_id 111111111111  # Replace with your 12-digit AWS account ID
   python manage.py configure prefix <value>               # Choose a unique name prefix (alphanumeric characters only)
 
+.. note::
+
+  * Update the ``file_format`` value in ``conf/lambda.json``, choose ``parquet`` or ``json``. We will set default value to ``parquet`` in the future release.
+
+  .. code-block:: bash
+
+    "athena_partition_refresh_config": {
+      "concurrency_limit": 10,
+      "file_format": "parquet",
+      "log_level": "info"
+    }
+
+  * For more information, please visit :ref:`historical_search` page for more information.
+
 2. Build the StreamAlert infrastructure for the first time:
 
 .. code-block:: bash

--- a/docs/source/historical-search.rst
+++ b/docs/source/historical-search.rst
@@ -1,4 +1,5 @@
-#################
+.. _historical_search:
+
 Historical Search
 #################
 

--- a/docs/source/historical-search.rst
+++ b/docs/source/historical-search.rst
@@ -1,5 +1,3 @@
-.. _historical_search:
-
 Historical Search
 #################
 

--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -25,7 +25,6 @@ from streamalert_cli.terraform import TERRAFORM_FILES_PATH
 
 # Build .zip files in the top-level of the terraform directory
 THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
-BUILD_DIRECTORY = os.path.join(THIS_DIRECTORY, '..', '..', 'terraform')
 LOGGER = get_logger(__name__)
 
 

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -618,7 +618,7 @@ def generate_global_lambda_settings(config, config_name, generate_func, tf_tmp_f
                 'It is required to explicitly set "file_format" for '
                 'athena_partition_refresh_config in "conf/lambda.json" when upgrading to v3.1.0. '
                 'Available values are "parquet" and "json". For more information, refer to '
-                'https://github.com/airbnb/streamalert/issues/1143'
+                'https://github.com/airbnb/streamalert/issues/1143. '
                 'In the future release, the default value of "file_format" will '
                 'be changed to "parquet".'
             )

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -409,7 +409,7 @@ def get_tf_modules(config, generate=False):
 
     modules = set()
     resources = set()
-    for root, _, files in os.walk('terraform'):
+    for root, _, files in os.walk(TERRAFORM_FILES_PATH):
         for file_name in files:
             path = os.path.join(root, file_name)
             if path.endswith('.tf.json'):

--- a/tests/unit/streamalert_cli/terraform/test_handlers.py
+++ b/tests/unit/streamalert_cli/terraform/test_handlers.py
@@ -1,0 +1,81 @@
+"""
+Copyright 2017-present Airbnb, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import os
+
+from mock import patch, Mock
+from nose.tools import assert_equal, assert_false
+from pyfakefs import fake_filesystem_unittest
+
+from streamalert_cli.terraform import TERRAFORM_FILES_PATH
+from streamalert_cli.terraform.handlers import get_tf_modules
+
+class TestTerraformHandlers(fake_filesystem_unittest.TestCase):
+    """Test class for the Terraform handler functions"""
+    # pylint: disable=attribute-defined-outside-init,no-self-use
+
+    def setUp(self):
+        """Setup before each method"""
+        self.setUpPyfakefs()
+
+        mock_main_tf_json = {
+            'module': {
+                'module1': {
+                    'foo': 'bar'
+                }
+            }
+        }
+        mock_prod_tf_json = {
+            'module': {
+                'module2': {
+                    'foo': 'bar'
+                }
+            },
+            'resource': {
+                'resource1': {'foo': 'test'},
+                'resource2': {'bar': 'test'},
+                'resource3': {'pan': 'test'}
+            }
+        }
+        # fake *.tf.json files
+        self.fs.create_file(
+            os.path.join(TERRAFORM_FILES_PATH, 'main.tf.json'),
+            contents=json.dumps(mock_main_tf_json)
+        )
+        self.fs.create_file(
+            os.path.join(TERRAFORM_FILES_PATH, 'prod.tf.json'),
+            contents=json.dumps(mock_prod_tf_json)
+        )
+
+    @patch('streamalert_cli.terraform.handlers.terraform_generate_handler', Mock(return_value=True))
+    def test_get_tf_modules_read_tf_json_files(self):
+        """CLI - Terraform handler function get tf modules read all *.tf.json files"""
+        config = {}
+        result = get_tf_modules(config)
+
+        expected_result = {
+            'module': {'module1', 'module2'},
+            'resource': {'resource1.foo', 'resource2.bar', 'resource3.pan'}
+        }
+
+        assert_equal(result, expected_result)
+
+    @patch(
+        'streamalert_cli.terraform.handlers.terraform_generate_handler', Mock(return_value=False)
+    )
+    def test_get_tf_modules_early_return(self):
+        """CLI - Terraform handler function get tf modules return early"""
+        assert_false(get_tf_modules(config={}, generate=True))


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
Deploy a fresh copy of `release-3-1-0` branch to staging environment, for, fun 🤷‍♀ and found couple minor bugs.

## Changes

* `python manage.py list-targets` command is broken due to recent change of terraform files path.
* Add use test cases to test the code change.
* Add a space when print out `WARNING` messing to remind user to update `file_format` setting.
* Add a `Note` in `getting_started` doc to remind user to update `file_format` setting.
![image](https://user-images.githubusercontent.com/21151436/77595306-0bd78b80-6eb6-11ea-92ce-a2b15f9a92bb.png)

## Testing
* Fresh checkout `release-3-1-0` branch
* ` python manage.py configure aws_account_id 111111111111`
* `python manage.py configure prefix cylinrelease31`
* `python manage.py init`
* A `ConfigError warming to set "file_format" to "parquet" in "athena_partition_refresh_config"` raised.
* Update "file_format" to "parquet" and re-init
* `python manage.py init` and StreamAlert initialization was successful.
* Create a kinesis stream in cluster "prod"
```
  "modules": {
    "cloudwatch_monitoring": {
      "enabled": true,
      "kinesis_alarms_enabled": false,
      "lambda_alarms_enabled": true
    },
    "kinesis": {
      "streams": {
        "create_user": true,
        "retention": 24,
        "shards": 1,
        "terraform_outputs": [
          "arn",
          "access_key_id",
          "secret_key"
        ]
      }
    },
    "kinesis_events": {
      "batch_size": 100,
      "enabled": true
    }
  }
```
* Add new kinesis name to the "data_sources" filed in conf/clusters/prod.json
```
  "data_sources": {
    "kinesis": {
      "prefix_cluster1_streamalert": [
        "cloudwatch",
        "ghe",
        "osquery"
      ],
      "cylinrelease31_prod_streamalert": [
        "cloudwatch",
        "osquery"
      ]
    },
```
* Run build and deploy "prod" classifier
```
python manage.py build --target kinesis_events_prod kinesis_prod
python manage.py deploy --function classifier
```
* Send testing cloudwatch events to the kinesis to trigger classifier, rules engine, alert processor, alert merger.
* Enable firehose and run build to create firehose and athena tables for cloudwatch events. in `conf/global.json`
```
  "infrastructure": {
    "alerts_table": {
      "read_capacity": 5,
      "write_capacity": 5
    },
    "firehose": {
      "use_prefix": true,
      "buffer_interval": 900,
      "buffer_size": 128,
      "enabled": true,
      "enabled_logs": {
        "cloudwatch": {},
        "osquery": {}
      }
    },
```
* `python manage.py build`
* `python manage.py deploy --function classifier`
* `python manage.py deploy --function athena`
* Send testing cloudwatch events to the kinesis to trigger classifier, rules engine, alert processor, alert merger and athena partition lambda function.
* Alerts and cloudWatch events are searchable in Athena table/
