### PR TITLE
adding "--config-dir" flag to CLI to support specifying path for config files

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -27,8 +27,9 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import sys
 
 from streamalert import __version__ as version
+from streamalert_cli.config import DEFAULT_CONFIG_PATH
 from streamalert_cli.runner import cli_runner, StreamAlertCLICommandRepository
-from streamalert_cli.utils import generate_subparser
+from streamalert_cli.utils import DirectoryType, generate_subparser
 
 
 def build_parser():
@@ -51,7 +52,6 @@ For additional help with any command above, try:
 
         {} [command] --help
 """
-
     parser = ArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
         prog=__file__
@@ -69,6 +69,14 @@ For additional help with any command above, try:
         '--debug',
         help='enable debugging logger output for all of the StreamAlert loggers',
         action='store_true'
+    )
+
+    parser.add_argument(
+        '-c',
+        '--config-dir',
+        default=DEFAULT_CONFIG_PATH,
+        help='Path to directory containing configuration files',
+        type=DirectoryType()
     )
 
     # Dynamically generate subparsers, and create a 'commands' block for the prog description

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -231,10 +231,10 @@ def load_config(conf_dir='conf/', exclude=None, include=None, validate=True):
         ]
 
     if not (conf_files or include_clusters or schema_files):
-        available_files = ', '.join("'{}'".format(name) for name in sorted(default_files))
-        raise ConfigError('No config files to load. This is likely due the misuse of '
-                          'the \'include\' or \'exclude\' keyword arguments. Available '
-                          'files are: {}, clusters, and schemas.'.format(available_files))
+        raise ConfigError(
+            'No config files to load. The supplied directory could be incorrect or this could '
+            'be due the misuse of the \'include\' or \'exclude\' keyword arguments.'
+        )
 
     config = defaultdict(dict)
     for name in conf_files:

--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -25,13 +25,13 @@ from streamalert_cli.helpers import continue_prompt
 from streamalert_cli.apps.helpers import save_app_auth_info
 
 LOGGER = get_logger(__name__)
+DEFAULT_CONFIG_PATH = 'conf'
 
 
 class CLIConfig:
     """A class to load, modify, and display the StreamAlertCLI Config"""
-    DEFAULT_CONFIG_PATH = 'conf/'
 
-    def __init__(self, config_path=DEFAULT_CONFIG_PATH):
+    def __init__(self, config_path):
         self.config_path = config_path
         self.config = config.load_config(config_path)
 

--- a/streamalert_cli/runner.py
+++ b/streamalert_cli/runner.py
@@ -59,7 +59,7 @@ def cli_runner(args):
     Returns:
         bool: False if errors occurred, True otherwise
     """
-    config = CLIConfig()
+    config = CLIConfig(args.config_dir)
 
     set_logger_levels(args.debug)
 

--- a/streamalert_cli/utils.py
+++ b/streamalert_cli/utils.py
@@ -99,9 +99,7 @@ class DirectoryType:
         if os.path.isdir(value):
             return value
 
-        raise ArgumentTypeError(
-            '\'%(filename)s\' is not a directory' % {'filename': value}
-        )
+        raise ArgumentTypeError('\'{}\' is not a directory'.format(value))
 
 
 def add_timeout_arg(parser):

--- a/tests/unit/streamalert_cli/test_cli_config.py
+++ b/tests/unit/streamalert_cli/test_cli_config.py
@@ -39,19 +39,19 @@ class TestCLIConfig:
         self.fs_patcher.setUp()
 
         self.fs_patcher.fs.create_file(
-            '/conf/global.json', contents=json.dumps(config_data['global']))
+            './conf/global.json', contents=json.dumps(config_data['global']))
         self.fs_patcher.fs.create_file(
-            '/conf/threat_intel.json', contents=json.dumps(config_data['threat_intel']))
+            './conf/threat_intel.json', contents=json.dumps(config_data['threat_intel']))
         self.fs_patcher.fs.create_file(
-            '/conf/normalized_types.json', contents=json.dumps(config_data['normalized_types']))
+            './conf/normalized_types.json', contents=json.dumps(config_data['normalized_types']))
         self.fs_patcher.fs.create_file(
-            '/conf/lambda.json', contents=json.dumps(config_data['lambda']))
+            './conf/lambda.json', contents=json.dumps(config_data['lambda']))
         self.fs_patcher.fs.create_file(
-            '/conf/clusters/prod.json', contents=json.dumps(config_data['clusters']['prod']))
+            './conf/clusters/prod.json', contents=json.dumps(config_data['clusters']['prod']))
 
         # Create the config instance after creating the fake filesystem so that
         # CLIConfig uses our mocked config files instead of the real ones.
-        self.config = CLIConfig()
+        self.config = CLIConfig('./conf/')
 
     def teardown(self):
         """Teardown after each method"""


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

With upcoming packaging changes, users will need to be able to specify a path to config files that need to be loaded.

## Changes

* Adding `-c/--config-dir` flag to top of manage.py to allow for loading config from users specified path (defaults to `conf/`)

## Testing

Updating unit tests
