### PR TITLE
GHSL-2021-121: fix ReDoS bug

### DIFF
--- a/streamalert/shared/description.py
+++ b/streamalert/shared/description.py
@@ -68,7 +68,7 @@ class RuleDescriptionParser:
         r'^(?!http:|https:)(?P<field>[a-zA-Z\d\-_&\s]{0,20}):(?P<remainder>.*)$'
     )
     _URL_REGEX = re.compile(
-        r'^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&\'\(\)\*\+,;=.]+$'
+        r'^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)[\w\-\._~:/?#[\]@!\$&\'\(\)\*\+,;=.]+$'
     )
 
     @classmethod


### PR DESCRIPTION
Fixes: #1317

This regex is very inefficient on strings like `"https://a.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-}"`