### PR TITLE
omitting coveralls runs for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: ${{ matrix.task.name }}
         run: ${{ matrix.task.command }}
       - name: Submit Coverage
-        run: coveralls
+        run: ([ ! -z "$COVERALLS_REPO_TOKEN" ] && coveralls)
         if: matrix.task.name == 'Test'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

Coveralls tries to run on PRs from forks, but [fails](https://github.com/airbnb/streamalert/pull/1255/checks?check_run_id=760183550) because forks do not have the token to submit to our coveralls.

## Changes

* Not running coveralls if repo token is not set.

## Testing

CI
