### PR TITLE
Resolve TF 12 error

### DIFF
--- a/streamalert_cli/_infrastructure/modules/tf_lambda/iam.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_lambda/iam.tf
@@ -28,6 +28,6 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_policy" {
 // Attach VPC policy (if applicable)
 resource "aws_iam_role_policy_attachment" "vpc_access" {
   count      = local.vpc_enabled ? 1 : 0
-  role       = aws_iam_role.role.id
+  role       = aws_iam_role.role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }


### PR DESCRIPTION
to:
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The following resolves an error in TF application as per https://github.com/hashicorp/terraform/issues/22480#issuecomment-521762472 

```
Error: Unsupported attribute

  on modules/tf_lambda/iam.tf line 24, in resource "aws_iam_role_policy_attachment" "lambda_basic_policy":
  24:   role       = aws_iam_role.role.id
    |----------------
    | aws_iam_role.role is empty tuple

This value does not have any attributes.


Error: Unsupported attribute

  on modules/tf_lambda/iam.tf line 24, in resource "aws_iam_role_policy_attachment" "lambda_basic_policy":
  24:   role       = aws_iam_role.role.id
    |----------------
    | aws_iam_role.role is empty tuple

This value does not have any attributes.

```

## Changes

Add relevant tf12 compatibale `count.index` for use in the count statement. 

## Testing

The following was tested and applied locally and used to deploy the latest 3.2.1 version tag. 
