### PR TITLE
Add record id to artifacts and record

### DIFF
--- a/publishers/community/generic.py
+++ b/publishers/community/generic.py
@@ -107,7 +107,7 @@ def remove_fields(alert, publication):
 
 @Register
 def remove_streamalert_normalization(_, publication):
-    """This publisher removes the super heavyweight 'streamalert:normalization' fields"""
+    """This publisher removes the super heavyweight 'streamalert_normalization' fields"""
     return _delete_dictionary_fields(publication, Normalizer.NORMALIZATION_KEY)
 
 

--- a/streamalert/shared/normalize.py
+++ b/streamalert/shared/normalize.py
@@ -171,7 +171,7 @@ class NormalizedType:
 class Normalizer:
     """Normalizer class to handle log key normalization in payloads"""
 
-    NORMALIZATION_KEY = 'streamalert:normalization'
+    NORMALIZATION_KEY = 'streamalert_normalization'
 
     # Store the normalized types mapping to original keys from the records
     _types_config = dict()

--- a/tests/unit/streamalert/artifact_extractor/helpers.py
+++ b/tests/unit/streamalert/artifact_extractor/helpers.py
@@ -18,6 +18,8 @@ import base64
 
 from streamalert.shared.normalize import Normalizer
 
+MOCK_RECORD_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
 def native_firehose_records(normalized=False, count=2):
     """Generate sample firehose records for unit tests"""
     json_data = [
@@ -44,7 +46,9 @@ def native_firehose_records(normalized=False, count=2):
     return [
         {
             'recordId': 'record_id_{}'.format(cnt),
-            'data': base64.b64encode(json.dumps(json_data[cnt]).encode('utf-8')),
+            'data': base64.b64encode(
+                (json.dumps(json_data[cnt], separators=(',', ':')) + '\n').encode('utf-8')
+            ).decode('utf-8'),
             'approximateArrivalTimestamp': 1583275630000+int(cnt)
         } for cnt in range(count)
     ]
@@ -69,14 +73,17 @@ def transformed_firehose_records(normalized=False, count=2):
                         'values': ['value2', 'value3'],
                         'function': None
                     }
-                ]
+                ],
+                'streamalert_record_id': MOCK_RECORD_ID
             }
 
     return {
         'records': [
             {
                 'result': 'Ok',
-                'data': base64.b64encode(json.dumps(json_data[cnt]).encode('utf-8')),
+                'data': base64.b64encode(
+                    (json.dumps(json_data[cnt], separators=(',', ':')) + '\n').encode('utf-8')
+                ).decode('utf-8'),
                 'recordId': 'record_id_{}'.format(cnt)
             } for cnt in range(count)
         ]
@@ -97,10 +104,10 @@ def generate_artifacts():
     artifacts = [
         {
             'function': 'None',
-            'record_id': 'None',
+            'streamalert_record_id': MOCK_RECORD_ID,
             'source_type': 'unit_test',
             'type': type,
-            'value': value,
+            'value': value
         } for type, value in normalized_values
     ]
 

--- a/tests/unit/streamalert/artifact_extractor/test_artifact_extractor.py
+++ b/tests/unit/streamalert/artifact_extractor/test_artifact_extractor.py
@@ -27,6 +27,7 @@ from tests.unit.streamalert.artifact_extractor.helpers import (
     native_firehose_records,
     transformed_firehose_records,
     generate_artifacts,
+    MOCK_RECORD_ID,
 )
 
 
@@ -44,7 +45,7 @@ class TestArtifact:
         )
         expected_result = {
             'function': 'None',
-            'record_id': 'test_record_id',
+            'streamalert_record_id': 'test_record_id',
             'source_type': 'test_source_type',
             'type': 'test_normalized_type',
             'value': 'test_value'
@@ -83,10 +84,12 @@ class TestArtifactExtractor:
         expected_result = transformed_firehose_records()
         assert_equal(result, expected_result)
 
+    @patch('uuid.uuid4')
     @patch.object(FirehoseClient, '_send_batch')
     @patch('streamalert.artifact_extractor.artifact_extractor.LOGGER')
-    def test_run(self, logger_mock, send_batch_mock):
+    def test_run(self, logger_mock, send_batch_mock, uuid_mock):
         """ArtifactExtractor - Test run method extract artifacts"""
+        uuid_mock.return_value = MOCK_RECORD_ID
         result = self._artifact_extractor.run(native_firehose_records(normalized=True))
 
         logger_mock.assert_has_calls([

--- a/tests/unit/streamalert/artifact_extractor/test_main.py
+++ b/tests/unit/streamalert/artifact_extractor/test_main.py
@@ -25,7 +25,8 @@ from streamalert.shared.firehose import FirehoseClient
 from tests.unit.streamalert.artifact_extractor.helpers import (
     native_firehose_records,
     transformed_firehose_records,
-    generate_artifacts
+    generate_artifacts,
+    MOCK_RECORD_ID,
 )
 
 
@@ -69,11 +70,13 @@ class TestArtifactExtractorHandler:
         expected_result = transformed_firehose_records()
         assert_equal(result, expected_result)
 
+    @patch('uuid.uuid4')
     @patch.dict(os.environ, {'DESTINATION_FIREHOSE_STREAM_NAME': 'unit_test_dst_fh_arn'})
     @patch.object(FirehoseClient, '_send_batch')
     @patch('streamalert.artifact_extractor.artifact_extractor.LOGGER')
-    def test_handler(self, logger_mock, send_batch_mock):
+    def test_handler(self, logger_mock, send_batch_mock, uuid_mock):
         """ArtifactExtractor - Test handler"""
+        uuid_mock.return_value = MOCK_RECORD_ID
         event = {
             'records': native_firehose_records(normalized=True),
             'region': 'us-east-1',

--- a/tests/unit/streamalert/rules_engine/test_threat_intel.py
+++ b/tests/unit/streamalert/rules_engine/test_threat_intel.py
@@ -85,7 +85,7 @@ class TestThreatIntel:
                     'recipientAccountId': '12345'
                 },
                 'source': '1.1.1.2',
-                'streamalert:normalization': {
+                'streamalert_normalization': {
                     'sourceAddress': {'1.1.1.2'},
                     'userName': {'alice'}
                 }
@@ -118,7 +118,7 @@ class TestThreatIntel:
                 'recipientAccountId': '12345'
             },
             'source': '1.1.1.2',
-            'streamalert:normalization': {
+            'streamalert_normalization': {
                 'sourceAddress': {'1.1.1.2'},
                 'userName': {'alice'}
             },
@@ -149,7 +149,7 @@ class TestThreatIntel:
                 'recipientAccountId': '12345'
             },
             'source': '1.1.1.2',
-            'streamalert:normalization': {
+            'streamalert_normalization': {
                 'sourceAddress': {'1.1.1.2'},
                 'userName': {'alice'}
             }

--- a/tests/unit/streamalert/shared/test_normalizer.py
+++ b/tests/unit/streamalert/shared/test_normalizer.py
@@ -211,7 +211,7 @@ class TestNormalizer:
                 }
             },
             'sourceIPAddress': '1.1.1.3',
-            'streamalert:normalization': {
+            'streamalert_normalization': {
                 'region': [
                     {
                         'values': ['region_name'],
@@ -263,7 +263,7 @@ class TestNormalizer:
             'original_key': {
                 'original_key': 'fizzbuzz',
             },
-            'streamalert:normalization': {
+            'streamalert_normalization': {
                 'normalized_key': [
                     {
                         'values': ['fizzbuzz'],
@@ -343,7 +343,7 @@ class TestNormalizer:
         expected_result = {'1.1.1.3'}
         record = {
             'sourceIPAddress': '1.1.1.3',
-            'streamalert:normalization': {
+            'streamalert_normalization': {
                 'ip_v4': [
                     {
                         'values': expected_result,
@@ -359,7 +359,7 @@ class TestNormalizer:
         """Normalizer - Get Values for Normalized Type, None"""
         record = {
             'sourceIPAddress': '1.1.1.3',
-            'streamalert:normalization': {}
+            'streamalert_normalization': {}
         }
 
         assert_equal(Normalizer.get_values_for_normalized_type(record, 'ip_v4'), None)

--- a/tests/unit/streamalert_cli/athena/test_helpers.py
+++ b/tests/unit/streamalert_cli/athena/test_helpers.py
@@ -157,8 +157,8 @@ def test_generate_artifact_table_schema():
 
     expected_result = [
         ('function', 'string'),
-        ('record_id', 'string'),
         ('source_type', 'string'),
+        ('streamalert_record_id', 'string'),
         ('type', 'string'),
         ('value', 'string')
     ]

--- a/tests/unit/streamalert_cli/terraform/test_artifact_extractor.py
+++ b/tests/unit/streamalert_cli/terraform/test_artifact_extractor.py
@@ -74,8 +74,8 @@ class TestTerraformArtifactExtractor:
                     'kms_key_arn': '${aws_kms_key.server_side_encryption.arn}',
                     'schema': [
                         ['function', 'string'],
-                        ['record_id', 'string'],
                         ['source_type', 'string'],
+                        ['streamalert_record_id', 'string'],
                         ['type', 'string'],
                         ['value', 'string']
                     ]


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:  #1238 
resolves:

## Background
This PR is tiny and it is to add a new key `streamalert_record_id` to artifacts as well as original records (in `streamalert_normalization` field). This new keywill be helpful tracing back to the original record when searching in "artifacts" table.

For example, we will be able to use table join search
```
SELECT artifacts.*,
         events.detail
FROM 
    (SELECT streamalert_record_id AS record_id,
         type,
         value
    FROM "PREFIX_streamalert"."artifacts"
    WHERE dt='2020-04-30-01'
            AND value='Root') AS artifacts
LEFT JOIN 
    (SELECT CAST(json_extract(streamalert_normalization,
         '$.streamalert_record_id') AS varchar) AS record_id, detail
    FROM "PREFIX_streamalert"."cloudwatch_events"
    WHERE dt='2020-04-30-01') AS events
    ON artifacts.record_id = events.record_id LIMIT 10 
```
<img width="989" alt="Screen Shot 2020-04-30 at 10 17 50 AM" src="https://user-images.githubusercontent.com/21151436/80742628-8b1d3800-8ad0-11ea-81df-7d43b87fb945.png">

## Changes
* Change key `streamalert:normalization` to `streamalert_normalization` to support athena better. 
* Add a new key `streamalert_record_id` to artifacts, for example
```
{
  "function": "AWS region",
  "streamalert_record_id": "abcdef0123456789",
  "source_type": "cloudwatch",
  "type": "cloudwatch:events",
  "value": "us-west-2"
}
```
* The new key `streamalert_record_id` will be also insert to original record which will be returned to source Firehose delivery stream and saved in S3 for Historical Search. Transformed record will look like this 
```
{
    "record": {
        "region": "us-east-1",
        "detail": {
            "awsRegion": "us-west-2"
        }
    },
    "streamalert_normalization": {
        "streamalert_record_id": "abcdef0123456789",
        "region": [
            {
                "values": ["region_name"],
                "function": "AWS region"
            },
            {
                "values": ["region_name"],
                "function": "AWS region"
            }
        ]
    }
}
```
## Testing
* Update unit test cases
* Deploy to staging
