### PR TITLE
install venv in vagrant

### DIFF
--- a/streamalert_cli/_infrastructure/modules/tf_globals/lambda_layers/README.rst
+++ b/streamalert_cli/_infrastructure/modules/tf_globals/lambda_layers/README.rst
@@ -102,8 +102,8 @@ SSH and Build Dependencies
   # make sure you create virtual environment with python3.7
   $ which python3.7
 
-  # Create and use venv
-  $ mkvirtualenv --python=$(which python3.7) venv
+  # Create and source venv
+  $ python3.7 -m venv venv && source venv/bin/activate
 
   # upgrade pip and setuptools if neccessary
   $ pip install --upgrade pip setuptools

--- a/vagrant/cli/python-virtualenvwrapper/install.sh
+++ b/vagrant/cli/python-virtualenvwrapper/install.sh
@@ -1,5 +1,5 @@
 # Install python dependencies
-apt-get install python-pip virtualenvwrapper -y
+apt-get install python-pip python3.7-venv virtualenvwrapper -y
 
 # Install Python with the version specified from the deadsnakes ppa
 apt-get install software-properties-common -y


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

Using `python3 -m venv venv` in vagrant fails with:
```bash
$ python3.7 -m venv venv 
Error: Command '['/home/vagrant/venv/bin/python3.7', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
```

## Changes

* Installing venv dep in vagrant

