### PR TITLE
Supports dynamic parameters

### DIFF
--- a/docs/source/scheduled-queries.rst
+++ b/docs/source/scheduled-queries.rst
@@ -129,8 +129,42 @@ All scheduled queries are located in the ``scheduled_queries/`` directory, locat
 * ``name`` - (str) The name of this query. This name is published in the final result, and is useful when writing rules.
 * ``description`` - (str) Description of this query. This is published in the final result.
 * ``query`` - (str) A template SQL statement sent to Athena, with query parameters identified ``{like_this}``.
-* ``params`` - (list[str]) A list of query parameters to pass to the query string. These have special values that are calculated at runtime, and are interpolated into the template SQL string.
+* ``params`` - (list[str]|dict[str,callable]) Read on below...
 * ``tags`` - (list[str]) Tags required by this query to be run. The simplest way to use this is to put the **Query pack name** into this array.
+
+params
+``````
+The "params" option specifies how to calculate special query parameters. It supports two formats.
+
+The first format is a list of strings from a predefined set of strings. These have special values that are calculated at runtime,
+and are interpolated into the template SQL string. Here is a list of the supported strings:
+
+
+
+The second format is a dictionary mapping parameter names to functions, like so:
+
+.. code-block:: python
+
+    def func1(date):
+        return date.timestamp()
+
+    def func2(date):
+        return LookupTables.get('aaaa', 'bbbb')
+
+    QueryPackConfiguration(
+        ...
+        query="""
+    SELECT *
+    FROM stuff
+    WHERE
+      dt = '{my_param_1}'
+      AND p2 = '{my_param_2}'
+    """,
+        params={
+            'my_param_1': func1,
+            'my_param_2': func2,
+        }
+    )
 
 
 

--- a/streamalert/scheduled_queries/query_packs/configuration.py
+++ b/streamalert/scheduled_queries/query_packs/configuration.py
@@ -52,7 +52,6 @@ Error:
 '''.strip().format(name=self.name, error=e, kwargs=kwargs)
             raise KeyError(msg)
 
-
     @property
     def query_template(self):
         return self._query_template

--- a/streamalert/scheduled_queries/query_packs/manager.py
+++ b/streamalert/scheduled_queries/query_packs/manager.py
@@ -78,7 +78,9 @@ class QueryPack:
 
         if isinstance(self._configuration.query_parameters, dict):
             self._query_parameters = {
-                param: self._execution_context.parameter_generator.generate_advanced(configuration)
+                param: self._execution_context.parameter_generator.generate_advanced(
+                    param, configuration
+                )
                 for param, configuration in self._configuration.query_parameters.items()
             }
         elif isinstance(self._configuration.query_parameters, list):

--- a/streamalert/scheduled_queries/query_packs/manager.py
+++ b/streamalert/scheduled_queries/query_packs/manager.py
@@ -76,10 +76,20 @@ class QueryPack:
         self._query_execution_id = None
         self._query_result = None
 
-        self._query_parameters = {
-            param: self._execution_context.parameter_generator.generate(param)
-            for param in self._configuration.query_parameters
-        }
+        if isinstance(self._configuration.query_parameters, dict):
+            self._query_parameters = {
+                param: self._execution_context.parameter_generator.generate_advanced(configuration)
+                for param, configuration in self._configuration.query_parameters.items()
+            }
+        elif isinstance(self._configuration.query_parameters, list):
+            self._query_parameters = {
+                param: self._execution_context.parameter_generator.generate(param)
+                for param in self._configuration.query_parameters
+            }
+        else:
+            # not intended to be reached
+            self._query_parameters = {}
+
         self._query_string = None
 
     @property

--- a/streamalert/scheduled_queries/query_packs/parameters.py
+++ b/streamalert/scheduled_queries/query_packs/parameters.py
@@ -60,7 +60,17 @@ class QueryParameterGenerator:
         if parameter == 'utctimestamp':
             return str(round(self._clock.now.timestamp()))
 
+        if parameter == 'utcisotime':
+            return str(round(self._clock.now.timestamp()))
+
         self._logger.error(
             'Parameter generator does not know how to handle "{}"'.format(parameter)
         )
         return None
+
+    def generate_advanced(self, key, configuration):
+        if callable(configuration):
+            return configuration(self._clock.now)
+
+        # else, default to whatever generate returns
+        return self.generate(key)

--- a/streamalert_cli/_infrastructure/modules/tf_scheduled_queries/outputs.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_scheduled_queries/outputs.tf
@@ -1,0 +1,4 @@
+# Role id of the lambda function that runs scheduled queries
+output "lambda_function_role_id" {
+  value = module.scheduled_queries_lambda.role_id
+}

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -548,6 +548,7 @@ def _generate_lookup_tables_settings(config):
         '${module.alert_processor_lambda.role_id}',
         '${module.alert_merger_lambda.role_id}',
         '${module.rules_engine_lambda.role_id}',
+        '${module.scheduled_queries.lambda_function_role_id}',
     }
 
     for cluster in config.clusters():

--- a/tests/unit/streamalert/scheduled_queries/query_packs/test_manager.py
+++ b/tests/unit/streamalert/scheduled_queries/query_packs/test_manager.py
@@ -261,6 +261,16 @@ class TestQueryParameterGenerator:
             'Parameter generator does not know how to handle "unsupported"'
         )
 
+    def test_generate_advanced_function(self):
+        """StreamQuery - QueryParameterGenerator - generate_advanced - Function"""
+        def thing(date):
+            return date.strftime('%Y-%m-%d-%H-%I-%S')
+        assert_equals(self._generator.generate_advanced('thing', thing), '2019-01-01-01-01-01')
+
+    def test_generate_advanced_nothing(self):
+        """StreamQuery - QueryParameterGenerator - generate_advanced - Nothing"""
+        assert_equals(self._generator.generate_advanced('utctimestamp', None), '1546304461')
+
 
 @patch('streamalert.scheduled_queries.query_packs.manager.QueryPacksManager')
 def test_new_manager(constructor_spy):


### PR DESCRIPTION
to: @chunyong-lin @ryandeivert @blakemotl 
cc: @airbnb/streamalert-maintainers

## Background

Add support for dynamic parameters on scheduled queries. This adds functionality for user-defined parameters, so users have more than just the pre-defined params.

Additionally, adds supports for LookupTables on scheduled queries. This opens UNLIMITED POSSIBILITIES!

## Deployment

Need to rebuild the LookupTables policies by redeploying scheduled queries:

```
./manage.py build -t scheduled_queries
```

```
./manage.py build -t lookup_tables_iam_dynamodb
```

## Testing

Tested on prod 🤣 