### PR TITLE
[apps][aliyun] Set EndTime in the request

### DIFF
--- a/streamalert/apps/_apps/aliyun.py
+++ b/streamalert/apps/_apps/aliyun.py
@@ -60,8 +60,8 @@ class AliyunApp(AppIntegration):
         self.request.set_MaxResults(self._MAX_RESULTS)
         self.request.set_StartTime(self._config.last_timestamp)
 
-        # Source code can be found here https://github.com/aliyun/aliyun-openapi-python-sdk/blob/
-        # master/aliyun-python-sdk-actiontrail/aliyunsdkactiontrail/request/v20171204/
+        # Source code can be found here https://github.com/aliyun/aliyun-openapi-python-sdk/
+        # blob/master/aliyun-python-sdk-actiontrail/aliyunsdkactiontrail/request/v20171204/
         # LookupEventsRequest.py
         self.request.set_EndTime(datetime.utcnow().strftime(self.date_formatter()))
 

--- a/streamalert/apps/_apps/aliyun.py
+++ b/streamalert/apps/_apps/aliyun.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from datetime import datetime
 import json
 import re
 
@@ -58,6 +59,11 @@ class AliyunApp(AppIntegration):
         self.request = LookupEventsRequest.LookupEventsRequest()
         self.request.set_MaxResults(self._MAX_RESULTS)
         self.request.set_StartTime(self._config.last_timestamp)
+
+        # Source code can be found here https://github.com/aliyun/aliyun-openapi-python-sdk/blob/
+        # master/aliyun-python-sdk-actiontrail/aliyunsdkactiontrail/request/v20171204/
+        # LookupEventsRequest.py
+        self.request.set_EndTime(datetime.utcnow().strftime(self.date_formatter()))
 
     @classmethod
     def _type(cls):


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers
related to:
resolves:

## Background
Looks Aliyun actiontrail api had change to require to `set_EndTime` in the request since yesterday. See a log stream for more error message
```
2020-05-18 07:11:43
START RequestId: bbbbbbbb-dddd-4444-bbbb-999999999999 Version: 34
[INFO]	2020-05-18 14:11:44,028.28Z	bbbbbbbb-dddd-4444-bbbb-999999999999	[aliyun_actiontrail] Starting app
[INFO]	2020-05-18 14:11:44,028.28Z	bbbbbbbb-dddd-4444-bbbb-999999999999	App executing as a successive invocation: False
[INFO]	2020-05-18 14:11:44,029.29Z	bbbbbbbb-dddd-4444-bbbb-999999999999	Starting last timestamp set to: 2020-05-18T14:02:35Z
[ERROR]	2020-05-18 14:11:44,798.798Z	bbbbbbbb-dddd-4444-bbbb-999999999999	ServerException occurred. Host:actiontrail.cn-hangzhou.aliyuncs.com SDK-Version:2.13.5 ServerException:HTTP Status: 400 Error:InvalidParameterEndTime invalid EndTime(null) RequestID: BBBBBBBB-AAAA-4444-BBBB-666666666666
[ERROR]	2020-05-18 14:11:44,798.798Z	bbbbbbbb-dddd-4444-bbbb-999999999999	Server error occurred
Traceback (most recent call last):
  File "/var/task/streamalert/apps/_apps/aliyun.py", line 121, in _gather_logs
    response = self.client.do_action_with_exception(self.request)
  File "/opt/python/aliyunsdkcore/client.py", line 456, in do_action_with_exception
    raise exception
aliyunsdkcore.acs_exception.exceptions.ServerException: HTTP Status: 400 Error:InvalidParameterEndTime invalid EndTime(null) RequestID: BBBBBBBB-AAAA-4444-BBBB-666666666666
[ERROR]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	[aliyun_actiontrail] Gather process was not able to poll any logs on poll #1
[INFO]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	[_gather] Function executed in 0.6834 seconds.
[INFO]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	Lambda remaining seconds: 899.07
[INFO]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	Lambda remaining seconds: 899.07
[INFO]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	Ending last timestamp is the same as the beginning last timestamp. This could occur if there were no logs collected for this execution.
[INFO]	2020-05-18 14:11:44,799.799Z	bbbbbbbb-dddd-4444-bbbb-999999999999	[aliyun_actiontrail] App complete; gathered 0 logs in 1 polls.
END RequestId: bbbbbbbb-dddd-4444-bbbb-999999999999
```

## Changes

* Set EndTime to current time when initialize aliyun app

## Testing
Deployed to production and it fixes the issue 🤷‍♀️ 
