### PR TITLE
[ISSUE-1318] Deployment Fails with "ResourceConflictException" in Lambda

### DIFF
--- a/streamalert_cli/_infrastructure/_include.tf
+++ b/streamalert_cli/_infrastructure/_include.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60.0"
+      version = ">= 3.60.0, < 4.0.0"
     }
   }
 }

--- a/streamalert_cli/_infrastructure/_include.tf
+++ b/streamalert_cli/_infrastructure/_include.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.3.0"
+      version = "~> 3.60.0"
     }
   }
 }


### PR DESCRIPTION
to: @ryandeivert @Ryxias @chunyong-lin 
cc:
related to: https://github.com/airbnb/streamalert/issues/1318
resolves: https://github.com/airbnb/streamalert/issues/1318
closes: https://github.com/airbnb/streamalert/issues/1318

## Background

AWS has added some additional state checking into the lambda deployment lifecycle, however, the current TF provider version doesn't know how to handle this.

https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/

Users can do a temporary state opt-out via adding `aws:states:opt-out` in the description until the 1st of October...

The smallest change is to update the TF AWS provider to use a new version of the AWS SDK that can handle this. 

## Changes

* Summary of changes
* ...

## Testing

Steps for how this change was tested and verified
