### PR TITLE
cloudtrail module config tweak

### DIFF
--- a/docs/source/config-clusters.rst
+++ b/docs/source/config-clusters.rst
@@ -273,12 +273,14 @@ Options
 ==============================  ===================================================  ===============
 **Key**                         **Default**                                          **Description**
 ------------------------------  ---------------------------------------------------  ---------------
+``enabled``                     ``true``                                             Toggle the ``cloudtrail`` module
 ``enable_logging``              ``true``                                             Toggle to ``false`` to pause logging to the CloudTrail
 ``exclude_home_region_events``  ``false``                                            Ignore events from the StreamAlert deployment region. This only has an effect if ``send_to_cloudwatch`` is set to ``true``
 ``is_global_trail``             ``true``                                             If ``true``, the CloudTrail is applied to all regions
 ``send_to_cloudwatch``          ``false``                                            Enable CloudTrail delivery to CloudWatch Logs. Logs sent to CloudWatch Logs are forwarded to this cluster's Kinesis stream for processing. If this is enabled, the ``enable_s3_events`` option should be disabled to avoid duplicative processing.
 ``cloudwatch_destination_arn``  (Computed from CloudWatch Logs Destination module)   CloudWatch Destination ARN used for forwarding data to this cluster's Kinesis stream. This has a default value but can be overriden here with a different CloudWatch Logs Destination ARN
 ``send_to_sns``                 ``false``                                            Create an SNS topic to which notifications should be sent when CloudTrail puts a new object in the S3 bucket. The topic name will be the same as the S3 bucket name
+``s3_settings``                 ``None``                                             Configuration options for CloudTrail related to S3. See the `S3 Options`_ section below for details.
 ==============================  ===================================================  ===============
 
 S3 Options
@@ -469,8 +471,8 @@ Options
 =====================  ===========  ===============
 **Key**                **Default**  **Description**
 ---------------------  -----------  ---------------
+``enabled``            ``true``     Toggle the ``cloudwatch_logs_destination`` module
 ``cross_account_ids``  ``[]``       Authorize StreamAlert to gather logs from these accounts
-``enabled``            ``true``     Toggle the CloudWatch Logs module
 ``excluded_regions``   ``[]``       Do not create CloudWatch Log destinations in these regions
 =====================  ===========  ===============
 
@@ -534,7 +536,7 @@ Options
 ==========================  ===========  ===============
 **Key**                     **Default**  **Description**
 --------------------------  -----------  ---------------
-``enabled``                 ``false``    Toggle the CloudWatch Monitoring module
+``enabled``                 ``false``    Toggle the ``cloudwatch_monitoring`` module
 ``kinesis_alarms_enabled``  ``true``     Toggle the Kinesis-specific metric alarms
 ``lambda_alarms_enabled``   ``true``     Toggle the Lambda-specific metric alarms
 ``settings``                ``{}``       Alarm-specific settings (see below)
@@ -785,7 +787,7 @@ Options
 =====================  =============================================================================================================================================  ===============
 **Key**                **Default**                                                                                                                                    **Description**
 ---------------------  ---------------------------------------------------------------------------------------------------------------------------------------------  ---------------
-``enabled``            ---                                                                                                                                            Toggle flow log creation
+``enabled``            ``true``                                                                                                                                       Toggle the ``flow_logs`` module
 ``flow_log_filter``    ``[version, account, eni, source, destination, srcport, destport, protocol, packets, bytes, windowstart, windowend, action, flowlogstatus]``   Toggle flow log creation
 ``log_retention``      ``7``                                                                                                                                          Day for which logs should be retained in the log group
 ``enis``               ``[]``                                                                                                                                         Add flow logs for these ENIs

--- a/docs/source/config-clusters.rst
+++ b/docs/source/config-clusters.rst
@@ -210,7 +210,9 @@ Example: CloudTrail via S3 Events
     },
     "modules": {
       "cloudtrail": {
-        "enable_s3_events": true
+        "s3_settings": {
+          "enable_events": true
+        }
       }
     }
   }
@@ -242,8 +244,10 @@ Example: CloudTrail via CloudWatch Logs
     },
     "modules": {
       "cloudtrail": {
-        "send_to_cloudwatch": true,
-        "enable_s3_events": false,
+        "s3_settings": {
+          "enable_events": true
+        },
+        "send_to_cloudwatch": true
       },
       "kinesis": {
         "streams": {
@@ -269,18 +273,27 @@ Options
 ==============================  ===================================================  ===============
 **Key**                         **Default**                                          **Description**
 ------------------------------  ---------------------------------------------------  ---------------
-``s3_cross_account_ids``        ``[]``                                               Grant write access to the CloudTrail S3 bucket for these account IDs. The primary, aka deployment account ID, will be added to this list.
 ``enable_logging``              ``true``                                             Toggle to ``false`` to pause logging to the CloudTrail
 ``exclude_home_region_events``  ``false``                                            Ignore events from the StreamAlert deployment region. This only has an effect if ``send_to_cloudwatch`` is set to ``true``
 ``is_global_trail``             ``true``                                             If ``true``, the CloudTrail is applied to all regions
 ``send_to_cloudwatch``          ``false``                                            Enable CloudTrail delivery to CloudWatch Logs. Logs sent to CloudWatch Logs are forwarded to this cluster's Kinesis stream for processing. If this is enabled, the ``enable_s3_events`` option should be disabled to avoid duplicative processing.
 ``cloudwatch_destination_arn``  (Computed from CloudWatch Logs Destination module)   CloudWatch Destination ARN used for forwarding data to this cluster's Kinesis stream. This has a default value but can be overriden here with a different CloudWatch Logs Destination ARN
 ``send_to_sns``                 ``false``                                            Create an SNS topic to which notifications should be sent when CloudTrail puts a new object in the S3 bucket. The topic name will be the same as the S3 bucket name
-``enable_s3_events``            ``false``                                            Enable S3 events for the logs sent to the S3 bucket. These will invoke this cluster's classifier for every new object in the CloudTrail S3 bucket
-``s3_bucket_name``              ``prefix-cluster-streamalert-cloudtrail``            Name of the S3 bucket to be used for the CloudTrail logs. This can be overriden, but defaults to ``prefix-cluster-streamalert-cloudtrail``
-``s3_event_selector_type``      ``""``                                               An S3 event selector to enable object level logging for the account's S3 buckets. Choices are: "ReadOnly", "WriteOnly", "All", or "", where "" disables object level logging for S3
 ==============================  ===================================================  ===============
 
+S3 Options
+----------
+The ``cloudtrail`` module has a subsection of ``s3_settings``, which contains options related to S3.
+
+========================  ===================================================  ===============
+**Key**                   **Default**                                          **Description**
+------------------------  ---------------------------------------------------  ---------------
+``cross_account_ids``     ``[]``                                               Grant write access to the CloudTrail S3 bucket for these account IDs. The primary, aka deployment account ID, will be added to this list.
+``enable_events``         ``false``                                            Enable S3 events for the logs sent to the S3 bucket. These will invoke this cluster's classifier for every new object in the CloudTrail S3 bucket
+``ignore_digest``         ``true``                                             If ``enable_events`` is enabled, setting ``ignore_digest`` to ``false`` will also process S3 files that are created within the ``AWSLogs/<account-id>/CloudTrail-Digest``. Defaults to ``true``.
+``bucket_name``           ``prefix-cluster-streamalert-cloudtrail``            Name of the S3 bucket to be used for the CloudTrail logs. This can be overriden, but defaults to ``prefix-cluster-streamalert-cloudtrail``
+``event_selector_type``   ``""``                                               An S3 event selector to enable object level logging for the account's S3 buckets. Choices are: "ReadOnly", "WriteOnly", "All", or "", where "" disables object level logging for S3
+========================  ===================================================  ===============
 
 .. _cloudwatch_events:
 
@@ -365,7 +378,7 @@ Options
 =====================  ===================================  ===============
 **Key**                **Default**                          **Description**
 ---------------------  -----------------------------------  ---------------
-``event_pattern``      ``{"account": ["<accound_id>"]}``    The `CloudWatch Events pattern <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>`_ to control what is sent to Kinesis
+``event_pattern``      ``{"account": ["<account-id>"]}``    The `CloudWatch Events pattern <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>`_ to control what is sent to Kinesis
 ``cross_account``      ``None``                             Configuration options to enable cross account access for specific AWS Accounts and Organizations. See the `Cross Account Options`_ section below for details.
 =====================  ===================================  ===============
 

--- a/streamalert_cli/terraform/cloudtrail.py
+++ b/streamalert_cli/terraform/cloudtrail.py
@@ -43,15 +43,16 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     region = config['global']['account']['region']
     prefix = config['global']['account']['prefix']
     send_to_cloudwatch = settings.get('send_to_cloudwatch', False)
-    enable_s3_events = settings.get('enable_s3_events', True)
+    s3_settings = settings.get('s3_settings', {})
+    enable_s3_events = s3_settings.get('enable_events', True)
 
-    s3_bucket_name = settings.get(
-        's3_bucket_name',
+    s3_bucket_name = s3_settings.get(
+        'bucket_name',
         '{}-{}-streamalert-cloudtrail'.format(prefix, cluster_name)
     )
 
     primary_account_id = config['global']['account']['aws_account_id']
-    account_ids = set(settings.get('s3_cross_account_ids', []))
+    account_ids = set(s3_settings.get('cross_account_ids', []))
     account_ids.add(primary_account_id)
     account_ids = sorted(account_ids)
 
@@ -72,12 +73,14 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     settings_with_defaults = {
         'enable_logging',
         'is_global_trail',
-        's3_event_selector_type',
         'send_to_sns',
     }
     for value in settings_with_defaults:
         if value in settings:
             module_info[value] = settings[value]
+
+    if 'event_selector_type' in s3_settings:
+        module_info['s3_event_selector_type'] = s3_settings.get('event_selector_type')
 
     if send_to_cloudwatch:
         if not generate_cloudtrail_cloudwatch(
@@ -102,6 +105,7 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     cluster_dict['module']['cloudtrail_{}'.format(cluster_name)] = module_info
 
     if enable_s3_events:
+        ignore_digest = s3_settings.get('ignore_digest', True)
         s3_event_account_ids = account_ids
         # Omit the primary account ID from the event notifications to avoid duplicative processing
         if send_to_cloudwatch:
@@ -113,7 +117,11 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
         bucket_info = {
             s3_bucket_name: [
                 {
-                    'filter_prefix': 'AWSLogs/{}/'.format(account_id)
+                    'filter_prefix': (
+                        'AWSLogs/{}/CloudTrail/'.format(account_id)
+                        if ignore_digest else
+                        'AWSLogs/{}/'.format(account_id)
+                    )
                 } for account_id in s3_event_account_ids
             ]
         }

--- a/streamalert_cli/terraform/cloudtrail.py
+++ b/streamalert_cli/terraform/cloudtrail.py
@@ -44,7 +44,7 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
     prefix = config['global']['account']['prefix']
     send_to_cloudwatch = settings.get('send_to_cloudwatch', False)
     s3_settings = settings.get('s3_settings', {})
-    enable_s3_events = s3_settings.get('enable_events', True)
+    enable_s3_events = s3_settings.get('enable_events', False)
 
     s3_bucket_name = s3_settings.get(
         'bucket_name',

--- a/streamalert_cli/terraform/flow_logs.py
+++ b/streamalert_cli/terraform/flow_logs.py
@@ -35,7 +35,7 @@ def generate_flow_logs(cluster_name, cluster_dict, config):
         bool: Result of applying the flow_logs module
     """
     modules = config['clusters'][cluster_name]['modules']
-    if not modules['flow_logs']['enabled']:
+    if not modules['flow_logs'].get('enabled', True):
         LOGGER.debug('Flow logs disabled, nothing to do')
         return True  # not an error
 

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -828,7 +828,6 @@ class TestTerraformGenerate:
             'kinesis_events_advanced',
             'flow_logs_advanced',
             'cloudtrail_advanced',
-            'cloudtrail_s3_events_unit-test_advanced_unit-test-advanced-streamalert-cloudtrail',
             'cloudwatch_events_advanced',
             's3_events_unit-test_advanced_unit-test-bucket_data',
             's3_events_unit-test_advanced_unit-test_cloudtrail_data'

--- a/tests/unit/streamalert_cli/terraform/test_generate.py
+++ b/tests/unit/streamalert_cli/terraform/test_generate.py
@@ -358,9 +358,11 @@ class TestTerraformGenerate:
         """CLI - Terraform Generate CloudTrail Module, Minimal Settings"""
         cluster_name = 'advanced'
         self.config['clusters']['advanced']['modules']['cloudtrail'] = {
+            's3_settings': {
+                'cross_account_ids': ['456789012345'],
+                'enable_events': False,
+            },
             'send_to_cloudwatch': False,
-            'enable_s3_events': False,
-            's3_cross_account_ids': ['456789012345'],
         }
         cloudtrail.generate_cloudtrail(
             cluster_name,
@@ -387,10 +389,12 @@ class TestTerraformGenerate:
         """CLI - Terraform Generate CloudTrail Module, With S3 Events"""
         cluster_name = 'advanced'
         self.config['clusters']['advanced']['modules']['cloudtrail'] = {
+            's3_settings':{
+                'bucket_name': 'unit-test-bucket',
+                'cross_account_ids': ['456789012345'],
+                'enable_events': True,
+            },
             'send_to_cloudwatch': False,
-            'enable_s3_events': True,
-            's3_cross_account_ids': ['456789012345'],
-            's3_bucket_name': 'unit-test-bucket'
         }
         cloudtrail.generate_cloudtrail(
             cluster_name,
@@ -420,10 +424,10 @@ class TestTerraformGenerate:
                 'bucket_name': 'unit-test-bucket',
                 'filters': [
                     {
-                        'filter_prefix': 'AWSLogs/12345678910/'
+                        'filter_prefix': 'AWSLogs/12345678910/CloudTrail/'
                     },
                     {
-                        'filter_prefix': 'AWSLogs/456789012345/'
+                        'filter_prefix': 'AWSLogs/456789012345/CloudTrail/'
                     }
                 ]
             }
@@ -435,8 +439,10 @@ class TestTerraformGenerate:
         """CLI - Terraform Generate CloudTrail Module, With CloudWatch Logs"""
         cluster_name = 'advanced'
         self.config['clusters']['advanced']['modules']['cloudtrail'] = {
+            's3_settings': {
+                'enable_events': False,
+            },
             'send_to_cloudwatch': True,
-            'enable_s3_events': False,
         }
         cloudtrail.generate_cloudtrail(
             cluster_name,
@@ -504,9 +510,11 @@ class TestTerraformGenerate:
         """CLI - Terraform Generate CloudTrail Module, With S3 and CloudWatch Logs"""
         cluster_name = 'advanced'
         self.config['clusters']['advanced']['modules']['cloudtrail'] = {
+            's3_settings': {
+                'cross_account_ids': ['456789012345'],
+                'enable_events': True,
+            },
             'send_to_cloudwatch': True,
-            's3_cross_account_ids': ['456789012345'],
-            'enable_s3_events': True,
         }
         cloudtrail.generate_cloudtrail(
             cluster_name,
@@ -577,7 +585,7 @@ class TestTerraformGenerate:
                 'bucket_name': 'unit-test-advanced-streamalert-cloudtrail',
                 'filters': [
                     {
-                        'filter_prefix': 'AWSLogs/456789012345/'
+                        'filter_prefix': 'AWSLogs/456789012345/CloudTrail/'
                     }
                 ]
             },


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

The cloudtrail module's settings are a bit messy, and can be confusing.

## Changes

* Updates to config structure for cloudtrail module to lump s3 settings together.
* Doc updates for the above change.

## Testing

Updates to unit tests
