### PR TITLE
updating cli description for supplying test files

### DIFF
--- a/streamalert_cli/test/handler.py
+++ b/streamalert_cli/test/handler.py
@@ -134,9 +134,8 @@ class TestCommand(CLICommand):
             '-f',
             '--test-files',
             dest='files',
-            metavar='FILENAMES',
             nargs='+',
-            help='One or more file to test, separated by spaces',
+            help='Full path to one or more file(s) to test, separated by spaces',
             action=UniqueSortedFileListAction,
             type=argparse.FileType('r'),
             default=[]


### PR DESCRIPTION
to: @chunyong-lin / @blakemotl 
cc: @airbnb/streamalert-maintainers

## Background

There is a confusing description for a command line flag related to test files. 

## Changes

* Updating description and removing metavar to make it more obvious that this should be full paths, not file names.

## Testing

n/a
