### PR TITLE
Adds missing netaddr lib to rule promo

### DIFF
--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -307,6 +307,7 @@ class RulePromotionPackage(LambdaPackage):
         'streamalert/shared'
     }
     package_name = 'rule_promotion'
+    package_libs = {'netaddr'}
 
 
 class ScheduledQueriesPackage(LambdaPackage):


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Causing rule promo to error
