### PR TITLE
fixing clean subcommand, remove unused constants

### DIFF
--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -23,8 +23,6 @@ from streamalert.shared.logger import get_logger
 from streamalert_cli.helpers import run_command
 from streamalert_cli.terraform import TERRAFORM_FILES_PATH
 
-# Build .zip files in the top-level of the terraform directory
-THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 LOGGER = get_logger(__name__)
 
 
@@ -84,6 +82,7 @@ class LambdaPackage:
             sys.exit(1)
 
         # Zip up files
+        # Build these in the top-level of the terraform directory
         result = shutil.make_archive(
             os.path.join(TERRAFORM_FILES_PATH, self.package_name), 'zip', temp_package_path)
         LOGGER.info('Successfully created %s', os.path.basename(result))

--- a/streamalert_cli/terraform/handlers.py
+++ b/streamalert_cli/terraform/handlers.py
@@ -298,7 +298,7 @@ class TerraformCleanCommand(CLICommand):
             print('Removing terraform file: {}'.format(path))
             os.remove(path)
 
-        for root, _, files in os.walk('terraform'):
+        for root, _, files in os.walk(TERRAFORM_FILES_PATH):
             for file_name in files:
                 path = os.path.join(root, file_name)
                 if path.endswith('.tf.json'):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #1210

## Background

Similar to #1210, previous changes broke the `clean` subcommand.

## Changes

* Fixing path to terraform files for cleaning
* Removing now-unused constants

