### PR TITLE
Add missing subcommand when setting example SNS output in the "Getting Started" section

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -208,7 +208,7 @@ Open ``conf/clusters/prod.json`` and change the ``data_sources`` section to look
 
 .. code-block:: bash
 
-  python manage.py output aws-sns
+  python manage.py output set aws-sns
 
   Please supply a short and unique descriptor for this SNS topic: test-email
 


### PR DESCRIPTION
cc: @airbnb/streamalert-maintainers 

## Background

Reason for the change

The current Getting Started instructions don't mention that you need to add the `set` command. As it stands, this is the error I received when setting up Streamalert:

```
(.env) jordan@mac:~/src/aws/streamalert/streamalert$ python manage.py output aws-sns
usage: manage.py output [-h]
                        {set,set-from-file,generate-skeleton,get,list} ...
manage.py output: error: invalid choice: 'aws-sns' (choose from 'set', 'set-from-file', 'generate-skeleton', 'get', 'list')
```

## Changes

* Added subcommand to the `python manage.py output` instructions.

## Testing

Received an error when running the command as prescribed in the documentation. Things seem to work when I added the subcommand.
