### PR TITLE
raising exceptions when error occurs while downloading from s3

### DIFF
--- a/streamalert/classifier/payload/s3.py
+++ b/streamalert/classifier/payload/s3.py
@@ -184,7 +184,7 @@ class S3Payload(StreamPayload):
                 client.download_fileobj(key, download)
             except (IOError, ClientError):
                 LOGGER.exception('Failed to download object from S3')
-                return
+                raise
 
             total_time = time.time() - start_time
             LOGGER.info('Completed download in %s seconds', round(total_time, 2))

--- a/tests/unit/streamalert/classifier/payload/test_payload_s3.py
+++ b/tests/unit/streamalert/classifier/payload/test_payload_s3.py
@@ -19,6 +19,7 @@ import os
 import tempfile
 
 import boto3
+from botocore.exceptions import ClientError
 
 from mock import patch
 from moto import mock_s3
@@ -168,12 +169,12 @@ class TestS3Payload:
         assert_equal(read_lines, [(1, value)])
 
     @mock_s3
-    @patch('logging.Logger.exception')
-    def test_read_file_error(self, log_mock):
+    def test_read_file_error(self):
         """S3Payload - Read File, Exception"""
         boto3.resource('s3').Bucket(self._bucket).create()
-        list(S3Payload(None, self._record)._read_file())
-        log_mock.assert_called_with('Failed to download object from S3')
+        payload = S3Payload(None, self._record)
+        result = payload._read_file()
+        assert_raises(ClientError, list, result)
 
     def test_pre_parse(self):
         """S3Payload - Pre Parse"""


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

This can happen
```
Traceback (most recent call last):
  File "/var/task/streamalert/classifier/payload/s3.py", line 184, in _read_file
    client.download_fileobj(key, download)
  File "/var/task/boto3/s3/inject.py", line 720, in bucket_download_fileobj
    Callback=Callback, Config=Config)
  File "/var/task/boto3/s3/inject.py", line 678, in download_fileobj
    return future.result()
  File "/var/task/s3transfer/futures.py", line 106, in result
    return self._coordinator.result()
  File "/var/task/s3transfer/futures.py", line 265, in result
    raise self._exception
  File "/var/task/s3transfer/tasks.py", line 255, in _main
    self._submit(transfer_future=transfer_future, **kwargs)
  File "/var/task/s3transfer/download.py", line 343, in _submit
    **transfer_future.meta.call_args.extra_args
  File "/var/task/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/task/botocore/client.py", line 635, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden
```

## Changes

* The above is bad so raising it.
