### PR TITLE
Return response from response_is_valid in streamalert helpers

### DIFF
--- a/streamalert_cli/helpers.py
+++ b/streamalert_cli/helpers.py
@@ -142,7 +142,7 @@ def user_input(requested_info, mask, input_restrictions):
         while not response:
             response = input(prompt)  # nosec
 
-        valid_response = response_is_valid(response, input_restrictions)
+        valid_response, response = response_is_valid(response, input_restrictions)
 
         if not valid_response:
             return user_input(requested_info, mask, input_restrictions)
@@ -185,7 +185,7 @@ def response_is_valid(response, input_restrictions):
                 '\'{}\''.format(restriction) for restriction in input_restrictions)
             LOGGER.error('The supplied input should not contain any of the following: %s',
                          restrictions)
-    return valid_response
+    return valid_response, response
 
 
 def save_parameter(region, name, value, description, force_overwrite=False):


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin @Ryxias 
cc: @airbnb/streamalert-maintainers
related to: #1261 
resolves: #1261 

## Background

Historically SA used to do validation of the response within the `user_input` function and if the input was callable overwrite the initial response with the return value from the function. 

When this was refactored this response by the function was no longer returned and as such the user input was unmodified. 

The following change returns the response.    

## Changes

* Return the response from `response_is_valid` within `streamalert_cli/helpers.py`

## Testing

manual testing. 
