### PR TITLE
Missing alerts table creation during init

### DIFF
--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -368,11 +368,6 @@ def create_table(table, bucket, config, schema_override=None):
 
     athena_client = get_athena_client(config)
 
-    config_data_bucket = firehose_data_bucket(config)
-    if not config_data_bucket:
-        LOGGER.error('The \'firehose\' module is not enabled in global.json')
-        return False
-
     # Check if the table exists
     if athena_client.check_table_exists(sanitized_table_name):
         LOGGER.info('The \'%s\' table already exists.', sanitized_table_name)
@@ -393,6 +388,11 @@ def create_table(table, bucket, config, schema_override=None):
         )
 
     else:  # all other tables are log types
+
+        config_data_bucket = firehose_data_bucket(config)
+        if not config_data_bucket:
+            LOGGER.error('The \'firehose\' module is not enabled in global.json')
+            return False
 
         # Use the bucket if supplied, otherwise use the default data bucket
         bucket = bucket or config_data_bucket

--- a/streamalert_cli/athena/handler.py
+++ b/streamalert_cli/athena/handler.py
@@ -391,7 +391,7 @@ def create_table(table, bucket, config, schema_override=None):
 
         config_data_bucket = firehose_data_bucket(config)
         if not config_data_bucket:
-            LOGGER.error('The \'firehose\' module is not enabled in global.json')
+            LOGGER.warning('The \'firehose\' module is not enabled in global.json')
             return False
 
         # Use the bucket if supplied, otherwise use the default data bucket

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -109,7 +109,7 @@ class TerraformInitCommand(CLICommand):
         alerts_bucket = firehose_alerts_bucket(config)
         create_table('alerts', alerts_bucket, config)
 
-        LOGGER.info('Building remainding infrastructure')
+        LOGGER.info('Building remaining infrastructure')
         return tf_runner(refresh=False)
 
     @staticmethod


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #1163
resolves:

## Background
In #1163, we had additional check on if `firehose` module (for logs) enable or not before creating the `alerts` table. By default, the `firehose` module is disabled and  `alerts` table won't be created during the init time. The `alerts` table is not depend on `firehose` module (for logs). The fix is easy, move the "firehose_data_bucket" check after "alerts" table creation. 

## Changes

* Move the "firehose_data_bucket" check after "alerts" table creation.
* Change logging severity to `warning` if `firehose` module is disabled in `conf/global.json`.
* Correct a typo in the logging message.

## Testing
Tested in staging and the `alerts` table is created as expected when `firehose` module remaining disable.