### PR TITLE
ISSUE-1110 Fix Key sanitisation for Athena Storage.

### DIFF
--- a/streamalert/shared/firehose.py
+++ b/streamalert/shared/firehose.py
@@ -85,7 +85,8 @@ class FirehoseClient:
         """
         # Write the json lines to the object in minimal form
         return [
-            json.dumps(record, separators=(',', ':')) + '\n' for record in records
+            json.dumps(cls.sanitize_keys(record), separators=(',', ':')) + '\n'
+            for record in records
         ]
 
     @classmethod


### PR DESCRIPTION
to: @Ryxias @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to: #1110 
resolves: #1110 

## Background

When creating Athena tables for firehose data, Athena helper classes converting special chars in log schema keys by replacing them with ‘_’
However, this sanitization was not performed for items before they're sent to sqs etc resulting in empty records for some keys such as `@timestamp` as used by Osquery & Github 
Athena table column name.. but classifier sending logs to firehose just as ‘@timestamp’ without sanitizing ..

## Changes

Re-add the data sanitization logic as per earlier stream alert instances, this looks to have been removed due to a number of refactors

## Testing

Deployed test cluster and confirmed before + after that once this change was deployed , newly classified records where stored in Athena correctly. 

```
SELECT COUNT(*),
         'null_tally' AS narrative
FROM "io_streamalert"."github"
WHERE _timestamp IS NULL
UNION
SELECT COUNT(*),
         'not_null_tally' AS narrative
FROM "io_streamalert"."github"
WHERE _timestamp IS NOT NULL;

count_timestamps | state
-- | --
1 | 53 | after_change
2 | 151740 | before_change
```


