### PR TITLE
Normalization reboot - Add terraform resources

### DIFF
--- a/conf/lambda.json
+++ b/conf/lambda.json
@@ -53,6 +53,8 @@
   "artifact_extractor_config": {
     "concurrency_limit": 10,
     "enabled": false,
+    "firehose_buffer_size": 128,
+    "firehose_buffer_interval": 900,
     "log_level": "info",
     "memory": 128,
     "metric_alarms": {

--- a/streamalert/artifact_extractor/artifact_extractor.py
+++ b/streamalert/artifact_extractor/artifact_extractor.py
@@ -42,11 +42,12 @@ class Artifact:
                 record processed by classifier. This field is very useful for cross reference back
                 to the original record in the future.
         """
-        self._function = kwargs.get('function', 'not_specified')
-        self._record_id = kwargs.get('record_id', 'RESERVED')
-        self._source_type = source_type
-        self._type = normalized_type
-        self._value = value
+        # Enforce all fields are strings in a Artifact to prevent type corruption in Parquet format
+        self._function = str(kwargs.get('function', 'not_specified'))
+        self._record_id = str(kwargs.get('record_id', 'RESERVED'))
+        self._source_type = str(source_type)
+        self._type = str(normalized_type)
+        self._value = str(value)
 
     @property
     def record(self):

--- a/streamalert/artifact_extractor/artifact_extractor.py
+++ b/streamalert/artifact_extractor/artifact_extractor.py
@@ -26,6 +26,8 @@ LOGGER = get_logger(__name__)
 class Artifact:
     """Encapsulation of a single Artifact that is extracted from an input record."""
 
+    RESERVED = 'RESERVED'
+
     def __init__(self, source_type, normalized_type, value, **kwargs):
         """Create a new Artifact based on normalized information
 
@@ -44,7 +46,7 @@ class Artifact:
         """
         # Enforce all fields are strings in a Artifact to prevent type corruption in Parquet format
         self._function = str(kwargs.get('function', 'not_specified'))
-        self._record_id = str(kwargs.get('record_id', 'RESERVED'))
+        self._record_id = str(kwargs.get('record_id', self.RESERVED))
         self._source_type = str(source_type)
         self._type = str(normalized_type)
         self._value = str(value)

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -465,7 +465,7 @@ def artifact_extractor_enabled(config, log_name=None):
     # if log_name is empty, it means caller only want to know if artifact extractor lambda
     # function enabled or not, so return early.
     if not log_name:
-        return False
+        return True
     # FIXME: (cylin) pretty this line and add more comment
     log_config = config.get('logs', {}).get(log_name, {})
     return 'normalization' in log_config.get('configuration', {})

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -497,6 +497,6 @@ def artifact_extractor_enabled(config, log_name=None):
     # function enabled or not, so return early.
     if not log_name:
         return True
-    
+
     log_config = config.get('logs', {}).get(log_name, {})
     return 'normalization' in log_config.get('configuration', {})

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -443,3 +443,29 @@ def _validate_sources(cluster_name, data_sources, existing_sources):
             existing_sources.add(source)
 
 # FIXME (derek.wang) write a configuration validator for lookuptables (new one)
+
+def artifact_extractor_enabled(config, log_name=None):
+    """Determine if artifactor extractor enabled one a firehose
+    TODO: (cylin) docstring
+    Args:
+        config (dict): The loaded config from the 'conf/' directory
+        log_name (string): expect to be original log names, e.g. 'aliyun', 'osquery:differential'
+
+    Returns:
+        bool: Return True if 'normalization' is configured in a log definition.
+    """
+    if not config['lambda'].get('artifact_extractor_config', {}).get('enabled', False):
+        return False
+
+    # Artifact extractor lambda is based on StreamAlert data Firehoses. Consider Artifact Extractor
+    # is enabled once when firehose is enabled
+    if not config['global']['infrastructure'].get('firehose', {}).get('enabled', False):
+        return False
+
+    # if log_name is empty, it means caller only want to know if artifact extractor lambda
+    # function enabled or not, so return early.
+    if not log_name:
+        return False
+    # FIXME: (cylin) pretty this line and add more comment
+    log_config = config.get('logs', {}).get(log_name, {})
+    return 'normalization' in log_config.get('configuration', {})

--- a/streamalert/shared/config.py
+++ b/streamalert/shared/config.py
@@ -444,7 +444,7 @@ def _validate_sources(cluster_name, data_sources, existing_sources):
 
 # FIXME (derek.wang) write a configuration validator for lookuptables (new one)
 
-def artifact_extractor_enabled(config, log_name=None):
+def _artifact_extractor_enabled_helper(config, log_name):
     """Validate if Artifactor Extractor enabled.
     There are two cases need validate if Artifact Extractor enabled.
     1. For deploy Artifact Extractor Lambda function.
@@ -500,3 +500,11 @@ def artifact_extractor_enabled(config, log_name=None):
 
     log_config = config.get('logs', {}).get(log_name, {})
     return 'normalization' in log_config.get('configuration', {})
+
+def artifact_extractor_enabled_for_log(config, log_name):
+    """Validate if Artifact Extractor enabled for a log"""
+    return _artifact_extractor_enabled_helper(config, log_name=log_name)
+
+def artifact_extractor_enabled(config):
+    """Validate if Artifact Extractor enabled"""
+    return _artifact_extractor_enabled_helper(config, log_name=None)

--- a/streamalert/shared/firehose.py
+++ b/streamalert/shared/firehose.py
@@ -344,18 +344,15 @@ class FirehoseClient:
         Returns:
             str: Artifacts Firehose Stream Name
         """
+        # support custom firehose stream name of Artifacts. User should make sure the length of
+        # the custom firehose name is no longer than 64 chars, otherwise the firehose will be
+        # failed to create. StreamAlert is not responsible for checking for custom firehose name
+        # since it should not change custom settings.
         stream_name = config.get('lambda', {}).get(
             'artifact_extractor_config', {}
         ).get('firehose_stream_name')
 
-        if stream_name:
-            # support custom firehose stream name of Artifacts. User should make sure the length of
-            # the custom firehose name is no longer than 64 chars, otherwise the firehose will be
-            # failed to create. StreamAlert is not responsible for checking for custom firehose name
-            # since it should not change custom settings.
-            return stream_name
-
-        return cls.generate_firehose_name(
+        return stream_name or cls.generate_firehose_name(
             prefix=config['global']['account']['prefix'],
             log_stream_name='artifacts'
         )

--- a/streamalert/shared/firehose.py
+++ b/streamalert/shared/firehose.py
@@ -335,6 +335,30 @@ class FirehoseClient:
         )[:cls.AWS_FIREHOSE_NAME_MAX_LEN]
 
     @classmethod
+    def artifacts_firehose_stream_name(cls, config):
+        """Return Artifacts Firehose Stream Name
+
+        Args:
+            config (dict): The loaded config from the 'conf/' directory
+
+        Returns:
+            str: Artifacts Firehose Stream Name
+        """
+        stream_name = config.get('lambda', {}).get(
+            'artifact_extractor_config', {}
+        ).get('firehose_stream_name')
+
+        if stream_name:
+            # support custom firehose stream name of Artifacts
+            return cls.generate_firehose_name(prefix='', log_stream_name=stream_name)
+
+        return cls.generate_firehose_name(
+            prefix=config['global']['account']['prefix'],
+            log_stream_name='artifacts'
+        )
+
+
+    @classmethod
     def enabled_log_source(cls, log_source_name):
         """Check that the incoming record is an enabled log source for Firehose
 

--- a/streamalert/shared/firehose.py
+++ b/streamalert/shared/firehose.py
@@ -349,8 +349,11 @@ class FirehoseClient:
         ).get('firehose_stream_name')
 
         if stream_name:
-            # support custom firehose stream name of Artifacts
-            return cls.generate_firehose_name(prefix='', log_stream_name=stream_name)
+            # support custom firehose stream name of Artifacts. User should make sure the length of
+            # the custom firehose name is no longer than 64 chars, otherwise the firehose will be
+            # failed to create. StreamAlert is not responsible for checking for custom firehose name
+            # since it should not change custom settings.
+            return stream_name
 
         return cls.generate_firehose_name(
             prefix=config['global']['account']['prefix'],

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/iam.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/iam.tf
@@ -87,29 +87,6 @@ data "aws_iam_policy_document" "firehose_s3" {
   }
 }
 
-# FIXME: Confirm do we need cloudwatch permission here. Probably we need.
-// IAM Policy: Write logs to CloudWatch
-resource "aws_iam_role_policy" "streamalert_firehose_cloudwatch" {
-  name   = "WriteDataToCloudWatch"
-  role   = aws_iam_role.streamalert_kinesis_firehose.id
-  policy = data.aws_iam_policy_document.firehose_cloudwatch.json
-}
-
-// IAM Policy Document: Write logs to CloudWatch
-data "aws_iam_policy_document" "firehose_cloudwatch" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "logs:PutLogEvents",
-    ]
-
-    resources = [
-      "arn:aws:logs:${var.region}:${var.account_id}:log-group:${var.cloudwatch_log_group}:log-stream:*",
-    ]
-  }
-}
-
 // IAM Policy: Interact with the Glue Catalog
 resource "aws_iam_role_policy" "streamalert_firehose_glue" {
   name = "FirehoseReadGlueCatalog"

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/iam.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/iam.tf
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "firehose_s3" {
       "kms:GenerateDataKey*",
     ]
 
-    resources = ["arn:aws:kms:${var.region}:${var.account_id}:key/${var.kms_key_id}"]
+    resources = [var.kms_key_arn]
   }
 }
 

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/main.tf
@@ -40,14 +40,12 @@ resource "aws_kinesis_firehose_delivery_stream" "streamalert_artifacts" {
         }
       }
       schema_configuration {
-        database_name = var.glue_catalog_db_name
+        database_name = aws_glue_catalog_table.artifacts.database_name
         role_arn      = aws_iam_role.streamalert_kinesis_firehose.arn
-        table_name    = var.glue_catalog_table_name
+        table_name    = aws_glue_catalog_table.artifacts.name
       }
     }
   }
-
-  depends_on = [aws_glue_catalog_table.artifacts]
 
   tags = {
     Name = "StreamAlert"

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/main.tf
@@ -1,0 +1,91 @@
+// AWS Firehose Stream dedicated to deliver Artifacts
+// This firehose will only convert and save Artifacts in Parquet format in the S3 bucket to take the
+// performance gain from Parquet format.
+locals {
+  s3_path_prefix = "parquet/${var.glue_catalog_table_name}"
+}
+
+locals {
+  data_location = "s3://${var.s3_bucket_name}/${local.s3_path_prefix}"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "streamalert_artifacts" {
+  name        = var.stream_name
+  destination = "extended_s3"
+
+  // AWS Firehose Stream for Artifacts will only support Parquet format
+  extended_s3_configuration {
+    role_arn            = aws_iam_role.streamalert_kinesis_firehose.arn
+    bucket_arn          = "arn:aws:s3:::${var.s3_bucket_name}"
+    prefix              = "${local.s3_path_prefix}/dt=!{timestamp:yyyy-MM-dd-HH}/"
+    error_output_prefix = "${local.s3_path_prefix}/!{firehose:error-output-type}/"
+    buffer_size         = var.buffer_size
+    buffer_interval     = var.buffer_interval
+
+    # The S3 destination's compression format must be set to UNCOMPRESSED
+    # when data format conversion is enabled.
+    compression_format = "UNCOMPRESSED"
+    kms_key_arn        = var.kms_key_arn
+
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          # # more resilient with log schemas that have nested JSON comparing to hive_json_ser_de
+          open_x_json_ser_de {}
+        }
+      }
+      output_format_configuration {
+        serializer {
+          parquet_ser_de {}
+        }
+      }
+      schema_configuration {
+        database_name = var.glue_catalog_db_name
+        role_arn      = aws_iam_role.streamalert_kinesis_firehose.arn
+        table_name    = var.glue_catalog_table_name
+      }
+    }
+  }
+
+  depends_on = [aws_glue_catalog_table.artifacts]
+
+  tags = {
+    Name = "StreamAlert"
+  }
+}
+
+// Artifacts Athena table
+resource "aws_glue_catalog_table" "artifacts" {
+  name          = var.glue_catalog_table_name
+  database_name = var.glue_catalog_db_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  partition_keys {
+    name = "dt"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = local.data_location
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "parque_ser_de"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+      parameters = {
+        ser_de_params_key   = "serialization.format"
+        ser_de_params_value = "1"
+      }
+    }
+
+    dynamic "columns" {
+      for_each = var.schema
+      content {
+        name = columns.value[0]
+        type = columns.value[1]
+      }
+    }
+  }
+}

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/variables.tf
@@ -1,0 +1,61 @@
+variable "account_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "function_role_id" {
+  description = "Artifact Extractor function IAM Role ID, exported from the tf_lambda module"
+}
+
+variable "function_alias_arn" {
+  type        = string
+  description = "Fully qualified function arn of alias of Artifact extractor lambda"
+}
+
+variable "glue_catalog_db_name" {
+  type        = string
+  description = "Athena Database name"
+}
+
+variable "glue_catalog_table_name" {
+  type        = string
+  description = "Athena table name for Artifacts"
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "StreamAlert data bucket name"
+}
+
+variable "stream_name" {
+  type        = string
+  description = "Fully qualified name to use for delivery stream"
+}
+
+variable "buffer_size" {
+  default = 5
+}
+
+variable "buffer_interval" {
+  default = 300
+}
+
+variable "kms_key_arn" {
+  type = string
+}
+
+variable "cloudwatch_log_group" {
+  type    = string
+  default = "/aws/kinesisfirehose/streamalert"
+}
+
+variable "schema" {
+  type = list(tuple([string, string]))
+}

--- a/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_artifact_extractor/variables.tf
@@ -51,11 +51,6 @@ variable "kms_key_arn" {
   type = string
 }
 
-variable "cloudwatch_log_group" {
-  type    = string
-  default = "/aws/kinesisfirehose/streamalert"
-}
-
 variable "schema" {
   type = list(tuple([string, string]))
 }

--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_delivery_stream/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_delivery_stream/main.tf
@@ -78,6 +78,26 @@ resource "aws_kinesis_firehose_delivery_stream" "streamalert_data" {
           table_name    = var.glue_catalog_table_name
         }
       }
+
+
+      processing_configuration {
+        # only enabled when function_alias_arn (Artifact Extractor Lambda function) is not empty
+        enabled = var.function_alias_arn == "" ? false : true
+
+        # processor block will only present if function_alias_arn is not empty
+        dynamic "processors" {
+          for_each = var.function_alias_arn == "" ? [] : [var.function_alias_arn]
+
+          content {
+            type = "Lambda"
+
+            parameters {
+              parameter_name  = "LambdaArn"
+              parameter_value = var.function_alias_arn
+            }
+          }
+        }
+      }
     }
   }
 

--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_delivery_stream/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_delivery_stream/variables.tf
@@ -66,3 +66,9 @@ variable "glue_catalog_table_name" {
 variable "schema" {
   type = list(tuple([string, string]))
 }
+
+variable "function_alias_arn" {
+  type        = string
+  default     = ""
+  description = "Fully qualified function arn of alias of Artifact extractor lambda"
+}

--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/iam.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/iam.tf
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "firehose_glue_catalog" {
 
 // IAM Policy: Invoke lambda function
 resource "aws_iam_role_policy" "streamalert_firehose_lambda" {
-  count = var.function_alias_arn == "" ? 0 : 1
+  count = var.artifact_extractor_enabled ? 1 : 0
   name  = "streamalert_firehose_invoke_lambda"
   role  = "${aws_iam_role.streamalert_kinesis_firehose.id}"
 
@@ -117,7 +117,7 @@ resource "aws_iam_role_policy" "streamalert_firehose_lambda" {
 
 // IAM Policy Document: Allow firehose to invoke artifact extractor lambda function
 data "aws_iam_policy_document" "firehose_lambda" {
-  count = var.function_alias_arn == "" ? 0 : 1
+  count = var.artifact_extractor_enabled ? 1 : 0
 
   statement {
     effect = "Allow"

--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/variables.tf
@@ -26,3 +26,9 @@ variable "s3_logging_bucket" {
 variable "kms_key_id" {
   type = string
 }
+
+variable "function_alias_arn" {
+  type        = string
+  default     = ""
+  description = "Fully qualified function arn of alias of Artifact extractor lambda"
+}

--- a/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_kinesis_firehose_setup/variables.tf
@@ -27,6 +27,12 @@ variable "kms_key_id" {
   type = string
 }
 
+variable "artifact_extractor_enabled" {
+  type        = bool
+  default     = false
+  description = "Is Artifact Extractor Lambda function enabled"
+}
+
 variable "function_alias_arn" {
   type        = string
   default     = ""

--- a/streamalert_cli/athena/helpers.py
+++ b/streamalert_cli/athena/helpers.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import re
 
+from streamalert.artifact_extractor.artifact_extractor import Artifact
 from streamalert.shared.firehose import FirehoseClient
 from streamalert.shared.logger import get_logger
 from streamalert.shared.alert import Alert
@@ -245,5 +246,22 @@ def generate_data_table_schema(config, table, schema_override=None):
                     'Schema override column %s not found in Athena Schema, skipping',
                     column_name
                 )
+
+    return format_schema_tf(athena_schema)
+
+def generate_artifacts_table_schema():
+    """Generate the schema for artifacts table in terraform by using a test artifact instance
+
+    Returns:
+        athena_schema (dict): Equivalent Athena schema used for generating create table statement
+    """
+    # alert = Alert('temp_rule_name', {}, {})
+    # output = alert.output_dict()
+    # schema = record_to_schema(output)
+    # athena_schema = logs_schema_to_athena_schema(schema, False)
+
+    artifact = Artifact('test_source_type', 'test_normalized_type', 'test_value')
+    schema = record_to_schema(artifact.record)
+    athena_schema = logs_schema_to_athena_schema(schema, False)
 
     return format_schema_tf(athena_schema)

--- a/streamalert_cli/athena/helpers.py
+++ b/streamalert_cli/athena/helpers.py
@@ -255,11 +255,6 @@ def generate_artifacts_table_schema():
     Returns:
         athena_schema (dict): Equivalent Athena schema used for generating create table statement
     """
-    # alert = Alert('temp_rule_name', {}, {})
-    # output = alert.output_dict()
-    # schema = record_to_schema(output)
-    # athena_schema = logs_schema_to_athena_schema(schema, False)
-
     artifact = Artifact('test_source_type', 'test_normalized_type', 'test_value')
     schema = record_to_schema(artifact.record)
     athena_schema = logs_schema_to_athena_schema(schema, False)

--- a/streamalert_cli/manage_lambda/deploy.py
+++ b/streamalert_cli/manage_lambda/deploy.py
@@ -185,7 +185,7 @@ def _lambda_terraform_targets(config, functions, clusters):
         },
         'artifact_extractor': {
             'targets': {
-                'module.artifact_extractor_iam',
+                'module.artifact_extractor',
                 'module.artifact_extractor_lambda'
             },
             'enabled': config['lambda'].get('artifact_extractor_config', {}).get('enabled', False)

--- a/streamalert_cli/terraform/artifact_extractor.py
+++ b/streamalert_cli/terraform/artifact_extractor.py
@@ -1,0 +1,76 @@
+
+"""
+Copyright 2017-present Airbnb, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from streamalert.shared import ARTIFACT_EXTRACTOR_NAME
+from streamalert.shared.config import artifact_extractor_enabled, firehose_data_bucket
+from streamalert.shared.firehose import FirehoseClient
+from streamalert.shared.utils import get_database_name
+from streamalert_cli.athena.helpers import generate_artifacts_table_schema
+from streamalert_cli.terraform.common import infinitedict
+from streamalert_cli.terraform.lambda_module import generate_lambda
+
+# FIXME: Should we provide custom artifacs table name?
+DEFAULT_ARTIFACTS_TABLE_NAME = 'artifacts'
+
+def generate_artifact_extractor(config):
+    """Generate Terraform for the Artifact Extractor Lambda function
+    Args:
+        config (dict): The loaded config from the 'conf/' directory
+    Returns:
+        dict: Artifact Extractor Terraform definition to be marshaled to JSON
+    """
+    result = infinitedict()
+
+    if not artifact_extractor_enabled(config):
+        return
+
+    ae_config = config['lambda']['artifact_extractor_config']
+    stream_name = FirehoseClient.artifacts_firehose_stream_name(config)
+
+    # generate Artifacts Firehose ARN
+    firehose_arn = 'arn:aws:firehose:{region}:{account}:deliverystream/{stream_name}'.format(
+        region=config['global']['account']['region'],
+        account=config['global']['account']['aws_account_id'],
+        stream_name=stream_name
+    )
+
+    # Set variables for the artifact extractor module
+    result['module']['artifact_extractor'] = {
+        'source': './modules/tf_artifact_extractor',
+        'account_id': config['global']['account']['aws_account_id'],
+        'prefix': config['global']['account']['prefix'],
+        'region': config['global']['account']['region'],
+        'function_role_id': '${module.artifact_extractor_lambda.role_id}',
+        'function_alias_arn': '${module.artifact_extractor_lambda.function_alias}',
+        'glue_catalog_db_name': get_database_name(config),
+        'glue_catalog_table_name': ae_config.get('table_name', DEFAULT_ARTIFACTS_TABLE_NAME),
+        's3_bucket_name': firehose_data_bucket(config),
+        'stream_name': stream_name,
+        'buffer_size': ae_config.get('firehose_buffer_size', 128),
+        'buffer_interval': ae_config.get('firehose_buffer_interval', 900),
+        'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+        'schema': generate_artifacts_table_schema()
+    }
+
+    # Set variables for the Lambda module
+    result['module']['artifact_extractor_lambda'] = generate_lambda(
+        '{}_streamalert_{}'.format(config['global']['account']['prefix'], ARTIFACT_EXTRACTOR_NAME),
+        'streamalert.artifact_extractor.main.handler',
+        ae_config,
+        config,
+        environment={
+            'DESTINATION_FIREHOSE_ARN': firehose_arn
+        }
+    )
+
+    return result

--- a/streamalert_cli/terraform/firehose.py
+++ b/streamalert_cli/terraform/firehose.py
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from streamalert.shared.firehose import FirehoseClient
-from streamalert.shared.config import artifact_extractor_enabled, firehose_data_bucket
+from streamalert.shared.config import (
+    artifact_extractor_enabled,
+    artifact_extractor_enabled_for_log,
+    firehose_data_bucket
+)
 from streamalert.shared.utils import get_database_name, get_data_file_format
 from streamalert_cli.athena.helpers import generate_data_table_schema
 from streamalert_cli.terraform.common import monitoring_topic_arn
@@ -121,7 +125,7 @@ def generate_firehose(logging_bucket, main_dict, config):
         # 1) lambda function is enabled in conf/lambda.json
         # 2) "normalization" field is configured in the log schema settings in conf/schemas/*.json
         #    or conf/logs.json
-        if artifact_extractor_enabled(config, log_type_name):
+        if artifact_extractor_enabled_for_log(config, log_type_name):
             module_dict['function_alias_arn'] = (
                 '${module.artifact_extractor_lambda.function_alias_arn}'
             )

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -519,7 +519,7 @@ def terraform_generate_handler(config, init=False, check_tf=True, check_creds=Tr
         config,
         conf_name='artifact_extractor_config',
         generate_func=generate_artifact_extractor,
-        tf_tmp_file_name=os.path.join(TERRAFORM_FILES_PATH, 'artifact_extractor.tf.json')
+        tf_tmp_file_name='artifact_extractor'
     )
 
     return True

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -30,6 +30,7 @@ from streamalert_cli.terraform.common import (
     s3_access_logging_bucket,
     terraform_state_bucket,
 )
+from streamalert_cli.terraform.artifact_extractor import generate_artifact_extractor
 from streamalert_cli.terraform.alert_merger import generate_alert_merger
 from streamalert_cli.terraform.alert_processor import generate_alert_processor
 from streamalert_cli.terraform.apps import generate_apps
@@ -512,6 +513,14 @@ def terraform_generate_handler(config, init=False, check_tf=True, check_creds=Tr
 
     # Setup StreamQuery
     _generate_streamquery_module(config)
+
+    # Setup Artifact Extractor if it is enabled
+    generate_global_lambda_settings(
+        config,
+        conf_name='artifact_extractor_config',
+        generate_func=generate_artifact_extractor,
+        tf_tmp_file_name=os.path.join(TERRAFORM_FILES_PATH, 'artifact_extractor.tf.json')
+    )
 
     return True
 

--- a/tests/unit/streamalert/shared/test_config.py
+++ b/tests/unit/streamalert/shared/test_config.py
@@ -27,6 +27,7 @@ from pyfakefs import fake_filesystem_unittest
 
 from streamalert.shared.config import (
     artifact_extractor_enabled,
+    artifact_extractor_enabled_for_log,
     _validate_config,
     load_config,
     parse_lambda_arn,
@@ -343,5 +344,5 @@ class TestConfigArtifactExtractor():
 
         self.default_conf_data['global']['infrastructure']['firehose']['enabled'] = True
         assert_true(artifact_extractor_enabled(self.default_conf_data))
-        assert_true(artifact_extractor_enabled(self.default_conf_data, 'test_log:type_1'))
-        assert_false(artifact_extractor_enabled(self.default_conf_data, 'test_log:type_2'))
+        assert_true(artifact_extractor_enabled_for_log(self.default_conf_data, 'test_log:type_1'))
+        assert_false(artifact_extractor_enabled_for_log(self.default_conf_data, 'test_log:type_2'))

--- a/tests/unit/streamalert/shared/test_firehose.py
+++ b/tests/unit/streamalert/shared/test_firehose.py
@@ -522,3 +522,30 @@ class TestFirehoseClient:
         ]
 
         assert_equal(expected_results, results)
+
+    def test_artifacts_firehose_stream_name(self):
+        """FirehoseClient - Test generate artifacts firehose stream name"""
+        config_data = {
+            'global': {
+                'account': {
+                    'prefix': 'unittest'
+                }
+            },
+            'lambda': {
+                'artifact_extractor_config': {}
+            }
+        }
+
+        assert_equal(
+            self._client.artifacts_firehose_stream_name(config_data),
+            'unittest_streamalert_artifacts'
+        )
+
+        config_data['lambda']['artifact_extractor_config']['firehose_stream_name'] = (
+            'test_artifacts_fh_name'
+        )
+
+        assert_equal(
+            self._client.artifacts_firehose_stream_name(config_data),
+            'test_artifacts_fh_name'
+        )

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -150,3 +150,17 @@ def test_generate_data_table_schema_2():
 
     assert_true(helpers.generate_data_table_schema(config, 'cloudwatch:test_match_types'))
     FirehoseClient._ENABLED_LOGS.clear()
+
+def test_generate_artifact_table_schema():
+    """CLI - Athena test generate_artifact_table_schema helper"""
+    result = helpers.generate_artifacts_table_schema()
+
+    expected_result = [
+        ('function', 'string'),
+        ('record_id', 'string'),
+        ('source_type', 'string'),
+        ('type', 'string'),
+        ('value', 'string')
+    ]
+
+    assert_equal(result, expected_result)

--- a/tests/unit/streamalert_cli/terraform/test_artifact_extractor.py
+++ b/tests/unit/streamalert_cli/terraform/test_artifact_extractor.py
@@ -1,0 +1,106 @@
+"""
+Copyright 2017-present Airbnb, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+
+from nose.tools import assert_equal, assert_is_none
+
+from streamalert_cli.config import CLIConfig
+from streamalert_cli.terraform import artifact_extractor
+
+class TestTerraformArtifactExtractor:
+    """Test class for test generating Artifact Extractor terrform modules"""
+
+    def __init__(self):
+        """Init config for the test cases"""
+        self.config = CLIConfig(config_path='tests/unit/conf')
+
+    def test_generate_artifact_extractor(self):
+        """CLI - Terraform generate artifact extractor"""
+        result = artifact_extractor.generate_artifact_extractor(self.config)
+        assert_is_none(result)
+
+        self.config['lambda']['artifact_extractor_config'] = {
+            'enabled': True,
+            'memory': 128,
+            'timeout': 300
+        }
+
+        self.config['global']['infrastructure']['firehose']['enabled_logs'] = {
+            'unit_test:type_1',
+            'unit_test:type_2'
+        }
+
+        self.config['logs']['unit_test:type_1'] = {
+            'schema': {},
+            'configuration': {
+                'normalization': {
+                    'normalized_type': ['original_key1', 'original_key2']
+                }
+            }
+        }
+        self.config['logs']['unit_test:type_2'] = {
+            'schema': {}
+        }
+
+        result = artifact_extractor.generate_artifact_extractor(self.config)
+        expected_result = {
+            'module': {
+                'artifact_extractor': {
+                    'source': './modules/tf_artifact_extractor',
+                    'account_id': '12345678910',
+                    'prefix': 'unit-test',
+                    'region': 'us-west-1',
+                    'function_role_id': '${module.artifact_extractor_lambda.role_id}',
+                    'function_alias_arn': '${module.artifact_extractor_lambda.function_alias}',
+                    'glue_catalog_db_name': 'unit-test_streamalert',
+                    'glue_catalog_table_name': 'artifacts',
+                    's3_bucket_name': 'unit-test-streamalert-data',
+                    'stream_name': 'unit_test_streamalert_artifacts',
+                    'buffer_size': 128,
+                    'buffer_interval': 900,
+                    'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
+                    'schema': [
+                        ['function', 'string'],
+                        ['record_id', 'string'],
+                        ['source_type', 'string'],
+                        ['type', 'string'],
+                        ['value', 'string']
+                    ]
+                },
+                'artifact_extractor_lambda': {
+                    'source': './modules/tf_lambda',
+                    'function_name': 'unit-test_streamalert_artifact_extractor',
+                    'description': 'Unit-Test Streamalert Artifact Extractor',
+                    'handler': 'streamalert.artifact_extractor.main.handler',
+                    'memory_size_mb': 128,
+                    'timeout_sec': 300,
+                    'environment_variables': {
+                        'ENABLE_METRICS': '0',
+                        'LOGGER_LEVEL': 'info',
+                        'DESTINATION_FIREHOSE_ARN': (
+                            'arn:aws:firehose:us-west-1:12345678910:deliverystream/'
+                            'unit_test_streamalert_artifacts'
+                        )
+                    },
+                    'tags': {}
+                }
+            }
+        }
+
+        # FIMME: not sure why assert_equal between result (defaultdict) and expected_result (dict)
+        # fails.
+        # assert_equal(result, expected_result)
+        assert_equal(json.dumps(result), json.dumps(expected_result))


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers 

related to: #1230 
resolves:

## Background
This PR is to add terraform resources for Normalization v2 including
* Create a new dedicated Firehose to deliver artifacts to s3 bucket if Artifact Extractor enabled
* Create an Athena table for artifacts if Artifact Extractor enabled
* Attach proper permissions to invoke Artifact Extractor lambda function for Firehoses if it is enabled
* Enable `processing_configuration` on the firehose where enables normalization configuration in its schema configuration field
* Add Artifact Extractor lambda terraform code and proper permissions.

## Testing
* Added unit test cases to cover the code change
* `python manage.py build` works as expected in staging for following cases
  1. With default conf, Artifact Extractor disabled, no resource changes
  2. Enable `Artifact Extractor` in `conf/lambda.json` and `firehose` in `conf/global.json`, `Artifact Extractor` lambda function, a new firehose and athena table for artifacts will be created.
  3. Based on case 2, add `normalization` dummy configuration to `osquery:differential` and `cloudwatch:cloudtrail` schemas, `processing_configuration` will be enabled to invoke `Artifact Extractor` lambda on `osquery_differential` and `cloudwatch_cloudtrail` FIrehoses. 

## Next Step
Refactor normalization configure and update classifier code related to normalization in next PR.