### PR TITLE
Add three custom metrics

### DIFF
--- a/docs/source/normalization.rst
+++ b/docs/source/normalization.rst
@@ -274,6 +274,32 @@ Deployment
 
     python manage.py deploy --function classifier
 
+Custom Metrics
+==============
+
+Artifact Exactor comes with three custom metrics.
+
+#. ``ArtifactExtractor-ExtractedArtifacts``: Log the number of artifacts extracted from the records
+#. ``ArtifactExtractor-FirehoseFailedRecords``: Log the number of records (artifacts) failed sent to Firehose
+#. ``ArtifactExtractor-FirehoseRecordsSent``: Log the number of records (artifacts) sent to Firehose
+
+By default, the custom metrics is disabled. Enable custom metrics and follow by a ``build`` to create new ``aws_cloudwatch_log_metric_filter`` resources.
+
+  .. code-block::
+
+    # conf/lambda.json
+    "artifact_extractor_config": {
+      "concurrency_limit": 10,
+      "enabled": true,
+      "enable_custom_metrics": true,
+      ...
+    }
+
+  .. code-block::
+
+    python manage.py build --target "metric_filters_ArtifactExtractor_*"
+
+
 Artifacts
 =========
 

--- a/streamalert/artifact_extractor/artifact_extractor.py
+++ b/streamalert/artifact_extractor/artifact_extractor.py
@@ -17,7 +17,8 @@ from os import environ as env
 import uuid
 
 from streamalert.shared.firehose import FirehoseClient
-from streamalert.shared import config
+from streamalert.shared import ARTIFACT_EXTRACTOR_NAME, config
+from streamalert.shared.metrics import MetricLogger
 from streamalert.shared.normalize import Normalizer
 from streamalert.shared.logger import get_logger
 
@@ -248,6 +249,12 @@ class ArtifactExtractor:
             transformed_records.append(firehose_record.transformed_record)
 
         LOGGER.debug('Extracted %d artifact(s)', len(self._artifacts))
+
+        MetricLogger.log_metric(
+            ARTIFACT_EXTRACTOR_NAME,
+            MetricLogger.EXTRACTED_ARTIFACTS,
+            len(self._artifacts)
+        )
 
         self.firehose.send_artifacts(self._artifacts, self._dst_firehose_arn)
 

--- a/streamalert/shared/metrics.py
+++ b/streamalert/shared/metrics.py
@@ -18,6 +18,7 @@ import os
 from streamalert.shared import (
     ALERT_MERGER_NAME,
     ALERT_PROCESSOR_NAME,
+    ARTIFACT_EXTRACTOR_NAME,
     ATHENA_PARTITIONER_NAME,
     CLASSIFIER_FUNCTION_NAME,
     RULES_ENGINE_FUNCTION_NAME
@@ -33,6 +34,7 @@ CLUSTER = os.environ.get('CLUSTER', 'unknown_cluster')
 # below when metrics are supported there
 FUNC_PREFIXES = {
     ALERT_MERGER_NAME: 'AlertMerger',
+    ARTIFACT_EXTRACTOR_NAME: 'ArtifactExtractor',
     CLASSIFIER_FUNCTION_NAME: 'Classifier',
     RULES_ENGINE_FUNCTION_NAME: 'RulesEngine'
 }
@@ -75,6 +77,9 @@ class MetricLogger:
     # Alert Merger metric names
     ALERT_ATTEMPTS = 'AlertAttempts'
 
+    # Artifact Extractor metric names
+    EXTRACTED_ARTIFACTS = 'ExtractedArtifacts'
+
     _default_filter = '{{ $.metric_name = "{}" }}'
     _default_value_lookup = '$.metric_value'
 
@@ -89,6 +94,14 @@ class MetricLogger:
             ALERT_ATTEMPTS: (_default_filter.format(ALERT_ATTEMPTS), _default_value_lookup)
         },
         ALERT_PROCESSOR_NAME: {},   # Placeholder for future alert processor metrics
+        ARTIFACT_EXTRACTOR_NAME: {
+            EXTRACTED_ARTIFACTS: (_default_filter.format(EXTRACTED_ARTIFACTS),
+                                  _default_value_lookup),
+            FIREHOSE_FAILED_RECORDS: (_default_filter.format(FIREHOSE_FAILED_RECORDS),
+                                      _default_value_lookup),
+            FIREHOSE_RECORDS_SENT: (_default_filter.format(FIREHOSE_RECORDS_SENT),
+                                    _default_value_lookup)
+        },
         ATHENA_PARTITIONER_NAME: {},  # Placeholder for future athena processor metrics
         CLASSIFIER_FUNCTION_NAME: {
             FAILED_PARSES: (_default_filter.format(FAILED_PARSES),

--- a/tests/unit/streamalert/artifact_extractor/test_artifact_extractor.py
+++ b/tests/unit/streamalert/artifact_extractor/test_artifact_extractor.py
@@ -99,7 +99,8 @@ class TestArtifactExtractor:
 
         send_batch_mock.assert_called_with(
             'unit_test_dst_fh_arn',
-            generate_artifacts()
+            generate_artifacts(),
+            'artifact_extractor'
         )
 
         expected_result = transformed_firehose_records(normalized=True)

--- a/tests/unit/streamalert/artifact_extractor/test_main.py
+++ b/tests/unit/streamalert/artifact_extractor/test_main.py
@@ -94,7 +94,8 @@ class TestArtifactExtractorHandler:
 
         send_batch_mock.assert_called_with(
             'unit_test_dst_fh_arn',
-            generate_artifacts()
+            generate_artifacts(),
+            'artifact_extractor'
         )
 
         expected_result = transformed_firehose_records(normalized=True)

--- a/tests/unit/streamalert/shared/test_firehose.py
+++ b/tests/unit/streamalert/shared/test_firehose.py
@@ -97,7 +97,7 @@ class TestFirehoseClient:
             ]
         ]
 
-        result = list(FirehoseClient._record_batches(records))
+        result = list(FirehoseClient._record_batches(records, 'test_function_name'))
         assert_equal(result, expected_result)
 
     @patch.object(FirehoseClient, '_log_failed')
@@ -107,15 +107,15 @@ class TestFirehoseClient:
             {'key': 'test' * 1000 * 1000}
         ]
 
-        result = list(FirehoseClient._record_batches(records))
+        result = list(FirehoseClient._record_batches(records, 'test_function_name'))
         assert_equal(result, [])
-        failure_mock.assert_called_with(1)
+        failure_mock.assert_called_with(1, 'test_function_name')
 
     def test_record_batches_max_batch_count(self):
         """FirehoseClient - Record Batches, Max Batch Count"""
         records = self._sample_raw_records(count=501)
 
-        result = list(FirehoseClient._record_batches(records))
+        result = list(FirehoseClient._record_batches(records, 'test_function_name'))
         assert_equal(len(result), 2)
         assert_equal(len(result[0]), 500)
         assert_equal(len(result[1]), 1)
@@ -126,7 +126,7 @@ class TestFirehoseClient:
             {'key_{}'.format(i): 'test' * 100000}
             for i in range(10)
         ]
-        result = list(FirehoseClient._record_batches(records))
+        result = list(FirehoseClient._record_batches(records, 'test_function_name'))
         assert_equal(len(result), 2)
         assert_equal(len(result[0]), 9)
         assert_equal(len(result[1]), 1)
@@ -229,8 +229,8 @@ class TestFirehoseClient:
             ]
         }
 
-        FirehoseClient._finalize(response, 'stream_name', 3)
-        failure_mock.assert_called_with(1)
+        FirehoseClient._finalize(response, 'stream_name', 3, 'test_function_name')
+        failure_mock.assert_called_with(1, 'test_function_name')
 
     @patch('logging.Logger.info')
     def test_finalize_success(self, log_mock):
@@ -244,7 +244,7 @@ class TestFirehoseClient:
             }
         }
 
-        FirehoseClient._finalize(response, stream_name, count)
+        FirehoseClient._finalize(response, stream_name, count, 'test_function_name')
         log_mock.assert_called_with(
             'Successfully sent %d message(s) to firehose %s with RequestId \'%s\'',
             count,
@@ -280,7 +280,7 @@ class TestFirehoseClient:
                 }
             ]
 
-            self._client._send_batch(stream_name, records)
+            self._client._send_batch(stream_name, records, 'test_function_name')
 
             boto_mock.put_record_batch.assert_called_with(
                 DeliveryStreamName=stream_name,
@@ -296,7 +296,7 @@ class TestFirehoseClient:
             error = ClientError({'Error': {'Code': 10}}, 'InvalidRequestException')
             boto_mock.put_record_batch.side_effect = error
 
-            self._client._send_batch(stream_name, ['data'])
+            self._client._send_batch(stream_name, ['data'], 'test_function_name')
 
             log_mock.assert_called_with('Firehose request failed')
 
@@ -412,7 +412,7 @@ class TestFirehoseClient:
         ]
         self._client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'unit_test_streamalert_log_type_01_sub_type_01', expected_batch
+            'unit_test_streamalert_log_type_01_sub_type_01', expected_batch, 'classifier'
         )
 
     @patch.object(FirehoseClient, '_send_batch')
@@ -434,7 +434,7 @@ class TestFirehoseClient:
 
         client.send(self._sample_payloads)
         send_batch_mock.assert_called_with(
-            'streamalert_log_type_01_sub_type_01', expected_batch
+            'streamalert_log_type_01_sub_type_01', expected_batch, 'classifier'
         )
 
     @property
@@ -476,7 +476,9 @@ class TestFirehoseClient:
 
         client.send(self._sample_payloads_long_log_name)
         send_batch_mock.assert_called_with(
-            'streamalert_very_very_very_long_log_stream_name_abcdefg_7c88167b', expected_batch
+            'streamalert_very_very_very_long_log_stream_name_abcdefg_7c88167b',
+            expected_batch,
+            'classifier'
         )
 
     def test_generate_firehose_name(self):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
Add three custom metrics for `Artifact Extractor`
1. `ArtifactExtractor-ExtractedArtifacts`: Log the number of artifacts extracted from the records
2. `ArtifactExtractor-FirehoseFailedRecords`: Log the number of records (artifacts) failed sent to Firehose
3. `ArtifactExtractor-FirehoseRecordsSent`: Log the number of records (artifacts) sent to Firehose

These three custom metrics are useful for tracking the metrics of artifacts by adding them to a CloudWatch dashboard, as well as helpful to set alarms if necessary.
<img width="1201" alt="artifact_extractor_custom_metrics" src="https://user-images.githubusercontent.com/21151436/81369860-73354d80-90a8-11ea-87b7-71b32ed54734.png">

## Changes

* Allow to pass `function_name` to custom metrics
* Add three custom metrics for `Artifact Extractor`
* Update unit test cases
* Update docs

## Testing

Steps for how this change was tested and verified
