### PR TITLE
proper cloudwatch events permissions for cross account access

### DIFF
--- a/docs/source/config-clusters.rst
+++ b/docs/source/config-clusters.rst
@@ -325,6 +325,18 @@ Example
             "EC2 Instance Terminate Successful",
             "EC2 Instance Terminate Unsuccessful"
           ]
+        },
+        "cross_account": {
+          "accounts": {
+            "123456789012": [
+              "us-east-1"
+            ]
+          },
+          "organizations": {
+            "o-aabbccddee": [
+              "us-east-1"
+            ]
+          }
         }
       },
       "kinesis": {
@@ -341,7 +353,7 @@ Example
   }
 
 This creates a CloudWatch Events Rule that will publish all events that match the provided
-``event_pattern`` to the Kinesis stream for this cluster. Note in the example above that a custom
+``event_pattern`` to the Kinesis Stream for this cluster. Note in the example above that a custom
 ``event_pattern`` is supplied, but may be omitted entirely. To override the default ``event_patten``
 (shown below), a value of ``None`` or ``{}`` may also be supplied to capture all events,
 regardless of which account the logs came from. In this case, rules should be written against
@@ -354,7 +366,19 @@ Options
 **Key**                **Default**                          **Description**
 ---------------------  -----------------------------------  ---------------
 ``event_pattern``      ``{"account": ["<accound_id>"]}``    The `CloudWatch Events pattern <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>`_ to control what is sent to Kinesis
+``cross_account``      ``None``                             Configuration options to enable cross account access for specific AWS Accounts and Organizations. See the `Cross Account Options`_ section below for details.
 =====================  ===================================  ===============
+
+Cross Account Options
+---------------------
+The ``cross_account`` section of the ``cloudwatch_events`` module has two subsections, outlined here. Usage of these is also shown in the example above.
+
+=====================  ===========  ===============
+**Key**                **Default**  **Description**
+---------------------  -----------  ---------------
+``accounts``           ``None``     A mapping of *account IDs* and regions for which cross account access should be enabled. Example: ``{"123456789012": ["us-east-1"], "234567890123": ["us-west-2"]}``
+``organizations``      ``None``     A mapping of *organization IDs* and regions for which cross account access should be enabled. Example: ``{"o-aabbccddee": ["us-west-2"]}``
+=====================  ===========  ===============
 
 
 .. _cloudwatch_logs:

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/README.md
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/README.md
@@ -1,0 +1,39 @@
+# StreamAlert CloudWatch Events Cross Account Terraform Module
+Configure the necessary resources to allow for cross account CloudWatch Events via EventBridge Events Bus
+
+## Components
+* Configures CloudWatch Event Permissions to allow external accounts or organizations to send events to the main account
+
+## Example
+```hcl
+module "cloudwatch_events_cross_account" {
+  source            = "./modules/tf_cloudwatch_events/cross_account"
+  organization_ids  = ["123456789012"]
+  org_ids           = ["o-aabbccddee"]
+  region            = "us-east-1"
+}
+```
+
+## Inputs
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Description</th>
+    <th>Default (None=Required)</th>
+  </tr>
+  <tr>
+    <td>account_ids</td>
+    <td>AWS Account IDs for which to enable cross account CloudWatch Events</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td>organization_ids</td>
+    <td>AWS Organization IDs for which to enable cross account CloudWatch Events</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td>region</td>
+    <td>AWS region in which this permission is being added</td>
+    <td>None</td>
+  </tr>
+</table>

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/README.md
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/README.md
@@ -7,10 +7,10 @@ Configure the necessary resources to allow for cross account CloudWatch Events v
 ## Example
 ```hcl
 module "cloudwatch_events_cross_account" {
-  source            = "./modules/tf_cloudwatch_events/cross_account"
-  organization_ids  = ["123456789012"]
-  org_ids           = ["o-aabbccddee"]
-  region            = "us-east-1"
+  source         = "./modules/tf_cloudwatch_events/cross_account"
+  accounts       = ["123456789012"]
+  organizations  = ["o-aabbccddee"]
+  region         = "us-east-1"
 }
 ```
 
@@ -22,12 +22,12 @@ module "cloudwatch_events_cross_account" {
     <th>Default (None=Required)</th>
   </tr>
   <tr>
-    <td>account_ids</td>
+    <td>accounts</td>
     <td>AWS Account IDs for which to enable cross account CloudWatch Events</td>
     <td>None</td>
   </tr>
   <tr>
-    <td>organization_ids</td>
+    <td>organizations</td>
     <td>AWS Organization IDs for which to enable cross account CloudWatch Events</td>
     <td>None</td>
   </tr>

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/main.tf
@@ -1,0 +1,19 @@
+// CloudWatch Event Permission for Individual AWS Accounts
+resource "aws_cloudwatch_event_permission" "account_access" {
+  count        = length(var.accounts)
+  principal    = element(var.accounts, count.index)
+  statement_id = "account_${element(var.accounts, count.index)}_${var.region}"
+}
+
+// CloudWatch Event Permission for AWS Orgs
+resource "aws_cloudwatch_event_permission" "organization_access" {
+  count        = length(var.organizations)
+  principal    = "*"
+  statement_id = "organization_${element(var.organizations, count.index)}_${var.region}"
+
+  condition {
+    key   = "aws:PrincipalOrgID"
+    type  = "StringEquals"
+    value = element(var.organizations, count.index)
+  }
+}

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/cross_account/variables.tf
@@ -1,0 +1,11 @@
+variable "accounts" {
+  type = list(string)
+}
+
+variable "organizations" {
+  type = list(string)
+}
+
+variable "region" {
+  type = string
+}

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
@@ -15,6 +15,7 @@ resource "aws_cloudwatch_event_rule" "capture_events" {
 resource "aws_cloudwatch_event_target" "kinesis" {
   target_id = "${var.prefix}_${var.cluster}_streamalert_kinesis"
   rule      = aws_cloudwatch_event_rule.capture_events.name
+  role_arn  = aws_iam_role.cloudwatch_events_role.arn
   arn       = var.kinesis_arn
 }
 

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
@@ -1,22 +1,3 @@
-// Cloudwatch event to capture Cloudtrail API calls
-resource "aws_cloudwatch_event_rule" "capture_events" {
-  name          = "${var.prefix}_${var.cluster}_streamalert_all_events"
-  description   = "Capture CloudWatch events"
-  role_arn      = aws_iam_role.cloudwatch_events_role.arn
-  event_pattern = var.event_pattern
-
-  tags = {
-    Name    = "StreamAlert"
-    Cluster = var.cluster
-  }
-}
-
-// The Kinesis destination for Cloudwatch events
-resource "aws_cloudwatch_event_target" "kinesis" {
-  rule = aws_cloudwatch_event_rule.capture_events.name
-  arn  = var.kinesis_arn
-}
-
 // IAM Role: CloudWatch Events
 resource "aws_iam_role" "cloudwatch_events_role" {
   name               = "${var.prefix}_${var.cluster}_cloudwatch_events_role"
@@ -62,3 +43,73 @@ data "aws_iam_policy_document" "kinesis_put_records" {
     ]
   }
 }
+
+
+// CloudFormation Stack to substitute for this limitation in Terraform:
+//   https://github.com/terraform-providers/terraform-provider-aws/issues/8759
+//
+// This stack creates a rule in EventBridge (vs CloudWatch Events) since Terraform currently
+// does not support apply this directly. EventBridge is needed for this rule, because content-based
+// filtering with Event Patterns is not a supported feature in the "legacy" aws_cloudwatch_event_rule
+// See here:
+//   https://docs.aws.amazon.com/eventbridge/latest/userguide/content-filtering-with-event-patterns.html#filtering-anything-but-matching-example
+//
+// The aws_cloudwatch_event_rule event patterns only support strings, or list of strings, vs the more
+// advanced mapping with things like "anything-but". Once this is supported by Terraform, this stack
+// can be removed and the below code uncommented to be applied.
+resource "aws_cloudformation_stack" "eventbridge_rule" {
+  name = "CloudWatchEvents${var.prefix}${var.cluster}StreamAlert"
+
+  // Ideally, the AWS::Events::Rule resource would also be tagged here. However, it appears that
+  // while the resource itself supports tagging, CloudFormation does not in fact support it for
+  // this resource type...
+  template_body = <<EOF
+Resources:
+  ${var.prefix}${var.cluster}StreamAlertEventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: "${var.prefix}_${var.cluster}_streamalert_all_events"
+      Description: "Capture CloudWatch events"
+      EventPattern: "${var.event_pattern}"
+      RoleArn: "${aws_iam_role.cloudwatch_events_role.arn}"
+      Targets:
+        - Arn: "${var.kinesis_arn}"
+          Id: "${var.prefix}_${var.cluster}_streamalert_kinesis"
+          RoleArn: "${aws_iam_role.cloudwatch_events_role.arn}"
+EOF
+
+  tags = {
+    Name    = "StreamAlert"
+    Cluster = var.cluster
+  }
+}
+
+// Uncomment the below when it is properly supported by Terraform, and remove the above stack
+########################################################
+########################################################
+################# KEEP FOR FUTURE USE ##################
+########################################################
+########################################################
+// Cloudwatch Event Rule: Capture CloudWatch Events
+# resource "aws_cloudwatch_event_rule" "capture_events" {
+#   name          = "${var.prefix}_${var.cluster}_streamalert_all_events"
+#   description   = "Capture CloudWatch events"
+#   role_arn      = aws_iam_role.cloudwatch_events_role.arn
+#   event_pattern = var.event_pattern
+#
+#   tags = {
+#     Name    = "StreamAlert"
+#     Cluster = var.cluster
+#   }
+# }
+#
+// The Kinesis destination for Cloudwatch events
+# resource "aws_cloudwatch_event_target" "kinesis" {
+#   rule = aws_cloudwatch_event_rule.capture_events.name
+#   arn  = var.kinesis_arn
+# }
+########################################################
+########################################################
+################# KEEP FOR FUTURE USE ##################
+########################################################
+########################################################

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_events/main.tf
@@ -1,3 +1,23 @@
+// Cloudwatch Event Rule: Capture CloudWatch Events
+resource "aws_cloudwatch_event_rule" "capture_events" {
+  name          = "${var.prefix}_${var.cluster}_streamalert_all_events"
+  description   = "Capture CloudWatch events"
+  role_arn      = aws_iam_role.cloudwatch_events_role.arn
+  event_pattern = var.event_pattern
+
+  tags = {
+    Name    = "StreamAlert"
+    Cluster = var.cluster
+  }
+}
+
+// The Kinesis destination for Cloudwatch events
+resource "aws_cloudwatch_event_target" "kinesis" {
+  target_id = "${var.prefix}_${var.cluster}_streamalert_kinesis"
+  rule      = aws_cloudwatch_event_rule.capture_events.name
+  arn       = var.kinesis_arn
+}
+
 // IAM Role: CloudWatch Events
 resource "aws_iam_role" "cloudwatch_events_role" {
   name               = "${var.prefix}_${var.cluster}_cloudwatch_events_role"
@@ -43,73 +63,3 @@ data "aws_iam_policy_document" "kinesis_put_records" {
     ]
   }
 }
-
-
-// CloudFormation Stack to substitute for this limitation in Terraform:
-//   https://github.com/terraform-providers/terraform-provider-aws/issues/8759
-//
-// This stack creates a rule in EventBridge (vs CloudWatch Events) since Terraform currently
-// does not support apply this directly. EventBridge is needed for this rule, because content-based
-// filtering with Event Patterns is not a supported feature in the "legacy" aws_cloudwatch_event_rule
-// See here:
-//   https://docs.aws.amazon.com/eventbridge/latest/userguide/content-filtering-with-event-patterns.html#filtering-anything-but-matching-example
-//
-// The aws_cloudwatch_event_rule event patterns only support strings, or list of strings, vs the more
-// advanced mapping with things like "anything-but". Once this is supported by Terraform, this stack
-// can be removed and the below code uncommented to be applied.
-resource "aws_cloudformation_stack" "eventbridge_rule" {
-  name = "CloudWatchEvents${var.prefix}${var.cluster}StreamAlert"
-
-  // Ideally, the AWS::Events::Rule resource would also be tagged here. However, it appears that
-  // while the resource itself supports tagging, CloudFormation does not in fact support it for
-  // this resource type...
-  template_body = <<EOF
-Resources:
-  ${var.prefix}${var.cluster}StreamAlertEventBridgeRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Name: "${var.prefix}_${var.cluster}_streamalert_all_events"
-      Description: "Capture CloudWatch events"
-      EventPattern: "${var.event_pattern}"
-      RoleArn: "${aws_iam_role.cloudwatch_events_role.arn}"
-      Targets:
-        - Arn: "${var.kinesis_arn}"
-          Id: "${var.prefix}_${var.cluster}_streamalert_kinesis"
-          RoleArn: "${aws_iam_role.cloudwatch_events_role.arn}"
-EOF
-
-  tags = {
-    Name    = "StreamAlert"
-    Cluster = var.cluster
-  }
-}
-
-// Uncomment the below when it is properly supported by Terraform, and remove the above stack
-########################################################
-########################################################
-################# KEEP FOR FUTURE USE ##################
-########################################################
-########################################################
-// Cloudwatch Event Rule: Capture CloudWatch Events
-# resource "aws_cloudwatch_event_rule" "capture_events" {
-#   name          = "${var.prefix}_${var.cluster}_streamalert_all_events"
-#   description   = "Capture CloudWatch events"
-#   role_arn      = aws_iam_role.cloudwatch_events_role.arn
-#   event_pattern = var.event_pattern
-#
-#   tags = {
-#     Name    = "StreamAlert"
-#     Cluster = var.cluster
-#   }
-# }
-#
-// The Kinesis destination for Cloudwatch events
-# resource "aws_cloudwatch_event_target" "kinesis" {
-#   rule = aws_cloudwatch_event_rule.capture_events.name
-#   arn  = var.kinesis_arn
-# }
-########################################################
-########################################################
-################# KEEP FOR FUTURE USE ##################
-########################################################
-########################################################

--- a/streamalert_cli/terraform/cloudwatch_events.py
+++ b/streamalert_cli/terraform/cloudwatch_events.py
@@ -83,7 +83,11 @@ def generate_cloudwatch_events(cluster_name, cluster_dict, config):
             'source': './modules/tf_cloudwatch_events/cross_account',
             'region': region,
             'accounts': sorted(values.get('accounts', [])),
-            'organizations': sorted(values.get('organizations', []))
+            'organizations': sorted(values.get('organizations', [])),
+            'providers': {
+                # use the aliased provider for this region from providers.tf
+                'aws': 'aws.{}'.format(region)
+            }
         }
 
     return True

--- a/streamalert_cli/terraform/cloudwatch_events.py
+++ b/streamalert_cli/terraform/cloudwatch_events.py
@@ -119,7 +119,7 @@ def _map_regions(settings):
     """
     region_map = defaultdict(dict)
     for scope in ['accounts', 'organizations']:
-        for aws_id, regions in settings[scope].items():
+        for aws_id, regions in settings.get(scope, {}).items():
             for region in regions:
                 region_map[region] = region_map.get(region, defaultdict(list))
                 region_map[region][scope].append(aws_id)

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -752,13 +752,19 @@ class TestTerraformGenerate:
                 'source': './modules/tf_cloudwatch_events/cross_account',
                 'region': 'us-east-1',
                 'accounts': ['123456789012', '234567890123'],
-                'organizations': []
+                'organizations': [],
+                'providers': {
+                    'aws': 'aws.us-east-1'
+                }
             },
             'cloudwatch_events_cross_account_advanced_us-west-1': {
                 'source': './modules/tf_cloudwatch_events/cross_account',
                 'region': 'us-west-1',
                 'accounts': [],
-                'organizations': ['o-aabbccddee']
+                'organizations': ['o-aabbccddee'],
+                'providers': {
+                    'aws': 'aws.us-west-1'
+                }
             },
         }
 

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -697,6 +697,73 @@ class TestTerraformGenerate:
 
         assert_true(log_mock.called)
 
+    def test_generate_cloudwatch_events_cross_account_map_regions(self):
+        """CLI - Terraform Generate CloudWatch Events Cross Account Region Map"""
+        # pylint: disable=protected-access
+        settings = {
+            'accounts': {
+                '123456789012': ['us-east-1'],
+                '234567890123': ['us-east-1']
+            },
+            'organizations': {
+                'o-aabbccddee': ['us-west-1']
+            }
+        }
+
+        result = cloudwatch_events._map_regions(settings)
+
+        expected = {
+            'us-east-1': {
+                'accounts': ['123456789012', '234567890123'],
+            },
+            'us-west-1': {
+                'organizations': ['o-aabbccddee']
+            }
+        }
+
+        assert_equal(expected, result)
+
+    def test_generate_cloudwatch_events_cross_account(self):
+        """CLI - Terraform Generate CloudWatch Events Cross Account"""
+        self.config['clusters']['advanced']['modules']['cloudwatch_events']['cross_account'] = {
+            'accounts': {
+                '123456789012': ['us-east-1'],
+                '234567890123': ['us-east-1']
+            },
+            'organizations': {
+                'o-aabbccddee': ['us-west-1']
+            }
+        }
+        cloudwatch_events.generate_cloudwatch_events(
+            'advanced',
+            self.cluster_dict,
+            self.config
+        )
+
+        expected = {
+            'cloudwatch_events_advanced': {
+                'source': './modules/tf_cloudwatch_events',
+                'prefix': 'unit-test',
+                'cluster': 'advanced',
+                'kinesis_arn': '${module.kinesis_advanced.arn}',
+                'event_pattern': '{"account": ["12345678910"]}',
+            },
+            'cloudwatch_events_cross_account_advanced_us-east-1': {
+                'source': './modules/tf_cloudwatch_events/cross_account',
+                'region': 'us-east-1',
+                'accounts': ['123456789012', '234567890123'],
+                'organizations': []
+            },
+            'cloudwatch_events_cross_account_advanced_us-west-1': {
+                'source': './modules/tf_cloudwatch_events/cross_account',
+                'region': 'us-west-1',
+                'accounts': [],
+                'organizations': ['o-aabbccddee']
+            },
+        }
+
+        assert_equal(expected, self.cluster_dict['module'])
+
     def test_generate_cluster_test(self):
         """CLI - Terraform Generate Test Cluster"""
 

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -697,7 +697,7 @@ class TestTerraformGenerate:
 
         assert_true(log_mock.called)
 
-    def test_generate_cloudwatch_events_cross_account_map_regions(self):
+    def test_generate_cwe_cross_acct_map_regions(self):
         """CLI - Terraform Generate CloudWatch Events Cross Account Region Map"""
         # pylint: disable=protected-access
         settings = {


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Changes

* Adding new submodule to the `tf_cloudwatch_events` module that allows for proper configuration/support of cross-account CloudWatch Events (via event bus). This includes support for both individual AWS accounts _and_ AWS organizations.

## Testing

* Added unit test for terraform generation code.
* Applied module in staging account.
