### PR TITLE
Add new cloud trail insights schema

### DIFF
--- a/conf/schemas/cloudtrail.json
+++ b/conf/schemas/cloudtrail.json
@@ -75,5 +75,23 @@
         "vpcEndpointId"
       ]
     }
+  },
+  "cloudtrail:insight": {
+    "schema": {
+      "eventVersion": "string",
+      "eventTime": "string",
+      "awsRegion": "string",
+      "eventID": "string",
+      "eventType": "string",
+      "recipientAccountId": "string",
+      "sharedEventID": "string",
+      "eventCategory": "string",
+      "insightDetails": {}
+    },
+    "parser": "json",
+    "configuration": {
+      "json_path": "Records[*]",
+      "optional_top_level_keys": []
+    }
   }
 }

--- a/conf/schemas/cloudtrail.json
+++ b/conf/schemas/cloudtrail.json
@@ -91,7 +91,6 @@
     "parser": "json",
     "configuration": {
       "json_path": "Records[*]",
-      "optional_top_level_keys": []
     }
   }
 }

--- a/conf/schemas/cloudtrail.json
+++ b/conf/schemas/cloudtrail.json
@@ -90,7 +90,7 @@
     },
     "parser": "json",
     "configuration": {
-      "json_path": "Records[*]",
+      "json_path": "Records[*]"
     }
   }
 }

--- a/rules/classifier/cloudtrail/cloudtrail_insights.json
+++ b/rules/classifier/cloudtrail/cloudtrail_insights.json
@@ -1,0 +1,96 @@
+[
+  {
+    "data": {
+      "Records": [
+        {
+          "eventVersion": "1.08",
+          "eventTime": "2022-04-12T16:10:00Z",
+          "awsRegion": "eu-central-1",
+          "eventID": "49dfd327-5991-494b-98bf-6fe1eb3e3732",
+          "eventType": "AwsCloudTrailInsight",
+          "recipientAccountId": "246337027688",
+          "sharedEventID": "26acc406-e3d7-4f74-90bd-aca9d06c5127",
+          "insightDetails": {
+            "state": "Start",
+            "eventSource": "autoscaling.amazonaws.com",
+            "eventName": "CompleteLifecycleAction",
+            "insightType": "ApiCallRateInsight",
+            "insightContext": {
+              "statistics": {
+                "baseline": {
+                  "average": 0.0000882145
+                },
+                "insight": {
+                  "average": 0.6
+                },
+                "insightDuration": 5,
+                "baselineDuration": 11336
+              },
+              "attributions": [
+                {
+                  "attribute": "userIdentityArn",
+                  "insight": [
+                    {
+                      "value": "arn:aws:sts::012345678901:assumed-role/CodeDeployRole1",
+                      "average": 0.2
+                    },
+                    {
+                      "value": "arn:aws:sts::012345678901:assumed-role/CodeDeployRole2",
+                      "average": 0.2
+                    },
+                    {
+                      "value": "arn:aws:sts::012345678901:assumed-role/CodeDeployRole3",
+                      "average": 0.2
+                    }
+                  ],
+                  "baseline": [
+                    {
+                      "value": "arn:aws:sts::012345678901:assumed-role/CodeDeployRole1",
+                      "average": 0.0000882145
+                    }
+                  ]
+                },
+                {
+                  "attribute": "userAgent",
+                  "insight": [
+                    {
+                      "value": "codedeploy.amazonaws.com",
+                      "average": 0.6
+                    }
+                  ],
+                  "baseline": [
+                    {
+                      "value": "codedeploy.amazonaws.com",
+                      "average": 0.0000882145
+                    }
+                  ]
+                },
+                {
+                  "attribute": "errorCode",
+                  "insight": [
+                    {
+                      "value": "null",
+                      "average": 0.6
+                    }
+                  ],
+                  "baseline": [
+                    {
+                      "value": "null",
+                      "average": 0.0000882145
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "eventCategory": "Insight"
+        }
+      ]
+    },
+    "description": "AwsCloudTrailInsight via cloudtrail",
+    "log": "cloudtrail:insight",
+    "service": "s3",
+    "source": "prefix.cluster.sample.bucket",
+    "classify_only": true
+  }
+]


### PR DESCRIPTION
to: @ryandeivert @chunyong-lin 
cc: @airbnb/streamalert-maintainers
related to:
resolves:

## Background

The following adds `cloudtrail:insight` as it's own dedicated log type , more information on this log type can be found at https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-insight-details.html 

This log type can be overloaded into Events but it is distinct enough to warrant it's own log type.


## Changes

* Add `cloudtrail:insights` 
* Add Test case from documentation https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html

## Testing

Existing unit tests.
