### PR TITLE
[core] rules/severity levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ubuntu*.log
 
 # Coverage artifacts
 /htmlcov
+
+# User Setup
+.vscode

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -142,6 +142,7 @@ The following table provides an overview of each rule option, with more details 
 ``outputs``            ``List[str]``             List of alert outputs
 ``dynamic_outputs``    ``List[function]``        List of functions which return valid outputs
 ``req_subkeys``        ``Dict[str, List[str]]``  Subkeys which must be present in the record
+``severity``           ``str``                   The severity of this rule triggering an Alert (default: low)
 =====================  ========================  ===============
 
 
@@ -287,6 +288,20 @@ The following table provides an overview of each rule option, with more details 
         # throw a KeyError.  Using req_subkeys avoids this.
         return rec['columns']['address'] == '127.0.0.1'
 
+:severity:
+
+  The ``severity`` keyword argument defines the severity level for this rule. The default is ``low``, but this can be set on a per-rule basis.
+
+  Severities, can be user defined but a recommended approach is to use the following severity levels:
+
+==================  ===================
+**Severity level**  **default meaning**
+------------------  -------------------
+``low``             ``Alert should be looked at when the user has time to investigate``
+``medium``          ``Alert should be looked at within 6 hours``
+``high``            ``Alert should be looked at within 30 minutes of it being raised``
+``critical``        ``Alert should be looked as soon as it is raised``
+==================  ===================
 
 ***************
 Disabling Rules

--- a/streamalert/shared/alert.py
+++ b/streamalert/shared/alert.py
@@ -30,7 +30,7 @@ class Alert:
     _EXPECTED_INIT_KWARGS = {
         'alert_id', 'attempts', 'cluster', 'context', 'created', 'dispatched', 'log_source',
         'log_type', 'merge_by_keys', 'merge_window', 'outputs_sent', 'publishers',
-        'rule_description', 'source_entity', 'source_service', 'staged'
+        'rule_description', 'severity', 'source_entity', 'source_service', 'staged'
     }
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
@@ -66,6 +66,7 @@ class Alert:
                     in order, for only that specific output service.
 
             rule_description (str): Description associated with the triggering rule.
+            severity (str): The severity of the rule being triggered to an Alert (default: low)
             source_entity (str): Name of location from which the record originated. E.g. "mychannel"
             source_service (str): Input type from which the record originated. E.g. "slack"
             staged (bool): Whether this rule is currently in the staging process. Defaults to False
@@ -104,6 +105,7 @@ class Alert:
         self.merge_window = kwargs.get('merge_window') or timedelta(minutes=0)
         self.outputs_sent = kwargs.get('outputs_sent') or set()
         self.rule_description = kwargs.get('rule_description') or None
+        self.severity = kwargs.get('severity') or 'low'
         self.source_entity = kwargs.get('source_entity') or None
         self.source_service = kwargs.get('source_service') or None
         self.staged = kwargs.get('staged') or False
@@ -165,6 +167,7 @@ class Alert:
             # (instead of just passing the dict) because Dynamo does not allow empty string values.
             'Record': json.dumps(self.record, separators=(',', ':'), default=list),
             'RuleDescription': self.rule_description,
+            'Severity': self.severity,
             'SourceEntity': self.source_entity,
             'SourceService': self.source_service,
             'Staged': self.staged
@@ -202,6 +205,7 @@ class Alert:
                 outputs_sent=set(record.get('OutputsSent') or []),
                 publishers=record.get('Publishers'),
                 rule_description=record.get('RuleDescription'),
+                severity=record.get('severity'),
                 source_entity=record.get('SourceEntity'),
                 source_service=record.get('SourceService'),
                 staged=record.get('Staged')
@@ -236,6 +240,7 @@ class Alert:
             'record': self.record,
             'rule_description': self.rule_description or '',
             'rule_name': self.rule_name or '',
+            'severity': self.severity,
             'source_entity': self.source_entity or '',
             'source_service': self.source_service or '',
             'staged': self.staged,
@@ -427,6 +432,7 @@ class Alert:
             log_type=alerts[0].log_type,
             publishers=alerts[0].publishers,
             rule_description=alerts[0].rule_description,
+            severity=alerts[0].severity,
             source_entity=alerts[0].source_entity,
             source_service=alerts[0].source_service,
             staged=any(alert.staged for alert in alerts)

--- a/streamalert/shared/rule.py
+++ b/streamalert/shared/rule.py
@@ -60,6 +60,7 @@ class Rule:
         self.merge_window_mins = kwargs.get('merge_window_mins') or 0
         self.outputs = kwargs.get('outputs')
         self.dynamic_outputs = kwargs.get('dynamic_outputs')
+        self.severity = kwargs.get('severity')
         self.publishers = kwargs.get('publishers')
         self.req_subkeys = kwargs.get('req_subkeys')
         self.initial_context = kwargs.get('context')

--- a/tests/unit/streamalert/alert_processor/outputs/test_demisto.py
+++ b/tests/unit/streamalert/alert_processor/outputs/test_demisto.py
@@ -72,6 +72,7 @@ EXPECTED_LABELS_FOR_SAMPLE_ALERT = [
     {'type': 'record.type', 'value': 'binarystore.file.added'},
     {'type': 'rule_description', 'value': 'Info about this rule and what actions to take'},
     {'type': 'rule_name', 'value': 'cb_binarystore_file_added'},
+    {'type': 'severity', 'value': 'low'},
     {'type': 'source_entity', 'value': 'corp-prefix.prod.cb.region'},
     {'type': 'source_service', 'value': 's3'},
     {'type': 'staged', 'value': 'False'},


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin
cc: @airbnb/streamalert-maintainers
related to: #1171 
resolves: #1157

## Background

Originally opened under #1171 but the diff got a bit nuts. So i've re-created the original bits but i don't have a test environment for this anymore so can't easily test. #1171 was contentious but i'd rather open this to be merged or closed so others don't ask on Slack if this feature will be enabled or not.

## Changes

* [core] Added severity levels to rules (#1157)
* [testing] Updated unit_tests accordingly
* [docs] Updated documentation for the rule so there is a description around severity levels
* [git] Updated .gitignore to ignore `.vscode` (i'll end up commiting it by mistake)

## Testing

Ran `./tests/scripts/unit_test.sh` locally and observed errors that are hard to see due to the environment not actually being deployed (AWS Creds are not available nor should be during testing)
