### PR TITLE
adding terraform references for some buckets

### DIFF
--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/outputs.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/outputs.tf
@@ -2,6 +2,10 @@ output "data_bucket_arn" {
   value = aws_s3_bucket.streamalert_data.arn
 }
 
+output "data_bucket_name" {
+  value = aws_s3_bucket.streamalert_data.bucket
+}
+
 output "firehose_role_arn" {
   value = aws_iam_role.streamalert_kinesis_firehose.arn
 }

--- a/streamalert_cli/terraform/athena.py
+++ b/streamalert_cli/terraform/athena.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from streamalert.shared import ATHENA_PARTITIONER_NAME
-from streamalert.shared.config import athena_partition_buckets, athena_query_results_bucket
+from streamalert.shared.config import athena_partition_buckets_tf, athena_query_results_bucket
 from streamalert_cli.manage_lambda.package import AthenaPartitionerPackage
 from streamalert_cli.terraform.common import (
     infinitedict,
@@ -37,7 +37,7 @@ def generate_athena(config):
     prefix = config['global']['account']['prefix']
     athena_config = config['lambda']['athena_partitioner_config']
 
-    data_buckets = sorted(athena_partition_buckets(config))
+    data_buckets = athena_partition_buckets_tf(config)
     database = athena_config.get('database_name', '{}_streamalert'.format(prefix))
 
     results_bucket_name = athena_query_results_bucket(config)

--- a/streamalert_cli/terraform/scheduled_queries.py
+++ b/streamalert_cli/terraform/scheduled_queries.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from streamalert.shared.config import athena_partition_buckets, athena_query_results_bucket
+from streamalert.shared.config import athena_partition_buckets_tf, athena_query_results_bucket
 from streamalert_cli.manage_lambda.package import ScheduledQueriesPackage
 from streamalert_cli.terraform.common import monitoring_topic_arn
 
@@ -37,7 +37,7 @@ def generate_scheduled_queries_module_configuration(config):
     # FIXME (derek.wang) DRY out this code
     results_bucket = athena_query_results_bucket(config)
 
-    athena_s3_buckets = sorted(athena_partition_buckets(config))
+    athena_s3_buckets = athena_partition_buckets_tf(config)
 
     # Copy the config over directly
     scheduled_queries_module = streamquery_config.get('config', {})

--- a/tests/unit/streamalert_cli/terraform/test_athena.py
+++ b/tests/unit/streamalert_cli/terraform/test_athena.py
@@ -43,8 +43,8 @@ def test_generate_athena():
                 'queue_name': '{}_streamalert_athena_s3_notifications'.format(prefix),
                 'results_bucket': '{}-streamalert-athena-results'.format(prefix),
                 'athena_data_buckets': [
-                    'unit-test-streamalert-data',
-                    'unit-test-streamalerts'
+                    '${aws_s3_bucket.streamalerts.bucket}',
+                    '${module.kinesis_firehose_setup.data_bucket_name}',
                 ],
                 'lambda_timeout': 60,
                 'kms_key_id': '${aws_kms_key.server_side_encryption.key_id}',

--- a/tests/unit/streamalert_cli/terraform/test_scheduled_queries.py
+++ b/tests/unit/streamalert_cli/terraform/test_scheduled_queries.py
@@ -37,9 +37,9 @@ def test_generate_scheduled_queries():
                 'athena_database': 'unit-test_streamalert',
                 'athena_results_bucket': 'unit-test-streamalert-athena-results',
                 'athena_s3_buckets': [
+                    '${aws_s3_bucket.streamalerts.bucket}',
+                    '${module.kinesis_firehose_setup.data_bucket_name}',
                     'bucket',
-                    'unit-test-streamalert-data',
-                    'unit-test-streamalerts'
                 ],
                 'lambda_filename': 'scheduled_queries.zip',
                 'lambda_handler': 'streamalert.scheduled_queries.main.handler',


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

A race condition could cause errors like:

```
Error: Error putting S3 notification configuration: NoSuchBucket: The specified bucket does not exist
	status code: 404, request id: 5A5ACCB6EB4055B8, host id: vIlTAABEslxBZXQXmF5QRhFi6z4kQ0wW2YUeJdMLKjGpJn4u5irjwctlzAPPDIY1RKsktnKyh5s=
  on modules/tf_athena/main.tf line 100, in resource "aws_s3_bucket_notification" "bucket_notification":
 100: resource "aws_s3_bucket_notification" "bucket_notification" {
...
```

## Changes

* Using references to terraform resources/outputs for bucket names to enforce the creation of the resources before we try to use their "value".

## Testing

Updates to unit tests.
