### PR TITLE
Fixes a bug where alert merging context is not correct

### DIFF
--- a/streamalert/shared/alert.py
+++ b/streamalert/shared/alert.py
@@ -422,7 +422,10 @@ class Alert:
             new_record,
             alerts[-1].outputs,  # Use the most recent set of outputs
             cluster=alerts[0].cluster,
-            context=alerts[0].context,
+            context={
+                alert.alert_id: alert.context
+                for alert in alerts
+            },
             log_source=alerts[0].log_source,
             log_type=alerts[0].log_type,
             publishers=alerts[0].publishers,


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers

## Background

Alert Merging doesn't properly merge `context` together, which makes it really tough for rules to pass information from individual records to a consolidated alert publisher. This means the alert publisher has to be "super smart" in order to extract out the proper fields and this is just too much work. 

## Changes

* During **alert output dispatching ONLY** (doesn't affect Firehose), when you have a rule with alert merging enabled, the `alert.context` field of each alert will now merge properly as such:;

### Example
Suppose two alerts:

**alert 1**
```
{
  alert_id: abc123,
  context: {"foo": "bar"},
  ...
}
```

**alert 2**
```
{
  alert_id: def456,
  context: {"baz": "buzz"},
  ...
}
```

**Old way**
The merged alert would look like:
```
{
  alert_id: ghi789,
  context: {"foo": "bar"},  # it just takes alert.context[0]
  ... merged stuff here
}
```

**NEW way**
The merged alert now looks like:
```
{
  alert_id: ghi789,
  context: {
    "abc123": {"foo": "bar"},
    "def456": {"baz": "buzz"},
  },
  ... merged stuff here
}
```
 
## Testing
Deployed internally.

Steps for how this change was tested and verified
