### PR TITLE
allow external accounts to publish to cloudtrail's sns topic

### DIFF
--- a/docs/source/config-clusters.rst
+++ b/docs/source/config-clusters.rst
@@ -278,8 +278,9 @@ Options
 ``exclude_home_region_events``  ``false``                                            Ignore events from the StreamAlert deployment region. This only has an effect if ``send_to_cloudwatch`` is set to ``true``
 ``is_global_trail``             ``true``                                             If ``true``, the CloudTrail is applied to all regions
 ``send_to_cloudwatch``          ``false``                                            Enable CloudTrail delivery to CloudWatch Logs. Logs sent to CloudWatch Logs are forwarded to this cluster's Kinesis stream for processing. If this is enabled, the ``enable_s3_events`` option should be disabled to avoid duplicative processing.
-``cloudwatch_destination_arn``  (Computed from CloudWatch Logs Destination module)   CloudWatch Destination ARN used for forwarding data to this cluster's Kinesis stream. This has a default value but can be overriden here with a different CloudWatch Logs Destination ARN
+``cloudwatch_destination_arn``  (Computed from CloudWatch Logs Destination module)   CloudWatch Destination ARN used for forwarding data to this cluster's Kinesis stream. This has a default value but can be overridden here with a different CloudWatch Logs Destination ARN
 ``send_to_sns``                 ``false``                                            Create an SNS topic to which notifications should be sent when CloudTrail puts a new object in the S3 bucket. The topic name will be the same as the S3 bucket name
+``allow_cross_account_sns``     ``false``                                            Allow account IDs specified in the ``cross_account_ids`` array within the ``s3_settings`` (see below) to also send SNS notifications to the created SNS Topic
 ``s3_settings``                 ``None``                                             Configuration options for CloudTrail related to S3. See the `S3 Options`_ section below for details.
 ==============================  ===================================================  ===============
 
@@ -293,7 +294,7 @@ The ``cloudtrail`` module has a subsection of ``s3_settings``, which contains op
 ``cross_account_ids``     ``[]``                                               Grant write access to the CloudTrail S3 bucket for these account IDs. The primary, aka deployment account ID, will be added to this list.
 ``enable_events``         ``false``                                            Enable S3 events for the logs sent to the S3 bucket. These will invoke this cluster's classifier for every new object in the CloudTrail S3 bucket
 ``ignore_digest``         ``true``                                             If ``enable_events`` is enabled, setting ``ignore_digest`` to ``false`` will also process S3 files that are created within the ``AWSLogs/<account-id>/CloudTrail-Digest``. Defaults to ``true``.
-``bucket_name``           ``prefix-cluster-streamalert-cloudtrail``            Name of the S3 bucket to be used for the CloudTrail logs. This can be overriden, but defaults to ``prefix-cluster-streamalert-cloudtrail``
+``bucket_name``           ``prefix-cluster-streamalert-cloudtrail``            Name of the S3 bucket to be used for the CloudTrail logs. This can be overridden, but defaults to ``prefix-cluster-streamalert-cloudtrail``
 ``event_selector_type``   ``""``                                               An S3 event selector to enable object level logging for the account's S3 buckets. Choices are: "ReadOnly", "WriteOnly", "All", or "", where "" disables object level logging for S3
 ========================  ===================================================  ===============
 

--- a/streamalert_cli/_infrastructure/modules/tf_cloudtrail/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudtrail/main.tf
@@ -262,5 +262,15 @@ data "aws_iam_policy_document" "cloudtrail" {
     resources = [
       aws_sns_topic.cloudtrail[0].arn,
     ]
+
+    dynamic "condition" {
+      for_each = var.allow_cross_account_sns ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+
+        values = var.s3_cross_account_ids
+      }
+    }
   }
 }

--- a/streamalert_cli/_infrastructure/modules/tf_cloudtrail/variables.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudtrail/variables.tf
@@ -55,6 +55,12 @@ variable "send_to_sns" {
   description = "Whether or not events should be sent to SNS when objects are created in S3. This creates an SNS topic when set to true"
 }
 
+variable "allow_cross_account_sns" {
+  type        = bool
+  default     = false
+  description = "Allow account IDs specified in the s3_cross_account_ids variable to also send SNS notifications to the created SNS Topic"
+}
+
 variable "cloudwatch_logs_role_arn" {
   type        = string
   default     = null

--- a/streamalert_cli/terraform/cloudtrail.py
+++ b/streamalert_cli/terraform/cloudtrail.py
@@ -74,6 +74,7 @@ def generate_cloudtrail(cluster_name, cluster_dict, config):
         'enable_logging',
         'is_global_trail',
         'send_to_sns',
+        'allow_cross_account_sns',
     }
     for value in settings_with_defaults:
         if value in settings:


### PR DESCRIPTION
to: @airbnb/streamalert-maintainers

## Background

Since we support cross-account putobject for s3 data from cloudtrail, we should also allow external accounts to publish to an SNS topic _not_ within the producer account.

## Changes

* Adding support to allow the same accounts that are enabled for cross account s3 access to publish to the cloudtrail sns topic managed by streamalert.

