### PR TITLE
support for packaging user specified conf directory

### DIFF
--- a/streamalert_cli/config.py
+++ b/streamalert_cli/config.py
@@ -24,8 +24,9 @@ from streamalert.shared.logger import get_logger
 from streamalert_cli.helpers import continue_prompt
 from streamalert_cli.apps.helpers import save_app_auth_info
 
-LOGGER = get_logger(__name__)
 DEFAULT_CONFIG_PATH = 'conf'
+
+LOGGER = get_logger(__name__)
 
 
 class CLIConfig:

--- a/streamalert_cli/manage_lambda/package.py
+++ b/streamalert_cli/manage_lambda/package.py
@@ -26,7 +26,7 @@ LOGGER = get_logger(__name__)
 
 class LambdaPackage:
     """Build the deployment package for StreamAlert Lambdas"""
-    # The name of the directory to pacakge and basename of the generated .zip file
+    # The name of the directory to package and basename of the generated .zip file
     PACKAGE_NAME = 'streamalert'
 
     # The configurable items for user specified files

--- a/tests/unit/streamalert_cli/manage_lambda/test_package.py
+++ b/tests/unit/streamalert_cli/manage_lambda/test_package.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2017-present Airbnb, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# pylint: disable=no-self-use,protected-access
+import os
+
+from mock import patch
+from pyfakefs import fake_filesystem_unittest
+
+from streamalert_cli.config import CLIConfig
+from streamalert_cli.manage_lambda import package
+
+
+class PackageTest(fake_filesystem_unittest.TestCase):
+    """Test the packaging logic for the Lambda package"""
+    TEST_CONFIG_PATH = 'tests/unit/conf'
+    MOCK_TEMP_PATH = '/tmp/test_packaging'
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.add_real_directory(self.TEST_CONFIG_PATH)
+
+        with patch('tempfile.gettempdir') as temp_dir_mock:
+            temp_dir_mock.return_value = self.MOCK_TEMP_PATH
+            self.packager = package.LambdaPackage(CLIConfig(self.TEST_CONFIG_PATH))
+
+    def test_copy_directory_destination(self):
+        """CLI - LambdaPackage copy directory using destination"""
+        self.packager._copy_directory(self.TEST_CONFIG_PATH, destination='conf_test')
+
+        # Ensure the specified destination exists and not the default
+        self.assertTrue(os.path.exists(self.MOCK_TEMP_PATH + '/streamalert/conf_test'))
+        self.assertFalse(os.path.exists(self.MOCK_TEMP_PATH + '/streamalert/conf'))


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

The current `conf` directory is hard coded into the packaging logic. This should not be the case.

## Changes

* Updating packaging logic to zip up the user-specified config directory (which has a default value of `conf`)

## Testing

Adding unit test to check for copying to custom destination.
