### PR TITLE
Normalization reboot - Add condition support to normalizer

### DIFF
--- a/streamalert/artifact_extractor/artifact_extractor.py
+++ b/streamalert/artifact_extractor/artifact_extractor.py
@@ -105,7 +105,7 @@ class FirehoseRecord:
         """
         artifacts = []
 
-        if Normalizer.NORMALIZATION_KEY not in self._decoded_record:
+        if not self._decoded_record.get(Normalizer.NORMALIZATION_KEY):
             # Return an empty list if the record doesn't have normalization information.
             return artifacts
 
@@ -149,7 +149,7 @@ class FirehoseRecord:
                     ))
 
         # Add a new key "streamalert_record_id" to "streamalert_normalization" field. This new key
-        # will behelpful tracing back to the original record when searching in "artifacts" table.
+        # will be helpful tracing back to the original record when searching in "artifacts" table.
         self._decoded_record[Normalizer.NORMALIZATION_KEY][RECORD_ID_KEY] = record_id
 
         return artifacts

--- a/streamalert/shared/normalize.py
+++ b/streamalert/shared/normalize.py
@@ -246,7 +246,7 @@ class Normalizer:
                 }
         """
         for param in paths_to_normalize.parsed_params:
-            if param.get('condition') and not cls._match_condition(record, param['condition']):
+            if param.get(CONST_CONDITION) and not cls._match_condition(record, param['condition']):
                 # If optional 'condition' block is configured, it will only extract values if
                 # condition is matched.
                 continue

--- a/streamalert/shared/normalize.py
+++ b/streamalert/shared/normalize.py
@@ -27,12 +27,13 @@ LOGGER_DEBUG_ENABLED = LOGGER.isEnabledFor(logging.DEBUG)
 
 CONST_FUNCTION = 'function'
 CONST_PATH = 'path'
+CONST_CONDITION = 'condition'
 CONST_VALUES = 'values'
 
 class NormalizedType:
     """The class encapsulates normalization information for each normalized type"""
 
-    VALID_KEYS = {CONST_PATH, CONST_FUNCTION}
+    VALID_KEYS = {CONST_PATH, CONST_FUNCTION, CONST_CONDITION}
     CONST_STR = 'str'
     CONST_DICT = 'dict'
 
@@ -156,7 +157,7 @@ class NormalizedType:
         if all(isinstance(param, str) for param in params):
             return self.CONST_STR
 
-        if all(isinstance(param, dict) and set(param.keys()) == self.VALID_KEYS
+        if all(isinstance(param, dict) and set(param.keys()).issubset(self.VALID_KEYS)
                for param in params
               ):
             return self.CONST_DICT
@@ -211,6 +212,22 @@ class Normalizer:
 
         return results
 
+    @classmethod
+    def _find_value(cls, record, path):
+        """Retrieve value from a record based on a json path"""
+        found_value = False
+        value = record
+        for key in path:
+            value = value.get(key)
+            if not value:
+                found_value = False
+                break
+            found_value = True
+
+        if not found_value:
+            return False, None
+
+        return True, value
 
     @classmethod
     def _extract_values(cls, record, paths_to_normalize):
@@ -229,14 +246,12 @@ class Normalizer:
                 }
         """
         for param in paths_to_normalize.parsed_params:
-            found_value = False
-            value = record
-            for key in param.get(CONST_PATH):
-                value = value.get(key)
-                if not value:
-                    found_value = False
-                    break
-                found_value = True
+            if param.get('condition') and not cls._match_condition(record, param['condition']):
+                # If optional 'condition' block is configured, it will only extract values if
+                # condition is matched.
+                continue
+
+            found_value, value = cls._find_value(record, param.get(CONST_PATH))
 
             if found_value:
                 yield {
@@ -245,6 +260,47 @@ class Normalizer:
                     # types
                     CONST_VALUES: value if isinstance(value, list) else [str(value)]
                 }
+
+    @classmethod
+    def _match_condition(cls, record, condition):
+        """Apply condition to a record before normalization kicked in.
+
+        Returns:
+            bool: Return True if the value of the condition path matches to the condition, otherwise
+                return False. It is False if the path doesn't exist.
+        """
+        if not condition.get('path'):
+            return False
+
+        found_value, value = cls._find_value(record, condition['path'])
+        if not found_value:
+            return False
+
+        # cast value to a str in all lowercases
+        value = str(value).lower()
+
+        # Only support extract one condition. The result is not quaranteed if multiple conditions
+        # configured.
+        # FIXME: log a warning if more than one condition configured.
+        if condition.get('is'):
+            return value == condition['is']
+
+        if condition.get('is_not'):
+            return value != condition['is_not']
+
+        if condition.get('in'):
+            return value in condition['in']
+
+        if condition.get('not_in'):
+            return value not in condition['not_in']
+
+        if condition.get('contains'):
+            return condition['contains'] in value
+
+        if condition.get('not_contains'):
+            return condition['not_contains'] not in value
+
+        return False
 
     @classmethod
     def normalize(cls, record, log_type):

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -64,7 +64,7 @@ from streamalert_cli.utils import CLICommand
 
 RESTRICTED_CLUSTER_NAMES = ('main', 'athena')
 TERRAFORM_VERSION = '~> 0.12.9'
-TERRAFORM_PROVIDER_VERSION = '~> 2.28.1'
+TERRAFORM_PROVIDER_VERSION = '~> 2.48.0'
 
 LOGGER = get_logger(__name__)
 

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -93,7 +93,7 @@ class TestTerraformGenerate:
         tf_main_expected = {
             'provider': {
                 'aws': {
-                    'version': '~> 2.28.1',  # Changes to this should require unit test update
+                    'version': '~> 2.48.0',  # Changes to this should require unit test update
                     'region': 'us-west-1'
                 }
             },


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to: #1178, #1230, #1238, #1237, #1242
resolves:

## Background
This PR is to add the optional block `condition` to normalization configure. With this support, we will have more flexibility to normalize only a subset of data. The normalizer will be skipped if the `condition` block presented and the condition is not met.

See [the updated doc](https://github.com/airbnb/streamalert/blob/fca035ed278d39ed2a98d037b9326c568d376f1e/docs/source/normalization.rst#configuration) for the usage of the `condition` block.

## Changes

* Upgrade terraform aws provider to `2.48.0` to avoid the bug [Unable to remove aws_kinesis_firehose_delivery_stream S3 processors](https://github.com/terraform-providers/terraform-provider-aws/issues/11305)
* Add `condition` block support
* Update the docs
* Add unit test cases

## Testing
* Unit test cases are passed
* Tested in staging account
