### PR TITLE
[rules] Add rule to detect creation of GitHub org hooks

### DIFF
--- a/rules/community/github/github_org_hook_create.json
+++ b/rules/community/github/github_org_hook_create.json
@@ -1,0 +1,33 @@
+[
+  {
+    "action": "hook.create",
+    "created_at": 1590685471482,
+    "data": {
+      "@timestamp": 1590685471482,
+      "_document_id": "...",
+      "areas_of_responsibility": [
+        "api",
+        "webhook"
+      ],
+      "controller": "Api::OrganizationHooks",
+      "current_user": "myuser",
+      "events": [
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "issues",
+        "issue_comment",
+        "meta"
+      ],
+      "hook_id": 1234,
+      "hook_type": "org",
+      "name": "webhook",
+      "request_category": "api",
+      "version": "v3",
+      "webhook": true
+    },
+    "from": "Api::OrganizationHooks#POST",
+    "org": "myorg",
+    "org_id": 1234
+  }
+]

--- a/rules/community/github/github_org_hook_create.py
+++ b/rules/community/github/github_org_hook_create.py
@@ -1,0 +1,15 @@
+"""Github organization-wide hook was created."""
+from streamalert.shared.rule import rule
+
+
+@rule(logs=['ghe:general'])
+def github_org_hook_create(rec):
+    """
+    author:       @mimeframe
+    description:  Github organization-wide hook was created.
+                  Organization hooks receive events for all repositories in an
+                  organization and have the potential to leak a lot of data.
+    repro_steps:  (a) Visit /organizations/<org>>/settings/hooks
+    """
+    return rec['action'] == 'hook.create' and rec['data']['hook_type'] == 'org'
+


### PR DESCRIPTION
to:
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

Changes to organizational-wide hooks should be rare and can leak
data to 3rd parties.

## Changes

* New rule to detect creation of org-wide hooks

## Testing

I have no clue since this is my first contribution to this repo. I suspect the added JSON file is wrong. I have no clue where the boilerplate for the existing JSON files comes from. But if you ping me privately, I can give you the link to a Kibana event in Airbnb's infra that we want to trigger this rule.
